### PR TITLE
docs(tests): settle deterministic test runner shape

### DIFF
--- a/docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md
+++ b/docs/adrs/drafts/20260609-fixtures-tests-dogfooding-and-evals.md
@@ -75,22 +75,24 @@ The first lifecycle dogfood target should be a small self-hosted `.skillset/` so
 
 `skillset test` is reserved for deterministic test runs that project selected source into isolated generated output and assert the result. It is not implemented by this ADR.
 
-The likely v1 shape is selector-driven rather than taxonomy-driven:
+The v1 shape is selector-driven and root-config backed rather than taxonomy-driven. Root `.skillset/config.yaml` should own the first test declarations so the command proves existing source without turning `.skillset/tests/` into a parallel source tree:
 
 ```yaml
 tests:
-  skillset-plugin:
-    source: plugin:skillset
+  self-hosted:
+    source: repo:.skillset
     targets:
       - claude
       - codex
     output:
-      kind: marketplace
-    assert:
-      - check
+      kind: isolated
+    assertions:
+      - build
       - noDrift
-      - exists: marketplaces/claude
+      - exists: plugins-claude/plugins/skillset/.claude-plugin/plugin.json
 ```
+
+The first implementation slice should support `repo:.skillset` by copying the current source root into an isolated run workspace and building it there. Typed source selectors such as `plugin:<name>`, `skill:<name>`, and internal `fixture:<case>` remain the intended grammar, but they should wait until source inventory and generated-output narrowing can be implemented consistently. `--scope` remains destination filtering; it is not a source selector.
 
 Large tests may move into `.skillset/tests/`, but that directory should not appear until the user-facing contract is clearer than a fixture mirror. If it appears, it should reference existing `.skillset/` subjects or fixture sources; it should not duplicate skills, plugins, agents, or instructions as a parallel source tree.
 
@@ -103,7 +105,11 @@ Generated test output belongs under `.skillset/build/tests/`:
   runs/<run-id>/
 ```
 
-`latest/` is a refreshed convenience output. `runs/<run-id>/` preserves distinct runs for comparison and debugging when retention keeps them. Build output remains definitions only: test runs may generate local plugin or marketplace trees, but they do not install, trust, publish, or activate them.
+Each run writes a complete retained directory under `runs/<run-id>/`, including an isolated workspace plus `report.json` and `report.md`. `latest/` is a refreshed real directory copy of the most recent run rather than a symlink, and `latest.json` records the active run id, source selector, report path, and generated output path. Retention defaults to keeping prior runs; pruning is future configuration.
+
+The first assertion vocabulary should stay small: `build` means the isolated build completed, `exists` checks a generated path, `contains` checks text inside a generated file, and `noDrift` runs a generated-output diff after the isolated build. Target validation commands are reportable manual follow-up instructions in v1, not executed runtime mutations.
+
+Release state and inline versions are observable in test reports, not migrated by the test runner. This keeps the SET-43 inline-version migration future-scoped: deterministic tests may verify that release state wins over source version fallbacks, but `skillset test` must not rewrite source `version` fields or introduce migration warnings.
 
 ### Evals Are Adapter-Aware Future Surface
 
@@ -141,7 +147,7 @@ The cost is slower implementation of `skillset test`. Skillset will continue to 
 
 ### What This Does NOT Decide
 
-This ADR does not implement `skillset test`, define a `.skillset/tests/` schema, define an eval schema, or decide how marketplace runtime testing is installed or activated. It does not change build semantics for real target output. It does not decide whether `latest/` should be a directory, symlink, or manifest pointer on every platform, though the preferred v1 direction is a refreshed real directory plus `latest.json`.
+This ADR does not implement every selector, define a `.skillset/tests/` schema, define an eval schema, start the inline-version migration, or decide how marketplace runtime testing is installed or activated. It does not change build semantics for real target output.
 
 ## References
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -26,24 +26,24 @@ Internal fixtures may include `fixtures/<case>/.skillset/src/` when a case needs
 
 `skillset test` should eventually run isolated deterministic scenarios. It should compile selected `.skillset/` source subjects, run Skillset lifecycle commands where configured, and assert files, lock provenance, changelog state, release state, drift, diagnostics, and target validation results.
 
-The likely first shape is selector-driven:
+The v1 design is selector-driven and config-backed. Root `.skillset/config.yaml` owns the first test declarations so authors can prove existing source without introducing a second source tree. `.skillset/tests/` remains reserved for larger declarations after the source contract is proven; if it appears later, it should reference existing source subjects rather than duplicating skills, plugins, agents, or instructions.
 
 ```yaml
 tests:
-  skillset-plugin:
-    source: plugin:skillset
+  self-hosted:
+    source: repo:.skillset
     targets:
       - claude
       - codex
     output:
-      kind: marketplace
-    assert:
-      - check
+      kind: isolated
+    assertions:
+      - build
       - noDrift
-      - exists: marketplaces/claude
+      - exists: plugins-claude/plugins/skillset/.claude-plugin/plugin.json
 ```
 
-Large tests may live under `.skillset/tests/`, but that directory is reserved until the source contract is clear. Tests may reference `repo:.skillset`, typed source selectors such as `plugin:skillset`, or internal fixture sources such as `fixture:kitchen-sink`. Tests should not duplicate source content as a parallel source tree.
+The first implementation slice supports `repo:.skillset`, which copies the current Skillset source root into an isolated run workspace and builds it there. Typed source selectors such as `plugin:<name>`, `skill:<name>`, and internal `fixture:<case>` references remain the intended grammar, but they should be added only when selection narrows source inventory and generated output consistently. `--scope` continues to mean generated-destination filtering, not source selection.
 
 Generated test output should live under the gitignored build root:
 
@@ -54,7 +54,11 @@ Generated test output should live under the gitignored build root:
   runs/<run-id>/
 ```
 
-`latest/` is for quick manual inspection and local target smoke commands. `runs/<run-id>/` preserves distinct output when retention keeps prior runs. Test output may include generated plugin or marketplace trees, but `skillset test` must not install, publish, trust, symlink, or activate them by default.
+Each run writes a complete retained directory under `runs/<run-id>/`, including the isolated workspace and `report.json` / `report.md`. `latest/` is a real refreshed copy of the most recent run, not a symlink, so local marketplaces or generated plugin trees can be inspected with stable paths on platforms where symlinks are fragile. `latest.json` records the active run id, source selector, report path, and generated output path. Retention defaults to keeping prior run directories; pruning is a future option rather than implicit cleanup.
+
+The first assertion vocabulary is deliberately small: `build` means the isolated build command succeeded, `exists` checks for a generated file or directory, `contains` checks text in a generated file, and `noDrift` runs the generated-output diff after the isolated build. Target validation commands are reportable manual follow-up instructions in v1; `skillset test` must not install, publish, trust, symlink, or activate Claude/Codex runtime configuration by default.
+
+Release state and inline versions are observable, not migrated, by deterministic tests. A test may assert the version that build emits after release state is applied, but it must not rewrite source `version` fields or start the SET-43 migration from inline versions to release-state-only authoring.
 
 ## Lifecycle Dogfooding
 


### PR DESCRIPTION
## Context

SET-49 needed the deterministic `skillset test` design to be concrete enough for the first implementation slice without turning fixtures into product source or evals into deterministic tests.

## What changed

- Settled root `.skillset/config.yaml` as the first declaration home.
- Defined `repo:.skillset` as the first implemented selector, with typed selectors reserved until source/output narrowing is consistent.
- Locked in `.skillset/build/tests/runs/<run-id>`, refreshed real `latest/`, and `latest.json` semantics.
- Defined the first assertion vocabulary: `build`, `exists`, `contains`, `noDrift`.
- Folded SET-43 in as an explicit non-goal: deterministic tests may observe release-state versions, but must not migrate inline source versions.

## Verification

- `bun .agents/skills/skillset-adrs/scripts/adr.ts check` - 0 errors / 0 warnings
- `bun .agents/skills/skillset-adrs/scripts/adr.ts map` - no remaining map diff
- `bun run check` - 204 pass / 0 fail; `skillset:lint`; `skillset:check` checked 47 generated files
- `git diff --check main...HEAD`