### PR TITLE
docs: remove personal public references

### DIFF
--- a/.agents/plans/2026-06-03-skillset-audit-hardening/2026-06-03-chatgpt-pro-review-digest.md
+++ b/.agents/plans/2026-06-03-skillset-audit-hardening/2026-06-03-chatgpt-pro-review-digest.md
@@ -2,8 +2,8 @@
 
 Date recorded: 2026-06-03
 
-Source provided by Matt:
-`/Users/mg/.codex/attachments/48a26abb-343d-4415-b342-5c87fd0b158d/pasted-text.txt`
+Source provided by the maintainer:
+`/path/to/review-response.txt`
 
 Context:
 
@@ -62,7 +62,7 @@ Initial coordinator read:
 
 - Conceptually strong.
 - This is probably a product-language decision more than a pure code fix.
-- Matt likely needs to decide whether the ergonomics of `rules` are worth the ambiguity.
+- the maintainer likely needs to decide whether the ergonomics of `rules` are worth the ambiguity.
 - If accepted, do it soon while the repo is still young.
 
 ### P0: Portable Tool Policy Over-Promises
@@ -124,7 +124,7 @@ Recommendation:
 
 Initial coordinator read:
 
-- This pushes against Matt's earlier preference for `skillset.name`.
+- This pushes against the maintainer's earlier preference for `skillset.name`.
 - The reviewer argues from Agent Skills and Codex standards.
 - Worth discussing carefully: plugin identity may still want `skillset.name`, while skill identity may be better standard-first.
 
@@ -265,7 +265,7 @@ Likely accept:
 - Add import reports.
 - Add `explain` / `diff` / `doctor` follow-ups.
 
-Needs Matt decision:
+Needs the maintainer decision:
 
 - Whether source directory should actually rename from `.skillset/rules` to `.skillset/instructions`.
 - Whether skill source should prefer top-level `name` over `skillset.name`.
@@ -286,7 +286,7 @@ Potential disagreements / verify before accepting:
 
 - The review labels Codex hook shape/path as P0. It may be a P1 if manifest hook path overrides are truly supported and stable, but it is still probably worth aligning with the documented default.
 - The review recommends top-level skill `name` over `skillset.name`. This conflicts with a prior local preference and may need a split decision: plugin source identity under `skillset.name`, skill source identity standard-first.
-- The review recommends `targets:` in one proposed instruction example, but Skillset has an explicit no-`targets:` design rule. If we adopt `.skillset/instructions`, keep top-level `claude` and `codex` toggles unless Matt reverses that decision.
+- The review recommends `targets:` in one proposed instruction example, but Skillset has an explicit no-`targets:` design rule. If we adopt `.skillset/instructions`, keep top-level `claude` and `codex` toggles unless the maintainer reverses that decision.
 
 ## Immediate Follow-Up Candidate Packet
 
@@ -303,11 +303,11 @@ Possible next implementation packet:
 7. Add Claude plugin pass-through paths.
 8. Update docs and generated outputs.
 
-## Matt Decision Notes
+## Maintainer Decision Notes
 
 Recorded: 2026-06-03
 
-Matt's current decisions from review triage:
+the maintainer's current decisions from review triage:
 
 - Accept canonical Codex hooks direction: use documented Codex hook defaults
   rather than leaning on a manifest override as the main path.
@@ -320,7 +320,7 @@ Matt's current decisions from review triage:
   generated skill's own version can stay clear as simple `metadata.version` (or
   equivalent target-appropriate metadata). Compiler/source provenance can remain
   separate from the output artifact's version.
-- Revisit `skillset.name`: Matt does not see why source would need a machine
+- Revisit `skillset.name`: the maintainer does not see why source would need a machine
   name distinct from the real `name`, especially when directory names already
   identify plugins/skills. This points toward standard-first top-level `name`
   for skills and likely simpler naming semantics for plugins too.

--- a/.agents/plans/2026-06-03-skillset-audit-hardening/GOAL.md
+++ b/.agents/plans/2026-06-03-skillset-audit-hardening/GOAL.md
@@ -1,13 +1,13 @@
 # Goal Prompt
 
-Paste this into Claude from `/Users/mg/Developer/galligan/skillset`.
+Paste this into Claude from `/path/to/skillset`.
 
 ````text
-/goal From repo `/Users/mg/Developer/galligan/skillset`, execute packet `.agents/plans/2026-06-03-skillset-audit-hardening/` end to end. Objective: implement the first Skillset audit hardening slice after Claude run `2b6f6349`: add a durable kitchen-sink fixture proving unexercised source surfaces, then fix P1/P2 guardrails around hook target compatibility, custom `resources.to` link behavior, fail-open generated-state handling, stable lock/hash ordering, and doc tracker drift.
+/goal From repo `/path/to/skillset`, execute packet `.agents/plans/2026-06-03-skillset-audit-hardening/` end to end. Objective: implement the first Skillset audit hardening slice after Claude run `2b6f6349`: add a durable kitchen-sink fixture proving unexercised source surfaces, then fix P1/P2 guardrails around hook target compatibility, custom `resources.to` link behavior, fail-open generated-state handling, stable lock/hash ordering, and doc tracker drift.
 
 Read first: `AGENTS.md`, `README.md`, `docs/layout.md`, packet `PLAN.md`/`REFS.md`, and the audit transcript path in `REFS.md`. Use `RETRO.md` as the durable ledger; update it after meaningful design, code, tracker, verification, review, or generated-output changes.
 
-Default fixture approach: keep fixture source inside the `skillset` repo, e.g. `fixtures/kitchen-sink/` or an equivalent test fixture, so it proves hooks/rules/shared resources/`.mcp.json`/target companion files without polluting Matt's real `agents` content. If that is not meaningful, stop and ask before changing `agents`.
+Default fixture approach: keep fixture source inside the `skillset` repo, e.g. `fixtures/kitchen-sink/` or an equivalent test fixture, so it proves hooks/rules/shared resources/`.mcp.json`/target companion files without polluting the maintainer's real `agents` content. If that is not meaningful, stop and ask before changing `agents`.
 
 Implementation requirements: add tests for the kitchen-sink fixture; add target-aware hook lint so Codex-enabled hooks fail on unsupported Codex events or handler types; fix or clearly reject ambiguous bare links when a declared resource uses custom `to`; fail loudly on corrupt `.skillset.lock` and real FS errors instead of silently disabling guards; replace locale-dependent `localeCompare` ordering for lock/hash inputs with stable ordering; update docs so PAT-52 owns changelog/version workflow, PAT-47 owns global/XDG installs, PAT-43 semver/version drift is done where applicable, and matrix rows separate implemented vs aspirational surfaces.
 
@@ -17,7 +17,7 @@ Work checkpoint-by-checkpoint. After each turn report checkpoint, changed files/
 
 Validation ladder: use narrow tests after slices. Before final run `bun run skillset:build`, `bun run skillset:check`, `bun run skillset:lint`, `bun run typecheck`, `bun test`, `bun run check`, and `git diff --check`. Record skips with reasons. Done only when implementation/docs satisfy `PLAN.md`, checks pass or skips are justified, review is recorded, forbidden-action audit is clean, and `RETRO.md` final state is complete.
 
-Stop/ask if official Claude/Codex docs contradict planned target behavior; meaningful fixture coverage requires touching `/Users/mg/Developer/galligan/agents`; user-level config/publish/install/symlink is required; unrelated verification stays broken after one focused retry; or three attempts do not shrink the failing surface.
+Stop/ask if official Claude/Codex docs contradict planned target behavior; meaningful fixture coverage requires touching `/path/to/content-repo`; user-level config/publish/install/symlink is required; unrelated verification stays broken after one focused retry; or three attempts do not shrink the failing surface.
 ````
 
 ## Handoff Notes

--- a/.agents/plans/2026-06-03-skillset-audit-hardening/PLAN.md
+++ b/.agents/plans/2026-06-03-skillset-audit-hardening/PLAN.md
@@ -6,7 +6,7 @@ Implement the first hardening slice after the Claude audit of `skillset` and
 `agents`: prove the currently unexercised source surfaces with a durable fixture,
 then fix the highest-value P1/P2 guardrails found by the audit.
 
-The executor should work in `/Users/mg/Developer/galligan/skillset`.
+The executor should work in `/path/to/skillset`.
 
 ## Background
 
@@ -23,7 +23,7 @@ This packet converts that audit into an implementation goal.
 Required implementation:
 
 1. Add a committed kitchen-sink fixture in the `skillset` repo that exercises
-   plugin source surfaces without polluting Matt's real `agents` content.
+   plugin source surfaces without polluting the maintainer's real `agents` content.
    Prefer a fixture source tree such as `fixtures/kitchen-sink/` or a similarly
    named test fixture that can be copied into temp dirs by tests.
 2. Use the fixture to prove at least these surfaces:
@@ -60,7 +60,7 @@ Required implementation:
 
 - Do not publish, install, trust, or symlink plugins or skills.
 - Do not mutate user-level Claude or Codex config.
-- Do not add a remote, push, open a PR, or merge unless Matt explicitly asks.
+- Do not add a remote, push, open a PR, or merge unless the maintainer explicitly asks.
 - Do not hand-edit generated outputs as source truth.
 - Do not migrate `agents` content, legacy GitButler content, Obsidian skills, or
   global skills.
@@ -159,7 +159,7 @@ rejection in `RETRO.md`.
 
 ## Stop Rules
 
-Stop and ask Matt if:
+Stop and ask the maintainer if:
 
 - official Claude/Codex docs or local snapshots contradict the hook-compatibility
   assumptions;

--- a/.agents/plans/2026-06-03-skillset-audit-hardening/REFS.md
+++ b/.agents/plans/2026-06-03-skillset-audit-hardening/REFS.md
@@ -3,7 +3,7 @@
 ## Primary Audit Evidence
 
 - Claude audit run:
-  `/Users/mg/.claude/projects/-Users-mg-Developer-galligan-skillset/2b6f6349-137b-4005-99fc-da3f9e8493c7.jsonl`
+  `/path/to/claude-transcript.jsonl`
 - Crew summary from run `2b6f6349`:
   - result: direction sound, no P0s, one P1, several P2s;
   - top priority: kitchen-sink fixture before adding more surface area;
@@ -11,10 +11,10 @@
 
 ## Local Repo Guidance
 
-- `/Users/mg/Developer/galligan/skillset/AGENTS.md`
-- `/Users/mg/Developer/galligan/skillset/README.md`
-- `/Users/mg/Developer/galligan/skillset/docs/layout.md`
-- `/Users/mg/Developer/galligan/skillset/package.json`
+- `/path/to/skillset/AGENTS.md`
+- `/path/to/skillset/README.md`
+- `/path/to/skillset/docs/layout.md`
+- `/path/to/skillset/package.json`
 
 ## Audit Findings To Address
 
@@ -97,19 +97,19 @@ Live docs checked on 2026-06-03 for closeout:
 
 Local snapshots from the audit:
 
-- `/Users/mg/patch/research/library/agent-skills/specification.md`
-- `/Users/mg/patch/research/library/claude-code/skills.md`
-- `/Users/mg/patch/research/library/claude-code/plugins-reference.md`
-- `/Users/mg/patch/research/library/claude-code/plugin-marketplaces.md`
-- `/Users/mg/patch/research/library/codex/skills.md`
-- `/Users/mg/patch/research/library/codex/guides--agents-md.md`
-- `/Users/mg/patch/research/library/codex/rules.md`
-- `/Users/mg/patch/research/library/codex/subagents.md`
-- `/Users/mg/patch/research/library/codex/cli--reference.md`
+- `/path/to/research/library/agent-skills/specification.md`
+- `/path/to/research/library/claude-code/skills.md`
+- `/path/to/research/library/claude-code/plugins-reference.md`
+- `/path/to/research/library/claude-code/plugin-marketplaces.md`
+- `/path/to/research/library/codex/skills.md`
+- `/path/to/research/library/codex/guides--agents-md.md`
+- `/path/to/research/library/codex/rules.md`
+- `/path/to/research/library/codex/subagents.md`
+- `/path/to/research/library/codex/cli--reference.md`
 
 Prior research note:
 
-- `/Users/mg/patch/research/notes/2026-06-01-claude-codex-agent-surface-map.md`
+- `/path/to/research/notes/2026-06-01-claude-codex-agent-surface-map.md`
 
 ## Validation Commands
 
@@ -128,6 +128,6 @@ git diff --check
 - No publish.
 - No install/trust/symlink into global Claude or Codex locations.
 - No user-level Claude/Codex config mutation.
-- No remote add, push, PR, or merge without Matt's approval.
+- No remote add, push, PR, or merge without the maintainer's approval.
 - No legacy GitButler, Obsidian, global-skill, or `agents` migration.
 - No hand-editing generated output as source truth.

--- a/.agents/plans/2026-06-03-skillset-audit-hardening/RETRO.md
+++ b/.agents/plans/2026-06-03-skillset-audit-hardening/RETRO.md
@@ -1,7 +1,7 @@
 # Retro: Skillset Audit Hardening
 
 Status: executed — implementation complete, checks green, final local review
-clean (awaiting Matt's staging/commit)
+clean (awaiting the maintainer's staging/commit)
 
 Packet:
 `.agents/plans/2026-06-03-skillset-audit-hardening/`
@@ -131,7 +131,7 @@ Current execution state:
   truth.
 - Execution branch:
   `pat-58-support-shared-resources-in-skillset-source-plugins` (worked in place;
-  no new branch created, no commits made — left for Matt to stage/commit/stack).
+  no new branch created, no commits made — left for the maintainer to stage/commit/stack).
   The `agents` repo is on the same branch name and received docs plus generated
   lock edits (uncommitted) for tracker-pointer / surface-matrix drift and
   generated-output freshness.
@@ -146,7 +146,7 @@ Current execution state:
 - Executor performed no tracker mutations: no Linear create/update/comment/
   status/dependency changes. PAT-43/47/52 ownership was corrected only in repo
   docs (`agents` repo), not in Linear.
-- 2026-06-03 — Skillset team backlog bootstrapped in Linear after Matt created
+- 2026-06-03 — Skillset team backlog bootstrapped in Linear after the maintainer created
   the new team. Created roadmap parent `SET-1` and child issues:
   - `SET-2`: Align Codex hook source and output with documented plugin defaults.
   - `SET-3`: Add `skillset.schema` and separate source schema from content
@@ -185,7 +185,7 @@ Current execution state:
   kitchen-sink fixture, hook compatibility lint, resource `to:` behavior,
   fail-open generated-state handling, stable ordering, and doc tracker drift.
 - Default fixture approach: keep fixture inside the `skillset` repo rather than
-  adding test content to `/Users/mg/Developer/galligan/agents`.
+  adding test content to `/path/to/content-repo`.
 - No tracker, source-control, generated-output, registry, install, symlink, or
   user-config mutation performed by planner.
 
@@ -202,7 +202,7 @@ Record executor decisions here:
   rule glob scans `fixtures/`.
 - Hook compatibility source of truth: live Codex hooks docs checked on
   2026-06-03 (`https://developers.openai.com/codex/hooks`), plus local snapshot
-  history in `/Users/mg/patch/research/library/codex/config-reference.md` and
+  history in `/path/to/research/library/codex/config-reference.md` and
   `config-advanced.md`. Codex events:
   PreToolUse, PermissionRequest, PostToolUse, PreCompact, PostCompact,
   SessionStart, SubagentStart, SubagentStop, UserPromptSubmit, Stop. Codex
@@ -351,7 +351,7 @@ Record local review score, summary, P0-P3 findings, and prompt-to-fix text:
   to the EACCES-on-companion-path edge (now fixed). Generated output confirmed
   fresh at 15 files.
 
-- 2026-06-03 — Coordinator closeout pass after Matt asked what blocks 5/5.
+- 2026-06-03 — Coordinator closeout pass after the maintainer asked what blocks 5/5.
 
   Live-doc update: current Codex hooks docs confirm the same event set and add
   that `async: true` command hooks are parsed but skipped. Added a validator
@@ -403,8 +403,8 @@ Record local review score, summary, P0-P3 findings, and prompt-to-fix text:
 
 - 2026-06-03 — ChatGPT Pro external conceptual review recorded.
 
-  Source: Matt-provided pasted response at
-  `/Users/mg/.codex/attachments/48a26abb-343d-4415-b342-5c87fd0b158d/pasted-text.txt`.
+  Source: maintainer-provided pasted response at
+  `/path/to/review-response.txt`.
 
   Durable digest:
   `.agents/plans/2026-06-03-skillset-audit-hardening/2026-06-03-chatgpt-pro-review-digest.md`
@@ -417,10 +417,10 @@ Record local review score, summary, P0-P3 findings, and prompt-to-fix text:
   should perhaps become `tool_intent`/`access_intent`; `skillset.version`
   should be separated from source schema/compiler provenance.
 
-- 2026-06-03 — Matt review triage decisions recorded.
+- 2026-06-03 — maintainer review triage decisions recorded.
 
   Digest section:
-  `.agents/plans/2026-06-03-skillset-audit-hardening/2026-06-03-chatgpt-pro-review-digest.md#Matt-Decision-Notes`
+  `.agents/plans/2026-06-03-skillset-audit-hardening/2026-06-03-chatgpt-pro-review-digest.md#Maintainer-Decision-Notes`
 
   Decisions: accept canonical Codex hook direction; rename source `rules` toward
   `instructions`; rename portable `tools` to `tool_intent`; add
@@ -481,7 +481,7 @@ Record unresolved P3s or evidence-based rejections:
   to `./hooks.json` and live docs allow manifest hook path overrides.
 - Codex hook shape supports `{"hooks": {...}}`; the validator also accepts
   top-level event maps for compatibility with earlier local examples.
-- `agents` repo docs/lock edits are uncommitted in its working tree for Matt to
+- `agents` repo docs/lock edits are uncommitted in its working tree for the maintainer to
   review.
 
 ## Final State
@@ -503,12 +503,12 @@ Complete before handoff:
 - Branch: in place on
   `pat-58-support-shared-resources-in-skillset-source-plugins`; no commits.
 - Remaining risks: see above (all P3/low).
-- Archive readiness: ready once Matt reviews and stages the `skillset` +
+- Archive readiness: ready once maintainer reviews and stages the `skillset` +
   `agents` working-tree changes; no push/PR performed per hard rules.
 
 ## Post-Review Polish - 2026-06-03
 
-Matt asked to clean up the remaining import polish while the branch was still
+The maintainer asked to clean up the remaining import polish while the branch was still
 open. Coordinator review had found one small file-safety wart: `skillset import`
 created the final `.skillset/skills/<name>` or `.skillset/plugins/<name>`
 directory before proving the copy/classification could complete, so a failed
@@ -543,7 +543,7 @@ mutation/remote/push/PR/merge.
 
 ## Import Inference Polish - 2026-06-03
 
-Matt asked to implement the import behavior discussed after the global
+The maintainer asked to implement the import behavior discussed after the global
 `.agents/skills`, `.claude/skills`, and `.codex/skills` review.
 
 Implemented:
@@ -595,87 +595,87 @@ PR, merge, legacy import, Obsidian import, or global migration. The adjacent
 
 ## Outfitter Public Repo Move - 2026-06-03
 
-Matt explicitly asked to move the compiler repo to `Developer/outfitter`, set a
+The maintainer explicitly asked to move the compiler repo into the public source workspace, set a
 remote, and get the public repo going.
 
 Actions completed:
 
-- Verified `/Users/mg/Developer/outfitter/skillset` already existed as an older
+- Verified `/path/to/skillset` already existed as an older
   local checkout with a stale `origin` pointing to missing
-  `https://github.com/outfitter-dev/skillset.git`.
+  `https://github.com/owner/skillset.git`.
 - Preserved that older checkout, including its dirty local `.beads` deletion
   state, by moving it to
-  `/Users/mg/Developer/outfitter/skillset-legacy-2026-06-03`.
+  `/path/to/legacy-skillset`.
 - Moved the current compiler repo from
-  `/Users/mg/Developer/galligan/skillset` to
-  `/Users/mg/Developer/outfitter/skillset`.
+  `/path/to/skillset` to
+  `/path/to/skillset`.
 - Added public-repo metadata to `package.json`, kept `"private": true` to avoid
   accidental npm publication, and updated README wording from local/private to
   public-source Outfitter development.
 - Updated self-hosted source skills to point at
-  `/Users/mg/Developer/outfitter/skillset` and rebuilt generated outputs.
+  `/path/to/skillset` and rebuilt generated outputs.
 - Fast-forwarded local `main` to the completed compiler branch so the public
   default branch contains the full implementation rather than the initial
   extract.
 - Created the public GitHub repo
-  `https://github.com/outfitter-dev/skillset` and set `origin` to
-  `https://github.com/outfitter-dev/skillset.git`.
+  `https://github.com/owner/skillset` and set `origin` to
+  `https://github.com/owner/skillset.git`.
 - Pushed `main` and verified GitHub reports
-  `nameWithOwner=outfitter-dev/skillset`, `visibility=PUBLIC`,
+  `nameWithOwner=owner/skillset`, `visibility=PUBLIC`,
   `isPrivate=false`, and `defaultBranchRef=main`.
 - Updated the adjacent `agents` content repo's local file dependency to
-  `file:../../outfitter/skillset`, refreshed `bun.lock`, and corrected stale
+  `file:/path/to/skillset`, refreshed `bun.lock`, and corrected stale
   compiler-path/import examples in `AGENTS.md`, `README.md`,
   `docs/skillset.md`, and `docs/tooling.md`.
 
 Verification:
 
-- `bun run check` in `/Users/mg/Developer/outfitter/skillset` after the move:
+- `bun run check` in `/path/to/skillset` after the move:
   typecheck, 96 tests, source lint, generated-output check, and
   `git diff --check` all green.
-- `gh repo view outfitter-dev/skillset --json nameWithOwner,visibility,url,description,defaultBranchRef,isPrivate`
+- `gh repo view owner/skillset --json nameWithOwner,visibility,url,description,defaultBranchRef,isPrivate`
   confirmed the public GitHub repo.
-- `bun run check` in `/Users/mg/Developer/galligan/agents` after relinking:
+- `bun run check` in `/path/to/content-repo` after relinking:
   `skillset lint` (1 source skill), `skillset check` (19 generated files), and
   `git diff --check` all green.
-- `rg` found no remaining `Developer/galligan/skillset`, `file:../skillset`,
+- `rg` found no remaining `/path/to/skillset`, `file:/path/to/skillset`,
   `skillset import skill`, or `skillset import plugin` references in the checked
   agents docs/package/lock surfaces.
 
 Forbidden-action audit update:
 
-- Remote add and push were explicitly requested by Matt and completed only for
-  `outfitter-dev/skillset`.
+- Remote add and push were explicitly requested by the maintainer and completed only for
+  `owner/skillset`.
 - No npm/package publish, plugin marketplace publish, install, trust, symlink,
   registry mutation, user-level Claude/Codex config mutation, PR, or merge.
 - The old Outfitter checkout was preserved rather than overwritten.
 
 ## npm Naming Alignment - 2026-06-03
 
-Matt clarified that the core CLI package should be named `skillset` on npm,
+The maintainer clarified that the core CLI package should be named `skillset` on npm,
 with the `@skillset` scope reserved for other packages.
 
 Actions completed:
 
-- Renamed the compiler package from `@galligan/skillset` to `skillset` in
+- Renamed the compiler package from the previous scoped package name to `skillset` in
   `package.json`.
 - Kept `"private": true`; this is naming alignment only, not npm publication.
 - Updated self-hosted source skills to refer to the local `skillset` compiler
-  instead of `@galligan/skillset` and rebuilt generated outputs.
+  instead of the previous scoped package name and rebuilt generated outputs.
 - Updated the adjacent `agents` content repo local dependency from
-  `@galligan/skillset` to `skillset` with the same
-  `file:../../outfitter/skillset` target, refreshed `bun.lock`, and updated the
+  the previous scoped package name to `skillset` with the same
+  `file:/path/to/skillset` target, refreshed `bun.lock`, and updated the
   stale linked-tool wording in `AGENTS.md` and `README.md`.
 
 Verification:
 
-- `bun run check` in `/Users/mg/Developer/outfitter/skillset` passed:
+- `bun run check` in `/path/to/skillset` passed:
   typecheck, 96 tests, source lint, generated-output check, and
   `git diff --check`.
-- `bun run check` in `/Users/mg/Developer/galligan/agents` passed:
+- `bun run check` in `/path/to/content-repo` passed:
   `skillset lint` (1 source skill), `skillset check` (19 generated files), and
   `git diff --check`.
-- `rg` found no remaining `@galligan/skillset` references in the checked
+- `rg` found no remaining previous scoped package references in the checked
   Skillset or agents source/docs/package surfaces.
 
 Forbidden-action audit unchanged: no npm publish, plugin marketplace publish,

--- a/.agents/plans/PLANNING.md
+++ b/.agents/plans/PLANNING.md
@@ -15,7 +15,7 @@ Archive location:
 ## Tracker
 
 Primary tracker:
-Linear PAT project, when Matt assigns or requests tracker work.
+Linear PAT project, when the maintainer assigns or requests tracker work.
 
 Issue hygiene:
 - Do not invent tracker state. If no Linear issue is assigned, record that in
@@ -36,7 +36,7 @@ untracked local branches.
 
 Branch/PR conventions:
 - Prefer a non-main branch for implementation.
-- Do not push, open PRs, or merge unless Matt explicitly asks.
+- Do not push, open PRs, or merge unless the maintainer explicitly asks.
 
 Plan packet commit policy:
 - Commit the packet on the execution branch only when the execution flow calls
@@ -71,7 +71,7 @@ Local review:
   prompt-to-fix text for actionable findings.
 
 Remote review:
-- Not required unless Matt asks for PR or source-control host work.
+- Not required unless explicitly asked for PR or source-control host work.
 - If remote review happens, record latest bot and human review state in
   `RETRO.md`.
 
@@ -101,7 +101,7 @@ Stop or ask before continuing if:
 - The work would require publishing, installing, trusting, symlinking, or
   mutating user-level Claude/Codex configuration.
 - The work would require adding a remote, pushing, opening a PR, or merging
-  without Matt's approval.
+  without the maintainer's approval.
 - Target official docs or local snapshots contradict the packet's target-fidelity
   assumptions.
 - Verification remains broken after a focused retry and the failing surface is

--- a/.agents/skills/.skillset.lock
+++ b/.agents/skills/.skillset.lock
@@ -7,9 +7,9 @@
       ],
       "kind": "standalone-skill",
       "name": "skillset-codex-development",
-      "outputHash": "sha256:b66442b7283732ce79cbc364fb5f2b9133a10eec7cb3016896e77d5f74d75d34",
+      "outputHash": "sha256:8224cae3bcd3c6cff3b9e56cb7206ac4b191e2458bbe9a8ffe3e15417768d4cd",
       "outputPath": "skillset-codex-development/SKILL.md",
-      "sourceHash": "sha256:494a98a58ef1887ecea188823b2b0027e67e93acf6206ec2412b35b847104715",
+      "sourceHash": "sha256:942fd81540a9b93c740c8398f43d1212cac410878544a4375810ba8dfe3ebe93",
       "sourcePath": ".skillset/skills/skillset-codex-development/SKILL.md",
       "version": "0.1.0"
     }

--- a/.agents/skills/skillset-codex-development/SKILL.md
+++ b/.agents/skills/skillset-codex-development/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when working on the local `skillset` compiler from a Codex-orient
 
 ## Working Context
 
-- Work in `/Users/mg/Developer/outfitter/skillset`.
+- Work in `/path/to/skillset`.
 - Treat `.skillset/` as editable source.
 - Treat `plugins-claude/`, `plugins-codex/`, `.claude/skills`, and `.agents/skills` as generated outputs.
 - Do not hand-edit generated outputs as source truth.

--- a/.claude/skills/.skillset.lock
+++ b/.claude/skills/.skillset.lock
@@ -7,9 +7,9 @@
       ],
       "kind": "standalone-skill",
       "name": "skillset-claude-development",
-      "outputHash": "sha256:0746d48adb2f528ba4408cc1d2cea3bbc79228765b3544831c85163a6b75d3bf",
+      "outputHash": "sha256:c0b8948d1947e0fe6b10ab55e88976158f4e4eaa394c5404850551a873b1c272",
       "outputPath": "skillset-claude-development/SKILL.md",
-      "sourceHash": "sha256:0bc0807962b189299be225304c4fc90a1d05a924c787539437f31b5fecc2e7ad",
+      "sourceHash": "sha256:c90761e4d1dd62d237f68c907ae68758a5fc4690c38e9cbf719e85da1eae80b0",
       "sourcePath": ".skillset/skills/skillset-claude-development/SKILL.md",
       "version": "0.1.0"
     }

--- a/.claude/skills/skillset-claude-development/SKILL.md
+++ b/.claude/skills/skillset-claude-development/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when working on the local `skillset` compiler from a Claude-orien
 
 ## Working Context
 
-- The compiler repo is `/Users/mg/Developer/outfitter/skillset`.
+- The compiler repo is `/path/to/skillset`.
 - `.skillset/` is source truth for this repo's own generated skills and plugin.
 - `plugins-claude/`, `plugins-codex/`, `.claude/skills`, and `.agents/skills` are generated outputs when self-building this repo.
 - Do not publish, globally install, symlink, or mutate user-level Claude/Codex config as part of normal development.

--- a/.skillset/config.yaml
+++ b/.skillset/config.yaml
@@ -6,7 +6,7 @@ skillset:
   description: Source skills and plugins for developing, reviewing, and using the skillset compiler.
   version: 0.1.0
   owner:
-    name: Matt Galligan
+    name: Skillset Maintainers
 
 claude:
   plugins: true

--- a/.skillset/plugins/skillset/skillset.yaml
+++ b/.skillset/plugins/skillset/skillset.yaml
@@ -6,7 +6,7 @@ skillset:
   description: Skillset compiles portable source skills and plugin bundles into target-native Claude and Codex artifacts.
   version: 0.1.0
   author:
-    name: Matt Galligan
+    name: Skillset Maintainers
   license: MIT
   keywords:
     - skillset

--- a/.skillset/skills/skillset-claude-development/SKILL.md
+++ b/.skillset/skills/skillset-claude-development/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when working on the local `skillset` compiler from a Claude-orien
 
 ## Working Context
 
-- The compiler repo is `/Users/mg/Developer/outfitter/skillset`.
+- The compiler repo is `/path/to/skillset`.
 - `.skillset/` is source truth for this repo's own generated skills and plugin.
 - `plugins-claude/`, `plugins-codex/`, `.claude/skills`, and `.agents/skills` are generated outputs when self-building this repo.
 - Do not publish, globally install, symlink, or mutate user-level Claude/Codex config as part of normal development.

--- a/.skillset/skills/skillset-codex-development/SKILL.md
+++ b/.skillset/skills/skillset-codex-development/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when working on the local `skillset` compiler from a Codex-orient
 
 ## Working Context
 
-- Work in `/Users/mg/Developer/outfitter/skillset`.
+- Work in `/path/to/skillset`.
 - Treat `.skillset/` as editable source.
 - Treat `plugins-claude/`, `plugins-codex/`, `.claude/skills`, and `.agents/skills` as generated outputs.
 - Do not hand-edit generated outputs as source truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ bun ./src/cli.ts doctor --root .
 
 ## Constraints
 
-- Do not publish this package or add a remote unless Matt explicitly asks.
+- Do not publish this package or add a remote unless the maintainer explicitly asks.
 - Do not mutate user-level Claude or Codex config.
 - Do not install, trust, or symlink generated plugins or skills into global runtime locations.
 - Do not hand-edit `.claude/skills`, `.agents/skills`, `plugins-claude`, or `plugins-codex` as source truth; edit `.skillset/` and rebuild.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The default contract is:
 Use explicit paths when building another repo:
 
 ```bash
-skillset build --root /Users/mg/Developer/galligan/agents
-skillset check --root /Users/mg/Developer/galligan/agents
+skillset build --root /path/to/content-repo
+skillset check --root /path/to/content-repo
 skillset build --root /tmp/example --source custom-source --dist generated
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@galligan/skillset",
+      "name": "skillset",
       "dependencies": {
         "yaml": "^2.8.1",
       },

--- a/fixtures/kitchen-sink/README.md
+++ b/fixtures/kitchen-sink/README.md
@@ -3,7 +3,7 @@
 A durable `.skillset/` source tree that exercises the implemented compiler
 surfaces in one build. Tests copy `.skillset/` into a temp repo and build it, so
 the fixture proves real behavior without touching the repo's own self-hosted
-source or `galligan/agents`.
+source or an example content repo.
 
 Surfaces covered:
 

--- a/plugins-claude/.claude-plugin/marketplace.json
+++ b/plugins-claude/.claude-plugin/marketplace.json
@@ -1,18 +1,18 @@
 {
   "metadata": {
     "description": "Self-hosted source for developing and using the skillset compiler.",
-    "generatedBy": "galligan/agents skillset compiler",
+    "generatedBy": "example content repo skillset compiler",
     "pluginRoot": "./plugins",
     "version": "0.1.0"
   },
   "name": "skillset",
   "owner": {
-    "name": "Matt Galligan"
+    "name": "Skillset Maintainers"
   },
   "plugins": [
     {
       "author": {
-        "name": "Matt Galligan"
+        "name": "Skillset Maintainers"
       },
       "category": "Developer Tools",
       "description": "Build source skills and plugins into Claude and Codex outputs.",

--- a/plugins-claude/.skillset.lock
+++ b/plugins-claude/.skillset.lock
@@ -10,10 +10,10 @@
       ],
       "kind": "plugin",
       "name": "skillset",
-      "outputHash": "sha256:f781b61074fec6dd1e542c689dd9db301ede1c6a2fd1b20dba3aaff16f579828",
+      "outputHash": "sha256:793ef6687c30393bbf1ab9f2a8942162e11ea7752d0be35887c208f691c3a150",
       "outputPath": "plugins/skillset/.claude-plugin/plugin.json",
       "skippedSkills": [],
-      "sourceHash": "sha256:f39aa62408e2358e25f020ef395423d53e8b1f69fb9c9ab9123763bea937f191",
+      "sourceHash": "sha256:ccf4e9cf0a0c765c8696f0683303a78d7e5b120af15080f23562d06251dbfef5",
       "sourcePath": ".skillset/plugins/skillset",
       "targetState": "sync",
       "version": "0.1.0"

--- a/plugins-claude/plugins/skillset/.claude-plugin/plugin.json
+++ b/plugins-claude/plugins/skillset/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "author": {
-    "name": "Matt Galligan"
+    "name": "Skillset Maintainers"
   },
   "description": "Build source skills and plugins into Claude and Codex outputs.",
   "keywords": [

--- a/plugins-codex/.skillset.lock
+++ b/plugins-codex/.skillset.lock
@@ -10,10 +10,10 @@
       ],
       "kind": "plugin",
       "name": "skillset",
-      "outputHash": "sha256:87ca2e2809bc51b94fae8f186080a3cec76b7b9b67e94e88f92c2423d5b0c465",
+      "outputHash": "sha256:aabbf5b2b5c430a85fc25f31371e165010c63ecd742f6bf1296bd4c01bf709cc",
       "outputPath": "plugins/skillset/.codex-plugin/plugin.json",
       "skippedSkills": [],
-      "sourceHash": "sha256:46b811d70810bcc434fa64a110cc1f59f69b2cebdd2ab9e463ab89c8c66cf5b8",
+      "sourceHash": "sha256:a928d87d6e12f9f37ab0cda64a163311fd74aaf4ecd36b6550140c398bca350e",
       "sourcePath": ".skillset/plugins/skillset",
       "targetState": "sync",
       "version": "0.1.0"

--- a/plugins-codex/plugins/skillset/.codex-plugin/plugin.json
+++ b/plugins-codex/plugins/skillset/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "author": {
-    "name": "Matt Galligan"
+    "name": "Skillset Maintainers"
   },
   "description": "Build source skills and plugins into Claude and Codex outputs.",
   "interface": {
@@ -14,7 +14,7 @@
     "defaultPrompt": [
       "Build or check this skillset source tree."
     ],
-    "developerName": "Matt Galligan",
+    "developerName": "Skillset Maintainers",
     "displayName": "Skillset",
     "longDescription": "Skillset compiles portable source skills and plugin bundles into target-native Claude and Codex artifacts.",
     "screenshots": [],

--- a/src/render.ts
+++ b/src/render.ts
@@ -170,16 +170,16 @@ function renderClaudeMarketplace(graph: BuildGraph): readonly RenderedFile[] {
   const portableMarketplace = readRecord(root, "marketplace") ?? {};
   const marketplace = mergeRecords(
     {
-      name: readString(portableMarketplace, "name") ?? readString(root, "name") ?? readString(root, "id") ?? "galligan",
+      name: readString(portableMarketplace, "name") ?? readString(root, "name") ?? readString(root, "id") ?? "skillset",
       owner,
       metadata: {
         description:
           readString(root, "summary") ??
           readString(root, "description") ??
-          "Source-first skillset plugins by @galligan",
+          "Source-first Skillset plugins",
         version: rootVersion(graph),
         pluginRoot: "./plugins",
-        generatedBy: "galligan/agents skillset compiler",
+        generatedBy: "example content repo skillset compiler",
       },
       plugins,
     },
@@ -305,7 +305,7 @@ function renderCodexInterface(graph: BuildGraph, plugin: SourcePlugin): JsonReco
     developerName:
       readPresentationString(presentation, "developer_name", "developerName") ??
       readString(author, "name") ??
-      "Matt Galligan",
+      "Skillset Maintainers",
     category: readString(presentation, "category") ?? readString(metadata, "category") ?? "Productivity",
     capabilities: [...(capabilities ?? ["Interactive", "Write"])],
     websiteURL: website,


### PR DESCRIPTION
## Summary
- Replace maintainer-specific names and local absolute paths with generic public placeholders
- Update default generated metadata to use neutral Skillset maintainer wording
- Rebuild generated skill/plugin outputs and locks so source and dist stay in sync

## Verification
- `rg --hidden -n "Matt|Galligan|galligan|/Users/mg|Users/mg|/mg/|\\bmg\\b|@galligan" -S . -g '!node_modules/**' -g '!.git/**'` returned no matches
- `rg --hidden -n "/Users/|Developer/galligan|Developer/outfitter|@galligan|Matt|Galligan|\\bmg\\b|former scoped|examplethe|research/research|tothe|docsthe|outfitterthe" -S . -g '!node_modules/**' -g '!.git/**'` returned no matches
- `bun run check`
- `bun ./src/cli.ts diff --root .`
- `git diff --check`
