### PR TITLE
docs: map test and eval boundaries

### DIFF
--- a/.agents/skills/.skillset.lock
+++ b/.agents/skills/.skillset.lock
@@ -31,9 +31,9 @@
       ],
       "kind": "standalone-skill",
       "name": "skillset-codex-development",
-      "outputHash": "sha256:94b12655bec3654cbded1bbf25c00179244b026c7f9bc65471325d3f81830433",
+      "outputHash": "sha256:971472d94e233e41f3bf13f3eb57fc80302a0a0954940d0d523a2545313fc156",
       "outputPath": "skillset-codex-development/SKILL.md",
-      "sourceHash": "sha256:a7c2e33c5b2d9fbe361ea8c8a2504b3e20689324d3488ee201dc9359ce619164",
+      "sourceHash": "sha256:40ccc3faf278f96165a9136e23aa9204d5d1b486b2a19439e4fe4d25a535294f",
       "sourcePath": ".skillset/skills/skillset-codex-development/SKILL.md",
       "version": "0.1.0"
     }

--- a/.agents/skills/skillset-codex-development/SKILL.md
+++ b/.agents/skills/skillset-codex-development/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when working on the local `skillset` compiler from a Codex-orient
 ## Implementation Loop
 
 1. Inspect the closest existing code path before editing. The core modules are `src/resolver.ts`, `src/render.ts`, `src/build.ts`, `src/config.ts`, `src/lint.ts`, and `src/import.ts`.
-2. Add or update fixtures in `src/__tests__/skillset.test.ts` for every behavior change.
+2. Add or update focused tests or fixtures in the appropriate `src/__tests__/` file for every behavior change.
 3. For source-only skill/plugin edits, run `bun run skillset:build`.
 4. Run `bun run check` before handoff.
 5. Report generated file counts and any skipped checks explicitly.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .envrc
 .claude/settings.local.json
 .scratch/
+.skillset/build/

--- a/.skillset/skills/skillset-codex-development/SKILL.md
+++ b/.skillset/skills/skillset-codex-development/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when working on the local `skillset` compiler from a Codex-orient
 ## Implementation Loop
 
 1. Inspect the closest existing code path before editing. The core modules are `src/resolver.ts`, `src/render.ts`, `src/build.ts`, `src/config.ts`, `src/lint.ts`, and `src/import.ts`.
-2. Add or update fixtures in `src/__tests__/skillset.test.ts` for every behavior change.
+2. Add or update focused tests or fixtures in the appropriate `src/__tests__/` file for every behavior change.
 3. For source-only skill/plugin edits, run `bun run skillset:build`.
 4. Run `bun run check` before handoff.
 5. Report generated file counts and any skipped checks explicitly.

--- a/docs/adrs/decision-map.json
+++ b/docs/adrs/decision-map.json
@@ -50,6 +50,11 @@
           "fromPath": "docs/adrs/drafts/20260609-change-release-edge-decisions.md"
         },
         {
+          "context": "- [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md) - source and generated-output doctrine.",
+          "from": "20260609",
+          "fromPath": "docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md"
+        },
+        {
           "context": "- [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md) - source-first doctrine.",
           "from": "20260609",
           "fromPath": "docs/adrs/drafts/20260609-source-change-release-provenance.md"

--- a/docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md
+++ b/docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md
@@ -1,0 +1,152 @@
+---
+slug: fixtures-tests-dogfooding-and-evals
+title: Fixtures, Tests, Dogfooding, and Evals
+status: draft
+created: 2026-06-09
+updated: 2026-06-09
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [0, feature-reference-and-schema-registry, source-change-release-provenance, change-release-edge-decisions]
+---
+
+# ADR: Fixtures, Tests, Dogfooding, and Evals
+
+## Context
+
+Skillset now has enough surface area that the word "test" can mean several different things. The compiler has internal fixtures and contract tests. The self-hosted repo needs to dogfood source-change and release workflows. Authors may eventually want deterministic tests that project selected `.skillset/` source subjects into isolated output and assert the result. Claude and Codex also have emerging eval conventions for model-facing behavior, and those conventions do not share one obvious portable shape.
+
+If these jobs collapse into one directory or command, Skillset will make the wrong abstraction public. A kitchen-sink compiler fixture could become a fake user-facing test. A dogfood checklist could become a public command that does not solve a user problem. A deterministic build assertion could be called an eval even though target evals include prompts, graders, baselines, token usage, and human review.
+
+The current repo already separates some of these concerns:
+
+- `fixtures/kitchen-sink/` is an internal fake repo source tree used by tests.
+- `src/__tests__/` contains compiler, contract, and audit-hardening tests.
+- `skillset check`, `doctor`, `diff`, `change check`, and `release plan` validate real source and generated output.
+- The self-hosted `.skillset/` tree is real source, not fixture data.
+
+The design question is where to draw the next boundary before implementing `skillset test`, lifecycle dogfooding, or eval support.
+
+## Decision
+
+Skillset separates fixtures, dogfooding, deterministic tests, and evals by purpose and authority.
+
+### Fixtures Stay Internal
+
+Fixtures are maintainer-owned fake repos for compiler tests. They stay outside `.skillset/` at repo root paths such as:
+
+```text
+fixtures/<case>/
+  .skillset/
+    config.yaml
+    plugins/
+    skills/
+    instructions/
+    src/
+```
+
+The fixture root should look like a realistic content repo so tests can copy `fixtures/<case>` into a temp directory and run Skillset commands with `--root <temp>`. In the current source contract, `.skillset/src/` is not the universal source root; it holds project agents and target-native islands, while plugins, standalone skills, and instructions live under their existing `.skillset/` directories. This keeps fixtures close to real authoring while preserving that they are implementation test material, not product source.
+
+A bare `fixtures/.skillset/src/` shape is acceptable only when `fixtures/` itself is intentionally treated as one fake repo root. The preferred shape remains `fixtures/<case>/.skillset/...` because it scales to multiple cases and keeps the repository's internal fixture inventory distinct from the repository's live `.skillset/` source.
+
+This means:
+
+- `fixtures/` may contain `.skillset/` trees.
+- `fixtures/` should not be scanned as the repo's own Skillset source.
+- Internal compiler tests may assert exact generated files, lock entries, drift behavior, and negative diagnostics from fixtures.
+- Moving or normalizing fixtures does not create a public source contract.
+
+### Dogfooding Is Practice, Not Product API
+
+Dogfooding is how the Skillset repo proves its own workflows. It uses real commands on real source changes, especially the change/release lifecycle:
+
+```bash
+skillset change status
+skillset change add ...
+skillset change check
+skillset release plan
+skillset release apply --yes
+skillset check
+```
+
+Dogfooding should live in repo scripts, retros, Linear acceptance criteria, and actual use of the workflow. It should not become a top-level `skillset dogfood` command unless a later user-facing problem justifies it.
+
+The first lifecycle dogfood target should be a small self-hosted `.skillset/` source edit that creates a pending reason, plans a release, applies it, refreshes generated output, and verifies no drift.
+
+### Deterministic Tests Are Future Product Surface
+
+`skillset test` is reserved for deterministic test runs that project selected source into isolated generated output and assert the result. It is not implemented by this ADR.
+
+The likely v1 shape is selector-driven rather than taxonomy-driven:
+
+```yaml
+tests:
+  skillset-plugin:
+    source: plugin:skillset
+    targets:
+      - claude
+      - codex
+    output:
+      kind: marketplace
+    assert:
+      - check
+      - noDrift
+      - exists: marketplaces/claude
+```
+
+Large tests may move into `.skillset/tests/`, but that directory should not appear until the user-facing contract is clearer than a fixture mirror. If it appears, it should reference existing `.skillset/` subjects or fixture sources; it should not duplicate skills, plugins, agents, or instructions as a parallel source tree.
+
+Generated test output belongs under `.skillset/build/tests/`:
+
+```text
+.skillset/build/tests/
+  latest/
+  latest.json
+  runs/<run-id>/
+```
+
+`latest/` is a refreshed convenience output. `runs/<run-id>/` preserves distinct runs for comparison and debugging when retention keeps them. Build output remains definitions only: test runs may generate local plugin or marketplace trees, but they do not install, trust, publish, or activate them.
+
+### Evals Are Adapter-Aware Future Surface
+
+Evals are behavioral and model-facing. They ask whether a skill, plugin, or agent helps an agent do the job. They may include prompts, baselines, graders, benchmark workspaces, measured token usage, reports, and human review.
+
+Skillset should not flatten Claude and Codex eval conventions into deterministic tests. Future eval support should be adapter-aware and may point at target-native eval files:
+
+```yaml
+evals:
+  claude:
+    source: repo:evals/claude/skillset/evals.json
+  codex:
+    source: repo:evals/codex/skillset/benchmark.json
+```
+
+Generated eval output belongs under `.skillset/build/evals/` if and when evals become a Skillset surface. That keeps deterministic test output and model-facing eval output separate while sharing the broader generated build root.
+
+Eval execution is opt-in. It must not become part of ordinary `skillset check` or `bun run check` until a specific eval mode is proven deterministic, local, credential-free, and side-effect-free. Target eval harnesses may require API keys, write their own benchmark setup files, or modify target runtime config, so Skillset should start by documenting and pointing at target-native eval conventions rather than wrapping them as normal compiler tests.
+
+### Build Root Carries Generated Experimental Output
+
+`.skillset/build/` is the gitignored home for generated Skillset working output that is not ordinary target projection. It can hold future preview, test, and eval outputs without confusing them with source or real generated destinations.
+
+This naming is preferred over hidden sibling directories such as `.skillset/.tests/` because `build/` makes the source/output boundary explicit.
+
+## Consequences
+
+### Positive
+
+This keeps internal fixtures useful without making them part of the public source model. It gives the change/release workflow a dogfood path that uses real commands and real source. It leaves room for `skillset test` without overcommitting the `.skillset/tests/` taxonomy. It also keeps future eval support compatible with Claude and Codex conventions instead of forcing one portable eval schema too early.
+
+### Tradeoffs
+
+The cost is slower implementation of `skillset test`. Skillset will continue to rely on compiler fixtures and real dogfooding before a public deterministic test runner exists. Authors who want declarative tests immediately will need to use repo scripts or existing validation commands.
+
+### What This Does NOT Decide
+
+This ADR does not implement `skillset test`, define a `.skillset/tests/` schema, define an eval schema, or decide how marketplace runtime testing is installed or activated. It does not change build semantics for real target output. It does not decide whether `latest/` should be a directory, symlink, or manifest pointer on every platform, though the preferred v1 direction is a refreshed real directory plus `latest.json`.
+
+## References
+
+- [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md) - source and generated-output doctrine.
+- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - feature docs and future registry direction.
+- [Source Change, Release, and Dependency Provenance](20260609-source-change-release-provenance.md) - source-change and release workflow this dogfood boundary must prove.
+- [Change and Release Edge Decisions](20260609-change-release-edge-decisions.md) - release and baseline edge decisions that should not be hidden in test fixtures.
+- [Tests and Evals](../../features/tests-and-evals.md) - feature-facing reference for the reserved test/eval surfaces.

--- a/docs/adrs/drafts/README.md
+++ b/docs/adrs/drafts/README.md
@@ -24,5 +24,7 @@ Draft map: `docs/adrs/drafts/decision-map.json`; numbered map: `docs/adrs/decisi
   - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md), [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md), [Global / XDG Managed Installs and Sync](20260604-global-xdg-managed-installs-and-sync.md)
 - [Change and Release Edge Decisions](20260609-change-release-edge-decisions.md)
   - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [Changelog and Version Bump Workflow](20260604-changelog-and-versioning.md)
+- [Fixtures, Tests, Dogfooding, and Evals](20260609-fixtures-tests-dogfooding-and-evals.md)
+  - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md), [Change and Release Edge Decisions](20260609-change-release-edge-decisions.md), [Source Change, Release, and Dependency Provenance](20260609-source-change-release-provenance.md)
 - [Source Change, Release, and Dependency Provenance](20260609-source-change-release-provenance.md)
   - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [Changelog and Version Bump Workflow](20260604-changelog-and-versioning.md), [Change and Release Edge Decisions](20260609-change-release-edge-decisions.md)

--- a/docs/adrs/drafts/decision-map.json
+++ b/docs/adrs/drafts/decision-map.json
@@ -71,6 +71,11 @@
           "context": "- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - tracks settings as future-only and target-native.",
           "from": "20260604",
           "fromPath": "docs/adrs/drafts/20260604-reviewed-settings-suggestions.md"
+        },
+        {
+          "context": "- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - feature docs and future registry direction.",
+          "from": "20260609",
+          "fromPath": "docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md"
         }
       ],
       "number": null,
@@ -214,6 +219,11 @@
       "depends_on": ["0", "changelog-and-versioning"],
       "inbound": [
         {
+          "context": "- [Change and Release Edge Decisions](20260609-change-release-edge-decisions.md) - release and baseline edge decisions that should not be hidden in test fixtures.",
+          "from": "20260609",
+          "fromPath": "docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md"
+        },
+        {
           "context": "The stable id and group semantics are defined in [Change and Release Edge Decisions](20260609-change-release-edge-decisions.md). One entry may cover multiple scopes only when the reason is one coheren",
           "from": "20260609",
           "fromPath": "docs/adrs/drafts/20260609-source-change-release-provenance.md"
@@ -252,10 +262,39 @@
       "created": "2026-06-09",
       "depends_on": [
         "0",
+        "feature-reference-and-schema-registry",
+        "source-change-release-provenance",
+        "change-release-edge-decisions"
+      ],
+      "inbound": [
+        {
+          "context": "See [Fixtures, Tests, Dogfooding, and Evals](../adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md), [Build Scopes](build-scopes.md), [Changes](changes.md), and [Releases and Changelogs](rele",
+          "from": "tests-and-evals",
+          "fromPath": "docs/features/tests-and-evals.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md",
+      "slug": "fixtures-tests-dogfooding-and-evals",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Fixtures, Tests, Dogfooding, and Evals",
+      "updated": "2026-06-09"
+    },
+    {
+      "created": "2026-06-09",
+      "depends_on": [
+        "0",
         "changelog-and-versioning",
         "change-release-edge-decisions"
       ],
       "inbound": [
+        {
+          "context": "- [Source Change, Release, and Dependency Provenance](20260609-source-change-release-provenance.md) - source-change and release workflow this dogfood boundary must prove.",
+          "from": "20260609",
+          "fromPath": "docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md"
+        },
         {
           "context": "See [Source Change, Release, and Dependency Provenance](../adrs/drafts/20260609-source-change-release-provenance.md) and [Change and Release Edge Decisions](../adrs/drafts/20260609-change-release-edge",
           "from": "changes",

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -28,6 +28,7 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 - [Skills](skills.md): standalone and plugin-bound skill frontmatter, target lowering, versions, metadata, and generated sidecars.
 - [Supports](supports.md): compatibility metadata, support ranges, source significance, and release severity boundaries.
 - [Target-Native Islands](target-native-islands.md): explicit Claude/Codex source islands, Codex `.rules` pass-through, and leakage rules.
+- [Tests and Evals](tests-and-evals.md): internal fixtures, dogfooding, planned deterministic tests, future adapter-aware evals, and generated run output boundaries.
 - [Themes](themes.md): Claude experimental theme pass-through, manifest wiring, and Codex unsupported boundaries.
 - [Tool Intent](tool-intent.md): portable tool intent metadata, Claude preapproval lowering, Codex metadata, and target-native escapes.
 
@@ -72,4 +73,5 @@ These are tracked as future/reserved unless a later issue promotes them:
 - [Reviewed settings suggestion workflow](../adrs/drafts/20260604-reviewed-settings-suggestions.md): Skillset may eventually propose or review target settings changes, but `skillset build` must not mutate user-level Claude or Codex config.
 - [Model and reasoning alias profiles](../adrs/drafts/20260604-model-and-reasoning-alias-profiles.md): shared aliases such as `review`, `fast`, or `deep` remain deferred; use target-native model and effort fields where supported.
 - [First-class sets](../adrs/drafts/20260604-first-class-sets.md): grouped marketplaces, bundles, and curated collections remain future vocabulary; v1 keeps build scopes and entity selectors separate.
+- [Tests and evals](tests-and-evals.md): deterministic `skillset test` and adapter-aware eval support remain planned/future; internal fixtures and validation commands exist today.
 - Generated feature docs: docs remain manual until the feature reference shape is stable enough to generate from typed registry data.

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -1,0 +1,114 @@
+# Tests and Evals
+
+Feature id: `tests-and-evals`
+
+Support vocabulary: [Feature Reference](README.md#support-vocabulary)
+
+Tests and evals are reserved future surfaces. They are related because both prove confidence in a Skillset loadout, but they answer different questions. Deterministic tests ask whether selected source projects into expected files and lifecycle state. Evals ask whether a skill, plugin, or agent helps a model do the intended work.
+
+## Current Boundary
+
+Skillset currently uses internal compiler fixtures and validation commands:
+
+| Surface | Location | Status | Purpose |
+| --- | --- | --- | --- |
+| Internal fixtures | `fixtures/<case>/.skillset/` | `implemented` / internal | Fake repos copied into temp directories by compiler tests. |
+| Contract tests | `src/__tests__/` | `implemented` / internal | Unit, contract, and audit-hardening tests for compiler behavior. |
+| Validation commands | `skillset check`, `doctor`, `diff`, `change check`, `release plan` | `implemented` | Public commands that validate real source and generated output. |
+| Dogfooding | repo scripts, Linear acceptance criteria, real Skillset source changes | internal practice | Proves workflows by using them on this repo. |
+| `skillset test` | n/a | `planned` | Future deterministic isolated projection and assertion runner. |
+| `.skillset/tests/` | n/a | `reserved` | Optional future authored test declarations; not a fixture mirror. |
+| `.skillset/evals/` | n/a | `future` | Future adapter-aware behavioral eval declarations or pointers. |
+
+Internal fixtures may include `fixtures/<case>/.skillset/src/` when a case needs project agents or target-native islands. A bare `fixtures/.skillset/src/` is acceptable only if `fixtures/` itself is intentionally the fake repo root; named fixture cases are preferred so the fixture inventory can grow without looking like live repo source.
+
+## Deterministic Tests
+
+`skillset test` should eventually run isolated deterministic scenarios. It should compile selected `.skillset/` source subjects, run Skillset lifecycle commands where configured, and assert files, lock provenance, changelog state, release state, drift, diagnostics, and target validation results.
+
+The likely first shape is selector-driven:
+
+```yaml
+tests:
+  skillset-plugin:
+    source: plugin:skillset
+    targets:
+      - claude
+      - codex
+    output:
+      kind: marketplace
+    assert:
+      - check
+      - noDrift
+      - exists: marketplaces/claude
+```
+
+Large tests may live under `.skillset/tests/`, but that directory is reserved until the source contract is clear. Tests may reference `repo:.skillset`, typed source selectors such as `plugin:skillset`, or internal fixture sources such as `fixture:kitchen-sink`. Tests should not duplicate source content as a parallel source tree.
+
+Generated test output should live under the gitignored build root:
+
+```text
+.skillset/build/tests/
+  latest/
+  latest.json
+  runs/<run-id>/
+```
+
+`latest/` is for quick manual inspection and local target smoke commands. `runs/<run-id>/` preserves distinct output when retention keeps prior runs. Test output may include generated plugin or marketplace trees, but `skillset test` must not install, publish, trust, symlink, or activate them by default.
+
+## Lifecycle Dogfooding
+
+Lifecycle dogfooding is not a product command. It is how this repo proves that the change/release workflow is usable:
+
+```bash
+skillset change status
+skillset change add ...
+skillset change check
+skillset release plan
+skillset release apply --yes
+skillset check
+```
+
+The first durable dogfood pass should use a small self-hosted `.skillset/` source edit, create a real pending reason, apply release state, refresh generated output, and confirm no drift. A separate fake-repo lifecycle fixture can cover edge cases, but it should not replace using the workflow on the real repo.
+
+## Evals
+
+Evals are future and adapter-aware. Claude and Codex evaluation conventions differ, so Skillset should start by pointing to target-native eval files rather than forcing one portable schema.
+
+Possible future shape:
+
+```yaml
+evals:
+  claude:
+    source: repo:evals/claude/skillset/evals.json
+  codex:
+    source: repo:evals/codex/skillset/benchmark.json
+```
+
+Generated eval output, if Skillset owns it later, should live under:
+
+```text
+.skillset/build/evals/
+  latest/
+  latest.json
+  runs/<run-id>/
+```
+
+Evals may include prompts, baselines, graders, benchmark workspaces, token measurements, reports, and human review. They should stay distinct from deterministic compile and lifecycle tests.
+
+Eval execution should stay opt-in. Some target eval harnesses require credentials, write benchmark setup files, or touch target runtime configuration. Those workflows are useful, but they are not safe default checks and should not be wired into `skillset check` or repo `bun run check` until a specific mode is proven deterministic, local, credential-free, and side-effect-free.
+
+## Diagnostics
+
+- `skillset test` should fail on missing source selectors, unsupported target validation, assertion failure, stale generated output, malformed lifecycle state, and unsafe activation attempts.
+- Test runs should report what they generated, what they asserted, what target validation was manual versus automated, and which commands are safe to run next.
+- Evals should identify whether a result is structural analysis, benchmark output, model behavior, or human review.
+- Evals should distinguish read-only analysis from benchmark or runtime modes that write setup files, consume credentials, call providers, or mutate target runtime state.
+
+## Provenance
+
+Test and eval runs should record the source selector, source hash or git ref, target set, compiler version, run id, generated output paths, assertion results, manual follow-up commands, and whether output was retained. This belongs in run reports under `.skillset/build/tests/` or `.skillset/build/evals/`, not in ordinary generated target files.
+
+## Evidence
+
+See [Fixtures, Tests, Dogfooding, and Evals](../adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md), [Build Scopes](build-scopes.md), [Changes](changes.md), and [Releases and Changelogs](releases.md).

--- a/fixtures/kitchen-sink/README.md
+++ b/fixtures/kitchen-sink/README.md
@@ -1,9 +1,8 @@
 # Kitchen Sink Fixture
 
-A durable `.skillset/` source tree that exercises the implemented compiler
-surfaces in one build. Tests copy `.skillset/` into a temp repo and build it, so
-the fixture proves real behavior without touching the repo's own self-hosted
-source or an example content repo.
+A durable fake repo with a `.skillset/` source tree that exercises implemented compiler surfaces in one build. Tests copy the fixture into a temp repo and build it, so the fixture proves compiler behavior without touching the repo's own self-hosted source or an example content repo.
+
+This is an internal compiler fixture, not a product-level `.skillset/tests/` case. Product dogfooding should use real `.skillset/` source changes and the public validation/change/release commands.
 
 Surfaces covered:
 
@@ -17,6 +16,4 @@ Surfaces covered:
 - rules that lower to Claude `.claude/rules/**` and Codex `AGENTS.md` files,
   including build-time `{{skillset.*}}` variable rendering.
 
-The fixture is intentionally valid so it builds; negative cases (ambiguous
-remapped bare links, Codex-incompatible hook events/handlers) live as dedicated
-tests in `src/__tests__/`.
+The fixture is intentionally valid so it builds; negative cases (ambiguous remapped bare links, Codex-incompatible hook events/handlers) live as dedicated tests in `src/__tests__/`.


### PR DESCRIPTION
## Context

Closes SET-46.

This captures the boundary Matt and I settled before implementing more Skillset testing/eval tooling. The important separation is: internal fixtures are fake repos for compiler tests, dogfooding is real repo practice, future `skillset test` should be deterministic and selector-driven, and future evals should stay adapter-aware.

Linear: https://linear.app/outfitter/issue/SET-46/land-fixture-dogfood-test-and-eval-boundary-docs

## What changed

- Added a draft ADR for fixtures, deterministic tests, dogfooding, and evals.
- Added `docs/features/tests-and-evals.md` and linked it from the feature reference.
- Clarified `fixtures/kitchen-sink` as an internal compiler fixture, not product-level `.skillset/tests` source.
- Reserved gitignored `.skillset/build/` for future generated preview/test/eval output.
- Updated the self-hosted Codex development skill to point behavior changes at the appropriate focused test file instead of one hard-coded test file, then rebuilt generated skill output.

## Verification

- `bun .agents/skills/skillset-adrs/scripts/adr.ts check`
- `bun run check`

## Notes

- Test output includes existing warning messages for legacy fixture shapes; all tests pass.
- `skillset test` and `.skillset/evals` are deliberately not implemented here.
