### PR TITLE
feat(import): round-trip plugin manifest metadata fields

### DIFF
--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -19,6 +19,21 @@ Plugin identity derives from the directory unless `skillset.name` is present and
 | Claude companion paths | commands, agents, hooks, MCP, LSP, output styles, themes, monitors, assets, scripts, src, bin | n/a unless separately supported | `target_native` / `implemented` | Target truth wins over fake portability. |
 | Codex companion paths | n/a unless separately supported | hooks, MCP, app manifest, assets, scripts, src | `target_native` / `implemented` | Codex plugin `agents/` and plugin `.rules` are unsupported. |
 
+## Manifest Field Authority
+
+Each generated-manifest field has exactly one writer; competing authorities are how versions drift. `skillset import` lifts all of these from a native manifest into plugin source metadata so imported plugins round-trip.
+
+| Field | Authority | Notes |
+| --- | --- | --- |
+| `name` | source (`skillset.name`, defaults to directory) | `manifest.name` is the explicit override. |
+| `version` | release state, with source `version` as fallback | `skillset check` reports version drift; do not hand-edit generated manifests. |
+| `description` | source (`summary`, falling back to `description`) | |
+| `author`, `homepage`, `repository`, `license`, `keywords` | source metadata | Projected verbatim into generated manifests. |
+| Component wiring (`commands`, `agents`, `skills`, `hooks`, `mcpServers`, …) | compiler | Derived from source layout and feature keys; never authored in generated output. |
+| `dependencies` (Claude) | compiler, from source `dependencies` | A `claude.manifest.dependencies` override fails the build rather than competing. |
+
+Target-native `claude.manifest` / `codex.manifest` blocks remain the visible per-target escape hatch: an override wins over the source-owned value for that target only, and stays reviewable in source.
+
 ## Diagnostics
 
 - Reject plugin identity conflicts and unsupported plugin config keys.

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -767,6 +767,37 @@ test("SET-10: skill import reports copied files and classifies frontmatter", asy
   expect(copied).toContain("frobnicate: maybe");
 });
 
+test("SET-58: imported plugin manifests round-trip metadata fields through build", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-import-root-"));
+  const external = await mkdtemp(join(tmpdir(), "skillset-import-src-"));
+  const originalManifest = {
+    name: "roundtrip",
+    version: "2.4.6",
+    description: "Round-trip fidelity plugin.",
+    author: { name: "Author Name", email: "author@example.com", url: "https://example.com/author" },
+    homepage: "https://example.com/home",
+    repository: "https://github.com/example/roundtrip",
+    license: "MIT",
+    keywords: ["alpha", "beta"],
+  };
+  await Bun.write(join(external, "roundtrip/.claude-plugin/plugin.json"), JSON.stringify(originalManifest));
+  await Bun.write(
+    join(external, "roundtrip/skills/demo/SKILL.md"),
+    "---\nname: demo\ndescription: Demo.\n---\n\nBody.\n"
+  );
+  await Bun.write(join(root, ".skillset/config.yaml"), "skillset:\n  name: roundtrip-root\nclaude: true\ncodex: false\n");
+
+  await importSource({ kind: "plugin", rootPath: root, sourcePath: join(external, "roundtrip") });
+  await buildSkillset(root);
+
+  const generated = JSON.parse(
+    await readFile(join(root, "plugins-claude/plugins/roundtrip/.claude-plugin/plugin.json"), "utf8")
+  ) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(originalManifest)) {
+    expect(generated[key]).toEqual(value);
+  }
+});
+
 test("SET-10: importing a SKILL.md path copies the full skill directory", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-import-root-"));
   const external = await mkdtemp(join(tmpdir(), "skillset-import-src-"));

--- a/src/import.ts
+++ b/src/import.ts
@@ -502,10 +502,19 @@ async function writeImportedPluginConfig(
   name: string
 ): Promise<void> {
   const nativeManifest = await readNativePluginManifest(targetPath);
+  // Lift every manifest field the generated projection round-trips, so an
+  // imported plugin compiles back to a manifest substantially identical to
+  // its origin. `version` stays a source fallback: release state owns it once
+  // releases exist (see the field-authority table in docs/features/plugins.md).
   const metadata: JsonRecord = {
     name,
     description: readString(nativeManifest, "description"),
     version: readString(nativeManifest, "version"),
+    author: nativeManifest.author,
+    homepage: nativeManifest.homepage,
+    repository: nativeManifest.repository,
+    license: nativeManifest.license,
+    keywords: nativeManifest.keywords,
   };
   await writeFile(
     join(targetPath, "skillset.yaml"),


### PR DESCRIPTION
Imported plugins now lift `author`, `homepage`, `repository`, `license`, and `keywords` from the native manifest into plugin source metadata, so the generated projection reproduces the original manifest **semantically identically** (canonical key order and compiler wiring pointers remain the only byte deltas — verified by jq comparison against the compound-engineering external fixture). Adds the manifest **field-authority table** (one writer per field) to the plugins feature page.

Linear: https://linear.app/outfitter/issue/SET-58
Gates: `bun run check` ✓ · external fixture run ✓ · new round-trip contract test ✓

Bottom of the Quality floor stack (#31 → #32 → #33 above).