### PR TITLE
docs(fixtures): document internal fixture convention and tiers

### DIFF
--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -12,7 +12,7 @@ Skillset currently uses internal compiler fixtures and validation commands:
 
 | Surface | Location | Status | Purpose |
 | --- | --- | --- | --- |
-| Internal fixtures | `fixtures/<case>/.skillset/` | `implemented` / internal | Fake repos copied into temp directories by compiler tests. |
+| Internal fixtures | `fixtures/<case>/.skillset/` ([convention](../../fixtures/README.md)) | `implemented` / internal | Fake repos copied into temp directories by compiler tests. |
 | Contract tests | `src/__tests__/` | `implemented` / internal | Unit, contract, and audit-hardening tests for compiler behavior. |
 | Validation commands | `skillset check`, `doctor`, `diff`, `change check`, `release plan` | `implemented` | Public commands that validate real source and generated output. |
 | Dogfooding | repo scripts, Linear acceptance criteria, real Skillset source changes | internal practice | Proves workflows by using them on this repo. |

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,54 @@
+# Internal Fixtures
+
+`fixtures/` holds maintainer-owned fake content repos used by the compiler's tests. They are internal test material, not product source and not a `.skillset/tests/` contract. See [Fixtures, Tests, Dogfooding, and Evals](../docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md) and [Tests and Evals](../docs/features/tests-and-evals.md) for the surrounding boundary.
+
+`fixtures/` is never scanned as this repo's own Skillset source.
+
+## Two tiers of fixture
+
+Tests build fake repos two ways. Pick the lighter one unless a case earns the heavier one.
+
+### In-test temp fixtures (default)
+
+Most coverage builds a small `.skillset/` tree inline and writes it to a temp directory per test. Each test file defines a tiny builder that takes a `Record<path, content>` map:
+
+- `fixture(...)` — `src/__tests__/skillset.test.ts`
+- `contractFixture(...)` — `src/__tests__/contract.test.ts`
+- `fixture(...)` — `src/__tests__/audit-hardening.test.ts`
+
+Use this for focused positive cases, negative/diagnostic cases, and change/release lifecycle scenarios. The fixture content lives next to the assertion that depends on it, so the test reads top to bottom. This is the common case by a wide margin and should stay inline — the maps are small and each is semantically distinct, so centralizing them would not meaningfully reduce volume.
+
+### Checked-in fixtures (`fixtures/<case>/`)
+
+A checked-in fixture is a durable fake content repo committed to the tree. Tests copy `fixtures/<case>` into a temp directory and run the compiler against it with `--root <temp>`. Reach for one only when a fixture:
+
+- must be inspected as a whole realistic repo, not just as inline literals;
+- is shared by many tests as a golden reference; or
+- is too large to keep readable inline.
+
+Today there is exactly one: [`kitchen-sink/`](kitchen-sink/README.md).
+
+## Layout convention
+
+A checked-in case looks like a realistic content repo:
+
+```text
+fixtures/<case>/
+  .skillset/
+    config.yaml
+    plugins/
+    skills/
+    instructions/
+    src/          # optional; project agents and target-native islands only
+  ...other repo files as needed
+```
+
+`.skillset/src/` is **not** the universal source root. In the current source contract, plugins, standalone skills, and instructions live under their own `.skillset/` directories (`.skillset/plugins`, `.skillset/skills`, `.skillset/instructions`, with `.skillset/rules` as a compatibility alias). `.skillset/src/` holds only project agents (`.skillset/src/agents`) and target-native islands (`.skillset/src/claude`, `.skillset/src/codex`, `.skillset/src/plugins/<plugin>/<target>`). Fixtures should match current compiler behavior, not a future contract.
+
+A bare `fixtures/.skillset/src/` shape — treating `fixtures/` itself as a single fake repo root — is acceptable only when there is intentionally one case. It is not the default: named `fixtures/<case>/` directories scale to multiple cases and keep the fixture inventory from looking like live repo source.
+
+## kitchen-sink scope
+
+`kitchen-sink/` is the complete-surface **positive** golden reference: one build that exercises plugins, skills, instructions, shared resources, hooks, and Claude/Codex companions. It stays broad and is not split.
+
+It intentionally does not cover negative cases, feature isolation, project agents/islands, or change/release lifecycle. Those live as in-test temp fixtures in `src/__tests__/`. If a future scenario needs a durable, inspectable fake repo (for example a lifecycle-specific case), add a new `fixtures/<case>/` rather than overloading kitchen-sink.

--- a/fixtures/kitchen-sink/README.md
+++ b/fixtures/kitchen-sink/README.md
@@ -2,7 +2,7 @@
 
 A durable fake repo with a `.skillset/` source tree that exercises implemented compiler surfaces in one build. Tests copy the fixture into a temp repo and build it, so the fixture proves compiler behavior without touching the repo's own self-hosted source or an example content repo.
 
-This is an internal compiler fixture, not a product-level `.skillset/tests/` case. Product dogfooding should use real `.skillset/` source changes and the public validation/change/release commands.
+This is an internal compiler fixture, not a product-level `.skillset/tests/` case. Product dogfooding should use real `.skillset/` source changes and the public validation/change/release commands. See [Internal Fixtures](../README.md) for the fixture convention and the checked-in-vs-inline decision rule.
 
 Surfaces covered:
 


### PR DESCRIPTION
## SET-47: Audit and normalize internal fixture layout

Closes SET-47. Documentation-only normalization of the internal fixture convention. No code, no behavior change, no fixture move/split.

### Audit findings
- **One checked-in fixture** (`fixtures/kitchen-sink/`) — a complete-surface *positive* golden reference, copied into a temp dir and built by a single test. Covers conventional sources (plugins/skills/instructions/shared/hooks/companions) but not `.skillset/src/` or negative cases.
- **~217 in-test temp-fixture sites** across the three `src/__tests__/` files, each via a near-identical inline builder (`fixture()` / `contractFixture()`, a `Record<path, content>` → temp-dir map). These cover everything kitchen-sink does not: negatives/diagnostics, dependency/supports validation, change/release lifecycle, project agents, target-native islands.
- **`.skillset/src/` is exercised** only for project agents (`src/agents`) and target-native islands (`src/claude`, `src/codex`, `src/plugins`), never for plugins/skills/instructions — confirming the layout matches the current source contract and `.skillset/src/` is **not** a universal root.

### Decision
- Keep `kitchen-sink` broad as the golden reference; **no split**.
- Keep in-test temp fixtures inline (the default). The ~217 sites are small and semantically distinct, so a shared builder would not meaningfully reduce volume — not worth the churn/risk. Out of scope per the issue ("update docs/tests only where the fixture convention itself is clarified").
- Document the two-tier model and the checked-in-vs-inline decision rule.

### Changes
- `fixtures/README.md` (new) — the internal fixture convention: two tiers, layout convention, `.skillset/src/` scope, the bare `fixtures/.skillset/src/` single-root exception, and kitchen-sink scope.
- `fixtures/kitchen-sink/README.md` — pointer to the convention doc.
- `docs/features/tests-and-evals.md` — link the Internal fixtures row to the convention doc.

### Acceptance criteria
- [x] Internal fixture shape documented in fixture README
- [x] Convention distinguishes checked-in fake repos from in-test temp construction
- [x] Bare `fixtures/.skillset/src/` documented as single-root option, not the default
- [x] No fixture move/split → no coverage reduction (existing 198 tests unchanged)
- [x] No `.skillset/tests/` product contract introduced

### Verification (local; repo has no CI workflows)
- `bun .agents/skills/skillset-adrs/scripts/adr.ts check` → 0 errors, 0 warnings
- `bun run check` → 198 pass / 0 fail; `skillset:check` confirmed 39 generated files fresh
