### PR TITLE
feat(fixtures): in-place isolated runs with a hard purity invariant

### DIFF
--- a/scripts/fixtures/__tests__/external.test.ts
+++ b/scripts/fixtures/__tests__/external.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { compareTrees, parseExternalManifest, renderExternalManifest, renderRunReportMarkdown, runExternalRepo } from '../external';
+import { checkClonePurity, compareTrees, parseExternalManifest, renderExternalManifest, renderRunReportMarkdown, runExternalRepo } from '../external';
 import type { ExternalRepoEntry } from '../external';
 import { gitSafeEnv } from '../../../apps/skillset/src/git-env';
 
@@ -94,8 +94,112 @@ test("compareTrees buckets identical, different, and one-sided files", async () 
   expect(comparison.generatedOnly).toEqual(["generated-only.lock"]);
 });
 
-test("runExternalRepo adopts a marketplace-shaped repo offline and reports round-trips", async () => {
-  const clone = await fixture({
+test("runExternalRepo adopts a marketplace-shaped repo in place and reports round-trips", async () => {
+  const clone = await gitFixture(marketplaceFiles());
+
+  const report = await runExternalRepo("demo-marketplace", clone, ["claude"]);
+
+  expect(report.stages.map((stage) => [stage.stage, stage.ok])).toEqual([
+    ["init", true],
+    ["import", true],
+    ["lint", true],
+    ["build", true],
+    ["purity", true],
+  ]);
+  expect(report.ok).toBe(true);
+  expect(report.roundTrips).toHaveLength(1);
+  const roundTrip = report.roundTrips[0];
+  expect(roundTrip?.kind).toBe("plugin");
+  expect(roundTrip?.name).toBe("demo");
+  expect(roundTrip?.originalRoot).toBe("plugins/demo");
+  expect(roundTrip?.generatedRoot).toBe(
+    ".skillset/build/out/plugins-claude/plugins/demo"
+  );
+  expect(roundTrip?.comparison.identical).toContain("commands/hello.md");
+  // Generated skill frontmatter gains metadata.version/generated, so the
+  // round-trip reports it as different rather than identical.
+  expect(roundTrip?.comparison.different).toContain(
+    "skills/demo-skill/SKILL.md"
+  );
+
+  // In-place isolated adoption only ever creates .skillset/; the live tree
+  // must not grow a projection root.
+  const rootEntries = await readdir(clone);
+  expect(rootEntries).not.toContain("plugins-claude");
+  expect(rootEntries).toContain(".skillset");
+
+  const markdown = renderRunReportMarkdown(report, {
+    ref: SHA,
+    repo: "https://github.com/example/demo",
+  } satisfies Pick<ExternalRepoEntry, "ref" | "repo">);
+  expect(markdown).toContain("# External fixture run: demo-marketplace");
+  expect(markdown).toContain("- result: pass");
+  expect(markdown).toContain("### plugin demo");
+});
+
+test("runExternalRepo passes when re-run on the same clone", async () => {
+  const clone = await gitFixture(marketplaceFiles());
+
+  const first = await runExternalRepo("demo-marketplace", clone, ["claude"]);
+  expect(first.ok).toBe(true);
+
+  // The run-start guarded clean drops the previous run's untracked .skillset/
+  // adoption, so import does not trip over its own prior output.
+  const second = await runExternalRepo("demo-marketplace", clone, ["claude"]);
+  expect(second.ok).toBe(true);
+  expect(
+    second.stages.map((stage) => [stage.stage, stage.ok])
+  ).toEqual([
+    ["init", true],
+    ["import", true],
+    ["lint", true],
+    ["build", true],
+    ["purity", true],
+  ]);
+});
+
+test("runExternalRepo refuses to clean a clone that tracks .skillset files", async () => {
+  const clone = await gitFixture({
+    ...marketplaceFiles(),
+    ".skillset/config.yaml": "skillset:\n  name: tracked\n",
+  });
+
+  await expect(
+    runExternalRepo("demo-marketplace", clone, ["claude"])
+  ).rejects.toThrow("tracked .skillset files; refusing to clean");
+});
+
+test("runExternalRepo fails the run when no import candidates are detected", async () => {
+  const clone = await gitFixture({ "README.md": "# Not adoptable\n" });
+
+  const report = await runExternalRepo("plain-repo", clone, ["claude"]);
+
+  expect(report.ok).toBe(false);
+  expect(report.stages[0]).toMatchObject({ ok: false, stage: "init" });
+  expect(report.roundTrips).toEqual([]);
+  const markdown = renderRunReportMarkdown(report, { ref: SHA, repo: "r" });
+  expect(markdown).toContain("- result: fail");
+  expect(markdown).toContain("No imported units to compare.");
+});
+
+test("checkClonePurity accepts .skillset/ additions and flags anything else", async () => {
+  const clone = await gitFixture({ "README.md": "# Repo\n" });
+
+  expect(await checkClonePurity(clone)).toEqual({ dirtyPaths: [], ok: true });
+
+  await Bun.write(join(clone, ".skillset/config.yaml"), "skillset:\n");
+  await Bun.write(join(clone, ".skillset/build/out/AGENTS.md"), "generated\n");
+  expect(await checkClonePurity(clone)).toEqual({ dirtyPaths: [], ok: true });
+
+  await Bun.write(join(clone, "stray.lock"), "dirty\n");
+  expect(await checkClonePurity(clone)).toEqual({
+    dirtyPaths: ["stray.lock"],
+    ok: false,
+  });
+});
+
+function marketplaceFiles(): Record<string, string> {
+  return {
     ".claude-plugin/marketplace.json": JSON.stringify({
       name: "demo-marketplace",
       plugins: [{ name: "demo", source: "./plugins/demo" }],
@@ -109,51 +213,8 @@ test("runExternalRepo adopts a marketplace-shaped repo offline and reports round
       "---\ndescription: Say hello.\n---\n\nSay hello.\n",
     "plugins/demo/skills/demo-skill/SKILL.md":
       "---\nname: demo-skill\ndescription: Demo skill.\n---\n\nBody.\n",
-  });
-
-  const report = await runExternalRepo("demo-marketplace", clone, ["claude"]);
-
-  expect(report.stages.map((stage) => [stage.stage, stage.ok])).toEqual([
-    ["init", true],
-    ["import", true],
-    ["lint", true],
-    ["build", true],
-  ]);
-  expect(report.ok).toBe(true);
-  expect(report.roundTrips).toHaveLength(1);
-  const roundTrip = report.roundTrips[0];
-  expect(roundTrip?.kind).toBe("plugin");
-  expect(roundTrip?.name).toBe("demo");
-  expect(roundTrip?.originalRoot).toBe("plugins/demo");
-  expect(roundTrip?.generatedRoot).toBe("plugins-claude/plugins/demo");
-  expect(roundTrip?.comparison.identical).toContain("commands/hello.md");
-  // Generated skill frontmatter gains metadata.version/generated, so the
-  // round-trip reports it as different rather than identical.
-  expect(roundTrip?.comparison.different).toContain(
-    "skills/demo-skill/SKILL.md"
-  );
-
-  const markdown = renderRunReportMarkdown(report, {
-    ref: SHA,
-    repo: "https://github.com/example/demo",
-  } satisfies Pick<ExternalRepoEntry, "ref" | "repo">);
-  expect(markdown).toContain("# External fixture run: demo-marketplace");
-  expect(markdown).toContain("- result: pass");
-  expect(markdown).toContain("### plugin demo");
-});
-
-test("runExternalRepo fails the run when no import candidates are detected", async () => {
-  const clone = await fixture({ "README.md": "# Not adoptable\n" });
-
-  const report = await runExternalRepo("plain-repo", clone, ["claude"]);
-
-  expect(report.ok).toBe(false);
-  expect(report.stages[0]).toMatchObject({ ok: false, stage: "init" });
-  expect(report.roundTrips).toEqual([]);
-  const markdown = renderRunReportMarkdown(report, { ref: SHA, repo: "r" });
-  expect(markdown).toContain("- result: fail");
-  expect(markdown).toContain("No imported units to compare.");
-});
+  };
+}
 
 async function fixture(files: Record<string, string>): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "skillset-external-test-"));
@@ -161,4 +222,40 @@ async function fixture(files: Record<string, string>): Promise<string> {
     await Bun.write(join(root, path), content);
   }
   return root;
+}
+
+/** A fixture that is also a git repo with everything committed, so the
+ * harness's git-backed clean and purity stages can run against it. */
+async function gitFixture(files: Record<string, string>): Promise<string> {
+  const root = await fixture(files);
+  await testGit(root, "init", "-q");
+  await testGit(root, "add", "-A");
+  await testGit(
+    root,
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Skillset Test",
+    "commit",
+    "-q",
+    "-m",
+    "fixture"
+  );
+  return root;
+}
+
+async function testGit(cwd: string, ...args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn({
+    cmd: ["git", "-C", cwd, ...args],
+    env: gitSafeEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}\n${stderr}`.trim());
+  }
 }

--- a/scripts/fixtures/external.ts
+++ b/scripts/fixtures/external.ts
@@ -6,31 +6,24 @@
  *
  * The committed manifest (fixtures/external/repos.yaml) pins each repo to an
  * exact commit. Clones live gitignored under fixtures/external/repos/ and are
- * never scanned as this repo's own source. Runs execute in throwaway temp
- * workspaces and write reports under .skillset/build/external/.
+ * never scanned as this repo's own source. Runs adopt each clone in place and
+ * build with the isolated mirror (everything lands under .skillset/build/out/),
+ * then write reports under .skillset/build/external/.
  *
- *   bun scripts/fixtures/external.ts sync   [name]   # clone/fetch at pinned refs
+ *   bun scripts/fixtures/external.ts sync   [name]   # reset clones pristine at pinned refs
  *   bun scripts/fixtures/external.ts update [name]   # re-pin to upstream HEAD, then sync
- *   bun scripts/fixtures/external.ts run    [name]   # init -> import -> lint -> build -> round-trip report
+ *   bun scripts/fixtures/external.ts run    [name]   # init -> import -> lint -> build -> purity -> round-trip report
  *
- * Run failures (init/import/lint/build errors) exit non-zero. The round-trip
- * comparison is report-only for now; per-repo expectations can harden into
- * assertions once the numbers settle.
+ * Run failures (init/import/lint/build/purity errors) exit non-zero. The
+ * purity stage is the hard invariant: after a run, `git status` in the clone
+ * may only show paths under .skillset/ — anything else is a toolchain defect.
+ * The round-trip comparison is report-only for now; per-repo expectations can
+ * harden into assertions once the numbers settle.
  */
-import {
-  cp,
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-} from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
-import { buildSkillset } from "../../apps/skillset/src/build";
+import { buildSkillset, ISOLATED_OUT_ROOT } from "../../apps/skillset/src/build";
 import { gitSafeEnv } from "../../apps/skillset/src/git-env";
 import { importSources } from "../../apps/skillset/src/import";
 import { lintSkillset } from "../../apps/skillset/src/lint";
@@ -42,7 +35,9 @@ import { parseYamlRecord } from "../../apps/skillset/src/yaml";
 const MANIFEST_PATH = "fixtures/external/repos.yaml";
 const CLONES_DIR = "fixtures/external/repos";
 const REPORTS_DIR = ".skillset/build/external";
-const COMPARISON_IGNORED = new Set([".git", ".DS_Store"]);
+// .skillset is ignored because in-place adoption creates it inside the clone;
+// it is harness material, not part of the original tree being round-tripped.
+const COMPARISON_IGNORED = new Set([".git", ".DS_Store", ".skillset"]);
 const REPORT_LIST_CAP = 100;
 
 export interface ExternalRepoEntry {
@@ -232,7 +227,7 @@ async function collectRelativeFiles(
 export interface ExternalStageResult {
   readonly detail: string;
   readonly ok: boolean;
-  readonly stage: "build" | "import" | "init" | "lint";
+  readonly stage: "build" | "import" | "init" | "lint" | "purity";
 }
 
 export interface ExternalRoundTrip {
@@ -250,10 +245,60 @@ export interface ExternalRunReport {
   readonly stages: readonly ExternalStageResult[];
 }
 
+/** How many dirty paths a failed purity stage lists before truncating. */
+const PURITY_DETAIL_CAP = 10;
+
 /**
- * Adopt one external repo clone in a throwaway workspace: init the source
- * scaffold, import every detected candidate, lint, build, and compare the
- * original clone against the generated Claude projection.
+ * The purity invariant: adoption may only ever create paths under .skillset/.
+ * Any other path reported by `git status` after a run is a toolchain defect.
+ * (.skillset/build/ is not gitignored in external repos, so it shows up in
+ * status — that is fine, it is under .skillset/.)
+ */
+export async function checkClonePurity(
+  clonePath: string
+): Promise<{ readonly dirtyPaths: readonly string[]; readonly ok: boolean }> {
+  const output = await gitOutput(
+    clonePath,
+    "status",
+    "--porcelain",
+    "--untracked-files=all"
+  );
+  const dirtyPaths: string[] = [];
+  for (const line of output.split("\n")) {
+    if (line.trim().length === 0) {continue;}
+    // Porcelain v1: two status chars, a space, then the path (renames list
+    // `old -> new`; both sides must stay under .skillset/).
+    for (const rawPath of line.slice(3).split(" -> ")) {
+      const path = rawPath.replaceAll('"', "");
+      if (!path.startsWith(".skillset/")) {dirtyPaths.push(path);}
+    }
+  }
+  return {
+    dirtyPaths: dirtyPaths.toSorted(compareStrings),
+    ok: dirtyPaths.length === 0,
+  };
+}
+
+/**
+ * Reruns must start clean: import never overwrites, so a prior run's
+ * .skillset/ adoption would fail the next one. Only untracked leftovers are
+ * cleaned; a clone that tracks .skillset/ content is not ours to delete.
+ */
+async function cleanSkillsetLeftovers(clonePath: string): Promise<void> {
+  const tracked = await gitOutput(clonePath, "ls-files", "--", ".skillset");
+  if (tracked.trim().length > 0) {
+    throw new Error(
+      `skillset: clone ${clonePath} has tracked .skillset files; refusing to clean`
+    );
+  }
+  await runGit(clonePath, "clean", "-fdx", "-q", "--", ".skillset");
+}
+
+/**
+ * Adopt one external repo clone in place: init the source scaffold, import
+ * every detected candidate, lint, build with the isolated mirror (the
+ * projection lands under .skillset/build/out/), verify the purity invariant,
+ * and compare the original clone against the generated Claude projection.
  */
 export async function runExternalRepo(
   name: string,
@@ -262,127 +307,134 @@ export async function runExternalRepo(
 ): Promise<ExternalRunReport> {
   const stages: ExternalStageResult[] = [];
   const roundTrips: ExternalRoundTrip[] = [];
-  const workspace = await mkdtemp(join(tmpdir(), `skillset-external-${name}-`));
 
+  await cleanSkillsetLeftovers(clonePath);
+
+  let candidates: readonly {
+    readonly kind: "plugin" | "plugins" | "skills";
+    readonly path: string;
+  }[] = [];
   try {
-    await cp(clonePath, workspace, {
-      filter: (source) => !source.split("/").includes(".git"),
-      recursive: true,
+    const init = await initSkillset({
+      cwd: clonePath,
+      targets,
+      useGitRoot: false,
+      write: true,
     });
+    candidates = init.importCandidates;
+    stages.push({
+      detail: `${candidates.length} import candidate(s): ${candidates.map((candidate) => `${candidate.kind}:${candidate.path}`).join(", ") || "none"}`,
+      ok: candidates.length > 0,
+      stage: "init",
+    });
+  } catch (error) {
+    stages.push({ detail: errorMessage(error), ok: false, stage: "init" });
+    return { name, ok: false, roundTrips, stages };
+  }
 
-    let candidates: readonly {
-      readonly kind: "plugin" | "plugins" | "skills";
-      readonly path: string;
-    }[] = [];
+  const imported: {
+    readonly kind: "plugin" | "skill";
+    readonly name: string;
+    readonly sourcePath: string;
+  }[] = [];
+  for (const candidate of candidates) {
     try {
-      const init = await initSkillset({
-        cwd: workspace,
-        targets,
-        useGitRoot: false,
-        write: true,
+      const batch = await importSources({
+        kind: candidate.kind,
+        rootPath: clonePath,
+        sourcePath: join(clonePath, candidate.path),
       });
-      candidates = init.importCandidates;
-      stages.push({
-        detail: `${candidates.length} import candidate(s): ${candidates.map((candidate) => `${candidate.kind}:${candidate.path}`).join(", ") || "none"}`,
-        ok: candidates.length > 0,
-        stage: "init",
-      });
-    } catch (error) {
-      stages.push({ detail: errorMessage(error), ok: false, stage: "init" });
-      return { name, ok: false, roundTrips, stages };
-    }
-
-    const imported: {
-      readonly kind: "plugin" | "skill";
-      readonly name: string;
-      readonly sourcePath: string;
-    }[] = [];
-    for (const candidate of candidates) {
-      try {
-        const batch = await importSources({
-          kind: candidate.kind,
-          rootPath: workspace,
-          sourcePath: join(workspace, candidate.path),
-        });
-        for (const report of batch.imports) {
-          const sourcePath = relative(workspace, report.sourcePath).replaceAll(
-            "\\",
-            "/"
-          );
-          imported.push({
-            kind: report.kind,
-            name: report.name,
-            sourcePath: sourcePath.length === 0 ? "." : sourcePath,
-          });
-        }
-        stages.push({
-          detail: `${candidate.kind}:${candidate.path} -> ${batch.imports.map((report) => `${report.kind} ${report.name}`).join(", ")} (${batch.files} files)`,
-          ok: true,
-          stage: "import",
-        });
-      } catch (error) {
-        stages.push({
-          detail: `${candidate.kind}:${candidate.path}: ${errorMessage(error)}`,
-          ok: false,
-          stage: "import",
+      for (const report of batch.imports) {
+        const sourcePath = relative(clonePath, report.sourcePath).replaceAll(
+          "\\",
+          "/"
+        );
+        imported.push({
+          kind: report.kind,
+          name: report.name,
+          sourcePath: sourcePath.length === 0 ? "." : sourcePath,
         });
       }
-    }
-
-    if (imported.length === 0) {
-      return { name, ok: false, roundTrips, stages };
-    }
-
-    // Partial import failures still run lint/build: they validate whatever did
-    // import, and the failed import stage already fails the overall run.
-    try {
-      const lint = await lintSkillset(workspace);
       stages.push({
-        detail: `linted ${lint.checkedSkills} source skills`,
+        detail: `${candidate.kind}:${candidate.path} -> ${batch.imports.map((report) => `${report.kind} ${report.name}`).join(", ")} (${batch.files} files)`,
         ok: true,
-        stage: "lint",
+        stage: "import",
       });
     } catch (error) {
-      stages.push({ detail: errorMessage(error), ok: false, stage: "lint" });
-    }
-
-    try {
-      const rendered = await buildSkillset(workspace);
       stages.push({
-        detail: `wrote ${rendered.length} generated files`,
-        ok: true,
-        stage: "build",
-      });
-    } catch (error) {
-      stages.push({ detail: errorMessage(error), ok: false, stage: "build" });
-    }
-
-    for (const item of imported) {
-      const generatedRoot =
-        item.kind === "plugin"
-          ? join("plugins-claude", "plugins", item.name)
-          : join(".claude", "skills", item.name);
-      const originalRoot =
-        item.sourcePath === "." ? clonePath : join(clonePath, item.sourcePath);
-      roundTrips.push({
-        comparison: await compareTrees(
-          originalRoot,
-          join(workspace, generatedRoot)
-        ),
-        generatedRoot,
-        kind: item.kind,
-        name: item.name,
-        originalRoot:
-          relative(clonePath, originalRoot) === ""
-            ? "."
-            : relative(clonePath, originalRoot),
+        detail: `${candidate.kind}:${candidate.path}: ${errorMessage(error)}`,
+        ok: false,
+        stage: "import",
       });
     }
-
-    return { name, ok: stages.every((stage) => stage.ok), roundTrips, stages };
-  } finally {
-    await rm(workspace, { force: true, recursive: true });
   }
+
+  if (imported.length === 0) {
+    return { name, ok: false, roundTrips, stages };
+  }
+
+  // Partial import failures still run lint/build: they validate whatever did
+  // import, and the failed import stage already fails the overall run.
+  try {
+    const lint = await lintSkillset(clonePath);
+    stages.push({
+      detail: `linted ${lint.checkedSkills} source skills`,
+      ok: true,
+      stage: "lint",
+    });
+  } catch (error) {
+    stages.push({ detail: errorMessage(error), ok: false, stage: "lint" });
+  }
+
+  try {
+    const rendered = await buildSkillset(clonePath, { isolated: true });
+    stages.push({
+      detail: `wrote ${rendered.length} generated files under ${ISOLATED_OUT_ROOT}/`,
+      ok: true,
+      stage: "build",
+    });
+  } catch (error) {
+    stages.push({ detail: errorMessage(error), ok: false, stage: "build" });
+  }
+
+  try {
+    const purity = await checkClonePurity(clonePath);
+    const listed = purity.dirtyPaths.slice(0, PURITY_DETAIL_CAP);
+    const overflow = purity.dirtyPaths.length - listed.length;
+    stages.push({
+      detail: purity.ok
+        ? "git status reports nothing outside .skillset/"
+        : `dirty paths outside .skillset/: ${listed.join(", ")}${overflow > 0 ? ` (and ${overflow} more)` : ""}`,
+      ok: purity.ok,
+      stage: "purity",
+    });
+  } catch (error) {
+    stages.push({ detail: errorMessage(error), ok: false, stage: "purity" });
+  }
+
+  for (const item of imported) {
+    const generatedRoot =
+      item.kind === "plugin"
+        ? join(ISOLATED_OUT_ROOT, "plugins-claude", "plugins", item.name)
+        : join(ISOLATED_OUT_ROOT, ".claude", "skills", item.name);
+    const originalRoot =
+      item.sourcePath === "." ? clonePath : join(clonePath, item.sourcePath);
+    roundTrips.push({
+      comparison: await compareTrees(
+        originalRoot,
+        join(clonePath, generatedRoot)
+      ),
+      generatedRoot,
+      kind: item.kind,
+      name: item.name,
+      originalRoot:
+        relative(clonePath, originalRoot) === ""
+          ? "."
+          : relative(clonePath, originalRoot),
+    });
+  }
+
+  return { name, ok: stages.every((stage) => stage.ok), roundTrips, stages };
 }
 
 export function renderRunReportMarkdown(
@@ -489,6 +541,12 @@ async function syncRepo(
     "--quiet",
     "HEAD"
   ).catch(() => "");
+  // Drop prior run artifacts (in-place .skillset/ adoptions included) so every
+  // sync leaves a pristine tree, even when the clone is already at the ref.
+  if (current.trim().length > 0) {
+    await runGit(clonePath, "reset", "--hard", "-q");
+  }
+  await runGit(clonePath, "clean", "-fdx", "-q");
   if (current.trim() === entry.ref) {
     console.log(`external: ${entry.name} already at ${entry.ref.slice(0, 12)}`);
     return;


### PR DESCRIPTION
The external fixture harness now adopts **in place against the clone** and builds with `--isolated`: no more temp-workspace copies. The round-trip diffs originals against the mirror, and a new **purity stage** hard-fails the run if `git status` reports anything outside `.skillset/` — the project's purity invariant is now mechanically enforced, and passed live against compound-engineering (twice; reruns are safe via a guarded clean of untracked `.skillset/` leftovers that refuses if the clone tracks `.skillset` files). `sync` hard-resets clones to their pinned ref so every run starts pristine. Round-trip numbers unchanged (197/40/6).

Linear: https://linear.app/outfitter/issue/SET-61
Gates: `bun run check` ✓ · 370 tests ✓ · live run + rerun both green with purity ✓

Top of the stack (on #34).