### PR TITLE
feat(lint): add frontmatter rule catalog with severity tiers

### DIFF
--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -31,5 +31,8 @@
   },
   "dependencies": {
     "yaml": "^2.8.1"
+  },
+  "devDependencies": {
+    "@skillset/lint": "workspace:*"
   }
 }

--- a/apps/skillset/src/__tests__/lint-rules.test.ts
+++ b/apps/skillset/src/__tests__/lint-rules.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { lintRules, registerLintRule } from "@skillset/lint";
+
+import { buildSkillset } from "../build";
+import { ciSkillset, renderCiReportMarkdown } from "../ci";
+import { gitSafeEnv } from "../git-env";
+import { lintSkillset } from "../lint";
+
+const WARN_RULE_NAME = "test-warn-marker";
+
+registerLintRule({
+  check: (subject) =>
+    subject.body.includes("WARN-MARKER")
+      ? [
+          {
+            message: "body contains WARN-MARKER",
+            path: subject.path,
+            rule: WARN_RULE_NAME,
+            severity: "warn",
+          },
+        ]
+      : [],
+  description: "Test-only warn rule keyed off a body marker.",
+  name: WARN_RULE_NAME,
+  severity: "warn",
+});
+
+afterAll(() => {
+  lintRules.delete(WARN_RULE_NAME);
+});
+
+test("lintSkillset throws on an error-severity rule violation", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md":
+      "---\nname: other\ndescription: Demo.\n---\n\nBody.\n",
+  });
+
+  await expect(lintSkillset(root)).rejects.toThrow(
+    "skill-name-directory-mismatch"
+  );
+  await expect(lintSkillset(root)).rejects.toThrow(
+    "frontmatter name other does not match skill directory demo"
+  );
+});
+
+test("lintSkillset returns warn-only issues without throwing", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md":
+      "---\nname: demo\ndescription: Demo.\n---\n\nBody with WARN-MARKER.\n",
+  });
+
+  const result = await lintSkillset(root);
+
+  expect(result.checkedSkills).toBe(1);
+  expect(result.issues).toEqual([
+    {
+      code: WARN_RULE_NAME,
+      message: "body contains WARN-MARKER",
+      path: ".skillset/skills/demo/SKILL.md",
+      severity: "warn",
+    },
+  ]);
+});
+
+test("ci reports lint warnings without failing", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md":
+      "---\nname: demo\ndescription: Demo.\n---\n\nBody with WARN-MARKER.\n",
+  });
+  await commitFixture(root);
+  await buildSkillset(root);
+
+  const report = await ciSkillset(root, { since: "HEAD" });
+
+  expect(report.ok).toBe(true);
+  expect(report.lintIssues).toEqual([
+    {
+      code: WARN_RULE_NAME,
+      message: "body contains WARN-MARKER",
+      path: ".skillset/skills/demo/SKILL.md",
+      severity: "warn",
+    },
+  ]);
+  const markdown = renderCiReportMarkdown(report);
+  expect(markdown).toContain("### Lint warnings");
+  expect(markdown).not.toContain("### Lint issues");
+  expect(markdown).toContain("do not fail CI");
+});
+
+test("ci fails on error-severity lint issues", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md": `---\nname: demo\ndescription: ${"x".repeat(1030)}\n---\n\nBody.\n`,
+  });
+  await commitFixture(root);
+  await buildSkillset(root);
+
+  const report = await ciSkillset(root, { since: "HEAD" });
+
+  expect(report.ok).toBe(false);
+  expect(
+    report.lintIssues.some(
+      (issue) =>
+        issue.code === "skill-description-length" && issue.severity === "error"
+    )
+  ).toBe(true);
+  const markdown = renderCiReportMarkdown(report);
+  expect(markdown).toContain("### Lint issues");
+  expect(markdown).toContain("1030");
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-lint-rules-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), content);
+  }
+  return root;
+}
+
+async function commitFixture(root: string): Promise<void> {
+  await runGit(root, "init", "-q");
+  await runGit(root, "config", "user.email", "skillset@example.com");
+  await runGit(root, "config", "user.name", "Skillset Test");
+  await runGit(root, "add", ".");
+  await runGit(root, "commit", "-qm", "baseline");
+}
+
+async function runGit(root: string, ...args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn({
+    cmd: ["git", "-C", root, ...args],
+    env: gitSafeEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed\n${stdout}${stderr}`);
+  }
+}

--- a/apps/skillset/src/ci.ts
+++ b/apps/skillset/src/ci.ts
@@ -31,10 +31,11 @@ const EMPTY_DRIFT: SkillsetDiff = { added: [], changed: [], missing: [], removed
 /**
  * Aggregate the checks a continuous-integration run needs: lint diagnostics,
  * change-entry coverage, and generated-output drift. Drift is the only
- * mechanical problem: with `fix` enabled, clean lint, clean change coverage,
- * and a resolved baseline, `ci` rebuilds generated output the same way
- * `skillset build --yes` would. Lint issues, missing change entries, and
- * build errors need authored source changes, so they stay report-only.
+ * mechanical problem: with `fix` enabled, no lint errors, clean change
+ * coverage, and a resolved baseline, `ci` rebuilds generated output the same
+ * way `skillset build --yes` would. Lint errors, missing change entries, and
+ * build errors need authored source changes, so they stay report-only; lint
+ * warnings are advisory and never fail the run.
  */
 export async function ciSkillset(rootPath: string, options: CiOptions = {}): Promise<CiReport> {
   const { fix, since, ...buildOptions } = options;
@@ -71,11 +72,12 @@ export async function ciSkillset(rootPath: string, options: CiOptions = {}): Pro
   }
 
   const changeErrors = changeIssues.filter((issue) => issue.severity === "error");
+  const lintErrors = lintIssues.filter((issue) => issue.severity === "error");
 
-  // Rebuild only when drift is the sole problem: lint issues, change-entry
+  // Rebuild only when drift is the sole problem: lint errors, change-entry
   // errors, or a build error mean the source is not trustworthy, and an
   // unresolvable change baseline means the CI setup itself needs fixing before
-  // pushing rebuild commits.
+  // pushing rebuild commits. Lint warnings are advisory and do not block.
   let fixedPaths: readonly string[] = [];
   if (
     fix === true &&
@@ -83,7 +85,7 @@ export async function ciSkillset(rootPath: string, options: CiOptions = {}): Pro
     buildError === undefined &&
     changeError === undefined &&
     changeErrors.length === 0 &&
-    lintIssues.length === 0
+    lintErrors.length === 0
   ) {
     const staleBefore = [...drift.added, ...drift.changed, ...drift.missing, ...drift.removed];
     try {
@@ -106,7 +108,7 @@ export async function ciSkillset(rootPath: string, options: CiOptions = {}): Pro
     ok:
       buildError === undefined &&
       changeError === undefined &&
-      lintIssues.length === 0 &&
+      lintErrors.length === 0 &&
       changeErrors.length === 0 &&
       !hasDrift(drift),
     warnings,
@@ -131,18 +133,24 @@ export const CI_REPORT_MARKER = "<!-- skillset-ci-report -->";
  */
 export function renderCiReportMarkdown(report: CiReport): string {
   const lines: string[] = [CI_REPORT_MARKER, "## Skillset CI", ""];
+  const lintErrors = report.lintIssues.filter((issue) => issue.severity === "error");
+  const lintWarnings = report.lintIssues.filter((issue) => issue.severity === "warn");
 
-  if (report.ok && report.fixedPaths.length === 0) {
+  if (report.ok && report.fixedPaths.length === 0 && lintWarnings.length === 0) {
     lines.push("All checks passed: source lint, change entries, and generated output are current.", "");
     return `${lines.join("\n").trimEnd()}\n`;
   }
 
-  lines.push(
-    report.ok
-      ? "Generated output was stale and has been rebuilt mechanically. No source changes are needed."
-      : "Skillset CI found problems; the sections below explain each one.",
-    ""
-  );
+  if (report.ok) {
+    lines.push(
+      report.fixedPaths.length > 0
+        ? "Generated output was stale and has been rebuilt mechanically. No source changes are needed."
+        : "All checks passed; the lint warnings below are advisory and do not fail CI.",
+      ""
+    );
+  } else {
+    lines.push("Skillset CI found problems; the sections below explain each one.", "");
+  }
 
   if (report.fixedPaths.length > 0) {
     lines.push("### Rebuilt generated output", "");
@@ -159,12 +167,20 @@ export function renderCiReportMarkdown(report: CiReport): string {
     lines.push("", "Run `skillset build --yes`, review the generated diff, and commit it.", "");
   }
 
-  if (report.lintIssues.length > 0) {
+  if (lintErrors.length > 0) {
     lines.push("### Lint issues", "");
-    for (const issue of report.lintIssues) {
+    for (const issue of lintErrors) {
       lines.push(`- \`${issue.path}\`: ${issue.code}: ${issue.message}`);
     }
     lines.push("", "Fix the source issues, then run `skillset lint` locally.", "");
+  }
+
+  if (lintWarnings.length > 0) {
+    lines.push("### Lint warnings", "");
+    for (const issue of lintWarnings) {
+      lines.push(`- \`${issue.path}\`: ${issue.code}: ${issue.message}`);
+    }
+    lines.push("", "Warnings do not fail CI, but cleaning them up keeps skills portable.", "");
   }
 
   if (report.changeError !== undefined) {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -225,6 +225,10 @@ export async function runCli(
 
   if (command === "lint") {
     const result = await lintSkillset(rootPath, options);
+    for (const issue of result.issues) {
+      if (issue.severity !== "warn") continue;
+      console.log(`  warn: ${issue.path}: ${issue.code}: ${issue.message}`);
+    }
     console.log(`skillset: linted ${result.checkedSkills} source skills`);
     return;
   }
@@ -341,7 +345,7 @@ export async function runCli(
     // stderr; the report still carries them for programmatic consumers.
     const report = await doctorSkillset(rootPath, options);
     for (const issue of report.lintIssues) {
-      console.log(`  lint: ${issue.path}: ${issue.code}: ${issue.message}`);
+      console.log(`  lint ${issue.severity}: ${issue.path}: ${issue.code}: ${issue.message}`);
     }
     if (report.buildError !== undefined) {
       console.log(`  build error: ${report.buildError}`);
@@ -497,7 +501,7 @@ function printChangeStatus(report: ChangeStatusReport): void {
 
 function printCiReport(report: CiReport): void {
   for (const issue of report.lintIssues) {
-    console.log(`  lint: ${issue.path}: ${issue.code}: ${issue.message}`);
+    console.log(`  lint ${issue.severity}: ${issue.path}: ${issue.code}: ${issue.message}`);
   }
   if (report.changeError !== undefined) {
     console.log(`  change check error: ${report.changeError}`);
@@ -525,8 +529,9 @@ function printCiReport(report: CiReport): void {
     return;
   }
   const changeErrors = report.changeIssues.filter((issue) => issue.severity === "error").length;
+  const lintErrors = report.lintIssues.filter((issue) => issue.severity === "error").length;
   const problems: string[] = [];
-  if (report.lintIssues.length > 0) problems.push(`${report.lintIssues.length} lint issue(s)`);
+  if (lintErrors > 0) problems.push(`${lintErrors} lint issue(s)`);
   if (report.changeError !== undefined) problems.push("a change check error");
   if (changeErrors > 0) problems.push(`${changeErrors} change entry error(s)`);
   if (hasDrift(report.drift)) problems.push("generated-output drift (run skillset build --yes or ci --fix)");

--- a/apps/skillset/src/lint.ts
+++ b/apps/skillset/src/lint.ts
@@ -1,5 +1,7 @@
 import { readFile, stat } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { basename, dirname, join, relative } from "node:path";
+
+import { type LintDiagnostic, type LintSubject, runLintRules } from "@skillset/lint";
 
 import { isOutputSelected } from "./config";
 import { validateHookDefinition } from "./hooks";
@@ -62,8 +64,9 @@ export async function lintSkillset(
   emitGraphWarnings(graph);
   const result = await inspectBuildGraph(graph);
 
-  if (result.issues.length > 0) {
-    throw new Error(formatLintError(result.issues));
+  const errors = result.issues.filter((issue) => issue.severity === "error");
+  if (errors.length > 0) {
+    throw new Error(formatLintError(errors));
   }
 
   return result;
@@ -83,9 +86,45 @@ async function inspectBuildGraph(graph: BuildGraph): Promise<LintResult> {
   const result = lintBuildGraph(graph);
   const hookIssues = await lintPluginHooks(graph);
   const resourceIssues = await lintResourceUsage(graph);
+  const ruleIssues = await lintSkillRules(graph);
   return {
     checkedSkills: result.checkedSkills,
-    issues: [...result.issues, ...hookIssues, ...resourceIssues],
+    issues: [...result.issues, ...hookIssues, ...resourceIssues, ...ruleIssues],
+  };
+}
+
+/**
+ * Run the registered `@skillset/lint` rules over every source skill
+ * (plugin-bound and standalone) and map their diagnostics into LintIssues.
+ */
+async function lintSkillRules(graph: BuildGraph): Promise<readonly LintIssue[]> {
+  const skills = [
+    ...graph.plugins.flatMap((plugin) => plugin.skills),
+    ...graph.standaloneSkills,
+  ];
+
+  const subjects: LintSubject[] = [];
+  for (const skill of skills) {
+    subjects.push({
+      body: skill.body,
+      directoryName: basename(dirname(skill.sourcePath)),
+      files: [basename(skill.sourcePath)],
+      frontmatter: skill.frontmatter,
+      kind: "skill",
+      path: relative(graph.rootPath, skill.sourcePath),
+      raw: await readFile(skill.sourcePath, "utf8"),
+    });
+  }
+
+  return runLintRules(subjects).map(lintIssueFromDiagnostic);
+}
+
+function lintIssueFromDiagnostic(diagnostic: LintDiagnostic): LintIssue {
+  return {
+    code: diagnostic.code === undefined ? diagnostic.rule : `${diagnostic.rule}:${diagnostic.code}`,
+    message: diagnostic.message,
+    path: diagnostic.path,
+    severity: diagnostic.severity,
   };
 }
 
@@ -134,6 +173,7 @@ async function lintHookFile(
     return [
       {
         code: "hook-invalid-json",
+        severity: "error",
         path,
         message: `${targetLabel} hook file ${path} is not valid JSON: ${message}`,
       },
@@ -144,7 +184,7 @@ async function lintHookFile(
     validateHookDefinition(parsed, { sourcePath: path, target });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return [{ code: "hook-target-incompatible", path, message }];
+    return [{ code: "hook-target-incompatible", message, path, severity: "error" }];
   }
 
   return [];
@@ -169,6 +209,7 @@ async function lintResourceUsage(graph: BuildGraph): Promise<readonly LintIssue[
     for (const undeclared of findUndeclaredResourceLinks(skill.body, skill.resources)) {
       issues.push({
         code: "resource-undeclared-link",
+        severity: "error",
         path,
         message:
           `${path} links to undeclared resource ${undeclared.reference}; ` +
@@ -179,6 +220,7 @@ async function lintResourceUsage(graph: BuildGraph): Promise<readonly LintIssue[
     for (const offender of findPluginRootScriptLinks(skill.body)) {
       issues.push({
         code: "skill-plugin-root-script",
+        severity: "error",
         path,
         message:
           `${path} links to a plugin-root script path ${offender}; ` +
@@ -191,6 +233,7 @@ async function lintResourceUsage(graph: BuildGraph): Promise<readonly LintIssue[
       if (await sourceIsExecutable(resource.sourcePath)) continue;
       issues.push({
         code: "resource-script-not-executable",
+        severity: "error",
         path,
         message:
           `${path} declares script resource ${resource.from} -> ${resource.targetPath}, ` +
@@ -258,6 +301,7 @@ function lintSkill(graph: BuildGraph, skill: SourceSkill): readonly LintIssue[] 
   const labels = matches.map((match) => match.label).join(", ");
   issues.push({
     code: "codex-claude-dynamic-context",
+        severity: "error",
     path,
     message:
       `${path} uses Claude dynamic context (${labels}) while Codex output is enabled. ` +
@@ -282,6 +326,7 @@ function lintToolEscapes(graph: BuildGraph, skill: SourceSkill): readonly LintIs
     return [
       {
         code: "skill-tools-invalid",
+        severity: "error",
         path,
         message,
       },
@@ -299,6 +344,7 @@ function lintCodexAllowedTools(graph: BuildGraph, skill: SourceSkill): readonly 
   return [
     {
       code: "codex-allowed-tools-unsupported",
+        severity: "error",
       path,
       message:
         `${path} sets allowed_tools for Codex, but Codex skills do not currently have a skill-local allowed-tools equivalent. ` +

--- a/apps/skillset/src/types.ts
+++ b/apps/skillset/src/types.ts
@@ -204,6 +204,8 @@ export interface LintIssue {
   readonly code: string;
   readonly message: string;
   readonly path: string;
+  /** Errors fail lint/ci; warnings flow through reporting without failing. */
+  readonly severity: "error" | "warn";
 }
 
 export interface LintResult {

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,9 @@
       "dependencies": {
         "yaml": "^2.8.1",
       },
+      "devDependencies": {
+        "@skillset/lint": "workspace:*",
+      },
     },
     "packages/lint": {
       "name": "@skillset/lint",

--- a/packages/lint/src/__tests__/engine.test.ts
+++ b/packages/lint/src/__tests__/engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  builtinLintRules,
   lintRules,
   listLintRules,
   registerLintRule,
@@ -10,10 +11,12 @@ import type { LintRule, LintSubject } from "../types";
 
 const subject: LintSubject = {
   body: "Use the thing.",
+  directoryName: "demo",
   files: ["SKILL.md"],
   frontmatter: { name: "demo" },
   kind: "skill",
   path: ".skillset/skills/demo/SKILL.md",
+  raw: "---\nname: demo\n---\n\nUse the thing.\n",
 };
 
 const dummyRule = (overrides: Partial<LintRule> = {}): LintRule => ({
@@ -32,18 +35,18 @@ const dummyRule = (overrides: Partial<LintRule> = {}): LintRule => ({
 });
 
 describe("lint engine", () => {
-  test("registry starts empty, registers, and rejects duplicates", () => {
-    expect(listLintRules()).toEqual([]);
+  test("registry holds built-in rules, registers, and rejects duplicates", () => {
+    expect(listLintRules()).toEqual(builtinLintRules);
 
     const rule = dummyRule();
     registerLintRule(rule);
-    expect(listLintRules()).toEqual([rule]);
+    expect(listLintRules()).toContain(rule);
     expect(() => registerLintRule(rule)).toThrow(
       "lint rule already registered: dummy"
     );
 
     lintRules.delete(rule.name);
-    expect(listLintRules()).toEqual([]);
+    expect(listLintRules()).toEqual(builtinLintRules);
   });
 
   test("runLintRules runs explicit rules over subjects", () => {
@@ -68,7 +71,7 @@ describe("lint engine", () => {
     expect(diagnostics[0]?.rule).toBe("hard");
   });
 
-  test("runLintRules with no registered rules yields no diagnostics", () => {
+  test("runLintRules with the default registry passes a clean subject", () => {
     expect(runLintRules([subject])).toEqual([]);
   });
 });

--- a/packages/lint/src/__tests__/rules.test.ts
+++ b/packages/lint/src/__tests__/rules.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  skillDescriptionHtmlTokenRule,
+  skillDescriptionLengthRule,
+  skillDescriptionStrictYamlRule,
+  skillNameDirectoryMismatchRule,
+} from "../rules";
+import type { LintSubject } from "../types";
+
+const makeSubject = (overrides: Partial<LintSubject> = {}): LintSubject => ({
+  body: "Use the thing.",
+  directoryName: "demo",
+  files: ["SKILL.md"],
+  frontmatter: { description: "Demo skill.", name: "demo" },
+  kind: "skill",
+  path: ".skillset/skills/demo/SKILL.md",
+  raw: "---\nname: demo\ndescription: Demo skill.\n---\n\nUse the thing.\n",
+  ...overrides,
+});
+
+describe("skill-description-length", () => {
+  test("flags descriptions longer than 1024 characters with the actual length", () => {
+    const description = "x".repeat(1100);
+    const diagnostics = skillDescriptionLengthRule.check(
+      makeSubject({ frontmatter: { description } })
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-description-length");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.message).toContain("1100");
+    expect(diagnostics[0]?.guidance?.summary).toContain("Shorten");
+  });
+
+  test("counts code points, not UTF-16 units", () => {
+    // 1024 emoji are 2048 UTF-16 units but exactly 1024 spread elements.
+    const description = "😀".repeat(1024);
+    expect(
+      skillDescriptionLengthRule.check(
+        makeSubject({ frontmatter: { description } })
+      )
+    ).toEqual([]);
+  });
+
+  test("passes at exactly 1024 characters and with no description", () => {
+    expect(
+      skillDescriptionLengthRule.check(
+        makeSubject({ frontmatter: { description: "x".repeat(1024) } })
+      )
+    ).toEqual([]);
+    expect(
+      skillDescriptionLengthRule.check(makeSubject({ frontmatter: {} }))
+    ).toEqual([]);
+  });
+});
+
+describe("skill-description-html-token", () => {
+  test("flags a bare angle-bracket token", () => {
+    const diagnostics = skillDescriptionHtmlTokenRule.check(
+      makeSubject({
+        frontmatter: { description: "Wraps output in <task> blocks." },
+      })
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-description-html-token");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.message).toContain("<task>");
+    expect(diagnostics[0]?.guidance?.summary).toContain("Backtick-wrap");
+  });
+
+  test("ignores tokens inside backtick spans", () => {
+    expect(
+      skillDescriptionHtmlTokenRule.check(
+        makeSubject({
+          frontmatter: { description: "Wraps output in `<task>` blocks." },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  test("ignores comparisons and non-tag angle brackets", () => {
+    expect(
+      skillDescriptionHtmlTokenRule.check(
+        makeSubject({
+          frontmatter: { description: "Use when count < 10 or x > y." },
+        })
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("skill-description-strict-yaml", () => {
+  test("flags an unquoted value containing colon-space", () => {
+    const raw =
+      "---\nname: demo\ndescription: Use this: it helps.\n---\n\nBody.\n";
+    const diagnostics = skillDescriptionStrictYamlRule.check(
+      makeSubject({ raw })
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-description-strict-yaml");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.guidance?.summary).toContain("js-yaml");
+  });
+
+  test("passes quoted and block-scalar values", () => {
+    for (const line of [
+      'description: "Use this: it helps."',
+      "description: 'Use this: it helps.'",
+      "description: |",
+      "description: >-",
+    ]) {
+      const raw = `---\nname: demo\n${line}\n  Use this: it helps.\n---\n\nBody.\n`;
+      expect(
+        skillDescriptionStrictYamlRule.check(makeSubject({ raw }))
+      ).toEqual([]);
+    }
+  });
+
+  test("passes absent descriptions and values without colon-space", () => {
+    expect(
+      skillDescriptionStrictYamlRule.check(
+        makeSubject({ raw: "---\nname: demo\n---\n\nBody.\n" })
+      )
+    ).toEqual([]);
+    expect(
+      skillDescriptionStrictYamlRule.check(
+        makeSubject({
+          raw: "---\ndescription: Plain text with a colon:in-word.\n---\n\nBody.\n",
+        })
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("skill-name-directory-mismatch", () => {
+  test("flags a frontmatter name that differs from the directory", () => {
+    const diagnostics = skillNameDirectoryMismatchRule.check(
+      makeSubject({ directoryName: "demo", frontmatter: { name: "other" } })
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-name-directory-mismatch");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.message).toContain("other");
+    expect(diagnostics[0]?.message).toContain("demo");
+  });
+
+  test("passes matching names and skills without a frontmatter name", () => {
+    expect(
+      skillNameDirectoryMismatchRule.check(
+        makeSubject({ directoryName: "demo", frontmatter: { name: "demo" } })
+      )
+    ).toEqual([]);
+    expect(
+      skillNameDirectoryMismatchRule.check(makeSubject({ frontmatter: {} }))
+    ).toEqual([]);
+  });
+});

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -1,4 +1,11 @@
 export { lintRules, listLintRules, registerLintRule } from "./registry";
+export {
+  builtinLintRules,
+  skillDescriptionHtmlTokenRule,
+  skillDescriptionLengthRule,
+  skillDescriptionStrictYamlRule,
+  skillNameDirectoryMismatchRule,
+} from "./rules";
 export { runLintRules } from "./run";
 export type {
   LintDiagnostic,

--- a/packages/lint/src/registry.ts
+++ b/packages/lint/src/registry.ts
@@ -2,7 +2,7 @@ import type { LintRule } from "./types";
 
 /**
  * Explicit rule registry. Rules are registered by name; no implicit
- * discovery. Empty until SET-56/57 migrate rules in.
+ * discovery. Built-in rules register on package import (see ./rules).
  */
 export const lintRules = new Map<string, LintRule>();
 

--- a/packages/lint/src/rules/description.ts
+++ b/packages/lint/src/rules/description.ts
@@ -1,0 +1,123 @@
+import type { LintDiagnostic, LintRule, LintSubject } from "../types";
+
+/**
+ * Harnesses (claude.ai, Claude Code plugin validation) reject skill
+ * descriptions longer than 1024 characters.
+ */
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+/** Bare angle-bracket token, e.g. `<task>`, that HTML-ish validators parse as a tag. */
+const HTML_TOKEN_PATTERN = /<[A-Za-z][\w-]*>/u;
+
+/** Inline code spans are exempt from the HTML-token check. */
+const BACKTICK_SPAN_PATTERN = /`[^`]*`/gu;
+
+const readDescription = (subject: LintSubject): string | undefined => {
+  const { description } = subject.frontmatter;
+  return typeof description === "string" ? description : undefined;
+};
+
+export const skillDescriptionLengthRule: LintRule = {
+  check: (subject): readonly LintDiagnostic[] => {
+    const description = readDescription(subject);
+    if (description === undefined) {
+      return [];
+    }
+    const { length } = [...description];
+    if (length <= MAX_DESCRIPTION_LENGTH) {
+      return [];
+    }
+    return [
+      {
+        guidance: {
+          summary: `Shorten the description; harnesses reject descriptions longer than ${MAX_DESCRIPTION_LENGTH} characters.`,
+        },
+        message: `description is ${length} characters; the maximum is ${MAX_DESCRIPTION_LENGTH}`,
+        path: subject.path,
+        rule: "skill-description-length",
+        severity: "error",
+      },
+    ];
+  },
+  description:
+    "Skill descriptions must stay within the 1024-character harness limit.",
+  name: "skill-description-length",
+  severity: "error",
+};
+
+export const skillDescriptionHtmlTokenRule: LintRule = {
+  check: (subject): readonly LintDiagnostic[] => {
+    const description = readDescription(subject);
+    if (description === undefined) {
+      return [];
+    }
+    const stripped = description.replace(BACKTICK_SPAN_PATTERN, "");
+    const match = stripped.match(HTML_TOKEN_PATTERN);
+    if (match === null) {
+      return [];
+    }
+    return [
+      {
+        guidance: {
+          summary: `Backtick-wrap ${match[0]} or rephrase it; downstream plugin validators parse bare angle-bracket tokens as HTML.`,
+        },
+        message: `description contains a bare angle-bracket token ${match[0]}`,
+        path: subject.path,
+        rule: "skill-description-html-token",
+        severity: "error",
+      },
+    ];
+  },
+  description:
+    "Skill descriptions must not contain bare angle-bracket tokens outside inline code spans.",
+  name: "skill-description-html-token",
+  severity: "error",
+};
+
+/** Single-line `description:` value inside the leading frontmatter block. */
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/u;
+
+export const skillDescriptionStrictYamlRule: LintRule = {
+  check: (subject): readonly LintDiagnostic[] => {
+    const frontmatter = subject.raw.match(FRONTMATTER_PATTERN)?.[1];
+    if (frontmatter === undefined) {
+      return [];
+    }
+    const line = frontmatter
+      .split(/\r?\n/u)
+      .find((candidate) => candidate.startsWith("description:"));
+    if (line === undefined) {
+      return [];
+    }
+    const value = line.slice("description:".length).trim();
+    // Absent or multi-line values have nothing on the key line to misparse.
+    if (value === "") {
+      return [];
+    }
+    const first = value[0];
+    // Quoted and block-scalar values are safe under strict YAML parsers.
+    if (first === '"' || first === "'" || first === "|" || first === ">") {
+      return [];
+    }
+    if (!value.includes(": ")) {
+      return [];
+    }
+    return [
+      {
+        guidance: {
+          summary:
+            'Quote the description value (or use a block scalar); strict YAML parsers such as js-yaml reject unquoted plain scalars containing ": ".',
+        },
+        message:
+          'unquoted description value contains ": ", which strict YAML parsers reject',
+        path: subject.path,
+        rule: "skill-description-strict-yaml",
+        severity: "error",
+      },
+    ];
+  },
+  description:
+    'Unquoted single-line description values must not contain ": " so strict YAML parsers can read them.',
+  name: "skill-description-strict-yaml",
+  severity: "error",
+};

--- a/packages/lint/src/rules/index.ts
+++ b/packages/lint/src/rules/index.ts
@@ -1,0 +1,27 @@
+import { registerLintRule } from "../registry";
+import type { LintRule } from "../types";
+import {
+  skillDescriptionHtmlTokenRule,
+  skillDescriptionLengthRule,
+  skillDescriptionStrictYamlRule,
+} from "./description";
+import { skillNameDirectoryMismatchRule } from "./name-directory";
+
+/** Built-in frontmatter rules, registered on package import. */
+export const builtinLintRules: readonly LintRule[] = [
+  skillDescriptionHtmlTokenRule,
+  skillDescriptionLengthRule,
+  skillDescriptionStrictYamlRule,
+  skillNameDirectoryMismatchRule,
+];
+
+for (const rule of builtinLintRules) {
+  registerLintRule(rule);
+}
+
+export {
+  skillDescriptionHtmlTokenRule,
+  skillDescriptionLengthRule,
+  skillDescriptionStrictYamlRule,
+  skillNameDirectoryMismatchRule,
+};

--- a/packages/lint/src/rules/name-directory.ts
+++ b/packages/lint/src/rules/name-directory.ts
@@ -1,0 +1,34 @@
+import type { LintDiagnostic, LintRule } from "../types";
+
+/**
+ * The Skillset resolver prefers frontmatter `name` over the directory name when
+ * deriving the skill id (apps/skillset resolver), so a mismatch silently
+ * renames the generated skill away from its source directory. Harness plugin
+ * validators additionally require the two to agree.
+ */
+export const skillNameDirectoryMismatchRule: LintRule = {
+  check: (subject): readonly LintDiagnostic[] => {
+    const { name } = subject.frontmatter;
+    if (typeof name !== "string" || name === "") {
+      return [];
+    }
+    if (name === subject.directoryName) {
+      return [];
+    }
+    return [
+      {
+        guidance: {
+          summary:
+            "Rename the skill directory or the frontmatter name so they match; mismatches silently rename the generated skill.",
+        },
+        message: `frontmatter name ${name} does not match skill directory ${subject.directoryName}`,
+        path: subject.path,
+        rule: "skill-name-directory-mismatch",
+        severity: "error",
+      },
+    ];
+  },
+  description: "Frontmatter name must match the skill directory name.",
+  name: "skill-name-directory-mismatch",
+  severity: "error",
+};

--- a/packages/lint/src/types.ts
+++ b/packages/lint/src/types.ts
@@ -18,12 +18,19 @@ export interface LintDiagnostic {
 
 /**
  * Minimal lint subject shape. SET-56/57 grow this as rules migrate in.
+ * Compiler-agnostic: adapters construct one subject per skill.
  */
 export interface LintSubject {
   readonly kind: "skill";
+  /** Repo-relative path to the skill's SKILL.md. */
   readonly path: string;
+  /** Name of the directory containing SKILL.md. */
+  readonly directoryName: string;
   readonly frontmatter: Record<string, unknown>;
+  /** Markdown body with frontmatter stripped. */
   readonly body: string;
+  /** Full original SKILL.md text, frontmatter included. */
+  readonly raw: string;
   readonly files: readonly string[];
 }
 


### PR DESCRIPTION
`LintIssue` gains `error|warn` severity: lint throws only on errors; warnings flow through `lint`/`doctor`/`ci` reporting without failing (ci's `--fix` gate keys off errors only). Four rules land in `@skillset/lint` from harness reality: description ≤1024 chars, bare HTML tokens in descriptions, strict-YAML description quoting, and name/directory mismatch (which the resolver silently allowed — frontmatter `name` was quietly winning over the directory). Wired via a per-skill `LintSubject` adapter; zero hits on our own source or the 40 external-fixture skills.

Linear: https://linear.app/outfitter/issue/SET-56
Gates: `bun run check` ✓ · 325 tests ✓ · external fixture lint stage ✓

Stacked on #31.