### PR TITLE
feat(lint): add skill portability and shell-safety rules

### DIFF
--- a/apps/skillset/src/__tests__/lint-rules.test.ts
+++ b/apps/skillset/src/__tests__/lint-rules.test.ts
@@ -49,6 +49,46 @@ test("lintSkillset throws on an error-severity rule violation", async () => {
   );
 });
 
+test("lintSkillset throws on a shell-safety pre-resolution violation", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md":
+      '---\nname: demo\ndescription: Demo.\n---\n\n!`[ -n "$x" ] && echo yes || echo no`\n',
+  });
+
+  await expect(lintSkillset(root)).rejects.toThrow(
+    "skill-preresolve-mixed-and-or"
+  );
+  await expect(lintSkillset(root)).rejects.toThrow(
+    "mixes `&&` and `||` at the same depth"
+  );
+});
+
+test("ci reports env-var fallback warnings without failing", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md":
+      "---\nname: demo\ndescription: Demo.\n---\n\nRun python3 ${CLAUDE_PLUGIN_ROOT}/scripts/setup.py first.\n",
+  });
+  await commitFixture(root);
+  await buildSkillset(root);
+
+  const report = await ciSkillset(root, { since: "HEAD" });
+
+  expect(report.ok).toBe(true);
+  expect(
+    report.lintIssues.some(
+      (issue) =>
+        issue.code === "skill-env-var-no-fallback" && issue.severity === "warn"
+    )
+  ).toBe(true);
+  const markdown = renderCiReportMarkdown(report);
+  expect(markdown).toContain("### Lint warnings");
+  expect(markdown).toContain("${CLAUDE_PLUGIN_ROOT}");
+});
+
 test("lintSkillset returns warn-only issues without throwing", async () => {
   const root = await fixture({
     ".skillset/config.yaml":

--- a/packages/lint/src/__tests__/portability-rules.test.ts
+++ b/packages/lint/src/__tests__/portability-rules.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  skillEnvVarNoFallbackRule,
+  skillFileReferenceEscapeRule,
+  skillPreresolveCaseStatementRule,
+  skillPreresolveMixedAndOrRule,
+  skillPreresolveParameterExpansionRule,
+  skillPreresolveQuotedSubstitutionRule,
+  skillPreresolveSemicolonRule,
+} from "../rules";
+import type { LintSubject } from "../types";
+
+const makeSubject = (body: string): LintSubject => ({
+  body,
+  directoryName: "demo",
+  files: ["SKILL.md"],
+  frontmatter: { description: "Demo skill.", name: "demo" },
+  kind: "skill",
+  path: ".skillset/skills/demo/SKILL.md",
+  raw: `---\nname: demo\ndescription: Demo skill.\n---\n\n${body}`,
+});
+
+describe("skill-file-reference-escape", () => {
+  test("flags relative traversal out of the skill directory", () => {
+    const diagnostics = skillFileReferenceEscapeRule.check(
+      makeSubject("See [schema](../other-skill/references/schema.yaml).")
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-file-reference-escape");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.message).toContain(
+      "../other-skill/references/schema.yaml"
+    );
+    expect(diagnostics[0]?.guidance?.summary).toContain("self-contained");
+  });
+
+  test("flags absolute filesystem paths, including images", () => {
+    const diagnostics = skillFileReferenceEscapeRule.check(
+      makeSubject(
+        "![diagram](/Users/demo/diagram.png) and [doc](/etc/skill/doc.md)"
+      )
+    );
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "links to /Users/demo/diagram.png, which escapes the skill directory",
+      "links to /etc/skill/doc.md, which escapes the skill directory",
+    ]);
+  });
+
+  test("flags mid-path traversal and dedupes repeats", () => {
+    const body =
+      "[a](references/../../escape.md) and again [b](references/../../escape.md)";
+    expect(skillFileReferenceEscapeRule.check(makeSubject(body))).toHaveLength(
+      1
+    );
+  });
+
+  test("passes skill-local links, URLs, anchors, and resource references", () => {
+    const body = [
+      "[local](references/guide.md)",
+      "[script](./scripts/run.sh)",
+      "[site](https://example.com/../up)",
+      "[mail](mailto:demo@example.com)",
+      "[anchor](#section)",
+      "[shared](shared:guides/intro.md)",
+    ].join("\n");
+    expect(skillFileReferenceEscapeRule.check(makeSubject(body))).toEqual([]);
+  });
+
+  test("ignores example links inside fenced code blocks and inline code", () => {
+    const body = [
+      "```markdown",
+      "- [Tenets](../tenets.md) - governing design principles.",
+      "```",
+      "Inline `[Doc title](../path.md)` example.",
+    ].join("\n");
+    expect(skillFileReferenceEscapeRule.check(makeSubject(body))).toEqual([]);
+  });
+});
+
+describe("skill-env-var-no-fallback", () => {
+  test("flags a platform placeholder with no fallback on the line", () => {
+    const diagnostics = skillEnvVarNoFallbackRule.check(
+      makeSubject("Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/setup.py`.")
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-env-var-no-fallback");
+    expect(diagnostics[0]?.severity).toBe("warn");
+    expect(diagnostics[0]?.message).toContain("${CLAUDE_PLUGIN_ROOT}");
+    expect(diagnostics[0]?.guidance?.summary).toContain("relative");
+  });
+
+  test("flags CODEX placeholders and reports one diagnostic per line", () => {
+    const body = "${CODEX_SESSION_ID}\nplain text\n${CLAUDE_SKILL_DIR}";
+    expect(skillEnvVarNoFallbackRule.check(makeSubject(body))).toHaveLength(2);
+  });
+
+  test("passes lines with a `:-` default or an `||` fallback", () => {
+    const body = [
+      'bash "${CLAUDE_SKILL_DIR:-.}/scripts/run.sh"',
+      'echo "${CLAUDE_PLUGIN_ROOT}" || echo unresolved',
+      "no placeholder here",
+    ].join("\n");
+    expect(skillEnvVarNoFallbackRule.check(makeSubject(body))).toEqual([]);
+  });
+});
+
+const preresolve = (command: string): string => `Intro.\n\n!\`${command}\`\n`;
+
+describe("skill-preresolve-case-statement", () => {
+  test("flags `case ... esac` inside a pre-resolution command", () => {
+    const diagnostics = skillPreresolveCaseStatementRule.check(
+      makeSubject(preresolve('case "$x" in /*) echo a ;; *) echo b ;; esac'))
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-preresolve-case-statement");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.guidance?.summary).toContain("case ... esac");
+  });
+
+  test("ignores case statements outside pre-resolution lines", () => {
+    expect(
+      skillPreresolveCaseStatementRule.check(
+        makeSubject('Run case "$x" in ... esac in a script instead.')
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("skill-preresolve-semicolon", () => {
+  test("flags a top-level `;` separator", () => {
+    const diagnostics = skillPreresolveSemicolonRule.check(
+      makeSubject(preresolve("git fetch; git status"))
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-preresolve-semicolon");
+    expect(diagnostics[0]?.severity).toBe("error");
+  });
+
+  test("passes `;` inside a subshell or quotes", () => {
+    for (const command of [
+      "(a; b) || echo fallback",
+      "echo 'a; b'",
+      "git status",
+    ]) {
+      expect(
+        skillPreresolveSemicolonRule.check(makeSubject(preresolve(command)))
+      ).toEqual([]);
+    }
+  });
+});
+
+describe("skill-preresolve-mixed-and-or", () => {
+  test("flags `A && B || C` at the same depth", () => {
+    const diagnostics = skillPreresolveMixedAndOrRule.check(
+      makeSubject(preresolve('[ -n "$x" ] && echo yes || echo no'))
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-preresolve-mixed-and-or");
+    expect(diagnostics[0]?.guidance?.summary).toContain("(A && B) || C");
+  });
+
+  test("passes `(A && B) || C` and single-operator chains", () => {
+    for (const command of [
+      "(a && b) || echo fallback",
+      "a && b && c",
+      "cmd 2>/dev/null || echo fallback",
+    ]) {
+      expect(
+        skillPreresolveMixedAndOrRule.check(makeSubject(preresolve(command)))
+      ).toEqual([]);
+    }
+  });
+});
+
+describe("skill-preresolve-quoted-substitution", () => {
+  test("flags `$(...)` containing a double quote", () => {
+    const diagnostics = skillPreresolveQuotedSubstitutionRule.check(
+      makeSubject(preresolve('basename "$(dirname "$common")"'))
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe("skill-preresolve-quoted-substitution");
+    expect(diagnostics[0]?.guidance?.summary).toContain("script");
+  });
+
+  test("passes `$(...)` without inner double quotes", () => {
+    expect(
+      skillPreresolveQuotedSubstitutionRule.check(
+        makeSubject(
+          preresolve(
+            'cat "$(git rev-parse --show-toplevel 2>/dev/null)/config.yaml" 2>/dev/null || echo none'
+          )
+        )
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("skill-preresolve-parameter-expansion", () => {
+  test("flags parameter-expansion operators", () => {
+    for (const command of [
+      'repo="${common%/.git}"',
+      'echo "${repo##*/}"',
+      'echo "${var:-fallback}"',
+      'echo "${var/foo/bar}"',
+    ]) {
+      const diagnostics = skillPreresolveParameterExpansionRule.check(
+        makeSubject(preresolve(command))
+      );
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.rule).toBe("skill-preresolve-parameter-expansion");
+    }
+  });
+
+  test("passes plain `${VAR}` expansion", () => {
+    expect(
+      skillPreresolveParameterExpansionRule.check(
+        makeSubject(preresolve('echo "${CLAUDE_PLUGIN_ROOT}"'))
+      )
+    ).toEqual([]);
+  });
+});

--- a/packages/lint/src/__tests__/shell.test.ts
+++ b/packages/lint/src/__tests__/shell.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  findCommandSubstitutions,
+  findTopLevelSeparators,
+  hasTopLevelMixedAndOr,
+  hasTopLevelSemicolon,
+} from "../shell";
+
+// Cases adapted from compound-engineering-plugin's
+// tests/skill-shell-safety.test.ts reference implementation.
+
+describe("hasTopLevelMixedAndOr", () => {
+  test("flags the `[A] && B || C` antipattern", () => {
+    expect(hasTopLevelMixedAndOr('[ -n "$x" ] && echo yes || echo no')).toBe(
+      true
+    );
+  });
+
+  test("does not flag `&&`-only chains", () => {
+    expect(hasTopLevelMixedAndOr('a=$(cmd) && [ -n "$a" ] && echo "$a"')).toBe(
+      false
+    );
+  });
+
+  test("does not flag `||`-only chains", () => {
+    expect(hasTopLevelMixedAndOr("cmd 2>/dev/null || echo fallback")).toBe(
+      false
+    );
+  });
+
+  test("does not flag `&&` inside subshells with `||` only at top level", () => {
+    expect(hasTopLevelMixedAndOr("(a && b) || (c && d) || echo fallback")).toBe(
+      false
+    );
+  });
+
+  test("does not flag operators inside quoted strings", () => {
+    expect(hasTopLevelMixedAndOr('echo "a && b || c"')).toBe(false);
+  });
+
+  test("does not flag `&&` inside `$(...)` with `||` at top level", () => {
+    expect(hasTopLevelMixedAndOr("x=$(a && b) || echo fallback")).toBe(false);
+  });
+});
+
+describe("hasTopLevelSemicolon", () => {
+  test("flags a bare `;` separator", () => {
+    expect(hasTopLevelSemicolon("setup; cmd")).toBe(true);
+  });
+
+  test("does not flag `;` inside a `(...)` subshell", () => {
+    expect(
+      hasTopLevelSemicolon(
+        '(top=$(git rev-parse --show-toplevel 2>/dev/null); cat "$top/file") || echo fallback'
+      )
+    ).toBe(false);
+  });
+
+  test("does not flag `;` inside quotes", () => {
+    expect(hasTopLevelSemicolon("echo 'a; b' \"c; d\"")).toBe(false);
+  });
+});
+
+describe("findTopLevelSeparators", () => {
+  test("reports separators in order", () => {
+    expect(findTopLevelSeparators("a; b && c || d")).toEqual([";", "&&", "||"]);
+  });
+
+  test("ignores separators below the top level", () => {
+    expect(findTopLevelSeparators("(a; b && c) || d")).toEqual(["||"]);
+  });
+});
+
+describe("findCommandSubstitutions", () => {
+  test("captures `$(...)` contents through double quotes", () => {
+    expect(findCommandSubstitutions('basename "$(dirname "$common")"')).toEqual(
+      ['dirname "$common"']
+    );
+  });
+
+  test("captures nested `$(...)` as one outer span", () => {
+    expect(
+      findCommandSubstitutions('basename "$(dirname "$(dirname "$x")")"')
+    ).toEqual(['dirname "$(dirname "$x")"']);
+  });
+
+  test("skips `$(` inside single quotes", () => {
+    expect(findCommandSubstitutions("echo '$(not a substitution)'")).toEqual(
+      []
+    );
+  });
+
+  test("returns nothing for plain commands", () => {
+    expect(findCommandSubstitutions("git status")).toEqual([]);
+  });
+});

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -4,9 +4,22 @@ export {
   skillDescriptionHtmlTokenRule,
   skillDescriptionLengthRule,
   skillDescriptionStrictYamlRule,
+  skillEnvVarNoFallbackRule,
+  skillFileReferenceEscapeRule,
   skillNameDirectoryMismatchRule,
+  skillPreresolveCaseStatementRule,
+  skillPreresolveMixedAndOrRule,
+  skillPreresolveParameterExpansionRule,
+  skillPreresolveQuotedSubstitutionRule,
+  skillPreresolveSemicolonRule,
 } from "./rules";
 export { runLintRules } from "./run";
+export {
+  findCommandSubstitutions,
+  findTopLevelSeparators,
+  hasTopLevelMixedAndOr,
+  hasTopLevelSemicolon,
+} from "./shell";
 export type {
   LintDiagnostic,
   LintGuidance,

--- a/packages/lint/src/rules/env-fallback.ts
+++ b/packages/lint/src/rules/env-fallback.ts
@@ -1,0 +1,43 @@
+import type { LintDiagnostic, LintRule, LintSubject } from "../types";
+
+/**
+ * Plain platform env-var placeholder, e.g. `${CLAUDE_PLUGIN_ROOT}` or
+ * `${CODEX_SESSION_ID}`. A placeholder carrying a bash default
+ * (`${CLAUDE_SKILL_DIR:-.}`) does not match: the `}` must directly follow
+ * the variable name.
+ */
+const PLAIN_PLACEHOLDER_PATTERN = /\$\{(?:CLAUDE|CODEX)_[A-Z0-9_]+\}/u;
+
+const hasFallbackMarker = (line: string): boolean =>
+  line.includes(":-") || line.includes("||");
+
+/**
+ * Warn (not error): knowingly target-locked skills legitimately rely on a
+ * single platform's variables. Portable skills should prefer relative paths
+ * or carry an explicit fallback so other harnesses degrade gracefully.
+ */
+export const skillEnvVarNoFallbackRule: LintRule = {
+  check: (subject: LintSubject): readonly LintDiagnostic[] => {
+    const diagnostics: LintDiagnostic[] = [];
+    for (const line of subject.body.split(/\r?\n/u)) {
+      const match = line.match(PLAIN_PLACEHOLDER_PATTERN);
+      if (match === null || hasFallbackMarker(line)) {
+        continue;
+      }
+      diagnostics.push({
+        guidance: {
+          summary: `Prefer paths relative to the skill directory; if ${match[0]} is unavoidable, provide an explicit fallback (a \`:-\` bash default or an \`||\` alternative) so targets that do not set it degrade gracefully.`,
+        },
+        message: `uses platform placeholder ${match[0]} without a fallback`,
+        path: subject.path,
+        rule: "skill-env-var-no-fallback",
+        severity: "warn",
+      });
+    }
+    return diagnostics;
+  },
+  description:
+    "Platform env-var placeholders should carry a fallback so skills stay portable across targets.",
+  name: "skill-env-var-no-fallback",
+  severity: "warn",
+};

--- a/packages/lint/src/rules/file-reference.ts
+++ b/packages/lint/src/rules/file-reference.ts
@@ -1,0 +1,88 @@
+import type { LintDiagnostic, LintRule, LintSubject } from "../types";
+
+/**
+ * Markdown link/image destinations, mirroring the pattern the compiler's
+ * resource machinery scans (apps/skillset/src/resources.ts). That machinery
+ * only validates `shared:`/`plugin:` resource URLs and plugin-root script
+ * links; bare `../` traversal and absolute filesystem paths pass through
+ * untouched, so this rule covers them.
+ */
+const LINK_PATTERN = /!?\[[^\]\n]*\]\((?<destination>[^) \t\n]+)\)/gu;
+
+/** Destinations with a URL scheme (`https://`, `mailto:`, `shared:`, ...). */
+const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/iu;
+
+const FENCE_PATTERN = /^\s*(?:```|~~~)/u;
+
+const INLINE_CODE_PATTERN = /`[^`]*`/gu;
+
+/**
+ * Blank out fenced code blocks and inline code spans so example links in
+ * documentation (e.g. an ADR template showing `[Tenets](../tenets.md)`)
+ * are not treated as real file references.
+ */
+const maskCodeRegions = (body: string): string => {
+  let inFence = false;
+  const lines = body.split(/\r?\n/u).map((line) => {
+    if (FENCE_PATTERN.test(line)) {
+      inFence = !inFence;
+      return "";
+    }
+    if (inFence) {
+      return "";
+    }
+    return line.replace(INLINE_CODE_PATTERN, "");
+  });
+  return lines.join("\n");
+};
+
+const escapesSkillDirectory = (destination: string): boolean => {
+  if (destination.startsWith("/")) {
+    return true;
+  }
+  const segments = destination.split("/");
+  return segments.includes("..");
+};
+
+/**
+ * SKILL.md sits at the skill-directory root, so any `../` link target or
+ * absolute filesystem path leaves the skill's own tree. Skills install at
+ * unpredictable locations (versioned plugin caches, per-target output
+ * roots) and are copied as isolated units, so escaping references break
+ * after install or conversion.
+ */
+export const skillFileReferenceEscapeRule: LintRule = {
+  check: (subject: LintSubject): readonly LintDiagnostic[] => {
+    const masked = maskCodeRegions(subject.body);
+    const flagged = new Set<string>();
+    const diagnostics: LintDiagnostic[] = [];
+    for (const match of masked.matchAll(LINK_PATTERN)) {
+      const destination = match.groups?.destination;
+      if (
+        destination === undefined ||
+        destination.startsWith("#") ||
+        SCHEME_PATTERN.test(destination) ||
+        !escapesSkillDirectory(destination) ||
+        flagged.has(destination)
+      ) {
+        continue;
+      }
+      flagged.add(destination);
+      diagnostics.push({
+        guidance: {
+          summary:
+            "Skills must be self-contained: move the file into the skill directory (references/, scripts/, assets/) and link it with a skill-relative path, or declare it via resources (shared:/plugin:) so the build copies it skill-local.",
+        },
+        message: `links to ${destination}, which escapes the skill directory`,
+        path: subject.path,
+        rule: "skill-file-reference-escape",
+        severity: "error",
+      });
+    }
+    return diagnostics;
+  },
+  description:
+    "Skill bodies must not link to files outside the skill's own directory tree.",
+  name: "skill-file-reference-escape",
+  severity: "error",
+};

--- a/packages/lint/src/rules/index.ts
+++ b/packages/lint/src/rules/index.ts
@@ -5,14 +5,30 @@ import {
   skillDescriptionLengthRule,
   skillDescriptionStrictYamlRule,
 } from "./description";
+import { skillEnvVarNoFallbackRule } from "./env-fallback";
+import { skillFileReferenceEscapeRule } from "./file-reference";
 import { skillNameDirectoryMismatchRule } from "./name-directory";
+import {
+  skillPreresolveCaseStatementRule,
+  skillPreresolveMixedAndOrRule,
+  skillPreresolveParameterExpansionRule,
+  skillPreresolveQuotedSubstitutionRule,
+  skillPreresolveSemicolonRule,
+} from "./preresolve";
 
-/** Built-in frontmatter rules, registered on package import. */
+/** Built-in rules, registered on package import. */
 export const builtinLintRules: readonly LintRule[] = [
   skillDescriptionHtmlTokenRule,
   skillDescriptionLengthRule,
   skillDescriptionStrictYamlRule,
+  skillEnvVarNoFallbackRule,
+  skillFileReferenceEscapeRule,
   skillNameDirectoryMismatchRule,
+  skillPreresolveCaseStatementRule,
+  skillPreresolveMixedAndOrRule,
+  skillPreresolveParameterExpansionRule,
+  skillPreresolveQuotedSubstitutionRule,
+  skillPreresolveSemicolonRule,
 ];
 
 for (const rule of builtinLintRules) {
@@ -23,5 +39,12 @@ export {
   skillDescriptionHtmlTokenRule,
   skillDescriptionLengthRule,
   skillDescriptionStrictYamlRule,
+  skillEnvVarNoFallbackRule,
+  skillFileReferenceEscapeRule,
   skillNameDirectoryMismatchRule,
+  skillPreresolveCaseStatementRule,
+  skillPreresolveMixedAndOrRule,
+  skillPreresolveParameterExpansionRule,
+  skillPreresolveQuotedSubstitutionRule,
+  skillPreresolveSemicolonRule,
 };

--- a/packages/lint/src/rules/preresolve.ts
+++ b/packages/lint/src/rules/preresolve.ts
@@ -1,0 +1,123 @@
+import {
+  findCommandSubstitutions,
+  hasTopLevelMixedAndOr,
+  hasTopLevelSemicolon,
+} from "../shell";
+import type { LintDiagnostic, LintRule, LintSubject } from "../types";
+
+/**
+ * Claude Code runs `` !`command` `` pre-resolution placeholders through its
+ * shell safety check at skill-load time. Several bash shapes are rejected
+ * outright, failing the skill before its body ever runs. Each rule below
+ * targets one rejected shape, ported from the incidents documented in
+ * compound-engineering-plugin's tests/skill-shell-safety.test.ts.
+ */
+
+interface PreResolutionCommand {
+  readonly command: string;
+  readonly line: number;
+}
+
+/**
+ * Lines whose trimmed content is a single inline pre-resolution command:
+ * starts with `` !` `` and ends with a closing backtick.
+ */
+const findPreResolutionCommands = (
+  body: string
+): readonly PreResolutionCommand[] => {
+  const commands: PreResolutionCommand[] = [];
+  for (const [index, raw] of body.split(/\r?\n/u).entries()) {
+    const trimmed = raw.trim();
+    if (!(trimmed.startsWith("!`") && trimmed.endsWith("`"))) {
+      continue;
+    }
+    const command = trimmed.slice(2, -1);
+    if (command === "") {
+      continue;
+    }
+    commands.push({ command, line: index + 1 });
+  }
+  return commands;
+};
+
+interface PreresolveRuleSpec {
+  readonly description: string;
+  readonly guidance: string;
+  readonly name: string;
+  readonly offends: (command: string) => boolean;
+  readonly reason: string;
+}
+
+const makePreresolveRule = (spec: PreresolveRuleSpec): LintRule => ({
+  check: (subject: LintSubject): readonly LintDiagnostic[] =>
+    findPreResolutionCommands(subject.body)
+      .filter(({ command }) => spec.offends(command))
+      .map(({ command }) => ({
+        guidance: { summary: spec.guidance },
+        message: `pre-resolution command ${spec.reason}: \`${command}\``,
+        path: subject.path,
+        rule: spec.name,
+        severity: "error",
+      })),
+  description: spec.description,
+  name: spec.name,
+  severity: "error",
+});
+
+const CASE_STATEMENT_PATTERN = /\bcase\b[\s\S]*\besac\b/u;
+
+export const skillPreresolveCaseStatementRule: LintRule = makePreresolveRule({
+  description:
+    "Pre-resolution commands must not contain case statements; Claude Code's safety check rejects them.",
+  guidance:
+    "Claude Code rejects `case ... esac` in `!` pre-resolution commands. Use `if`/`&&`/`||` chaining or extract the logic to a script invoked from the skill body.",
+  name: "skill-preresolve-case-statement",
+  offends: (command) => CASE_STATEMENT_PATTERN.test(command),
+  reason: "contains a `case ... esac` statement",
+});
+
+export const skillPreresolveSemicolonRule: LintRule = makePreresolveRule({
+  description:
+    "Pre-resolution commands must not use top-level `;` separators; Claude Code's safety check rejects them.",
+  guidance:
+    "Claude Code rejects `;` command separators in `!` pre-resolution commands. Chain with `&&`/`||`, wrap the statements in a `(...)` subshell, or extract to a script.",
+  name: "skill-preresolve-semicolon",
+  offends: hasTopLevelSemicolon,
+  reason: "uses a top-level `;` separator",
+});
+
+export const skillPreresolveMixedAndOrRule: LintRule = makePreresolveRule({
+  description:
+    "Pre-resolution commands must not mix `&&` and `||` at the same depth; Claude Code rejects the shape as ambiguous.",
+  guidance:
+    'Claude Code rejects the `A && B || C` shape as "ambiguous syntax with command separators". Wrap the `&&` chain in a subshell so only `||` remains at top level: `(A && B) || C`.',
+  name: "skill-preresolve-mixed-and-or",
+  offends: hasTopLevelMixedAndOr,
+  reason: "mixes `&&` and `||` at the same depth",
+});
+
+export const skillPreresolveQuotedSubstitutionRule: LintRule =
+  makePreresolveRule({
+    description:
+      "Pre-resolution commands must not nest double-quoted strings inside `$(...)`; Claude Code rejects the shape.",
+    guidance:
+      'Claude Code rejects `$(...)` containing a double-quoted string as "Unhandled node type: string" (e.g. `basename "$(dirname "$common")"`). Extract the logic to a script invoked from the skill body.',
+    name: "skill-preresolve-quoted-substitution",
+    offends: (command) =>
+      findCommandSubstitutions(command).some((inner) => inner.includes('"')),
+    reason: "nests a double-quoted string inside `$(...)`",
+  });
+
+/** `${VAR` followed by a parameter-expansion operator; plain `${VAR}` is fine. */
+const PARAMETER_EXPANSION_PATTERN = /\$\{[A-Za-z_][A-Za-z0-9_]*[%#:/^,@-]/u;
+
+export const skillPreresolveParameterExpansionRule: LintRule =
+  makePreresolveRule({
+    description:
+      "Pre-resolution commands must not use bash parameter-expansion operators; Claude Code rejects them.",
+    guidance:
+      'Claude Code rejects parameter-expansion operators (`${var%pat}`, `${var##pat}`, `${var:-default}`, ...) as "Contains expansion". Use simple `${var}` only, or extract the logic to a script invoked from the skill body.',
+    name: "skill-preresolve-parameter-expansion",
+    offends: (command) => PARAMETER_EXPANSION_PATTERN.test(command),
+    reason: "uses a bash parameter-expansion operator",
+  });

--- a/packages/lint/src/shell.ts
+++ b/packages/lint/src/shell.ts
@@ -1,0 +1,151 @@
+/**
+ * Quote/depth-aware scanners for the bash command strings inside Claude
+ * Code's `` !`command` `` pre-resolution placeholders.
+ *
+ * Ported from the reference implementation in compound-engineering-plugin's
+ * tests/skill-shell-safety.test.ts (`hasTopLevelMixedAndOr`,
+ * `findCommandSubstitutionContents`), which documents the Claude Code
+ * permission-checker incidents behind each pattern (their issues #709/#710).
+ */
+
+export type TopLevelSeparator = ";" | "&&" | "||";
+
+/**
+ * Separators (`;`, `&&`, `||`) at the top lexical level of a command:
+ * outside single/double quotes and outside `(...)` subshells and `$(...)`
+ * command substitutions.
+ */
+export const findTopLevelSeparators = (
+  command: string
+): readonly TopLevelSeparator[] => {
+  const found: TopLevelSeparator[] = [];
+  let depth = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    const next = command[index + 1];
+
+    if (!inDoubleQuote && char === "'") {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+    if (!inSingleQuote && char === '"') {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+    if (inSingleQuote || inDoubleQuote) {
+      continue;
+    }
+
+    if (char === "$" && next === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth -= 1;
+      continue;
+    }
+    if (depth !== 0) {
+      continue;
+    }
+
+    if (char === ";") {
+      found.push(";");
+      continue;
+    }
+    if (char === "&" && next === "&") {
+      found.push("&&");
+      index += 1;
+      continue;
+    }
+    if (char === "|" && next === "|") {
+      found.push("||");
+      index += 1;
+    }
+  }
+
+  return found;
+};
+
+/**
+ * True when both `&&` and `||` appear at the same top lexical depth — the
+ * `[A] && B || C` shape Claude Code rejects as "ambiguous syntax with
+ * command separators". `(A && B) || C` is fine.
+ */
+export const hasTopLevelMixedAndOr = (command: string): boolean => {
+  const separators = findTopLevelSeparators(command);
+  return separators.includes("&&") && separators.includes("||");
+};
+
+/**
+ * True when a lone `;` separator appears at the top lexical depth. A `;`
+ * inside a `(...)` subshell is not flagged: wrapping a multi-statement
+ * chain in a subshell is the documented fix shape (compound-engineering
+ * ships `(top=$(...); ...) || echo fallback` in production skills).
+ */
+export const hasTopLevelSemicolon = (command: string): boolean =>
+  findTopLevelSeparators(command).includes(";");
+
+/**
+ * Contents of every top-level `$(...)` in the command, with parens matched
+ * correctly even when nested. Only single quotes suppress detection
+ * (matching the reference implementation): the canonical offender
+ * `basename "$(dirname "$common")"` places `$(` inside a double-quoted
+ * string, so double quotes must not hide substitutions.
+ */
+export const findCommandSubstitutions = (
+  command: string
+): readonly string[] => {
+  const results: string[] = [];
+  let index = 0;
+  let inSingleQuote = false;
+
+  while (index < command.length) {
+    const char = command[index];
+    if (char === "'") {
+      inSingleQuote = !inSingleQuote;
+      index += 1;
+      continue;
+    }
+    if (inSingleQuote) {
+      index += 1;
+      continue;
+    }
+    if (char === "$" && command[index + 1] === "(") {
+      let depth = 1;
+      let scan = index + 2;
+      const start = scan;
+      while (scan < command.length && depth > 0) {
+        if (command[scan] === "$" && command[scan + 1] === "(") {
+          depth += 1;
+          scan += 2;
+          continue;
+        }
+        if (command[scan] === "(") {
+          depth += 1;
+          scan += 1;
+          continue;
+        }
+        if (command[scan] === ")") {
+          depth -= 1;
+          scan += 1;
+          continue;
+        }
+        scan += 1;
+      }
+      results.push(command.slice(start, Math.max(start, scan - 1)));
+      index = scan;
+      continue;
+    }
+    index += 1;
+  }
+
+  return results;
+};


### PR DESCRIPTION
Skill portability + shell-safety rules in `@skillset/lint`: file references escaping the skill tree (complements resources.ts, which never rejected `../` or absolute body links), env-var placeholders without fallbacks (warn — 4 real hits on the external fixture's `coding-tutor`, correctly non-failing), and the five bash patterns Claude Code's `!` pre-resolution safety check rejects, ported from compound-engineering's incident-annotated test suite with a depth-aware scanner (their documented `(A && B) || C` subshell fix passes; naive semicolon matching would have false-positived on their production skills).

Linear: https://linear.app/outfitter/issue/SET-57
Gates: `bun run check` ✓ · 360 tests ✓ · external fixture run ✓

Top of the Quality floor stack.