### PR TITLE
fix(tests): stop git hook env corrupting the shared repo, plus decision housekeeping

### DIFF
--- a/.skillset/shared/scripts/skillset-runtime-hooks.ts
+++ b/.skillset/shared/scripts/skillset-runtime-hooks.ts
@@ -122,6 +122,7 @@ async function capture(argv: readonly string[], options: { readonly cwd: string 
   const proc = Bun.spawn({
     cmd: [...argv],
     cwd: options.cwd,
+    env: gitSafeEnv(),
     stderr: "ignore",
     stdout: "pipe",
   });
@@ -156,4 +157,30 @@ if (import.meta.main) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
+}
+
+/**
+ * Hook processes inherit repository-targeting GIT_* variables (git exports
+ * GIT_DIR to its hooks), and those override `-C`/cwd repository discovery in
+ * spawned git commands. Strip them so this script always inspects the repo it
+ * was pointed at.
+ */
+function gitSafeEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (
+      key === "GIT_DIR" ||
+      key === "GIT_WORK_TREE" ||
+      key === "GIT_INDEX_FILE" ||
+      key === "GIT_OBJECT_DIRECTORY" ||
+      key === "GIT_COMMON_DIR" ||
+      key === "GIT_NAMESPACE" ||
+      key.startsWith("GIT_ALTERNATE_OBJECT")
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
 }

--- a/docs/adrs/drafts/20260610-one-action-repo-adoption.md
+++ b/docs/adrs/drafts/20260610-one-action-repo-adoption.md
@@ -3,7 +3,7 @@ slug: one-action-repo-adoption
 title: One-Action Repo Adoption
 status: draft
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [0, fixtures-tests-dogfooding-and-evals, global-xdg-managed-installs-and-sync, source-change-release-provenance]
 ---
@@ -25,7 +25,7 @@ The goal this ADR commits to: point Skillset at an existing repo — a local pat
 
 ## Decision
 
-Skillset gets a whole-repo adoption flow: survey everything adoptable, lower each surface into its canonical `.skillset/` home, transform target-native authoring into portable source where the conversion is mechanical, leave the original tree untouched, and record where everything came from.
+Skillset gets a whole-repo adoption flow — `skillset adopt <path|git-remote>` — that surveys everything adoptable, lowers each surface into its canonical `.skillset/` home, transforms target-native authoring into portable source where the conversion is mechanical, leaves the original tree untouched, and records where everything came from.
 
 ### Adoption surveys the whole repo, not just manifests
 
@@ -66,24 +66,25 @@ Every rewrite lands in the migration report: what changed, from what, to what, a
 
 Adopted source is regenerable by design: re-running adoption against the same original produces the same `.skillset/` tree. Hand-tuning is expected to start *after* migration settles, which is what makes the refresh loop below safe for fixtures and predictable for users.
 
+The transform mappings are an intent-keyed registry — typed data, one portable concept per entry with per-target surface forms, each entry carrying target-truth evidence and a round-trip identity test (Claude form → intent → Claude form must reproduce the original). The same registry runs at two stages. Adopt-time normalization is the default: the portable form is persisted as source. Build-time translation is the deferral path: source may stay in a target dialect — Claude- or Codex-flavored authoring, detected from indicators such as target-native frontmatter keys or manifest presence, and declarable explicitly in frontmatter, with declaration winning — and the build lowers it through the intent hub per projection. Dialect source is distinct from target-native islands: islands are target-locked and never translated; dialect source translates to every enabled target.
+
 ### The original tree stays pure
 
 Adoption writes `.skillset/` and nothing else. The invariant is mechanically checkable: in a clean clone, `git status --porcelain` after adopt-and-build shows only `.skillset/`. Any other dirty path is a toolchain defect, not a judgment call.
 
 This is what keeps the original usable as the round-trip baseline. Generated output is diffed against the original files sitting untouched in place, so fidelity gaps are visible as ordinary diffs rather than archaeology over an overwritten tree.
 
-### Isolated output roots are pure configuration
+Cutover is documentation, not a feature. A real migration ends with generated output replacing the originals, and the existing unmanaged-overwrite protection rightly refuses while originals linger. The migration report therefore ends with explicit cutover instructions — remove or relocate the listed originals, then build against live roots — instead of a `--replace` mode. If real migrations show that manual step failing at scale, a guided cutover command can earn its place later.
 
-Builds during adoption must not write into the original repo's live surfaces — `plugins-claude/`, `.claude/skills`, `.claude/rules`, and derived `AGENTS.md` destinations can all collide with original files. The fix is not an adoption-only build mode; it is finishing output-root configuration:
+### Isolated build output is a binary mode
 
-- every output surface (plugins, skills, rules, instruction destinations) becomes configurable the way plugin outputs already are through target output objects such as `claude.plugins.path`;
-- a root-oriented reproduction under `.skillset/build/out/` — the generated tree laid out as the repo root would be — is one ordinary configuration of those roots, aligned with the Skillset-owned `~/.skillset/build` preview area and with `skillset test`'s isolated runs under `.skillset/build/tests/`.
+Builds during adoption must not write into the original repo's live surfaces — `plugins-claude/`, `.claude/skills`, `.claude/rules`, and derived `AGENTS.md` destinations can all collide with original files. The fix is one binary choice: generated output goes either to the live directed roots (today's behavior, the default) or wholesale into `.skillset/build/out/` — a root-oriented reproduction of the projection, the generated tree laid out as the repo root would be. One flag on `build`/`check`/`diff` selects the mode; locks, drift, and check compute against whichever root is active.
 
-This means adoption, external fixtures, deterministic tests, and global loadouts are all consumers of the same configuration. Fixtures get no privileged build mode; "isolated" is a place you point the existing build at, and the build contract — determinism, locks, drift checks — applies identically.
+Adoption, external fixtures, and the future `~/.skillset/build` global preview are all callers of the same flag — fixtures get no privileged build mode, and the build contract (determinism, locks, drift checks) applies identically in both modes. A fuller per-surface output-root vocabulary (redirecting individual surfaces) was considered and deferred: derived `AGENTS.md` destinations cannot be expressed as a single root anyway, and no current consumer needs partial redirection. Revisit if in-place preview or the XDG build area demands it.
 
 ### Acquisition is sugar; provenance makes refresh real
 
-`skillset adopt <git-url>` shallow-clones to a Skillset-owned cache location and runs the same flow as `skillset adopt <path>`. Acquisition adds no semantics.
+`skillset adopt` accepts a local path or a git remote — exactly what `git clone` accepts, no other acquisition schemes. A remote shallow-clones to a Skillset-owned cache location and runs the same flow as a path. Acquisition adds no semantics.
 
 Imported source records its origin — repository, pinned commit, and original path — in lock provenance. That record is what turns "upstream moved" into a defined operation: a future `adopt --refresh` re-pins, re-runs the regenerable migration, and reports the delta, instead of asking the user to remember where source came from. Refresh semantics beyond wholesale regeneration (merging upstream changes into hand-tuned source) are explicitly deferred.
 
@@ -114,7 +115,6 @@ Imported source records its origin — repository, pinned commit, and original p
 
 ## Non-Decisions
 
-- The command spelling (`skillset adopt` versus `skillset import --all`) is an implementation choice; this ADR decides the behavior, not the flag surface.
 - Which transforms ship in the first slice, and the exact source vocabulary for converted variables, are implementation-time decisions guided by the external fixture reports.
 - Cache location and eviction for URL acquisition follow the Skillset-owned XDG paths draft when that lands.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,11 @@
 pre-commit:
   piped: true
   jobs:
+    - name: repo-sanity
+      env:
+        GIT_PAGER: cat
+      run: |
+        test "$(git config --default false core.bare)" = "false" || { echo "core.bare is true — a concurrent tool corrupted .git/config and checkouts will fail; repair with 'git config core.bare false'"; exit 1; }
     - name: whitespace
       env:
         GIT_PAGER: cat
@@ -30,6 +35,11 @@ pre-commit:
 pre-push:
   piped: true
   jobs:
+    - name: repo-sanity
+      env:
+        GIT_PAGER: cat
+      run: |
+        test "$(git config --default false core.bare)" = "false" || { echo "core.bare is true — a concurrent tool corrupted .git/config and checkouts will fail; repair with 'git config core.bare false'"; exit 1; }
     - name: whitespace
       env:
         GIT_PAGER: cat

--- a/scripts/__tests__/bootstrap.test.ts
+++ b/scripts/__tests__/bootstrap.test.ts
@@ -12,6 +12,7 @@ import {
   readPinnedBunVersion,
 } from "../bootstrap/bun";
 import { loadBootstrapConfig } from "../bootstrap/config";
+import { gitSafeEnv } from "../../src/git-env";
 import { isLinkedWorktree, readRepoHealth } from "../bootstrap/git";
 import { detectHost, resolveRepoRoot } from "../bootstrap/host";
 import { parseBootstrapArgs } from "../bootstrap/main";
@@ -298,9 +299,13 @@ describe("bootstrap repo policy", () => {
 });
 
 describe("readRepoHealth", () => {
+  const git = (root: string, ...args: string[]): void => {
+    Bun.spawnSync({ cmd: ["git", ...args], cwd: root, env: gitSafeEnv() });
+  };
+
   const initRepo = (): string => {
     const root = mkdtempSync(join(tmpdir(), "skillset-repo-health-"));
-    Bun.spawnSync({ cmd: ["git", "init", "-q"], cwd: root });
+    git(root, "init", "-q");
     return root;
   };
 
@@ -314,54 +319,25 @@ describe("readRepoHealth", () => {
 
   test("flags core.bare corruption", () => {
     const root = initRepo();
-    Bun.spawnSync({ cmd: ["git", "config", "core.bare", "true"], cwd: root });
+    git(root, "config", "core.bare", "true");
     expect(readRepoHealth(root).coreBare).toBe(true);
     rmSync(root, { force: true, recursive: true });
   });
 
   test("flags worktrees locked by dead processes and keeps live locks", () => {
     const root = initRepo();
-    Bun.spawnSync({
-      cmd: ["git", "config", "user.email", "t@example.com"],
-      cwd: root,
-    });
-    Bun.spawnSync({ cmd: ["git", "config", "user.name", "t"], cwd: root });
+    git(root, "config", "user.email", "t@example.com");
+    git(root, "config", "user.name", "t");
     writeFileSync(join(root, "file.txt"), "x\n");
-    Bun.spawnSync({ cmd: ["git", "add", "."], cwd: root });
-    Bun.spawnSync({ cmd: ["git", "commit", "-qm", "init"], cwd: root });
+    git(root, "add", ".");
+    git(root, "commit", "-qm", "init");
 
     const deadPath = join(root, "wt-dead");
     const livePath = join(root, "wt-live");
-    Bun.spawnSync({
-      cmd: ["git", "worktree", "add", "-q", deadPath],
-      cwd: root,
-    });
-    Bun.spawnSync({
-      cmd: ["git", "worktree", "add", "-q", livePath],
-      cwd: root,
-    });
-    Bun.spawnSync({
-      cmd: [
-        "git",
-        "worktree",
-        "lock",
-        "--reason",
-        "agent x (pid 999999999 start now)",
-        deadPath,
-      ],
-      cwd: root,
-    });
-    Bun.spawnSync({
-      cmd: [
-        "git",
-        "worktree",
-        "lock",
-        "--reason",
-        `agent y (pid ${process.pid} start now)`,
-        livePath,
-      ],
-      cwd: root,
-    });
+    git(root, "worktree", "add", "-q", deadPath);
+    git(root, "worktree", "add", "-q", livePath);
+    git(root, "worktree", "lock", "--reason", "agent x (pid 999999999 start now)", deadPath);
+    git(root, "worktree", "lock", "--reason", `agent y (pid ${process.pid} start now)`, livePath);
 
     const health = readRepoHealth(root);
     // git reports realpath; macOS tmpdir is a symlink, so compare suffixes.

--- a/scripts/__tests__/bootstrap.test.ts
+++ b/scripts/__tests__/bootstrap.test.ts
@@ -1,8 +1,7 @@
+import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-import { describe, expect, test } from "bun:test";
 
 import {
   isBunVersionAllowed,
@@ -13,7 +12,7 @@ import {
   readPinnedBunVersion,
 } from "../bootstrap/bun";
 import { loadBootstrapConfig } from "../bootstrap/config";
-import { isLinkedWorktree } from "../bootstrap/git";
+import { isLinkedWorktree, readRepoHealth } from "../bootstrap/git";
 import { detectHost, resolveRepoRoot } from "../bootstrap/host";
 import { parseBootstrapArgs } from "../bootstrap/main";
 import { ensureBunAvailable, listWorkspaceGlobs } from "../bootstrap/repo";
@@ -42,7 +41,10 @@ const makeRepoRoot = (): string => {
     '{"name":"skillset","packageManager":"bun@1.3.14","engines":{"bun":">=1.3.14"},"workspaces":[]}\n'
   );
   writeFileSync(join(root, ".bun-version"), "1.3.14\n");
-  writeFileSync(join(root, ".skillset/config.yaml"), "skillset:\n  name: skillset\n");
+  writeFileSync(
+    join(root, ".skillset/config.yaml"),
+    "skillset:\n  name: skillset\n"
+  );
   writeFileSync(join(root, "src/cli.ts"), "");
   return root;
 };
@@ -292,5 +294,82 @@ describe("bootstrap repo policy", () => {
     const config = loadBootstrapConfig();
     expect(config.cleanup.directories).toContain("dist");
     expect(config.cleanup.directories).toContain(".skillset/build");
+  });
+});
+
+describe("readRepoHealth", () => {
+  const initRepo = (): string => {
+    const root = mkdtempSync(join(tmpdir(), "skillset-repo-health-"));
+    Bun.spawnSync({ cmd: ["git", "init", "-q"], cwd: root });
+    return root;
+  };
+
+  test("reports a healthy repo", () => {
+    const root = initRepo();
+    const health = readRepoHealth(root);
+    expect(health.coreBare).toBe(false);
+    expect(health.staleWorktrees).toEqual([]);
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  test("flags core.bare corruption", () => {
+    const root = initRepo();
+    Bun.spawnSync({ cmd: ["git", "config", "core.bare", "true"], cwd: root });
+    expect(readRepoHealth(root).coreBare).toBe(true);
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  test("flags worktrees locked by dead processes and keeps live locks", () => {
+    const root = initRepo();
+    Bun.spawnSync({
+      cmd: ["git", "config", "user.email", "t@example.com"],
+      cwd: root,
+    });
+    Bun.spawnSync({ cmd: ["git", "config", "user.name", "t"], cwd: root });
+    writeFileSync(join(root, "file.txt"), "x\n");
+    Bun.spawnSync({ cmd: ["git", "add", "."], cwd: root });
+    Bun.spawnSync({ cmd: ["git", "commit", "-qm", "init"], cwd: root });
+
+    const deadPath = join(root, "wt-dead");
+    const livePath = join(root, "wt-live");
+    Bun.spawnSync({
+      cmd: ["git", "worktree", "add", "-q", deadPath],
+      cwd: root,
+    });
+    Bun.spawnSync({
+      cmd: ["git", "worktree", "add", "-q", livePath],
+      cwd: root,
+    });
+    Bun.spawnSync({
+      cmd: [
+        "git",
+        "worktree",
+        "lock",
+        "--reason",
+        "agent x (pid 999999999 start now)",
+        deadPath,
+      ],
+      cwd: root,
+    });
+    Bun.spawnSync({
+      cmd: [
+        "git",
+        "worktree",
+        "lock",
+        "--reason",
+        `agent y (pid ${process.pid} start now)`,
+        livePath,
+      ],
+      cwd: root,
+    });
+
+    const health = readRepoHealth(root);
+    // git reports realpath; macOS tmpdir is a symlink, so compare suffixes.
+    expect(
+      health.staleWorktrees.map((worktree) =>
+        worktree.path.endsWith("/wt-dead")
+      )
+    ).toEqual([true]);
+    rmSync(root, { force: true, recursive: true });
   });
 });

--- a/scripts/__tests__/skillset-runtime-hooks.test.ts
+++ b/scripts/__tests__/skillset-runtime-hooks.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { gitSafeEnv } from "../../src/git-env";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -80,6 +81,7 @@ async function runGit(root: string, ...args: readonly string[]): Promise<void> {
   const proc = Bun.spawn({
     cmd: ["git", ...args],
     cwd: root,
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/scripts/bootstrap/doctor.ts
+++ b/scripts/bootstrap/doctor.ts
@@ -1,5 +1,6 @@
 import { checkBunVersion } from "./bun";
 import type { BootstrapConfig } from "./config";
+import { readRepoHealth } from "./git";
 import type { HostInfo } from "./host";
 import { hasRepoInstallState } from "./repo";
 import { collectToolStatus, printToolStatuses } from "./tools";
@@ -24,6 +25,20 @@ export const runDoctor = async (
   console.error(
     `  dependencies: ${(await hasRepoInstallState(repoRoot)) ? "ok" : "missing"}`
   );
+
+  const health = readRepoHealth(repoRoot);
+  console.error(
+    `  core.bare: ${health.coreBare ? "TRUE — broken; run: git config core.bare false" : "ok"}`
+  );
+  if (health.staleWorktrees.length > 0) {
+    console.error("  stale worktrees:");
+    for (const worktree of health.staleWorktrees) {
+      console.error(`    ${worktree.path} (${worktree.reason})`);
+    }
+    console.error(
+      "    remove with: git worktree remove --force <path> && git worktree prune"
+    );
+  }
 
   console.error("");
   printToolStatuses(

--- a/scripts/bootstrap/git.ts
+++ b/scripts/bootstrap/git.ts
@@ -81,3 +81,58 @@ export const printAgentGitDiagnostics = (
     }
   }
 };
+
+export interface RepoHealth {
+  readonly coreBare: boolean;
+  readonly staleWorktrees: readonly StaleWorktree[];
+}
+
+export interface StaleWorktree {
+  readonly path: string;
+  readonly reason: string;
+}
+
+/**
+ * Shared-repo health: `core.bare` must stay false for a repo with working
+ * trees (a concurrent tool once flipped it and broke every checkout), and
+ * worktrees whose agent lock points at a dead process are stale leftovers.
+ */
+export const readRepoHealth = (repoRoot: string): RepoHealth => {
+  const bare = run(["git", "config", "core.bare"], repoRoot);
+  const coreBare = bare.exitCode === 0 && bare.stdout.trim() === "true";
+
+  const staleWorktrees: StaleWorktree[] = [];
+  const list = run(["git", "worktree", "list", "--porcelain"], repoRoot);
+  if (list.exitCode === 0) {
+    let path: string | undefined;
+    for (const line of list.stdout.split("\n")) {
+      if (line.startsWith("worktree ")) {path = line.slice("worktree ".length);}
+      if (line.startsWith("locked") && path !== undefined) {
+        const match = /pid (\d+)/.exec(line);
+        if (match?.[1] !== undefined && !isProcessAlive(Number(match[1]))) {
+          staleWorktrees.push({
+            path,
+            reason: `lock holder pid ${match[1]} is not running`,
+          });
+        }
+      }
+    }
+  }
+
+  return { coreBare, staleWorktrees };
+};
+
+const isProcessAlive = (pid: number): boolean => {
+  if (!Number.isInteger(pid) || pid <= 0) {return false;}
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "EPERM"
+    );
+  }
+};

--- a/scripts/bootstrap/shared.ts
+++ b/scripts/bootstrap/shared.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { gitSafeEnv } from "../../src/git-env";
+
 export const BOOTSTRAP_DIR = dirname(fileURLToPath(import.meta.url));
 export const SCRIPTS_DIR = resolve(BOOTSTRAP_DIR, "..");
 export const DEFAULT_REPO_ROOT = resolve(SCRIPTS_DIR, "..");
@@ -22,6 +24,9 @@ export const run = (cmd: readonly string[], cwd: string): ExecResult => {
   const result = Bun.spawnSync({
     cmd: [...cmd],
     cwd,
+    // Bootstrap runs inside agent/git hooks; repository-targeting GIT_* vars
+    // must not leak into spawned commands (see src/git-env.ts).
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });
@@ -38,6 +43,7 @@ export const runInherit = async (
 ): Promise<number> => {
   const proc = Bun.spawn([...cmd], {
     cwd,
+    env: gitSafeEnv(),
     stderr: "inherit",
     stdout: "inherit",
   });

--- a/scripts/fixtures/__tests__/external.test.ts
+++ b/scripts/fixtures/__tests__/external.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import { compareTrees, parseExternalManifest, renderExternalManifest, renderRunReportMarkdown, runExternalRepo } from '../external';
 import type { ExternalRepoEntry } from '../external';
+import { gitSafeEnv } from '../../../src/git-env';
 
 const SHA = "4719dc509fdc45656a830e3ed6060f674e206076";
 

--- a/scripts/fixtures/external.ts
+++ b/scripts/fixtures/external.ts
@@ -31,6 +31,7 @@ import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 
 import { buildSkillset } from "../../src/build";
+import { gitSafeEnv } from "../../src/git-env";
 import { importSources } from "../../src/import";
 import { lintSkillset } from "../../src/lint";
 import { compareStrings, validateSlug } from "../../src/path";
@@ -530,6 +531,7 @@ async function gitOutput(
 ): Promise<string> {
   const proc = Bun.spawn({
     cmd: ["git", "-C", cwd, ...args],
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/src/__tests__/ci.test.ts
+++ b/src/__tests__/ci.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { parseYamlRecord } from "../yaml";
+import { gitSafeEnv } from "../git-env";
 import { buildSkillset } from "../build";
 import { CI_REPORT_MARKER, CI_WORKFLOW_PATH, ciSkillset, renderCiReportMarkdown, renderCiWorkflow } from "../ci";
 import { initSkillset } from "../setup";
@@ -251,6 +252,7 @@ async function commitFixture(root: string): Promise<void> {
 async function runGit(root: string, ...args: readonly string[]): Promise<void> {
   const proc = Bun.spawn({
     cmd: ["git", "-C", root, ...args],
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -12,6 +12,7 @@ import { lintSkillset } from "../lint";
 import { readReleaseState } from "../release-state";
 import { loadBuildGraph } from "../resolver";
 import { createSkillset, initSkillset } from "../setup";
+import { gitSafeEnv } from "../git-env";
 import { sourceUnitDisplay } from "../source-unit-selector";
 
 test("SET-52: source-unit selectors render conventional display labels", () => {
@@ -4694,6 +4695,7 @@ async function commitFixture(root: string): Promise<void> {
 async function runGit(root: string, ...args: readonly string[]): Promise<void> {
   const proc = Bun.spawn({
     cmd: ["git", "-C", root, ...args],
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/src/change-status.ts
+++ b/src/change-status.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { diffSkillset, type SkillsetDiff } from "./build";
 import { readString } from "./config";
 import { compareStrings, resolveInside } from "./path";
+import { gitSafeEnv } from "./git-env";
 import { preprocessText } from "./preprocess";
 import { readReleaseState } from "./release-state";
 import { loadBuildGraph } from "./resolver";
@@ -937,6 +938,7 @@ async function runCommand(
   const proc = Bun.spawn({
     cmd: [...cmd],
     cwd,
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/src/git-env.ts
+++ b/src/git-env.ts
@@ -1,0 +1,31 @@
+/**
+ * Environment for spawning git against an explicit repository path.
+ *
+ * Git hooks (pre-push, pre-commit) run with `GIT_DIR` — and sometimes
+ * `GIT_WORK_TREE` and `GIT_INDEX_FILE` — exported, and those variables
+ * override `git -C <path>` repository discovery. Any git subprocess spawned
+ * from inside a hook would silently operate on the hook's repository instead
+ * of the intended one; this is how test fixtures once rewrote the real repo's
+ * `.git/config` (setting `core.bare = true`) when the test suite ran under a
+ * lefthook pre-push gate. Strip repository-targeting variables so explicit
+ * paths always win.
+ */
+export function gitSafeEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) {continue;}
+    if (
+      key === "GIT_DIR" ||
+      key === "GIT_WORK_TREE" ||
+      key === "GIT_INDEX_FILE" ||
+      key === "GIT_OBJECT_DIRECTORY" ||
+      key === "GIT_COMMON_DIR" ||
+      key === "GIT_NAMESPACE" ||
+      key.startsWith("GIT_ALTERNATE_OBJECT")
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative, resolve } from "node:path";
 import { seedReleaseBaselines, type ReleaseBaselineEntry } from "./adoption";
 import { CI_WORKFLOW_PATH, renderCiWorkflow } from "./ci";
 import { validateConfigDocument } from "./config";
+import { gitSafeEnv } from "./git-env";
 import type { TargetName } from "./types";
 import { validateSlug } from "./path";
 import { parseYamlRecord } from "./yaml";
@@ -142,6 +143,7 @@ async function initRootPath(options: SetupOptions): Promise<string> {
 async function gitRoot(cwd: string): Promise<string | undefined> {
   const proc = Bun.spawn({
     cmd: ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+    env: gitSafeEnv(),
     stderr: "pipe",
     stdout: "pipe",
   });


### PR DESCRIPTION
## What

Housekeeping from the design-decision review, plus the root-cause fix for the `core.bare` repo corruption.

### The corruption, root-caused and fixed

`git push` exports `GIT_DIR` to hook processes, and **`GIT_DIR` overrides `git -C` repository discovery**. When the test suite ran under the lefthook pre-push gate (added in #27), every temp-fixture git call silently operated on the real shared `.git` instead of its fixture directory:

- fixture `git init` wrote `core.bare = true` into the shared config — breaking status/index operations in every checkout and worktree (observed three times)
- fixture identities (`user.email = skillset@example.com`) and `extensions.worktreeConfig` landed in the real config
- fixture worktrees (`wt-dead`, `wt-live`) registered against the real repo, and one fixture commit landed on a real branch
- the mysterious `error: git add . failed` spam was our own test helpers erroring against the wrong repo

Earlier suspicion of concurrent agents (Codex worktree daemon, a remote-control session) was wrong — caught red-handed via a config watchdog during a reproduced push.

**Fix:** `src/git-env.ts` exports `gitSafeEnv()`, which strips repository-targeting `GIT_*` variables; every git spawn now uses it — production (`change-status`, `setup`), all test helpers, the external-fixtures harness, bootstrap's shared runners, and the self-hosted runtime-hooks script (source + rebuilt outputs).

**Proof:** full suite run with `GIT_DIR` exported (hook conditions): 0 failures, shared config byte-identical before/after. This PR was itself pushed through the full lefthook pre-push gates with a config watchdog armed — clean.

### Guardrails

- lefthook `repo-sanity` job (pre-commit + pre-push, first in the pipe): fails fast with a repair hint if `core.bare` is true
- `bootstrap.sh doctor` now reports `core.bare` state and stale worktrees (agent locks pointing at dead pids) with removal instructions, with tests

### ADR updates (from the decision review)

`docs/adrs/drafts/20260610-one-action-repo-adoption.md` now records the worked-through resolutions: `skillset adopt <path|git-remote>` as the command surface; isolated build output rescoped to a binary live-vs-`.skillset/build/out/` mode (per-surface roots deferred as YAGNI); cutover as documentation, not a v1 feature; and the transform registry as intent-keyed typed data usable at adopt time (default) or build time for dialect source, with dialect detection/declaration and islands staying target-locked.

Audited `docs/features/ci.md` against main's amended `--fix` gate: already accurate, no change needed.

## Testing

- `bun run check` green; `bun test src scripts` green with and without `GIT_DIR` exported
- `skillset ci` green; `bun scripts/adr.ts check` 0 errors
- 3 new tests for `readRepoHealth` (healthy, corrupted, dead-pid stale worktree vs live lock)
- Pushed through the full pre-push gates with config watchdog: no config mutation
