### PR TITLE
feat(changes): add source-unit selectors

### DIFF
--- a/.skillset.lock
+++ b/.skillset.lock
@@ -3,15 +3,15 @@
   "generatedBy": "skillset@0.1.0",
   "items": [
     {
-      "feature": "standalone-skill",
+      "feature": "skill",
       "files": [
         ".skillset/skills/skillset-repo-test-fixtures/CHANGELOG.md"
       ],
       "kind": "changelog",
       "name": "skillset-repo-test-fixtures",
-      "outputHash": "sha256:71462e2cd32e8bd212466271692c26f38a17cad83f157f34875e5e3dce608656",
+      "outputHash": "sha256:7ffe47fb797eadd7aec24d8f6fbcc747aa02c3ad25782ea7c7efba970847fce3",
       "outputPath": ".skillset/skills/skillset-repo-test-fixtures/CHANGELOG.md",
-      "sourceHash": "sha256:599bda05c5e4d2ab1f4801ecc332ef8b69c901ab84fbf1635a48472a594a0192",
+      "sourceHash": "sha256:595144ac0f6e67bb92fdecaa554de4cbc6d2ffecd7cdcd75124b5e58005e9467",
       "sourcePath": ".skillset/skills/skillset-repo-test-fixtures/SKILL.md",
       "targetState": "generated",
       "validation": "structured"

--- a/.skillset/changes/state.json
+++ b/.skillset/changes/state.json
@@ -6,7 +6,7 @@
       "updatedAt": "2026-06-09T19:30:31.040Z",
       "version": "0.1.1"
     },
-    "standalone-skill:skillset-repo-test-fixtures": {
+    "skill:skillset-repo-test-fixtures": {
       "sourceHash": "sha256:eb36818c80abc98165ab2b77f45f86cbfbeb7cd53b7a86f0d9c4425c470966cb",
       "updatedAt": "2026-06-09T19:30:31.040Z",
       "version": "0.1.1"

--- a/.skillset/skills/skillset-repo-test-fixtures/CHANGELOG.md
+++ b/.skillset/skills/skillset-repo-test-fixtures/CHANGELOG.md
@@ -2,13 +2,13 @@
 metadata:
   generated: skillset@0.1.0
   kind: changelog
-  target: standalone-skill:skillset-repo-test-fixtures
+  target: skill:skillset-repo-test-fixtures
 ---
 
 # Changelog
 
 ## 8a04cd78d692
 
-bump: patch | group: fixture-guidance | scopes: standalone-skill:skillset-repo-test-fixtures
+bump: patch | group: fixture-guidance | scopes: skill: skillset-repo-test-fixtures
 
 Add a repo-local fixture guidance skill so agents can work on Skillset's internal compiler fixtures without confusing them with future product-level test surfaces.

--- a/docs/adrs/drafts/20260604-changelog-and-versioning.md
+++ b/docs/adrs/drafts/20260604-changelog-and-versioning.md
@@ -46,7 +46,7 @@ Each change entry is markdown with frontmatter declaring scope and bump:
 
 ```yaml
 ---
-scope: plugin:skillset      # root | plugin:<name> | skill:<plugin>/<name> | skill:<name>
+scope: plugin:skillset      # config:root | plugin:<name> | plugin.<plugin>.skill:<name> | skill:<name>
 bump: minor                 # major | minor | patch
 ---
 

--- a/docs/adrs/drafts/20260604-first-class-sets.md
+++ b/docs/adrs/drafts/20260604-first-class-sets.md
@@ -12,7 +12,7 @@ depends_on: [0, 1, feature-reference-and-schema-registry, global-xdg-managed-ins
 
 ## Context
 
-Skillset v1 deliberately keeps build scopes and entity selectors separate. `--scope repo`, `--scope plugins`, `--scope project`, `--scope user`, and `--scope all` describe destination classes. Typed selectors such as `plugin:<name>`, `skill:<plugin>/<name>`, `agent:<name>`, and a future `set:<name>` describe authored entities inside those destinations.
+Skillset v1 deliberately keeps build scopes and entity selectors separate. `--scope repo`, `--scope plugins`, `--scope project`, `--scope user`, and `--scope all` describe destination classes. Typed selectors such as `plugin:<name>`, `plugin.<plugin>.skill:<name>`, `skill:<name>`, `agent:<name>`, and a future `set:<name>` describe authored entities inside those destinations.
 
 That split keeps build planning understandable. A scope answers "where may this command write or inspect?" A selector answers "which source-owned thing am I focusing?" Mixing the two would make `--scope` behave like an arbitrary collection system and weaken lock explanations, dry-run safety, and future install workflows.
 
@@ -42,7 +42,7 @@ skillset:
 
 members:
   - "plugin:skillset"
-  - "skill:skillset/use-skillset"
+  - "plugin.skillset.skill:use-skillset"
   - "agent:reviewer"
   - "instruction:project"
 

--- a/docs/adrs/drafts/20260609-source-change-release-provenance.md
+++ b/docs/adrs/drafts/20260609-source-change-release-provenance.md
@@ -50,7 +50,7 @@ id: a83f2c91d4e7
 group:
   provider: linear
   id: SET-31
-scope: skill:skillset/use-skillset
+scope: plugin.skillset.skill:use-skillset
 bump: minor
 baseHash: sha256:abc123
 sourceHash: sha256:def456

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -11,6 +11,23 @@ import { importSource, importSources } from "../import";
 import { lintSkillset } from "../lint";
 import { loadBuildGraph } from "../resolver";
 import { createSkillset } from "../setup";
+import { sourceUnitDisplay, sourceUnitLegacyId, sourceUnitSelector } from "../source-unit-selector";
+
+test("SET-52: source-unit selectors normalize legacy ids and render conventional display labels", () => {
+  const cases: Array<[string, string, string, string]> = [
+    ["standalone-skill:demo", "skill:demo", "skill: demo", "standalone-skill:demo"],
+    ["plugin-skill:alpha/child", "plugin.alpha.skill:child", "skill(plugin:alpha): child", "plugin-skill:alpha/child"],
+    ["plugin-feature:alpha/mcp", "plugin.alpha.feature:mcp", "feature(plugin:alpha): mcp", "plugin-feature:alpha/mcp"],
+    ["target-native-island:codex:project:rules/deny.rules", "codex.rules:rules/deny.rules", "codex.rules: rules/deny.rules", "target-native-island:codex:project:rules/deny.rules"],
+    ["target-native-island:codex:plugin:alpha:.app.json", "plugin.alpha.codex.app:.app.json", "codex.app(plugin:alpha): .app.json", "target-native-island:codex:plugin:alpha:.app.json"],
+  ];
+
+  for (const [legacy, selector, display, roundTrip] of cases) {
+    expect(sourceUnitSelector(legacy)).toBe(selector);
+    expect(sourceUnitDisplay(selector)).toBe(display);
+    expect(sourceUnitLegacyId(selector)).toBe(roundTrip);
+  }
+});
 
 // SET-3: skillset.schema separates the source-contract schema from content
 // version (skillset.version), generated metadata.version, and lock provenance.
@@ -1032,17 +1049,17 @@ Unstaged body.
   const status = await runSkillsetCli("change", "status", "--staged", "--root", root);
   expect(status.exitCode).toBe(0);
   expect(status.stdout).toContain("baseline git ref HEAD");
-  expect(status.stdout).toContain("standalone-skill:demo");
+  expect(status.stdout).toContain("skill: demo");
   expect(status.stdout).not.toContain("unstaged");
 
   const stagedStatus = await changeStatus(root, { staged: true });
-  const demoHash = stagedStatus.sourceChanges.find((change) => change.id === "standalone-skill:demo")?.currentHash;
+  const demoHash = stagedStatus.sourceChanges.find((change) => change.id === "skill:demo")?.currentHash;
   expect(demoHash).toBeDefined();
   await mkdir(join(root, ".skillset/changes/pending"), { recursive: true });
   const pendingPath = join(root, ".skillset/changes/pending/demo.md");
   await writeFile(pendingPath, `---
 id: abcdef123456
-scope: standalone-skill:demo
+scope: skill:demo
 bump: patch
 evidence:
   sourceHash: ${demoHash}
@@ -1053,7 +1070,7 @@ short
   await runGit(root, "add", pendingPath);
   await writeFile(pendingPath, `---
 id: abcdef123456
-scope: standalone-skill:demo
+scope: skill:demo
 bump: patch
 evidence:
   sourceHash: ${demoHash}
@@ -1100,13 +1117,13 @@ Changed body.
 `);
   await runGit(root, "add", ".skillset/skills/demo/SKILL.md");
   const stagedStatus = await changeStatus(root, { staged: true });
-  const demoHash = stagedStatus.sourceChanges.find((change) => change.id === "standalone-skill:demo")?.currentHash;
+  const demoHash = stagedStatus.sourceChanges.find((change) => change.id === "skill:demo")?.currentHash;
   expect(demoHash).toBeDefined();
   await mkdir(join(root, ".skillset/changes/pending"), { recursive: true });
   const pendingPath = join(root, ".skillset/changes/pending/demo.md");
   await writeFile(pendingPath, `---
 id: abcdef123456
-scope: standalone-skill:demo
+scope: skill:demo
 bump: patch
 evidence:
   sourceHash: ${demoHash}
@@ -1188,7 +1205,7 @@ Body.
   const status = await runSkillsetCli("change", "status", "--root", root, "--since", "HEAD");
   expect(status.exitCode).toBe(0);
   expect(status.stdout).toContain("source hash schema skillset-source-unit-v1");
-  expect(status.stdout).toContain("~ standalone-skill standalone-skill:demo");
+  expect(status.stdout).toContain("~ skill: demo");
   expect(status.stdout).toContain("source change(s) needing entries");
   expect(status.stdout).toContain("generated-output drift");
   expect(status.stdout).toContain("generated ~ .claude/skills/demo/SKILL.md");
@@ -1231,8 +1248,8 @@ Body.
   );
 
   const report = await changeStatus(root, { since: "HEAD" });
-  expect(report.sourceChanges.map((change) => change.id)).toContain("standalone-skill:demo");
-  const unit = report.sourceUnits.find((item) => item.id === "standalone-skill:demo");
+  expect(report.sourceChanges.map((change) => change.id)).toContain("skill:demo");
+  const unit = report.sourceUnits.find((item) => item.id === "skill:demo");
   expect(unit?.regions).toEqual([
     { name: "dependencies", severityBearing: true },
     { name: "supports", severityBearing: false },
@@ -1399,16 +1416,16 @@ Body.
 `
   );
   const status = await changeStatus(root, { since: "HEAD" });
-  const demo = status.sourceChanges.find((change) => change.id === "standalone-skill:demo");
+  const demo = status.sourceChanges.find((change) => change.id === "skill:demo");
   expect(demo?.currentHash).toBeDefined();
   expect(demo?.currentRegions).toContainEqual({ name: "supports", severityBearing: false });
   await writePendingChange(root, "supports.md", `
 ---
 id: 888888ffffff
 bump: none
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     currentHash: ${demo?.currentHash}
 ---
 
@@ -1871,7 +1888,7 @@ Plugin body.
 
   const report = await changeStatus(root, { since: "HEAD" });
   expect(report.sourceChanges.map((change) => change.id)).toEqual(
-    expect.arrayContaining(["plugin-skill:alpha/plugin-skill", "plugin:alpha"])
+    expect.arrayContaining(["plugin.alpha.skill:plugin-skill", "plugin:alpha"])
   );
 });
 
@@ -1908,7 +1925,7 @@ description: Demo.
   const report = await changeStatus(root, { since: "HEAD" });
   const changedIds = report.sourceChanges.map((change) => change.id);
   expect(changedIds).toContain("instruction:root");
-  expect(changedIds).toContain("standalone-skill:demo");
+  expect(changedIds).toContain("skill:demo");
   const instruction = report.sourceUnits.find((unit) => unit.id === "instruction:root");
   expect(instruction?.sourcePaths).toContain(".skillset/shared/common.md");
   expect(report.generatedDrift.changed).toContain(".claude/rules/root.md");
@@ -1942,7 +1959,7 @@ Body.
   const checked = await runSkillsetCli("change", "check", "--root", root, "--since", "HEAD");
   expect(checked.exitCode).toBe(1);
   expect(checked.stdout).toContain("change-uncovered");
-  expect(checked.stdout).toContain("standalone-skill:demo");
+  expect(checked.stdout).toContain("skill: demo");
 });
 
 test("SET-35: valid pending entries cover multiple scopes with group and ignored metadata", async () => {
@@ -1975,8 +1992,8 @@ Two body.
   await Bun.write(join(root, ".skillset/skills/one/SKILL.md"), "---\nname: one\ndescription: One.\n---\n\nOne changed.\n");
   await Bun.write(join(root, ".skillset/skills/two/SKILL.md"), "---\nname: two\ndescription: Two.\n---\n\nTwo changed.\n");
   const report = await changeStatus(root, { since: "HEAD" });
-  const one = report.sourceChanges.find((change) => change.id === "standalone-skill:one");
-  const two = report.sourceChanges.find((change) => change.id === "standalone-skill:two");
+  const one = report.sourceChanges.find((change) => change.id === "skill:one");
+  const two = report.sourceChanges.find((change) => change.id === "skill:two");
   expect(one?.currentHash).toBeDefined();
   expect(two?.currentHash).toBeDefined();
 
@@ -1989,12 +2006,12 @@ group:
   provider: linear
   id: SET-35
 scopes:
-  - standalone-skill:one
-  - standalone-skill:two
+  - skill:one
+  - skill:two
 evidence:
-  - scope: standalone-skill:one
+  - scope: skill:one
     currentHash: ${one?.currentHash}
-  - scope: standalone-skill:two
+  - scope: skill:two
     currentHash: ${two?.currentHash}
 ---
 
@@ -2028,9 +2045,9 @@ Body.
   await writePendingChange(root, "invalid.md", `
 ---
 id: not-hex
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     currentHash: sha256:stale
 group:
   provider: linear
@@ -2072,7 +2089,7 @@ Body.
 
   await Bun.write(join(root, ".skillset/skills/demo/SKILL.md"), "---\nname: demo\ndescription: Demo.\n---\n\nChanged body.\n");
   const report = await changeStatus(root, { since: "HEAD" });
-  const demo = report.sourceChanges.find((change) => change.id === "standalone-skill:demo");
+  const demo = report.sourceChanges.find((change) => change.id === "skill:demo");
   expect(demo?.currentHash).toBeDefined();
 
   for (const filename of ["one.md", "two.md"]) {
@@ -2080,9 +2097,9 @@ Body.
 ---
 id: abcdef123456
 bump: patch
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     currentHash: ${demo?.currentHash}
 ---
 
@@ -2119,7 +2136,7 @@ Body.
 
   await Bun.write(join(root, ".skillset/skills/demo/SKILL.md"), "---\nname: demo\ndescription: Demo.\n---\n\nBody.\n");
   const report = await changeStatus(root, { since: "HEAD" });
-  const demo = report.sourceChanges.find((change) => change.id === "standalone-skill:demo");
+  const demo = report.sourceChanges.find((change) => change.id === "skill:demo");
   expect(demo?.currentHash).toBeDefined();
   expect(demo?.baselineRegions).toContainEqual({ name: "dependencies", severityBearing: true });
 
@@ -2127,9 +2144,9 @@ Body.
 ---
 id: abcdef123456
 bump: none
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     currentHash: ${demo?.currentHash}
 ---
 
@@ -2161,7 +2178,7 @@ Body.
   });
   await commitFixture(root);
   const report = await changeStatus(root, { since: "HEAD" });
-  const demo = report.sourceUnits.find((unit) => unit.id === "standalone-skill:demo");
+  const demo = report.sourceUnits.find((unit) => unit.id === "skill:demo");
   expect(demo?.hash).toBeDefined();
 
   for (const id of ["abcdef111111", "abcdef222222"]) {
@@ -2169,9 +2186,9 @@ Body.
 ---
 id: ${id}
 bump: patch
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     currentHash: ${demo?.hash}
 ---
 
@@ -2221,7 +2238,7 @@ Body.
     "--since",
     "HEAD",
     "--scope",
-    "standalone-skill:demo",
+    "skill:demo",
     "--bump",
     "patch",
     "--group",
@@ -2231,13 +2248,13 @@ Body.
   );
   expect(added.exitCode).toBe(0);
   const ref = extractChangeRef(added.stdout);
-  expect(added.stdout).toContain("standalone-skill:demo");
+  expect(added.stdout).toContain("skill: demo");
 
   const list = await runSkillsetCli("change", "list", "--root", root, "--group", "linear:SET-36");
   expect(list.exitCode).toBe(0);
   expect(list.stdout).toContain(ref);
   expect(list.stdout).toContain("linear:SET-36");
-  expect(list.stdout).toContain("standalone-skill:demo");
+  expect(list.stdout).toContain("skill: demo");
 
   const show = await runSkillsetCli("change", "show", ref, "--root", root);
   expect(show.exitCode).toBe(0);
@@ -2277,7 +2294,7 @@ Body.
     "--since",
     "HEAD",
     "--scope",
-    "standalone-skill:demo",
+    "skill:demo",
     "--bump",
     "patch",
     "--reason",
@@ -2333,9 +2350,9 @@ Body.
 ---
 id: abcdef123456
 bump: patch
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     sourceHash: sha256:pending
 ---
 
@@ -2348,16 +2365,16 @@ Pending reason wins when the same ref also exists in applied history.
       JSON.stringify({
         id: "abcdef123456",
         bump: "minor",
-        scope: "standalone-skill:demo",
+        scope: "skill:demo",
         reason: "Applied record with the same id should not win change show.",
-        evidence: [{ scope: "standalone-skill:demo", sourceHash: "sha256:history" }],
+        evidence: [{ scope: "skill:demo", sourceHash: "sha256:history" }],
       }),
       JSON.stringify({
         id: "123456abcdef",
         bump: "patch",
-        scope: "standalone-skill:demo",
+        scope: "skill:demo",
         reason: "Applied history remains inspectable through the history command.",
-        evidence: [{ scope: "standalone-skill:demo", sourceHash: "sha256:applied" }],
+        evidence: [{ scope: "skill:demo", sourceHash: "sha256:applied" }],
       }),
     ].join("\n") + "\n",
     "utf8"
@@ -2400,9 +2417,9 @@ Body.
 ---
 id: abcdef111111
 bump: patch
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     sourceHash: sha256:pending
 ---
 
@@ -2414,9 +2431,9 @@ Pending entry has a colliding prefix with an applied history entry.
     `${JSON.stringify({
       id: "abcdef222222",
       bump: "patch",
-      scope: "standalone-skill:demo",
+      scope: "skill:demo",
       reason: "History entry has a colliding prefix with a pending entry.",
-      evidence: [{ scope: "standalone-skill:demo", sourceHash: "sha256:history" }],
+      evidence: [{ scope: "skill:demo", sourceHash: "sha256:history" }],
     })}\n`,
     "utf8"
   );
@@ -2454,9 +2471,9 @@ Body.
 ---
 id: abcdef123456
 bump: patch
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     sourceHash: sha256:pending
 ---
 
@@ -2466,16 +2483,16 @@ Pending changes stay out of committed changelog projections.
     {
       id: "111111aaaaaa",
       bump: "patch",
-      scope: "standalone-skill:demo",
+      scope: "skill:demo",
       reason: "Clarified the standalone skill behavior for applied history.",
-      evidence: [{ scope: "standalone-skill:demo", sourceHash: "sha256:one" }],
+      evidence: [{ scope: "skill:demo", sourceHash: "sha256:one" }],
     },
     {
       id: "222222bbbbbb",
       bump: "none",
-      scope: "standalone-skill:demo",
+      scope: "skill:demo",
       reason: "Recorded an audit-only correction that should still appear in history.",
-      evidence: [{ scope: "standalone-skill:demo", sourceHash: "sha256:two" }],
+      evidence: [{ scope: "skill:demo", sourceHash: "sha256:two" }],
     },
   ]);
 
@@ -2523,9 +2540,9 @@ Body.
     {
       id: "333333cccccc",
       bump: "minor",
-      scope: "plugin-skill:alpha/demo",
+      scope: "plugin.alpha.skill:demo",
       reason: "Updated the plugin child skill and projected it into the plugin changelog.",
-      evidence: [{ scope: "plugin-skill:alpha/demo", sourceHash: "sha256:child" }],
+      evidence: [{ scope: "plugin.alpha.skill:demo", sourceHash: "sha256:child" }],
     },
   ]);
 
@@ -2533,8 +2550,87 @@ Body.
   const pluginChangelog = await readFile(join(root, ".skillset/plugins/alpha/CHANGELOG.md"), "utf8");
   expect(pluginChangelog).toContain("target: plugin:alpha");
   expect(pluginChangelog).toContain("## 333333cccccc");
-  expect(pluginChangelog).toContain("scopes: plugin-skill:alpha/demo");
+  expect(pluginChangelog).toContain("scopes: skill(plugin:alpha): demo");
   expect(pluginChangelog).toContain("Updated the plugin child skill");
+});
+
+test("SET-52: legacy source-unit scopes normalize through check, release, and changelog projection", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: legacy-selector-root
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+version: 0.1.0
+---
+
+Original body.
+`,
+  });
+  await commitFixture(root);
+  const initial = await collectSourceInventory(root);
+  const initialHash = sourceInventoryUnit(initial, "skill:demo").hash;
+  await mkdir(join(root, ".skillset/changes"), { recursive: true });
+  await writeFile(
+    join(root, ".skillset/changes/state.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      scopes: {
+        "standalone-skill:demo": {
+          sourceHash: initialHash,
+          updatedAt: "2026-06-09T00:00:00.000Z",
+          version: "0.1.1",
+        },
+      },
+    }),
+    "utf8"
+  );
+  await writeHistory(root, [
+    {
+      id: "111111aaaaaa",
+      bump: "patch",
+      scope: "standalone-skill:demo",
+      reason: "Legacy history entries continue to project into the generated changelog.",
+      evidence: [{ scope: "standalone-skill:demo", sourceHash: initialHash }],
+    },
+  ]);
+
+  await buildSkillset(root);
+  const changelog = await readFile(join(root, ".skillset/skills/demo/CHANGELOG.md"), "utf8");
+  expect(changelog).toContain("target: skill:demo");
+  expect(changelog).toContain("scopes: skill: demo");
+
+  await Bun.write(
+    join(root, ".skillset/skills/demo/SKILL.md"),
+    "---\nname: demo\ndescription: Demo.\nversion: 0.1.0\n---\n\nChanged body.\n"
+  );
+  const status = await changeStatus(root);
+  const demo = status.sourceChanges.find((change) => change.id === "skill:demo");
+  expect(demo?.currentHash).toBeDefined();
+  await writePendingChange(root, "legacy.md", `
+---
+id: 222222bbbbbb
+bump: patch
+scope: standalone-skill:demo
+evidence:
+  - scope: standalone-skill:demo
+    currentHash: ${demo?.currentHash}
+---
+
+Legacy pending scope syntax still covers the normalized selector and can release cleanly.
+`);
+
+  const checked = await runSkillsetCli("change", "check", "--root", root);
+  expect(checked.exitCode).toBe(0);
+  const plan = await runSkillsetCli("release", "plan", "--root", root);
+  expect(plan.exitCode).toBe(0);
+  expect(plan.stdout).toContain("@222222 pending patch skill: demo");
+  expect(plan.stdout).toContain("skill: demo: 0.1.1 -> 0.1.2 (patch)");
 });
 
 test("SET-37: generated changelogs do not perturb source inventory hashes", async () => {
@@ -2571,16 +2667,16 @@ Plugin child body.
     {
       id: "444444dddddd",
       bump: "patch",
-      scope: "standalone-skill:demo",
+      scope: "skill:demo",
       reason: "Applied standalone skill change.",
-      evidence: [{ scope: "standalone-skill:demo", sourceHash: "sha256:standalone" }],
+      evidence: [{ scope: "skill:demo", sourceHash: "sha256:standalone" }],
     },
     {
       id: "555555eeeeee",
       bump: "minor",
-      scope: "plugin-skill:alpha/child",
+      scope: "plugin.alpha.skill:child",
       reason: "Applied plugin child skill change.",
-      evidence: [{ scope: "plugin-skill:alpha/child", sourceHash: "sha256:child" }],
+      evidence: [{ scope: "plugin.alpha.skill:child", sourceHash: "sha256:child" }],
     },
   ]);
 
@@ -2588,7 +2684,7 @@ Plugin child body.
   await buildSkillset(root);
   const after = await collectSourceInventory(root);
 
-  for (const id of ["standalone-skill:demo", "plugin-skill:alpha/child", "plugin:alpha"]) {
+  for (const id of ["skill:demo", "plugin.alpha.skill:child", "plugin:alpha"]) {
     expect(sourceInventoryUnit(after, id)).toEqual(sourceInventoryUnit(before, id));
   }
 });
@@ -2618,15 +2714,15 @@ Body.
     "---\nname: demo\ndescription: Demo.\nversion: 0.1.0\n---\n\nChanged body.\n"
   );
   const status = await changeStatus(root, { since: "HEAD" });
-  const demo = status.sourceChanges.find((change) => change.id === "standalone-skill:demo");
+  const demo = status.sourceChanges.find((change) => change.id === "skill:demo");
   expect(demo?.currentHash).toBeDefined();
   await writePendingChange(root, "demo.md", `
 ---
 id: aaaabbbbcccc
 bump: patch
-scope: standalone-skill:demo
+scope: skill:demo
 evidence:
-  - scope: standalone-skill:demo
+  - scope: skill:demo
     currentHash: ${demo?.currentHash}
 ---
 
@@ -2635,8 +2731,8 @@ Release the standalone skill body update with a patch version and generated chan
 
   const plan = await runSkillsetCli("release", "plan", "--root", root);
   expect(plan.exitCode).toBe(0);
-  expect(plan.stdout).toContain("@aaaabb pending patch standalone-skill:demo");
-  expect(plan.stdout).toContain("standalone-skill:demo: 0.1.0 -> 0.1.1 (patch)");
+  expect(plan.stdout).toContain("@aaaabb pending patch skill: demo");
+  expect(plan.stdout).toContain("skill: demo: 0.1.0 -> 0.1.1 (patch)");
   expect(await Bun.file(join(root, ".skillset/changes/state.json")).exists()).toBe(false);
 
   const dryRun = await runSkillsetCli("release", "apply", "--dry-run", "--root", root);
@@ -2652,12 +2748,12 @@ Release the standalone skill body update with a patch version and generated chan
   const state = JSON.parse(await readFile(join(root, ".skillset/changes/state.json"), "utf8")) as {
     scopes: Record<string, { version: string; sourceHash: string }>;
   };
-  expect(state.scopes["standalone-skill:demo"]?.version).toBe("0.1.1");
-  expect(state.scopes["standalone-skill:demo"]?.sourceHash).toBe(demo?.currentHash);
+  expect(state.scopes["skill:demo"]?.version).toBe("0.1.1");
+  expect(state.scopes["skill:demo"]?.sourceHash).toBe(demo?.currentHash);
   const history = await readFile(join(root, ".skillset/changes/history.jsonl"), "utf8");
   expect(history).toContain("aaaabbbbcccc");
   const releases = await readFile(join(root, ".skillset/changes/releases.jsonl"), "utf8");
-  expect(releases).toContain("standalone-skill:demo");
+  expect(releases).toContain("skill:demo");
   const changelog = await readFile(join(root, ".skillset/skills/demo/CHANGELOG.md"), "utf8");
   expect(changelog).toContain("## aaaabbbbcccc");
   const generatedSkill = await readFile(join(root, ".claude/skills/demo/SKILL.md"), "utf8");
@@ -2669,7 +2765,7 @@ Release the standalone skill body update with a patch version and generated chan
   expect(await readFile(join(root, ".skillset/changes/history.jsonl"), "utf8")).toBe(history);
 
   const releasedStatus = await changeStatus(root);
-  expect(releasedStatus.sourceChanges.map((change) => change.id)).not.toContain("standalone-skill:demo");
+  expect(releasedStatus.sourceChanges.map((change) => change.id)).not.toContain("skill:demo");
   await runGit(root, "add", ".");
   await runGit(root, "commit", "-qm", "release demo");
   await Bun.write(
@@ -2679,7 +2775,7 @@ Release the standalone skill body update with a patch version and generated chan
   await runGit(root, "add", ".");
   await runGit(root, "commit", "-qm", "unreleased demo change");
   const unreleasedStatus = await changeStatus(root);
-  expect(unreleasedStatus.sourceChanges.map((change) => change.id)).toContain("standalone-skill:demo");
+  expect(unreleasedStatus.sourceChanges.map((change) => change.id)).toContain("skill:demo");
 });
 
 test("SET-38: plugin child release bumps the plugin aggregate by default", async () => {
@@ -2711,15 +2807,15 @@ Child body.
     "---\nname: child\ndescription: Child.\n---\n\nChanged child body.\n"
   );
   const status = await changeStatus(root, { since: "HEAD" });
-  const child = status.sourceChanges.find((change) => change.id === "plugin-skill:alpha/child");
+  const child = status.sourceChanges.find((change) => change.id === "plugin.alpha.skill:child");
   expect(child?.currentHash).toBeDefined();
   await writePendingChange(root, "child.md", `
 ---
 id: dddd11112222
 bump: minor
-scope: plugin-skill:alpha/child
+scope: plugin.alpha.skill:child
 evidence:
-  - scope: plugin-skill:alpha/child
+  - scope: plugin.alpha.skill:child
     currentHash: ${child?.currentHash}
 ---
 
@@ -2728,15 +2824,15 @@ Release the plugin child skill behavior as a minor update to the containing plug
 
   const plan = await runSkillsetCli("release", "plan", "--root", root);
   expect(plan.exitCode).toBe(0);
-  expect(plan.stdout).toContain("plugin-skill:alpha/child: 0.1.0 -> 0.2.0 (minor)");
-  expect(plan.stdout).toContain("plugin:alpha: 0.1.0 -> 0.2.0 (minor)");
+  expect(plan.stdout).toContain("skill(plugin:alpha): child: 0.1.0 -> 0.2.0 (minor)");
+  expect(plan.stdout).toContain("plugin: alpha: 0.1.0 -> 0.2.0 (minor)");
 
   const applied = await runSkillsetCli("release", "apply", "--yes", "--root", root);
   expect(applied.exitCode).toBe(0);
   const state = JSON.parse(await readFile(join(root, ".skillset/changes/state.json"), "utf8")) as {
     scopes: Record<string, { version: string }>;
   };
-  expect(state.scopes["plugin-skill:alpha/child"]?.version).toBe("0.2.0");
+  expect(state.scopes["plugin.alpha.skill:child"]?.version).toBe("0.2.0");
   expect(state.scopes["plugin:alpha"]?.version).toBe("0.2.0");
   expect(await readFile(join(root, ".skillset/plugins/alpha/CHANGELOG.md"), "utf8")).toContain("## dddd11112222");
   expect(await readFile(join(root, "plugins-claude/plugins/alpha/.claude-plugin/plugin.json"), "utf8")).toContain('"version": "0.2.0"');
@@ -2775,17 +2871,17 @@ Ignored body.
   await Bun.write(join(root, ".skillset/skills/audit/SKILL.md"), "---\nname: audit\ndescription: Audit.\nversion: 0.1.0\n---\n\nAudit-only change.\n");
   await Bun.write(join(root, ".skillset/skills/ignored/SKILL.md"), "---\nname: ignored\ndescription: Ignored.\nversion: 0.1.0\n---\n\nIgnored change.\n");
   const status = await changeStatus(root, { since: "HEAD" });
-  const audit = status.sourceChanges.find((change) => change.id === "standalone-skill:audit");
-  const ignored = status.sourceChanges.find((change) => change.id === "standalone-skill:ignored");
+  const audit = status.sourceChanges.find((change) => change.id === "skill:audit");
+  const ignored = status.sourceChanges.find((change) => change.id === "skill:ignored");
   expect(audit?.currentHash).toBeDefined();
   expect(ignored?.currentHash).toBeDefined();
   await writePendingChange(root, "audit.md", `
 ---
 id: 333333ffffff
 bump: none
-scope: standalone-skill:audit
+scope: skill:audit
 evidence:
-  - scope: standalone-skill:audit
+  - scope: skill:audit
     currentHash: ${audit?.currentHash}
 ---
 
@@ -2796,9 +2892,9 @@ Record the audit-only source correction without changing the published semantic 
 id: 444444ffffff
 bump: patch
 ignored: true
-scope: standalone-skill:ignored
+scope: skill:ignored
 evidence:
-  - scope: standalone-skill:ignored
+  - scope: skill:ignored
     currentHash: ${ignored?.currentHash}
 ---
 
@@ -2807,10 +2903,10 @@ Preserve this ignored audit reason in history while keeping it out of release pl
 
   const plan = await runSkillsetCli("release", "plan", "--root", root);
   expect(plan.exitCode).toBe(0);
-  expect(plan.stdout).toContain("@333333 pending none standalone-skill:audit");
-  expect(plan.stdout).toContain("@444444 ignored patch standalone-skill:ignored");
-  expect(plan.stdout).toContain("standalone-skill:audit: 0.1.0 -> 0.1.0 (none)");
-  expect(plan.stdout).not.toContain("standalone-skill:ignored: 0.1.0 -> 0.1.1");
+  expect(plan.stdout).toContain("@333333 pending none skill: audit");
+  expect(plan.stdout).toContain("@444444 ignored patch skill: ignored");
+  expect(plan.stdout).toContain("skill: audit: 0.1.0 -> 0.1.0 (none)");
+  expect(plan.stdout).not.toContain("skill: ignored: 0.1.0 -> 0.1.1");
 
   const applied = await runSkillsetCli("release", "apply", "--yes", "--root", root);
   expect(applied.exitCode).toBe(0);
@@ -2820,14 +2916,14 @@ Preserve this ignored audit reason in history while keeping it out of release pl
   const state = JSON.parse(await readFile(join(root, ".skillset/changes/state.json"), "utf8")) as {
     scopes: Record<string, { sourceHash?: string; version: string }>;
   };
-  expect(state.scopes["standalone-skill:audit"]?.version).toBe("0.1.0");
-  expect(state.scopes["standalone-skill:ignored"]?.version).toBe("0.1.0");
-  expect(state.scopes["standalone-skill:ignored"]?.sourceHash).toBe(ignored?.currentHash);
+  expect(state.scopes["skill:audit"]?.version).toBe("0.1.0");
+  expect(state.scopes["skill:ignored"]?.version).toBe("0.1.0");
+  expect(state.scopes["skill:ignored"]?.sourceHash).toBe(ignored?.currentHash);
   expect(await readFile(join(root, ".skillset/skills/audit/CHANGELOG.md"), "utf8")).toContain("## 333333ffffff");
   expect(await Bun.file(join(root, ".skillset/skills/ignored/CHANGELOG.md")).exists()).toBe(false);
 
   const releasedStatus = await changeStatus(root);
-  expect(releasedStatus.sourceChanges.map((change) => change.id)).not.toContain("standalone-skill:ignored");
+  expect(releasedStatus.sourceChanges.map((change) => change.id)).not.toContain("skill:ignored");
 });
 
 test("SET-38: release apply tombstones deleted source units as released", async () => {
@@ -2863,8 +2959,8 @@ Kept body.
   await writeFile(join(root, ".skillset/changes/state.json"), JSON.stringify({
     schemaVersion: 1,
     scopes: {
-      "standalone-skill:deleted": {
-        sourceHash: sourceInventoryUnit(initialInventory, "standalone-skill:deleted").hash,
+      "skill:deleted": {
+        sourceHash: sourceInventoryUnit(initialInventory, "skill:deleted").hash,
         version: "1.2.3",
       },
     },
@@ -2872,16 +2968,16 @@ Kept body.
 
   await rm(join(root, ".skillset/skills/deleted/SKILL.md"));
   const status = await changeStatus(root, { since: "HEAD" });
-  const deleted = status.sourceChanges.find((change) => change.id === "standalone-skill:deleted");
+  const deleted = status.sourceChanges.find((change) => change.id === "skill:deleted");
   expect(deleted?.baselineHash).toBeDefined();
   expect(deleted?.status).toBe("removed");
   await writePendingChange(root, "deleted.md", `
 ---
 id: 777777ffffff
 bump: patch
-scope: standalone-skill:deleted
+scope: skill:deleted
 evidence:
-  - scope: standalone-skill:deleted
+  - scope: skill:deleted
     sourceHash: ${deleted?.baselineHash}
 ---
 
@@ -2893,11 +2989,11 @@ Release the removal of the deleted standalone skill so default status treats the
   const state = JSON.parse(await readFile(join(root, ".skillset/changes/state.json"), "utf8")) as {
     scopes: Record<string, { removed?: boolean; version: string }>;
   };
-  expect(state.scopes["standalone-skill:deleted"]?.removed).toBe(true);
-  expect(state.scopes["standalone-skill:deleted"]?.version).toBe("1.2.4");
+  expect(state.scopes["skill:deleted"]?.removed).toBe(true);
+  expect(state.scopes["skill:deleted"]?.version).toBe("1.2.4");
 
   const releasedStatus = await changeStatus(root);
-  expect(releasedStatus.sourceChanges.map((change) => change.id)).not.toContain("standalone-skill:deleted");
+  expect(releasedStatus.sourceChanges.map((change) => change.id)).not.toContain("skill:deleted");
 
   await Bun.write(
     join(root, ".skillset/skills/deleted/SKILL.md"),
@@ -2956,16 +3052,16 @@ skillset:
     {
       id: "666666ffffff",
       bump: "patch",
-      scope: "plugin-feature:alpha/mcp",
+      scope: "plugin.alpha.feature:mcp",
       reason: "Released the plugin MCP server definition so setup requirements appear in the plugin changelog.",
-      evidence: [{ scope: "plugin-feature:alpha/mcp", sourceHash: "sha256:feature" }],
+      evidence: [{ scope: "plugin.alpha.feature:mcp", sourceHash: "sha256:feature" }],
     },
   ]);
 
   await buildSkillset(root);
   const changelog = await readFile(join(root, ".skillset/plugins/alpha/CHANGELOG.md"), "utf8");
   expect(changelog).toContain("## 666666ffffff");
-  expect(changelog).toContain("plugin-feature:alpha/mcp");
+  expect(changelog).toContain("feature(plugin:alpha): mcp");
 });
 
 test("SET-38: malformed release state fails loudly before version lowering", async () => {
@@ -2980,7 +3076,7 @@ codex: false
 {
   "schemaVersion": 1,
   "scopes": {
-    "standalone-skill:demo": { "version": "next" }
+    "skill:demo": { "version": "next" }
   }
 }
 `,
@@ -2996,7 +3092,7 @@ Body.
 
   const checked = await runSkillsetCli("check", "--root", root);
   expect(checked.exitCode).toBe(1);
-  expect(checked.stderr).toContain("release state scope standalone-skill:demo.version");
+  expect(checked.stderr).toContain("release state scope skill:demo.version");
   expect(checked.stderr).toContain("semantic version");
 });
 

--- a/src/change-entries.ts
+++ b/src/change-entries.ts
@@ -11,6 +11,7 @@ import {
 } from "./change-status";
 import { readString } from "./config";
 import { compareStrings, resolveInside } from "./path";
+import { pluginScopeFromSourceUnit, sourceUnitDisplay, sourceUnitSelector } from "./source-unit-selector";
 import type { JsonRecord, JsonValue } from "./types";
 import { isJsonRecord, parseMarkdown, parseYamlRecord } from "./yaml";
 
@@ -122,7 +123,7 @@ async function validateChangeCheck(
       if (covered.has(change.id)) continue;
       issues.push({
         code: "change-uncovered",
-        message: `source change ${change.id} is missing a pending change entry`,
+        message: `source change ${sourceUnitDisplay(change.id)} is missing a pending change entry`,
         severity: "error",
       });
     }
@@ -141,11 +142,8 @@ async function validateChangeCheck(
 }
 
 function impliedCoveredScopes(scope: string): readonly string[] {
-  if (scope.startsWith("plugin-skill:")) return [`plugin:${scope.slice("plugin-skill:".length).split("/")[0]}`];
-  if (scope.startsWith("plugin-feature:")) return [`plugin:${scope.slice("plugin-feature:".length).split("/")[0]}`];
-  if (scope.startsWith("plugin-companion:")) return [`plugin:${scope.slice("plugin-companion:".length).split("/")[0]}`];
-  const island = scope.match(/^target-native-island:[^:]+:plugin:([^:]+):/);
-  return island?.[1] === undefined ? [] : [`plugin:${island[1]}`];
+  const pluginScope = pluginScopeFromSourceUnit(scope);
+  return pluginScope === undefined || pluginScope === sourceUnitSelector(scope) ? [] : [pluginScope];
 }
 
 export async function readPendingChangeEntries(
@@ -238,7 +236,7 @@ function validatePendingEntry(
     }
     for (const scope of entry.scopes) {
       if (!context.validScopeIds.has(scope)) {
-        issues.push(entryError(entry, "change-scope-invalid", `scope ${scope} does not match a known source unit`));
+        issues.push(entryError(entry, "change-scope-invalid", `scope ${sourceUnitDisplay(scope)} does not match a known source unit`));
       }
     }
   }
@@ -265,11 +263,11 @@ function validatePendingEntry(
     if (expectedHash === undefined) continue;
     const hashes = entry.sourceHashes.get(scope) ?? [];
     if (hashes.length === 0) {
-      issues.push(entryError(entry, "change-evidence-missing", `scope ${scope} requires source hash evidence`));
+      issues.push(entryError(entry, "change-evidence-missing", `scope ${sourceUnitDisplay(scope)} requires source hash evidence`));
       continue;
     }
     if (!hashes.includes(expectedHash)) {
-      issues.push(entryError(entry, "change-evidence-stale", `scope ${scope} source hash evidence is stale`));
+      issues.push(entryError(entry, "change-evidence-stale", `scope ${sourceUnitDisplay(scope)} source hash evidence is stale`));
     }
   }
 
@@ -294,7 +292,7 @@ function suggestBumpWarnings(
     if (!severityBearing) continue;
     warnings.push({
       code: "change-bump-lower-than-suggested",
-      message: `scope ${scope} may need a release bump above none`,
+      message: `scope ${sourceUnitDisplay(scope)} may need a release bump above none`,
       path: entry.path,
       severity: "warning",
     });
@@ -335,7 +333,7 @@ function readScopes(frontmatter: JsonRecord): readonly string[] {
   const values: string[] = [];
   if (scope !== undefined) values.push(...readScopeValue(scope));
   if (scopes !== undefined) values.push(...readScopeValue(scopes));
-  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))].sort(compareStrings);
+  return [...new Set(values.map((value) => sourceUnitSelector(value.trim())).filter((value) => value.length > 0))].sort(compareStrings);
 }
 
 function readScopeValue(value: JsonValue): readonly string[] {
@@ -366,9 +364,10 @@ function readSourceHashEvidence(
   const evidence = new Map<string, string[]>();
   const add = (scope: string | undefined, hash: string | undefined): void => {
     if (scope === undefined || hash === undefined) return;
-    const current = evidence.get(scope) ?? [];
+    const normalizedScope = sourceUnitSelector(scope);
+    const current = evidence.get(normalizedScope) ?? [];
     current.push(hash);
-    evidence.set(scope, current);
+    evidence.set(normalizedScope, current);
   };
 
   const singleScope = scopes.length === 1 ? scopes[0] : undefined;
@@ -414,7 +413,8 @@ async function readReasonMinLength(rootPath: string, options: ChangeStatusOption
 }
 
 function scopeClass(scope: string): "repo" | "user" {
-  return scope.startsWith("user:") || scope.startsWith("global:") ? "user" : "repo";
+  const normalizedScope = sourceUnitSelector(scope);
+  return normalizedScope.startsWith("user:") || normalizedScope.startsWith("global:") ? "user" : "repo";
 }
 
 function compareIssues(left: ChangeCheckIssue, right: ChangeCheckIssue): number {

--- a/src/change-status.ts
+++ b/src/change-status.ts
@@ -9,6 +9,20 @@ import { compareStrings, resolveInside } from "./path";
 import { preprocessText } from "./preprocess";
 import { readReleaseState } from "./release-state";
 import { loadBuildGraph } from "./resolver";
+import {
+  isPluginOwnedSelector,
+  selectorForInstruction,
+  selectorForPluginCompanion,
+  selectorForPluginConfig,
+  selectorForPluginFeature,
+  selectorForPluginSkill,
+  selectorForProjectAgent,
+  selectorForRootConfig,
+  selectorForStandaloneSkill,
+  selectorForTargetNativeIsland,
+  sourceUnitLegacyId,
+  sourceUnitSelector,
+} from "./source-unit-selector";
 import type {
   BuildGraph,
   JsonRecord,
@@ -151,10 +165,17 @@ export async function collectSourceInventory(
 async function sourceInventoryForGraph(graph: BuildGraph): Promise<SourceInventory> {
   const units: SourceUnit[] = [];
   const rootConfigPath = join(graph.sourcePath, ROOT_CONFIG_FILE);
-  units.push(await fileUnit(graph, "root-config", "root-config", rootConfigPath, await regionsForYaml(rootConfigPath)));
+  units.push(await fileUnit(
+    graph,
+    "root-config",
+    selectorForRootConfig(),
+    rootConfigPath,
+    await regionsForYaml(rootConfigPath),
+    "root-config"
+  ));
 
   for (const skill of graph.standaloneSkills) {
-    units.push(await skillUnit(graph, skill, "standalone-skill", `standalone-skill:${skill.id}`));
+    units.push(await skillUnit(graph, skill, "standalone-skill", selectorForStandaloneSkill(skill.id)));
   }
 
   for (const rule of graph.rules) {
@@ -170,10 +191,17 @@ async function sourceInventoryForGraph(graph: BuildGraph): Promise<SourceInvento
   }
 
   for (const plugin of graph.plugins) {
-    units.push(await fileUnit(graph, "plugin-config", `plugin-config:${plugin.id}`, plugin.configPath, await regionsForYaml(plugin.configPath)));
+    units.push(await fileUnit(
+      graph,
+      "plugin-config",
+      selectorForPluginConfig(plugin.id),
+      plugin.configPath,
+      await regionsForYaml(plugin.configPath),
+      `plugin-config:${plugin.id}`
+    ));
 
     for (const skill of plugin.skills) {
-      units.push(await skillUnit(graph, skill, "plugin-skill", `plugin-skill:${plugin.id}/${skill.id}`, plugin));
+      units.push(await skillUnit(graph, skill, "plugin-skill", selectorForPluginSkill(plugin.id, skill.id), plugin));
     }
 
     for (const feature of plugin.features) {
@@ -201,11 +229,12 @@ async function fileUnit(
   kind: SourceUnitKind,
   id: string,
   sourcePath: string,
-  regions: readonly SourceUnitRegion[] = []
+  regions: readonly SourceUnitRegion[] = [],
+  hashId: string = sourceUnitLegacyId(id)
 ): Promise<SourceUnit> {
   const sourcePaths = [relativePath(graph, sourcePath)];
   return {
-    hash: await hashPath(kind, sourcePath, { id, sourcePaths }),
+    hash: await hashPath(kind, sourcePath, { id: hashId, sourcePaths }),
     hashSchema: SOURCE_HASH_SCHEMA,
     id,
     kind,
@@ -227,7 +256,7 @@ async function skillUnit(
   const sourcePaths = await sourcePathsForSkill(graph, sourceDir, skill.resources, preprocessDependencies);
   const hash = createSourceHash(kind);
   hash.update("id\0");
-  hash.update(id);
+  hash.update(sourceUnitLegacyId(id));
   hash.update("\0");
   await hashDirectory(hash, sourceDir, isGeneratedEntityChangelogPath);
   await hashResources(hash, skill.resources);
@@ -258,7 +287,7 @@ async function ruleUnit(graph: BuildGraph, rule: SourceRule): Promise<SourceUnit
   return {
     hash: digest(hash),
     hashSchema: SOURCE_HASH_SCHEMA,
-    id: `instruction:${rule.id}`,
+    id: selectorForInstruction(rule.id),
     kind: "instruction",
     regions: regionsForRecord(rule.frontmatter),
     sourcePath,
@@ -283,7 +312,7 @@ async function projectAgentUnit(graph: BuildGraph, agent: SourceProjectAgent): P
   return {
     hash: digest(hash),
     hashSchema: SOURCE_HASH_SCHEMA,
-    id: `project-agent:${agent.outputName}`,
+    id: selectorForProjectAgent(agent.outputName),
     kind: "project-agent",
     regions: regionsForRecord(agent.frontmatter),
     sourcePath,
@@ -296,11 +325,11 @@ async function islandUnit(
   island: BuildGraph["projectIslands"][number]
 ): Promise<SourceUnit> {
   const preprocessDependencies = await islandPreprocessDependencies(graph, island);
-  const owner = island.plugin === undefined ? "project" : `plugin:${island.plugin}`;
-  const id = `target-native-island:${island.target}:${owner}:${island.relativePath}`;
+  const owner: "project" | `plugin:${string}` = island.plugin === undefined ? "project" : `plugin:${island.plugin}`;
+  const id = selectorForTargetNativeIsland(island.target, owner, island.relativePath);
   const hash = createSourceHash("target-native-island");
   hash.update("id\0");
-  hash.update(id);
+  hash.update(sourceUnitLegacyId(id));
   hash.update("\0target\0");
   hash.update(island.target);
   hash.update("\0plugin\0");
@@ -328,11 +357,11 @@ async function pluginFeatureUnit(
   plugin: SourcePlugin,
   feature: SourcePluginFeature
 ): Promise<SourceUnit> {
-  const id = `plugin-feature:${plugin.id}/${feature.key}`;
+  const id = selectorForPluginFeature(plugin.id, feature.key);
   const sourcePaths = await sourcePathsForPath(graph, feature.sourcePath);
   const hash = createSourceHash("plugin-feature");
   hash.update("id\0");
-  hash.update(id);
+  hash.update(sourceUnitLegacyId(id));
   hash.update("\0key\0");
   hash.update(feature.key);
   hash.update("\0origin\0");
@@ -367,9 +396,10 @@ async function pluginCompanionUnits(
       await fileUnit(
         graph,
         "plugin-companion",
-        `plugin-companion:${plugin.id}/${companionPath}`,
+        selectorForPluginCompanion(plugin.id, companionPath),
         sourcePath,
-        companionRegions(companionPath)
+        companionRegions(companionPath),
+        `plugin-companion:${plugin.id}/${companionPath}`
       )
     );
   }
@@ -381,20 +411,8 @@ function pluginAggregateUnit(
   plugin: SourcePlugin,
   units: readonly SourceUnit[]
 ): SourceUnit {
-  const childPrefix = new Set([
-    `plugin-config:${plugin.id}`,
-    `plugin-feature:${plugin.id}/`,
-    `plugin-companion:${plugin.id}/`,
-    `plugin-skill:${plugin.id}/`,
-    `target-native-island:claude:plugin:${plugin.id}:`,
-    `target-native-island:codex:plugin:${plugin.id}:`,
-  ]);
   const childUnits = units
-    .filter((unit) =>
-      [...childPrefix].some((prefix) =>
-        prefix.endsWith(":") || prefix.endsWith("/") ? unit.id.startsWith(prefix) : unit.id === prefix
-      )
-    )
+    .filter((unit) => isPluginOwnedSelector(unit.id, plugin.id))
     .sort((left, right) => compareStrings(left.id, right.id));
   const hash = createSourceHash("plugin");
   hash.update("id\0");
@@ -405,7 +423,7 @@ function pluginAggregateUnit(
   hash.update(stringifyJson({ claude: plugin.targets.claude.options, codex: plugin.targets.codex.options }));
   hash.update("\0children\0");
   for (const child of childUnits) {
-    hash.update(child.id);
+    hash.update(sourceUnitLegacyId(child.id));
     hash.update("\0");
     hash.update(child.hash);
     hash.update("\0");
@@ -776,12 +794,13 @@ async function sourceInventoryFromReleaseState(
   const currentUnits = new Map(current.units.map((unit) => [unit.id, unit]));
   const units = new Map(fallbackUnits);
   for (const [id, scope] of releaseScopes) {
+    const selector = sourceUnitSelector(id);
     if (scope.removed === true) {
-      units.delete(id);
+      units.delete(selector);
       continue;
     }
-    const template = currentUnits.get(id) ?? fallbackUnits.get(id) ?? inferredReleaseUnit(id, scope.sourceHash ?? "");
-    units.set(id, {
+    const template = currentUnits.get(selector) ?? fallbackUnits.get(selector) ?? inferredReleaseUnit(selector, scope.sourceHash ?? "");
+    units.set(selector, {
       ...template,
       hash: scope.sourceHash ?? template.hash,
       hashSchema: SOURCE_HASH_SCHEMA,
@@ -811,16 +830,17 @@ function inferredReleaseUnit(id: string, hash: string): SourceUnit {
 }
 
 function kindForSourceUnitId(id: string): SourceUnitKind {
-  if (id === "root-config") return "root-config";
-  if (id.startsWith("instruction:")) return "instruction";
-  if (id.startsWith("plugin:")) return "plugin";
-  if (id.startsWith("plugin-companion:")) return "plugin-companion";
-  if (id.startsWith("plugin-config:")) return "plugin-config";
-  if (id.startsWith("plugin-feature:")) return "plugin-feature";
-  if (id.startsWith("plugin-skill:")) return "plugin-skill";
-  if (id.startsWith("project-agent:")) return "project-agent";
-  if (id.startsWith("standalone-skill:")) return "standalone-skill";
-  if (id.startsWith("target-native-island:")) return "target-native-island";
+  const selector = sourceUnitSelector(id);
+  if (selector === "config:root") return "root-config";
+  if (selector.startsWith("instruction:")) return "instruction";
+  if (selector.startsWith("plugin:")) return "plugin";
+  if (selector.startsWith("agent:")) return "project-agent";
+  if (selector.startsWith("skill:")) return "standalone-skill";
+  if (/^plugin\.[^.]+\.companion:/.test(selector)) return "plugin-companion";
+  if (/^plugin\.[^.]+\.config:/.test(selector)) return "plugin-config";
+  if (/^plugin\.[^.]+\.feature:/.test(selector)) return "plugin-feature";
+  if (/^plugin\.[^.]+\.skill:/.test(selector)) return "plugin-skill";
+  if (/^(?:plugin\.[^.]+\.)?(?:claude|codex)\.[^.]+:/.test(selector)) return "target-native-island";
   return "root-config";
 }
 
@@ -857,11 +877,12 @@ async function sourceInventoryFromLock(
     ) {
       continue;
     }
+    const selector = sourceUnitSelector(id);
     units.push({
       hash,
       hashSchema,
-      id,
-      kind,
+      id: selector,
+      kind: kindForSourceUnitId(selector),
       regions: [],
       sourcePath,
       sourcePaths: [sourcePath],

--- a/src/change-workflow.ts
+++ b/src/change-workflow.ts
@@ -13,6 +13,7 @@ import {
 import { changeStatus, type ChangeStatusOptions, type SourceUnit, type SourceUnitChange } from "./change-status";
 import { readString } from "./config";
 import { compareStrings, resolveInside } from "./path";
+import { sourceUnitSelector } from "./source-unit-selector";
 import type { JsonRecord, JsonValue, SkillsetOptions } from "./types";
 import { isJsonRecord, parseMarkdown, stringifyMarkdown } from "./yaml";
 
@@ -99,13 +100,14 @@ const MIN_REF_LENGTH = 6;
 export async function addChangeEntry(rootPath: string, options: ChangeAddOptions): Promise<ChangeAddReport> {
   if (options.scopes.length === 0) throw new Error("skillset: change add requires at least one --scope");
   if (options.bump === undefined) throw new Error("skillset: change add requires --bump major, minor, patch, or none");
+  const scopes = [...new Set(options.scopes.map(sourceUnitSelector))].sort(compareStrings);
   const reason = await resolveReason(rootPath, options.reason);
   const statusOptions = sourceStatusOptions(options);
   const status = await changeStatus(rootPath, statusOptions);
   const existing = await readAllChangeEntries(rootPath, statusOptions);
-  const id = await generateChangeId(rootPath, options, existing.map((entry) => entry.id));
+  const id = await generateChangeId(rootPath, { ...options, scopes }, existing.map((entry) => entry.id));
   const sourceHashes = new Map<string, readonly string[]>();
-  for (const scope of options.scopes) {
+  for (const scope of scopes) {
     const hash = sourceHashForScope(scope, status.sourceUnits, status.sourceChanges);
     if (hash === undefined) throw new Error(`skillset: unknown change scope ${scope}`);
     sourceHashes.set(scope, [hash]);
@@ -119,7 +121,7 @@ export async function addChangeEntry(rootPath: string, options: ChangeAddOptions
     bump: options.bump,
     ...(group === undefined ? {} : { group }),
     id,
-    scopes: options.scopes,
+    scopes,
     sourceHashes,
   });
   await mkdir(resolveInside(rootPath, join(sourceDir, PENDING_DIR)), { recursive: true });
@@ -310,7 +312,7 @@ function pendingView(entry: PendingChangeEntry, refs: ReadonlyMap<string, string
     path: entry.path,
     reason: entry.reason,
     ref: refs.get(entry.id ?? "") ?? `@${entry.id ?? ""}`,
-    scopes: entry.scopes,
+    scopes: entry.scopes.map(sourceUnitSelector),
     sourceHashes: entry.sourceHashes,
     status: "pending",
   };
@@ -334,7 +336,7 @@ function historyView(entry: HistoryEntry, refs: ReadonlyMap<string, string>): Ch
     path: entry.path,
     reason: entry.reason,
     ref: refs.get(entry.id) ?? `@${entry.id}`,
-    scopes: entry.scopes,
+    scopes: entry.scopes.map(sourceUnitSelector),
     sourceHashes: entry.sourceHashes,
     status: "history",
   };
@@ -474,7 +476,7 @@ function readHistoryScopes(record: JsonRecord): readonly string[] {
       if (typeof item === "string") values.push(item);
     }
   }
-  return [...new Set(values)].sort(compareStrings);
+  return [...new Set(values.map(sourceUnitSelector))].sort(compareStrings);
 }
 
 function readHistoryBump(value: JsonValue | undefined): ChangeBump | undefined {
@@ -493,9 +495,10 @@ function readHistoryEvidence(raw: JsonValue | undefined, scopes: readonly string
   const evidence = new Map<string, string[]>();
   const add = (scope: string | undefined, hash: string | undefined): void => {
     if (scope === undefined || hash === undefined) return;
-    const current = evidence.get(scope) ?? [];
+    const normalizedScope = sourceUnitSelector(scope);
+    const current = evidence.get(normalizedScope) ?? [];
     current.push(hash);
-    evidence.set(scope, current);
+    evidence.set(normalizedScope, current);
   };
   const singleScope = scopes.length === 1 ? scopes[0] : undefined;
   if (!Array.isArray(raw)) return evidence;

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative } from "node:path";
 
 import { readAppliedChangeRecords, type AppliedChangeRecord, groupRef } from "./change-workflow";
 import { compareStrings } from "./path";
+import { isPluginOwnedSelector, selectorForStandaloneSkill, sourceUnitDisplays } from "./source-unit-selector";
 import type { BuildGraph, JsonRecord, RenderedFile, SourcePlugin, SourceSkill } from "./types";
 import { stringifyMarkdown } from "./yaml";
 
@@ -11,7 +12,7 @@ const GENERATED_BY = "skillset@0.1.0";
 
 export interface ChangelogProjection {
   readonly entityId: string;
-  readonly entityKind: "plugin" | "standalone-skill";
+  readonly entityKind: "plugin" | "skill";
   readonly outputPath: string;
   readonly sourcePath: string;
   readonly sourceHash: string;
@@ -25,7 +26,7 @@ export async function renderChangelogProjections(graph: BuildGraph): Promise<rea
 
   const projections: ChangelogProjection[] = [];
   for (const skill of graph.standaloneSkills) {
-    const scoped = changesForScopes(changes, [`standalone-skill:${skill.id}`]);
+    const scoped = changesForScopes(changes, [selectorForStandaloneSkill(skill.id)]);
     if (scoped.length === 0) continue;
     projections.push(renderSkillChangelog(graph, skill, scoped));
   }
@@ -45,7 +46,7 @@ function renderSkillChangelog(
   changes: readonly AppliedChangeRecord[]
 ): ChangelogProjection {
   const outputPath = join(dirname(relative(graph.rootPath, skill.sourcePath)), "CHANGELOG.md");
-  return projection("standalone-skill", skill.id, outputPath, relative(graph.rootPath, skill.sourcePath), changes);
+  return projection("skill", skill.id, outputPath, relative(graph.rootPath, skill.sourcePath), changes);
 }
 
 function renderPluginChangelog(
@@ -103,7 +104,7 @@ function renderChangeSection(change: AppliedChangeRecord): string {
   if (change.bump !== undefined) details.push(`bump: ${change.bump}`);
   const group = groupRef(change.group);
   if (group !== undefined) details.push(`group: ${group}`);
-  if (change.scopes.length > 0) details.push(`scopes: ${change.scopes.join(", ")}`);
+  if (change.scopes.length > 0) details.push(`scopes: ${sourceUnitDisplays(change.scopes)}`);
   if (details.length > 0) lines.push("", details.join(" | "));
   lines.push("", change.reason.trim());
   return lines.join("\n");
@@ -129,13 +130,7 @@ function changesForPlugin(
 }
 
 function isPluginChangelogScope(scope: string, pluginId: string): boolean {
-  return scope === `plugin:${pluginId}` ||
-    scope === `plugin-config:${pluginId}` ||
-    scope.startsWith(`plugin-skill:${pluginId}/`) ||
-    scope.startsWith(`plugin-feature:${pluginId}/`) ||
-    scope.startsWith(`plugin-companion:${pluginId}/`) ||
-    scope.startsWith(`target-native-island:claude:plugin:${pluginId}:`) ||
-    scope.startsWith(`target-native-island:codex:plugin:${pluginId}:`);
+  return isPluginOwnedSelector(scope, pluginId);
 }
 
 function compareChangeRecords(left: AppliedChangeRecord, right: AppliedChangeRecord): number {

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -20,6 +20,7 @@ import { importSources, type ImportKind, type ImportProvider, type ImportReport 
 import { lintSkillset } from "./lint";
 import { applyRelease, planRelease, type ReleasePlanReport, type ReleaseSubcommand } from "./release";
 import { createSkillset, initSkillset, type SetupReport } from "./setup";
+import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "./source-unit-selector";
 import type { BuildScope, CompileBuildMode, SkillsetOptions, TargetName } from "./types";
 
 type Command = "build" | "change" | "check" | "create" | "diff" | "doctor" | "explain" | "hooks" | "import" | "init" | "lint" | "list" | "release";
@@ -393,9 +394,9 @@ function printChangeEntry(verb: string, entry: ChangeEntryView): void {
   if (entry.bump !== undefined) console.log(`  bump: ${entry.bump}`);
   const group = groupRef(entry.group);
   if (group !== undefined) console.log(`  group: ${group}`);
-  if (entry.scopes.length > 0) console.log(`  scopes: ${entry.scopes.join(", ")}`);
+  if (entry.scopes.length > 0) console.log(`  scopes: ${sourceUnitDisplays(entry.scopes)}`);
   for (const [scope, hashes] of entry.sourceHashes) {
-    for (const hash of hashes) console.log(`  source hash: ${scope} ${hash}`);
+    for (const hash of hashes) console.log(`  source hash: ${sourceUnitDisplay(scope)} ${hash}`);
   }
   if (entry.reason.length > 0) {
     console.log("  reason:");
@@ -407,7 +408,7 @@ function printChangeList(entries: readonly ChangeEntryView[]): void {
   for (const entry of entries) {
     const group = groupRef(entry.group) ?? "-";
     const bump = entry.bump ?? "-";
-    console.log(`${entry.ref} ${entry.status} ${bump} ${group} ${entry.scopes.join(",")} ${entry.path}`);
+    console.log(`${entry.ref} ${entry.status} ${bump} ${group} ${sourceUnitDisplays(entry.scopes)} ${entry.path}`);
   }
   console.log(`skillset: listed ${entries.length} pending change entr${entries.length === 1 ? "y" : "ies"}`);
 }
@@ -445,7 +446,7 @@ function printChangeStatus(report: ChangeStatusReport): void {
   } else {
     for (const change of report.sourceChanges) {
       const marker = change.status === "added" ? "+" : change.status === "removed" ? "-" : "~";
-      console.log(`  ${marker} ${change.kind} ${change.id} ${change.sourcePath}`);
+      console.log(`  ${marker} ${sourceUnitDisplay(change.id)} ${change.sourcePath}`);
     }
     console.log(`skillset: ${report.sourceChanges.length} source change(s) needing entries`);
   }
@@ -472,7 +473,7 @@ function printReleasePlan(report: ReleasePlanReport): void {
   }
   for (const entry of report.entries) {
     const marker = entry.ignored ? "ignored" : "pending";
-    console.log(`${entry.ref} ${marker} ${entry.bump} ${entry.scopes.join(",")} ${entry.path}`);
+    console.log(`${entry.ref} ${marker} ${entry.bump} ${sourceUnitDisplays(entry.scopes)} ${entry.path}`);
   }
   if (report.scopes.length === 0) {
     console.log(`skillset: release plan has ${report.entries.length} pending entr${report.entries.length === 1 ? "y" : "ies"} and no release scopes`);
@@ -481,7 +482,7 @@ function printReleasePlan(report: ReleasePlanReport): void {
   if (report.releaseId !== undefined) console.log(`skillset: release ${report.releaseId}`);
   for (const scope of report.scopes) {
     const sourceHash = scope.sourceHash === undefined ? "" : ` ${scope.sourceHash}`;
-    console.log(`  ${scope.scope}: ${scope.currentVersion} -> ${scope.nextVersion} (${scope.bump}) entries ${scope.entries.join(",")}${sourceHash}`);
+    console.log(`  ${sourceUnitDisplay(scope.scope)}: ${scope.currentVersion} -> ${scope.nextVersion} (${scope.bump}) entries ${scope.entries.join(",")}${sourceHash}`);
   }
   console.log(`skillset: release plan has ${report.entries.length} pending entr${report.entries.length === 1 ? "y" : "ies"} and ${report.scopes.length} release scope${report.scopes.length === 1 ? "" : "s"}`);
 }
@@ -891,7 +892,7 @@ function isChangeSubcommand(value: string | undefined): value is ChangeSubcomman
 function readChangeScopes(value: string): readonly string[] {
   const scopes = value.split(",").map((scope) => scope.trim()).filter((scope) => scope.length > 0);
   if (scopes.length === 0) throw new Error("skillset: --scope requires at least one source unit scope");
-  return scopes;
+  return scopes.map(sourceUnitSelector);
 }
 
 function readChangeBump(value: string): ChangeBump {

--- a/src/release-state.ts
+++ b/src/release-state.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 
 import { readString } from "./config";
 import { compareStrings, resolveInside } from "./path";
+import { sourceUnitSelector } from "./source-unit-selector";
 import type { JsonRecord, ReleaseScopeState, ReleaseState, SkillsetOptions } from "./types";
 import { validateVersionField } from "./versioning";
 import { isJsonRecord, stringifyJson } from "./yaml";
@@ -53,7 +54,7 @@ export async function readReleaseState(
       throw new Error(`skillset: release state scope ${scope} sourceHash must be a sha256 digest`);
     }
     const updatedAt = readString(value, "updatedAt");
-    scopes[scope] = {
+    scopes[sourceUnitSelector(scope)] = {
       ...(removed === true ? { removed } : {}),
       ...(sourceHash === undefined ? {} : { sourceHash }),
       ...(updatedAt === undefined ? {} : { updatedAt }),
@@ -72,7 +73,7 @@ export async function writeReleaseState(
   const absolutePath = resolveInside(rootPath, relativePath);
   const scopes: Record<string, JsonRecord> = {};
   for (const [scope, value] of Object.entries(state.scopes).sort(([left], [right]) => compareStrings(left, right))) {
-    scopes[scope] = {
+    scopes[sourceUnitSelector(scope)] = {
       ...(value.removed === true ? { removed: true } : {}),
       ...(value.sourceHash === undefined ? {} : { sourceHash: value.sourceHash }),
       ...(value.updatedAt === undefined ? {} : { updatedAt: value.updatedAt }),

--- a/src/release.ts
+++ b/src/release.ts
@@ -7,6 +7,12 @@ import { changeCheck, readPendingChangeEntries, type ChangeBump, type PendingCha
 import { compareStrings, resolveInside } from "./path";
 import { readReleaseState, writeReleaseState } from "./release-state";
 import { loadBuildGraph } from "./resolver";
+import {
+  pluginIdForSelector,
+  pluginScopeFromSourceUnit,
+  sourceUnitLegacyId,
+  sourceUnitSelector,
+} from "./source-unit-selector";
 import type { BuildGraph, JsonRecord, ReleaseScopeState, ReleaseState, SkillsetOptions, SourcePlugin } from "./types";
 import { pluginVersion, rootVersion, skillVersion } from "./versioning";
 
@@ -154,7 +160,7 @@ function releaseEntryPlan(entry: PendingChangeEntry): readonly ReleaseEntryPlan[
     path: entry.path,
     reason: entry.reason,
     ref: `@${entry.id.slice(0, 6)}`,
-    scopes: entry.scopes,
+    scopes: entry.scopes.map(sourceUnitSelector),
   }];
 }
 
@@ -221,13 +227,7 @@ function mergeScopePlans(
 }
 
 function aggregateScope(scope: string): string | undefined {
-  if (scope.startsWith("plugin:")) return scope;
-  if (scope.startsWith("plugin-config:")) return `plugin:${scope.slice("plugin-config:".length)}`;
-  if (scope.startsWith("plugin-skill:")) return `plugin:${scope.slice("plugin-skill:".length).split("/")[0]}`;
-  if (scope.startsWith("plugin-feature:")) return `plugin:${scope.slice("plugin-feature:".length).split("/")[0]}`;
-  if (scope.startsWith("plugin-companion:")) return `plugin:${scope.slice("plugin-companion:".length).split("/")[0]}`;
-  const island = scope.match(/^target-native-island:[^:]+:plugin:([^:]+):/);
-  return island?.[1] === undefined ? undefined : `plugin:${island[1]}`;
+  return pluginScopeFromSourceUnit(scope);
 }
 
 function maxBump(left: ChangeBump, right: ChangeBump): ChangeBump {
@@ -246,30 +246,37 @@ function bumpVersion(version: string, bump: ChangeBump): string {
 }
 
 function versionForScope(graph: BuildGraph, scope: string): string {
-  const releaseScope = graph.releaseState.scopes[scope];
+  const selector = sourceUnitSelector(scope);
+  const releaseScope = graph.releaseState.scopes[selector] ?? graph.releaseState.scopes[sourceUnitLegacyId(selector)];
   const releasedVersion = releaseScope?.removed === true ? undefined : releaseScope?.version;
   if (releasedVersion !== undefined) return releasedVersion;
-  if (scope === "root-config") return rootVersion(graph);
-  if (scope.startsWith("standalone-skill:")) {
-    const skill = graph.standaloneSkills.find((item) => item.id === scope.slice("standalone-skill:".length));
+  if (selector === "config:root") return rootVersion(graph);
+  if (selector.startsWith("skill:")) {
+    const skill = graph.standaloneSkills.find((item) => item.id === selector.slice("skill:".length));
     if (skill !== undefined) return skillVersion(graph, undefined, skill);
   }
-  if (scope.startsWith("plugin:")) {
-    const plugin = pluginForScope(graph, scope);
+  if (selector.startsWith("plugin:")) {
+    const plugin = pluginForScope(graph, selector);
     if (plugin !== undefined) return pluginVersion(graph, plugin);
   }
-  if (scope.startsWith("plugin-skill:")) {
-    const scoped = scope.slice("plugin-skill:".length);
-    const [pluginId, skillId] = scoped.split("/");
+  const pluginSkill = selector.match(/^plugin\.([^.]+)\.skill:(.+)$/);
+  if (pluginSkill !== null) {
+    const [, pluginId, skillId] = pluginSkill;
     const plugin = pluginId === undefined ? undefined : graph.plugins.find((item) => item.id === pluginId);
     const skill = plugin?.skills.find((item) => item.id === skillId);
     if (plugin !== undefined && skill !== undefined) return skillVersion(graph, plugin, skill);
+  }
+  const pluginId = pluginIdForSelector(selector);
+  if (pluginId !== undefined) {
+    const plugin = graph.plugins.find((item) => item.id === pluginId);
+    if (plugin !== undefined) return pluginVersion(graph, plugin);
   }
   return rootVersion(graph);
 }
 
 function pluginForScope(graph: BuildGraph, scope: string): SourcePlugin | undefined {
-  return graph.plugins.find((plugin) => plugin.id === scope.slice("plugin:".length));
+  const pluginId = pluginIdForSelector(scope);
+  return pluginId === undefined ? undefined : graph.plugins.find((plugin) => plugin.id === pluginId);
 }
 
 function nextReleaseState(
@@ -279,7 +286,7 @@ function nextReleaseState(
 ): ReleaseState {
   const scopes: Record<string, ReleaseScopeState> = { ...state.scopes };
   for (const scope of scopesToWrite) {
-    scopes[scope.scope] = {
+    scopes[sourceUnitSelector(scope.scope)] = {
       ...(scope.removed ? { removed: true } : {}),
       ...(scope.sourceHash === undefined ? {} : { sourceHash: scope.sourceHash }),
       updatedAt,
@@ -398,8 +405,9 @@ async function exists(path: string): Promise<boolean> {
 function historyEvidence(entry: PendingChangeEntry): readonly JsonRecord[] {
   const evidence: JsonRecord[] = [];
   for (const scope of entry.scopes) {
-    for (const sourceHash of entry.sourceHashes.get(scope) ?? []) {
-      evidence.push({ scope, sourceHash });
+    const selector = sourceUnitSelector(scope);
+    for (const sourceHash of entry.sourceHashes.get(selector) ?? entry.sourceHashes.get(scope) ?? []) {
+      evidence.push({ scope: selector, sourceHash });
     }
   }
   return evidence;

--- a/src/source-unit-selector.ts
+++ b/src/source-unit-selector.ts
@@ -1,0 +1,183 @@
+import { compareStrings } from "./path";
+
+export type SourceUnitDisplayMode = "display" | "selector";
+
+const TARGETS = new Set(["claude", "codex"]);
+
+export function sourceUnitSelector(raw: string): string {
+  return legacySourceUnitToSelector(raw) ?? raw;
+}
+
+export function sourceUnitLegacyId(raw: string): string {
+  const selector = sourceUnitSelector(raw);
+  if (selector === "config:root") return "root-config";
+  if (selector.startsWith("skill:")) return `standalone-skill:${selector.slice("skill:".length)}`;
+  if (selector.startsWith("agent:")) return `project-agent:${selector.slice("agent:".length)}`;
+  if (selector.startsWith("instruction:")) return selector;
+  if (selector.startsWith("plugin:")) return selector;
+
+  const pluginNativeMatch = selector.match(/^plugin\.([^.]+)\.([^.]+)\.([^.]+):(.+)$/);
+  if (pluginNativeMatch !== null) {
+    const [, pluginId, target, , path] = pluginNativeMatch;
+    if (pluginId === undefined || target === undefined || path === undefined || !TARGETS.has(target)) return selector;
+    return `target-native-island:${target}:plugin:${pluginId}:${path}`;
+  }
+
+  const pluginMatch = selector.match(/^plugin\.([^.]+)\.([^.]+):(.+)$/);
+  if (pluginMatch !== null) {
+    const [, pluginId, surface, name] = pluginMatch;
+    if (pluginId === undefined || surface === undefined || name === undefined) return selector;
+    if (surface === "config") return `plugin-config:${pluginId}`;
+    if (surface === "skill") return `plugin-skill:${pluginId}/${name}`;
+    if (surface === "feature") return `plugin-feature:${pluginId}/${name}`;
+    if (surface === "companion") return `plugin-companion:${pluginId}/${name}`;
+  }
+
+  const nativeMatch = selector.match(/^([^.]+)\.([^.]+):(.+)$/);
+  if (nativeMatch !== null) {
+    const [, target, , path] = nativeMatch;
+    if (target === undefined || path === undefined || !TARGETS.has(target)) return selector;
+    return `target-native-island:${target}:project:${path}`;
+  }
+
+  return selector;
+}
+
+export function sourceUnitDisplay(raw: string, mode: SourceUnitDisplayMode = "display"): string {
+  const selector = sourceUnitSelector(raw);
+  if (mode === "selector") return selector;
+
+  if (selector === "config:root") return "config: root";
+  if (selector.startsWith("skill:")) return `skill: ${selector.slice("skill:".length)}`;
+  if (selector.startsWith("instruction:")) return `instruction: ${selector.slice("instruction:".length)}`;
+  if (selector.startsWith("agent:")) return `agent: ${selector.slice("agent:".length)}`;
+  if (selector.startsWith("plugin:")) return `plugin: ${selector.slice("plugin:".length)}`;
+
+  const pluginNativeMatch = selector.match(/^plugin\.([^.]+)\.([^.]+)\.([^.]+):(.+)$/);
+  if (pluginNativeMatch !== null) {
+    const [, pluginId, target, surface, name] = pluginNativeMatch;
+    if (pluginId !== undefined && target !== undefined && surface !== undefined && name !== undefined && TARGETS.has(target)) {
+      return `${target}.${surface}(plugin:${pluginId}): ${name}`;
+    }
+  }
+
+  const pluginMatch = selector.match(/^plugin\.([^.]+)\.([^.]+):(.+)$/);
+  if (pluginMatch !== null) {
+    const [, pluginId, surface, name] = pluginMatch;
+    if (pluginId !== undefined && surface !== undefined && name !== undefined) {
+      return `${surface}(plugin:${pluginId}): ${name}`;
+    }
+  }
+
+  const nativeMatch = selector.match(/^([^.]+)\.([^.]+):(.+)$/);
+  if (nativeMatch !== null) {
+    const [, target, surface, name] = nativeMatch;
+    if (target !== undefined && surface !== undefined && name !== undefined && TARGETS.has(target)) {
+      return `${target}.${surface}: ${name}`;
+    }
+  }
+
+  return selector;
+}
+
+export function sourceUnitDisplays(scopes: readonly string[], mode: SourceUnitDisplayMode = "display"): string {
+  return scopes.map((scope) => sourceUnitDisplay(scope, mode)).sort(compareStrings).join(", ");
+}
+
+export function pluginScopeFromSourceUnit(raw: string): string | undefined {
+  const selector = sourceUnitSelector(raw);
+  if (selector.startsWith("plugin:")) return selector;
+  const pluginMatch = selector.match(/^plugin\.([^.]+)\./);
+  return pluginMatch?.[1] === undefined ? undefined : `plugin:${pluginMatch[1]}`;
+}
+
+export function pluginIdForSelector(raw: string): string | undefined {
+  const selector = sourceUnitSelector(raw);
+  if (selector.startsWith("plugin:")) return selector.slice("plugin:".length);
+  return selector.match(/^plugin\.([^.]+)\./)?.[1];
+}
+
+export function isPluginOwnedSelector(raw: string, pluginId: string): boolean {
+  const selector = sourceUnitSelector(raw);
+  return selector === `plugin:${pluginId}` || selector.startsWith(`plugin.${pluginId}.`);
+}
+
+export function selectorForRootConfig(): string {
+  return "config:root";
+}
+
+export function selectorForStandaloneSkill(skillId: string): string {
+  return `skill:${skillId}`;
+}
+
+export function selectorForPluginConfig(pluginId: string): string {
+  return `plugin.${pluginId}.config:root`;
+}
+
+export function selectorForPluginSkill(pluginId: string, skillId: string): string {
+  return `plugin.${pluginId}.skill:${skillId}`;
+}
+
+export function selectorForPluginFeature(pluginId: string, featureKey: string): string {
+  return `plugin.${pluginId}.feature:${featureKey}`;
+}
+
+export function selectorForPluginCompanion(pluginId: string, companionPath: string): string {
+  return `plugin.${pluginId}.companion:${companionPath}`;
+}
+
+export function selectorForInstruction(ruleId: string): string {
+  return `instruction:${ruleId}`;
+}
+
+export function selectorForProjectAgent(agentName: string): string {
+  return `agent:${agentName}`;
+}
+
+export function selectorForTargetNativeIsland(target: string, owner: "project" | `plugin:${string}`, relativePath: string): string {
+  const surface = targetNativeSurface(relativePath);
+  if (owner === "project") return `${target}.${surface}:${relativePath}`;
+  return `${owner.replace(":", ".")}.${target}.${surface}:${relativePath}`;
+}
+
+export function targetNativeSurface(relativePath: string): string {
+  if (relativePath === ".app.json") return "app";
+  if (relativePath === ".mcp.json") return "mcp";
+  if (relativePath === ".lsp.json") return "lsp";
+  if (relativePath === "hooks.json" || relativePath.startsWith("hooks/")) return "hooks";
+  const first = relativePath.split("/")[0] ?? "";
+  if (first.length === 0) return "native";
+  return first.replace(/[^A-Za-z0-9-]/g, "") || "native";
+}
+
+function legacySourceUnitToSelector(raw: string): string | undefined {
+  if (raw === "root-config") return selectorForRootConfig();
+  if (raw.startsWith("standalone-skill:")) return selectorForStandaloneSkill(raw.slice("standalone-skill:".length));
+  if (raw.startsWith("project-agent:")) return selectorForProjectAgent(raw.slice("project-agent:".length));
+  if (raw.startsWith("instruction:")) return raw;
+  if (raw.startsWith("plugin-config:")) return selectorForPluginConfig(raw.slice("plugin-config:".length));
+  if (raw.startsWith("plugin-skill:")) {
+    const [pluginId, skillId] = raw.slice("plugin-skill:".length).split("/");
+    if (pluginId !== undefined && skillId !== undefined) return selectorForPluginSkill(pluginId, skillId);
+  }
+  if (raw.startsWith("plugin-feature:")) {
+    const [pluginId, featureKey] = raw.slice("plugin-feature:".length).split("/");
+    if (pluginId !== undefined && featureKey !== undefined) return selectorForPluginFeature(pluginId, featureKey);
+  }
+  if (raw.startsWith("plugin-companion:")) {
+    const [pluginId, ...pathParts] = raw.slice("plugin-companion:".length).split("/");
+    const companionPath = pathParts.join("/");
+    if (pluginId !== undefined && companionPath.length > 0) return selectorForPluginCompanion(pluginId, companionPath);
+  }
+  if (raw.startsWith("target-native-island:")) {
+    const parts = raw.slice("target-native-island:".length).split(":");
+    const [target, ownerKind, ownerIdOrPath, ...pathParts] = parts;
+    if (target === undefined || ownerKind === undefined || ownerIdOrPath === undefined) return undefined;
+    if (ownerKind === "project") return selectorForTargetNativeIsland(target, "project", [ownerIdOrPath, ...pathParts].join(":"));
+    if (ownerKind === "plugin") {
+      const [relativePath] = [pathParts.join(":")];
+      if (relativePath.length > 0) return selectorForTargetNativeIsland(target, `plugin:${ownerIdOrPath}`, relativePath);
+    }
+  }
+  return undefined;
+}

--- a/src/versioning.ts
+++ b/src/versioning.ts
@@ -1,4 +1,5 @@
 import { readString } from "./config";
+import { selectorForPluginSkill, selectorForRootConfig, selectorForStandaloneSkill, sourceUnitLegacyId, sourceUnitSelector } from "./source-unit-selector";
 import type { BuildGraph, JsonRecord, SourcePlugin, SourceSkill } from "./types";
 
 export const DEFAULT_VERSION = "0.1.0";
@@ -49,7 +50,7 @@ export function validateVersionField(record: JsonRecord, label: string): void {
 }
 
 export function rootVersion(graph: BuildGraph): string {
-  return activeReleaseVersion(graph, "root-config") ??
+  return activeReleaseVersion(graph, selectorForRootConfig()) ??
     readString(graph.root.metadata, "version") ??
     DEFAULT_VERSION;
 }
@@ -66,8 +67,8 @@ export function skillVersion(
   skill: SourceSkill
 ): string {
   const releaseScope = plugin === undefined
-    ? `standalone-skill:${skill.id}`
-    : `plugin-skill:${plugin.id}/${skill.id}`;
+    ? selectorForStandaloneSkill(skill.id)
+    : selectorForPluginSkill(plugin.id, skill.id);
   return (
     activeReleaseVersion(graph, releaseScope) ??
     readString(skill.frontmatter, "version") ??
@@ -86,7 +87,8 @@ export function skillVersionLabel(
 }
 
 function activeReleaseVersion(graph: BuildGraph, scope: string): string | undefined {
-  const state = graph.releaseState.scopes[scope];
+  const selector = sourceUnitSelector(scope);
+  const state = graph.releaseState.scopes[selector] ?? graph.releaseState.scopes[sourceUnitLegacyId(selector)];
   if (state?.removed === true) return undefined;
   return state?.version;
 }


### PR DESCRIPTION
## Summary
- adds canonical source-unit selectors plus conventional-commit-style display labels for change/release output
- normalizes legacy scope syntax on read for pending entries, history, release state, locks, and changelog projection while preserving legacy hash identity
- updates self-hosted release state/changelog output and durable ADR examples to the new selector shape

## Review
- Local review worker score: 4/5
- Fixed P2: restored append-only history/release JSONL entries instead of rewriting historical ledgers
- Fixed P3s: added legacy-scope migration coverage and updated stale durable selector examples

## Verification
- bun run check
- bun ./src/cli.ts change status --root .

Local status reports no source changes needing entries and no generated-output drift.