### PR TITLE
feat(build): add --isolated mirror output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ skillset init               # preview a minimal .skillset/ scaffold for the curr
 skillset create             # preview a new my-skillset source repo scaffold
 skillset build              # plan generated changes without writing
 skillset build --yes        # write generated outputs
+skillset build --isolated   # mirror the projection under .skillset/build/out/ (also: check, diff)
 skillset lint               # source authoring diagnostics
 skillset check              # fail if generated outputs are stale
 skillset diff               # show pending generated changes without writing

--- a/apps/skillset/src/__tests__/isolated-build.test.ts
+++ b/apps/skillset/src/__tests__/isolated-build.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildSkillset, checkSkillset, diffSkillset, ISOLATED_OUT_ROOT } from "../build";
+
+const DEMO_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": `
+skillset:
+  name: isolated-root
+claude: true
+codex: true
+`,
+  ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Body.
+`,
+  ".skillset/instructions/guide.md": `
+---
+name: guide
+description: Guide.
+---
+
+Guidance body.
+`,
+};
+
+const LIVE_SKILL = ".claude/skills/demo/SKILL.md";
+const MIRROR_SKILL = join(ISOLATED_OUT_ROOT, LIVE_SKILL);
+
+test("isolated build writes the full projection under the mirror only", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+
+  const rendered = await buildSkillset(root, { isolated: true });
+
+  expect(rendered.length).toBeGreaterThan(0);
+  for (const file of rendered) {
+    expect(file.path).toStartWith(`${ISOLATED_OUT_ROOT}/`);
+  }
+  expect(await exists(join(root, LIVE_SKILL))).toBe(false);
+  expect(await exists(join(root, "AGENTS.md"))).toBe(false);
+  expect(await exists(join(root, ".skillset.lock"))).toBe(false);
+  expect(await exists(join(root, MIRROR_SKILL))).toBe(true);
+  expect(await exists(join(root, ISOLATED_OUT_ROOT, "AGENTS.md"))).toBe(true);
+  expect(await exists(join(root, ISOLATED_OUT_ROOT, ".skillset.lock"))).toBe(true);
+  expect(await exists(join(root, ISOLATED_OUT_ROOT, ".claude/skills/.skillset.lock"))).toBe(true);
+});
+
+test("isolated build leaves a previous live build byte-unchanged", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+  const liveRendered = await buildSkillset(root);
+  const before = await hashPaths(root, liveRendered.map((file) => file.path));
+
+  await buildSkillset(root, { isolated: true });
+
+  const after = await hashPaths(root, liveRendered.map((file) => file.path));
+  expect(after).toEqual(before);
+});
+
+test("isolated check tracks the mirror while live check tracks live output", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+  await buildSkillset(root);
+  await buildSkillset(root, { isolated: true });
+
+  expect((await checkSkillset(root, { isolated: true })).checkedFiles).toBeGreaterThan(0);
+
+  const mirrorPath = join(root, MIRROR_SKILL);
+  await writeFile(mirrorPath, `${await readFile(mirrorPath, "utf8")}\nhand edit\n`);
+
+  await expect(checkSkillset(root, { isolated: true })).rejects.toThrow(MIRROR_SKILL);
+  expect((await checkSkillset(root)).checkedFiles).toBeGreaterThan(0);
+});
+
+test("isolated diff reports drift against the mirror only", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+  await buildSkillset(root);
+  await buildSkillset(root, { isolated: true });
+
+  const mirrorPath = join(root, MIRROR_SKILL);
+  await writeFile(mirrorPath, `${await readFile(mirrorPath, "utf8")}\nhand edit\n`);
+
+  const isolatedDiff = await diffSkillset(root, { isolated: true });
+  expect(isolatedDiff.changed).toEqual([MIRROR_SKILL]);
+  expect(isolatedDiff.added).toEqual([]);
+  expect(isolatedDiff.missing).toEqual([]);
+  expect(isolatedDiff.removed).toEqual([]);
+
+  const liveDiff = await diffSkillset(root);
+  expect(liveDiff).toEqual({ added: [], changed: [], missing: [], removed: [] });
+});
+
+test("isolated rebuild is idempotent", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+  await buildSkillset(root, { isolated: true });
+  const before = await mirrorTreeHashes(root);
+
+  await buildSkillset(root, { isolated: true });
+
+  expect(await mirrorTreeHashes(root)).toEqual(before);
+});
+
+test("isolated build protects unmanaged files planted inside the mirror", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+  await Bun.write(join(root, ISOLATED_OUT_ROOT, "AGENTS.md"), "user file\n");
+
+  await expect(buildSkillset(root, { isolated: true })).rejects.toThrow(
+    `refusing to overwrite unmanaged workspace file ${join(ISOLATED_OUT_ROOT, "AGENTS.md")}`
+  );
+});
+
+test("CLI accepts --isolated for build and rejects it elsewhere", async () => {
+  const root = await fixture(DEMO_FIXTURE);
+
+  const build = await runSkillsetCli("build", "--isolated", "--yes", "--root", root);
+  expect(build.exitCode).toBe(0);
+  expect(await exists(join(root, MIRROR_SKILL))).toBe(true);
+  expect(await exists(join(root, LIVE_SKILL))).toBe(false);
+
+  const check = await runSkillsetCli("check", "--isolated", "--root", root);
+  expect(check.exitCode).toBe(0);
+
+  const lint = await runSkillsetCli("lint", "--isolated", "--root", root);
+  expect(lint.exitCode).toBe(1);
+  expect(lint.stderr).toContain("--isolated is only supported with build, check, or diff");
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-isolated-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}
+
+async function exists(path: string): Promise<boolean> {
+  return Bun.file(path).exists();
+}
+
+async function hashPaths(
+  root: string,
+  paths: readonly string[]
+): Promise<ReadonlyMap<string, string>> {
+  const hashes = new Map<string, string>();
+  for (const path of [...paths].sort()) {
+    hashes.set(path, createHash("sha256").update(await readFile(join(root, path))).digest("hex"));
+  }
+  return hashes;
+}
+
+async function mirrorTreeHashes(root: string): Promise<ReadonlyMap<string, string>> {
+  const mirrorRoot = join(root, ISOLATED_OUT_ROOT);
+  const files = await Array.fromAsync(
+    new Bun.Glob("**/*").scan({ cwd: mirrorRoot, dot: true, onlyFiles: true })
+  );
+  const hashes = new Map<string, string>();
+  for (const file of files.sort()) {
+    hashes.set(file, createHash("sha256").update(await readFile(join(mirrorRoot, file))).digest("hex"));
+  }
+  return hashes;
+}
+
+async function runSkillsetCli(...args: readonly string[]): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/build.ts
+++ b/apps/skillset/src/build.ts
@@ -8,6 +8,33 @@ import type { BuildGraph, BuildScope, CheckResult, RenderedFile, SkillsetOptions
 import { isJsonRecord, parseMarkdown } from "./yaml";
 
 const WORKSPACE_LOCK_FILE = ".skillset.lock";
+
+/** Mirror root for isolated builds; the full projection lands under it. */
+export const ISOLATED_OUT_ROOT = ".skillset/build/out";
+
+/** Maps a repo-relative generated path to its on-disk location. */
+type OutPath = (path: string) => string;
+
+const livePath: OutPath = (path) => path;
+
+function outPathMapper(options: SkillsetOptions): OutPath {
+  if (options.isolated !== true) return livePath;
+  return (path) => join(ISOLATED_OUT_ROOT, path);
+}
+
+function mirroredRenderedFiles(
+  rendered: readonly RenderedFile[],
+  outPath: OutPath
+): readonly RenderedFile[] {
+  if (outPath === livePath) return rendered;
+  return rendered.map((file) => ({ ...file, path: outPath(file.path) }));
+}
+
+function mirroredOutputRoots(outputRoots: readonly string[], outPath: OutPath): readonly string[] {
+  if (outPath === livePath) return outputRoots;
+  return outputRoots.map((outputRoot) => outPath(outputRoot));
+}
+
 const textDecoder = new TextDecoder();
 
 /**
@@ -35,13 +62,18 @@ export async function buildSkillset(
 ): Promise<readonly RenderedFile[]> {
   const graph = await loadBuildGraph(rootPath, options);
   emitGraphWarnings(graph);
-  const rendered = scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes);
-  const outputRoots = scopedOutputRoots(graph, options.scopes);
+  const outPath = outPathMapper(options);
+  const rendered = mirroredRenderedFiles(
+    scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
+    outPath
+  );
+  const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
+  const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
   const includeWorkspaceLock = includesProjectScope(options.scopes);
   warnLargeInstructionFiles(rendered);
   const expectedPaths = new Set(rendered.map((file) => file.path));
-  const previousWorkspaceManagedPaths = includeWorkspaceLock ? await readWorkspaceManagedPaths(rootPath) : new Set<string>();
-  const previousManagedPaths = await readManagedPaths(rootPath, outputRoots, includeWorkspaceLock);
+  const previousWorkspaceManagedPaths = includeWorkspaceLock ? await readWorkspaceManagedPaths(rootPath, outPath) : new Set<string>();
+  const previousManagedPaths = await readManagedPaths(rootPath, liveOutputRoots, includeWorkspaceLock, outPath);
   await warnMissingManagedOutputs(rootPath, rendered, previousManagedPaths);
 
   await assertNoUnmanagedWorkspaceOverwrites(
@@ -67,7 +99,7 @@ export async function buildSkillset(
     return rendered;
   }
 
-  const actualPaths = new Set(await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock));
+  const actualPaths = new Set(await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock, outPath));
   await removeStaleGeneratedFiles(rootPath, actualPaths, expectedPaths);
   await writeChangedRenderedFiles(rootPath, rendered, actualPaths);
 
@@ -91,13 +123,18 @@ export async function diffSkillset(
 ): Promise<SkillsetDiff> {
   const graph = await loadBuildGraph(rootPath, options);
   emitGraphWarnings(graph);
-  const rendered = scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes);
+  const outPath = outPathMapper(options);
+  const rendered = mirroredRenderedFiles(
+    scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
+    outPath
+  );
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
-  const outputRoots = scopedOutputRoots(graph, options.scopes);
+  const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
+  const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
   const includeWorkspaceLock = includesProjectScope(options.scopes);
-  const actualPaths = await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock);
+  const actualPaths = await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock, outPath);
   const actual = new Set(actualPaths);
-  const previousManagedPaths = await readManagedPaths(rootPath, outputRoots, includeWorkspaceLock);
+  const previousManagedPaths = await readManagedPaths(rootPath, liveOutputRoots, includeWorkspaceLock, outPath);
 
   const added: string[] = [];
   const changed: string[] = [];
@@ -134,14 +171,19 @@ export async function checkSkillset(
 ): Promise<CheckResult> {
   const graph = await loadBuildGraph(rootPath, options);
   emitGraphWarnings(graph);
-  const rendered = scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes);
+  const outPath = outPathMapper(options);
+  const rendered = mirroredRenderedFiles(
+    scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
+    outPath
+  );
   warnLargeInstructionFiles(rendered);
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
-  const outputRoots = scopedOutputRoots(graph, options.scopes);
+  const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
+  const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
   const includeWorkspaceLock = includesProjectScope(options.scopes);
-  const actualPaths = await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock);
+  const actualPaths = await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock, outPath);
   const actual = new Set(actualPaths);
-  const previousManagedPaths = await readManagedPaths(rootPath, outputRoots, includeWorkspaceLock);
+  const previousManagedPaths = await readManagedPaths(rootPath, liveOutputRoots, includeWorkspaceLock, outPath);
   const failures: string[] = [];
 
   for (const file of rendered) {
@@ -243,10 +285,11 @@ async function listGeneratedFiles(
   rootPath: string,
   outputRoots: readonly string[],
   rendered: readonly RenderedFile[],
-  includeWorkspaceLock: boolean
+  includeWorkspaceLock: boolean,
+  outPath: OutPath
 ): Promise<readonly string[]> {
   const paths = new Set(await listOutputFiles(rootPath, outputRoots));
-  const previousWorkspaceManagedPaths = includeWorkspaceLock ? await readWorkspaceManagedPaths(rootPath) : new Set<string>();
+  const previousWorkspaceManagedPaths = includeWorkspaceLock ? await readWorkspaceManagedPaths(rootPath, outPath) : new Set<string>();
 
   for (const path of previousWorkspaceManagedPaths) {
     if (isInsideAnyOutputRoot(path, outputRoots)) continue;
@@ -360,30 +403,39 @@ function includesProjectScope(scopes: readonly BuildScope[] | undefined): boolea
   return scopes === undefined || scopes.includes("project");
 }
 
-async function readWorkspaceManagedPaths(rootPath: string): Promise<ReadonlySet<string>> {
-  return readManagedPathsFromLock(rootPath, WORKSPACE_LOCK_FILE, ".");
+async function readWorkspaceManagedPaths(rootPath: string, outPath: OutPath): Promise<ReadonlySet<string>> {
+  return readManagedPathsFromLock(rootPath, WORKSPACE_LOCK_FILE, ".", outPath);
 }
 
 async function readManagedPaths(
   rootPath: string,
-  outputRoots: readonly string[],
-  includeWorkspaceLock: boolean
+  liveOutputRoots: readonly string[],
+  includeWorkspaceLock: boolean,
+  outPath: OutPath
 ): Promise<ReadonlySet<string>> {
-  const paths = includeWorkspaceLock ? new Set(await readWorkspaceManagedPaths(rootPath)) : new Set<string>();
-  for (const outputRoot of outputRoots) {
+  const paths = includeWorkspaceLock ? new Set(await readWorkspaceManagedPaths(rootPath, outPath)) : new Set<string>();
+  for (const outputRoot of liveOutputRoots) {
     const lockPath = join(outputRoot, WORKSPACE_LOCK_FILE);
-    const managed = await readManagedPathsFromLock(rootPath, lockPath, outputRoot);
+    const managed = await readManagedPathsFromLock(rootPath, lockPath, outputRoot, outPath);
     for (const path of managed) paths.add(path);
   }
   return paths;
 }
 
+/**
+ * Reads managed paths from a generated lock. `lockPath` and
+ * `expectedOutputRoot` stay in live repo-relative form because lock content
+ * records live output roots even when written into the isolated mirror;
+ * `outPath` maps the read location and the returned paths to the mirror.
+ */
 async function readManagedPathsFromLock(
   rootPath: string,
   lockPath: string,
-  expectedOutputRoot: string
+  expectedOutputRoot: string,
+  outPath: OutPath
 ): Promise<ReadonlySet<string>> {
-  const absoluteLockPath = resolveInside(rootPath, lockPath);
+  const displayLockPath = outPath(lockPath);
+  const absoluteLockPath = resolveInside(rootPath, displayLockPath);
   if (!(await exists(absoluteLockPath))) return new Set();
 
   let parsed: unknown;
@@ -391,40 +443,40 @@ async function readManagedPathsFromLock(
     parsed = JSON.parse(await readFile(absoluteLockPath, "utf8")) as unknown;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw corruptManagedLock(lockPath, `it is not valid JSON: ${message}`);
+    throw corruptManagedLock(lockPath, displayLockPath, `it is not valid JSON: ${message}`);
   }
 
   if (!isRecord(parsed) || typeof parsed.generatedBy !== "string") {
-    throw corruptManagedLock(lockPath, "it is missing a string generatedBy field");
+    throw corruptManagedLock(lockPath, displayLockPath, "it is missing a string generatedBy field");
   }
   if (!parsed.generatedBy.startsWith("skillset@")) {
-    throw corruptManagedLock(lockPath, `its generatedBy ${JSON.stringify(parsed.generatedBy)} is not a skillset lock`);
+    throw corruptManagedLock(lockPath, displayLockPath, `its generatedBy ${JSON.stringify(parsed.generatedBy)} is not a skillset lock`);
   }
   if (
     lockPath !== WORKSPACE_LOCK_FILE &&
     parsed.outputRoot === undefined &&
     parsed.items === undefined
   ) {
-    return new Set([lockPath]);
+    return new Set([displayLockPath]);
   }
   if (parsed.outputRoot !== expectedOutputRoot) {
     const expected = expectedOutputRoot === "." ? "the workspace root" : JSON.stringify(expectedOutputRoot);
-    throw corruptManagedLock(lockPath, `its outputRoot ${JSON.stringify(parsed.outputRoot)} is not ${expected}`);
+    throw corruptManagedLock(lockPath, displayLockPath, `its outputRoot ${JSON.stringify(parsed.outputRoot)} is not ${expected}`);
   }
   if (!Array.isArray(parsed.items)) {
-    throw corruptManagedLock(lockPath, "its items field is not an array");
+    throw corruptManagedLock(lockPath, displayLockPath, "its items field is not an array");
   }
 
-  const paths = new Set<string>([lockPath]);
+  const paths = new Set<string>([displayLockPath]);
   for (const item of parsed.items) {
     if (!isRecord(item) || !Array.isArray(item.files)) {
-      throw corruptManagedLock(lockPath, "one of its items is missing a files array");
+      throw corruptManagedLock(lockPath, displayLockPath, "one of its items is missing a files array");
     }
     for (const file of item.files) {
       if (typeof file !== "string" || file.trim().length === 0) {
-        throw corruptManagedLock(lockPath, "one of its tracked file entries is not a non-empty string");
+        throw corruptManagedLock(lockPath, displayLockPath, "one of its tracked file entries is not a non-empty string");
       }
-      paths.add(joinOutputRoot(expectedOutputRoot, file));
+      paths.add(outPath(joinOutputRoot(expectedOutputRoot, file)));
     }
   }
 
@@ -436,17 +488,17 @@ function joinOutputRoot(outputRoot: string, file: string): string {
   return `${outputRoot}/${file}`;
 }
 
-function corruptManagedLock(lockPath: string, reason: string): Error {
-  if (lockPath === WORKSPACE_LOCK_FILE) return corruptWorkspaceLock(reason);
+function corruptManagedLock(lockPath: string, displayLockPath: string, reason: string): Error {
+  if (lockPath === WORKSPACE_LOCK_FILE) return corruptWorkspaceLock(displayLockPath, reason);
   return new Error(
-    `skillset: generated lock ${lockPath} cannot guard generated state because ${reason}. ` +
+    `skillset: generated lock ${displayLockPath} cannot guard generated state because ${reason}. ` +
       "Fix or remove the lock before running build, check, or diff."
   );
 }
 
-function corruptWorkspaceLock(reason: string): Error {
+function corruptWorkspaceLock(displayLockPath: string, reason: string): Error {
   return new Error(
-    `skillset: workspace lock ${WORKSPACE_LOCK_FILE} cannot guard generated state because ${reason}. ` +
+    `skillset: workspace lock ${displayLockPath} cannot guard generated state because ${reason}. ` +
       "Restore it from a clean build (skillset build) or remove it deliberately before rebuilding."
   );
 }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -29,8 +29,9 @@ import type { BuildScope, CompileBuildMode, SkillsetOptions, TargetName } from "
 type Command = "build" | "change" | "check" | "ci" | "create" | "diff" | "doctor" | "explain" | "hooks" | "import" | "init" | "lint" | "list" | "release" | "test";
 
 const USAGE = [
-  "usage: skillset build [--yes|--dry-run] [--updated|--all] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
-  "       skillset <check|diff|doctor|lint|list> [--updated|--all] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
+  "usage: skillset build [--yes|--dry-run] [--updated|--all] [--isolated] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
+  "       skillset <check|diff> [--updated|--all] [--isolated] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
+  "       skillset <doctor|lint|list> [--updated|--all] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset ci [--fix] [--since <ref>] [--report <path>] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset change status [--since <ref>] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset change check [@ref|--ref <ref>] [--since <ref>] [--root <path>] [--source <dir>] [--dist <dir>]",
@@ -704,6 +705,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let distDir: string | undefined;
   let buildMode: CompileBuildMode | undefined;
   let dryRun = false;
+  let isolated = false;
   let scopes: readonly BuildScope[] | undefined;
   let setupGlobal = false;
   let setupIncludes: readonly SetupInclude[] | undefined;
@@ -815,6 +817,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag !== "--dry-run" &&
       flag !== "--updated" &&
       flag !== "--all" &&
+      flag !== "--isolated" &&
       flag !== "--scope" &&
       flag !== "--global" &&
       flag !== "--targets" &&
@@ -835,6 +838,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag === "--dry-run" ||
       flag === "--updated" ||
       flag === "--all" ||
+      flag === "--isolated" ||
       flag === "--append" ||
       flag === "--staged" ||
       flag === "--global" ||
@@ -848,6 +852,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       if (flag === "--dry-run") dryRun = true;
       if (flag === "--updated") buildMode = setBuildMode(buildMode, "updated");
       if (flag === "--all") buildMode = setBuildMode(buildMode, "all");
+      if (flag === "--isolated") isolated = true;
       if (flag === "--append") changeAppend = true;
       if (flag === "--staged") changeStaged = true;
       if (flag === "--global") setupGlobal = true;
@@ -954,6 +959,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     yes,
   });
 
+  validateIsolatedFlag(command, isolated);
+
   if (command === "release" && scopes !== undefined) {
     throw new Error("skillset: --scope is not supported with release commands yet");
   }
@@ -970,6 +977,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(scopes === undefined ? {} : { scopes }),
     ...(sourceDir === undefined ? {} : { sourceDir }),
     ...(distDir === undefined ? {} : { distDir }),
+    ...(isolated ? { isolated: true } : {}),
   };
 
   return {
@@ -1216,6 +1224,12 @@ function readSetupTargets(value: string): readonly TargetName[] {
     seen.add(target);
   }
   return [...seen];
+}
+
+function validateIsolatedFlag(command: Command, isolated: boolean): void {
+  if (!isolated) return;
+  if (command === "build" || command === "check" || command === "diff") return;
+  throw new Error("skillset: --isolated is only supported with build, check, or diff");
 }
 
 function validateCiFlags(

--- a/apps/skillset/src/types.ts
+++ b/apps/skillset/src/types.ts
@@ -192,6 +192,8 @@ export interface SkillsetOptions {
   readonly buildMode?: CompileBuildMode;
   readonly scopes?: readonly BuildScope[];
   readonly distDir?: string;
+  /** Re-root every generated path under `.skillset/build/out`, leaving live outputs untouched. */
+  readonly isolated?: boolean;
   readonly sourceDir?: string;
   readonly targetFilter?: readonly TargetName[];
 }

--- a/docs/features/build-scopes.md
+++ b/docs/features/build-scopes.md
@@ -25,6 +25,8 @@ skillset build --yes
 
 `--dry-run` is accepted for every build scope and always prevents writes, even when `--yes` is also present. Explicit `--scope` selectors filter generated destinations for build, diff, top-level check, list, and explain. They are not source-coverage filters for `skillset change status` or `skillset change check`. Repo scripts that intentionally refresh all generated output should omit `--scope` and pass `--yes`.
 
+`--isolated` (build, check, and diff only) re-roots the entire projection under the gitignored `.skillset/build/out/` mirror, preserving repo-relative layout: writes, locks, drift detection, stale-file removal, and unmanaged-overwrite protection all operate against the mirror while live generated outputs stay untouched.
+
 ## Support Table
 
 | Behavior | Build | Check | Diff/list/explain | Status | Notes |


### PR DESCRIPTION
Binary output mode from the project's resolved decisions: `build`/`check`/`diff` accept `--isolated`, writing the full projection under `.skillset/build/out/` with repo-relative layout preserved (derived `AGENTS.md` files included). Locks, drift, stale-file removal, and unmanaged-overwrite protection all compute against the mirror; live mode is byte-identical to before (the re-rooting is a single path-mapper applied at the build/diff/check seams). The gitignored mirror is what lets adopt and the fixture harness build in place without touching originals.

Linear: https://linear.app/outfitter/issue/SET-60
Gates: `bun run check` ✓ · 367 tests ✓ · external fixture ✓ · live-output byte-stability test ✓

Stacked on #33.