### PR TITLE
feat(adopt): one-action repo migration with report and cutover

### DIFF
--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, readdir, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+import { ADOPT_REPORT_DIR, adoptSkillset, renderAdoptReportMarkdown } from "../adopt";
+import { ISOLATED_OUT_ROOT } from "../build";
+
+const AGENTS_CONTENT = "# Demo agents\n\nHandwritten instructions.\n";
+
+const MARKETPLACE_FIXTURE: Record<string, string> = {
+  ".claude-plugin/marketplace.json": JSON.stringify({
+    name: "demo-marketplace",
+    plugins: [{ name: "demo", source: "./plugins/demo" }],
+  }),
+  ".claude/commands/x.md": "---\ndescription: Project command.\n---\n\nDo x.\n",
+  "AGENTS.md": AGENTS_CONTENT,
+  "README.md": "# Demo repo\n",
+  "plugins/demo/.claude-plugin/plugin.json": JSON.stringify({
+    name: "demo",
+    version: "1.0.0",
+  }),
+  "plugins/demo/commands/hello.md": "---\ndescription: Say hello.\n---\n\nSay hello.\n",
+  "plugins/demo/skills/demo-skill/SKILL.md":
+    "---\nname: demo-skill\ndescription: Demo skill.\n---\n\nBody.\n",
+};
+
+test("adopt plan mode surveys only and writes nothing", async () => {
+  const root = await fixture(MARKETPLACE_FIXTURE);
+  const before = await walkFiles(root);
+
+  const report = await adoptSkillset(root);
+
+  expect(report.write).toBe(false);
+  expect(report.ok).toBe(true);
+  expect(report.alreadyAdopted).toBe(false);
+  expect(report.candidates).toEqual([
+    { kind: "instructions", path: "AGENTS.md" },
+    { kind: "plugin", path: "plugins/demo" },
+  ]);
+  expect(report.surveySkips.map((skip) => skip.path)).toEqual([".claude/commands"]);
+  expect(report.imports).toEqual([]);
+  expect(report.builtFiles).toBe(0);
+  expect(report.cutover).toEqual([]);
+  expect(await walkFiles(root)).toEqual(before);
+});
+
+test("adopt write mode imports everything, builds the mirror, and writes the report", async () => {
+  const root = await fixture(MARKETPLACE_FIXTURE);
+  const before = await walkFiles(root);
+
+  const report = await adoptSkillset(root, { write: true });
+
+  expect(report.ok).toBe(true);
+  expect(report.write).toBe(true);
+  expect(report.imports.map((result) => [result.candidate.kind, result.ok])).toEqual([
+    ["instructions", true],
+    ["plugin", true],
+  ]);
+  expect(report.builtFiles).toBeGreaterThan(0);
+  expect(report.buildError).toBeUndefined();
+  expect(report.cutover).toEqual(["AGENTS.md"]);
+
+  // Imported source lands in canonical .skillset/ homes; instructions copy verbatim.
+  expect(await readFile(join(root, ".skillset/config.yaml"), "utf8")).toContain("targets:");
+  expect(await exists(join(root, ".skillset/plugins/demo/skillset.yaml"))).toBe(true);
+  expect(await readFile(join(root, ".skillset/instructions/agents.md"), "utf8")).toBe(
+    AGENTS_CONTENT
+  );
+
+  // The build is isolated: the projection lives in the mirror, not the live tree.
+  expect(await exists(join(root, ISOLATED_OUT_ROOT))).toBe(true);
+  expect(await exists(join(root, "plugins-claude"))).toBe(false);
+
+  // The migration report persists in both shapes.
+  const markdown = await readFile(join(root, ADOPT_REPORT_DIR, "report.md"), "utf8");
+  expect(markdown).toBe(renderAdoptReportMarkdown(report, { rootPath: root }));
+  expect(markdown).toContain("## Summary");
+  expect(markdown).toContain("## Cutover");
+  expect(markdown).toContain("`AGENTS.md`");
+  expect(markdown).toContain("unmanaged");
+  const json = JSON.parse(await readFile(join(root, ADOPT_REPORT_DIR, "report.json"), "utf8")) as {
+    ok: boolean;
+  };
+  expect(json.ok).toBe(true);
+
+  // Purity: adoption only ever creates paths under .skillset/.
+  const added = [...(await walkFiles(root))].filter((path) => !before.has(path));
+  expect(added.length).toBeGreaterThan(0);
+  expect(added.every((path) => path.startsWith(".skillset/"))).toBe(true);
+});
+
+test("adopt records an instructions collision as a failed import without throwing", async () => {
+  const root = await fixture({
+    ...MARKETPLACE_FIXTURE,
+    ".skillset/instructions/agents.md": "pre-existing\n",
+  });
+
+  const report = await adoptSkillset(root, { write: true });
+
+  expect(report.ok).toBe(false);
+  const failed = report.imports.find((result) => result.candidate.kind === "instructions");
+  expect(failed?.ok).toBe(false);
+  expect(failed?.detail).toContain("already exists");
+  expect(await readFile(join(root, ".skillset/instructions/agents.md"), "utf8")).toBe(
+    "pre-existing\n"
+  );
+  // The collision must not block the rest of the migration.
+  expect(report.imports.find((result) => result.candidate.kind === "plugin")?.ok).toBe(true);
+  expect(report.cutover).toEqual([]);
+  expect(renderAdoptReportMarkdown(report, { rootPath: root })).toContain("## Failed imports");
+});
+
+test("adopt fails on lint errors and the CLI exits nonzero", async () => {
+  const files = {
+    ".claude/skills/bad/SKILL.md":
+      "---\nname: bad\ndescription: Uses Claude dynamic context.\n---\n\nUse $ARGUMENTS here.\n",
+  };
+
+  const report = await adoptSkillset(await fixture(files), { write: true });
+  expect(report.ok).toBe(false);
+  expect(
+    report.lintIssues.some(
+      (issue) => issue.severity === "error" && issue.code === "codex-claude-dynamic-context"
+    )
+  ).toBe(true);
+  const markdown = renderAdoptReportMarkdown(report, { rootPath: "ignored" });
+  expect(markdown).toContain("- result: fail");
+  expect(markdown).toContain("codex-claude-dynamic-context");
+
+  const cliRoot = await fixture(files);
+  const result = await runSkillsetCli("adopt", cliRoot, "--yes");
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toContain("FAIL lint");
+  expect(result.stdout).toContain("adopt found problems");
+});
+
+test("adopt CLI without --yes prints the survey and writes nothing", async () => {
+  const root = await fixture(MARKETPLACE_FIXTURE);
+  const before = await walkFiles(root);
+
+  const result = await runSkillsetCli("adopt", root);
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("import candidate instructions AGENTS.md");
+  expect(result.stdout).toContain("import candidate plugin plugins/demo");
+  expect(result.stdout).toContain("skipped commands .claude/commands");
+  expect(result.stdout).toContain("rerun with --yes to adopt");
+  expect(await walkFiles(root)).toEqual(before);
+});
+
+test("adopt CLI rejects isolation and build-shape flags", async () => {
+  const isolated = await runSkillsetCli("adopt", ".", "--isolated");
+  expect(isolated.exitCode).toBe(1);
+  expect(isolated.stderr).toContain("--isolated is only supported with build, check, or diff");
+
+  const scoped = await runSkillsetCli("adopt", ".", "--scope", "plugins");
+  expect(scoped.exitCode).toBe(1);
+  expect(scoped.stderr).toContain("not supported with adopt");
+
+  const updated = await runSkillsetCli("adopt", ".", "--updated");
+  expect(updated.exitCode).toBe(1);
+  expect(updated.stderr).toContain("not supported with adopt");
+
+  const include = await runSkillsetCli("adopt", ".", "--include", "ci");
+  expect(include.exitCode).toBe(1);
+  expect(include.stderr).toContain("--include is not supported with adopt");
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-adopt-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), content);
+  }
+  return root;
+}
+
+async function walkFiles(root: string): Promise<ReadonlySet<string>> {
+  const files = new Set<string>();
+  const walk = async (dir: string): Promise<void> => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) await walk(path);
+      else if (entry.isFile()) files.add(relative(root, path).replaceAll("\\", "/"));
+    }
+  };
+  await walk(root);
+  return files;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runSkillsetCli(...args: readonly string[]): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -1,0 +1,370 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+
+import type { ReleaseBaselineEntry } from "./adoption";
+import { buildSkillset, ISOLATED_OUT_ROOT } from "./build";
+import { importSources } from "./import";
+import { inspectSkillset } from "./lint";
+import { loadBuildGraph } from "./resolver";
+import {
+  initSkillset,
+  type SetupFile,
+  type SetupImportCandidate,
+  type SurveySkip,
+} from "./setup";
+import type { LintIssue, SkillsetOptions, TargetName } from "./types";
+
+export interface AdoptOptions extends SkillsetOptions {
+  readonly targets?: readonly TargetName[];
+  readonly write?: boolean;
+}
+
+/** A plugin or skill landed in `.skillset/` by one candidate import. */
+export interface AdoptImportedUnit {
+  readonly kind: "plugin" | "skill";
+  readonly name: string;
+  /** Original path relative to the adopted root (`.` for a root plugin). */
+  readonly sourcePath: string;
+}
+
+export interface AdoptImportResult {
+  readonly candidate: SetupImportCandidate;
+  /** Instructions destination relative to the root (e.g. `.skillset/instructions/agents.md`). */
+  readonly destination?: string;
+  readonly detail: string;
+  readonly ok: boolean;
+  readonly units: readonly AdoptImportedUnit[];
+}
+
+export interface AdoptReport {
+  readonly alreadyAdopted: boolean;
+  readonly baselines: readonly ReleaseBaselineEntry[];
+  readonly buildError?: string;
+  readonly builtFiles: number;
+  readonly candidates: readonly SetupImportCandidate[];
+  /**
+   * Original paths a live (non-isolated) build would own. While they sit in
+   * place, live builds refuse to overwrite them as unmanaged files — that
+   * protection is the cutover safety net.
+   */
+  readonly cutover: readonly string[];
+  readonly imports: readonly AdoptImportResult[];
+  readonly lintIssues: readonly LintIssue[];
+  readonly ok: boolean;
+  readonly rootPath: string;
+  readonly setupFiles: readonly SetupFile[];
+  readonly surveySkips: readonly SurveySkip[];
+  readonly write: boolean;
+}
+
+/** Where write-mode adoption persists its migration report. */
+export const ADOPT_REPORT_DIR = ".skillset/build/adopt";
+
+const INSTRUCTIONS_DIR = ".skillset/instructions";
+
+/**
+ * One-action repo adoption: survey via `init`, import every candidate
+ * (plugins, skills, and verbatim instruction files), lint without throwing,
+ * and build isolated so the generated projection lands under
+ * `.skillset/build/out/` instead of the repo's live surfaces. Write mode only
+ * ever creates paths under `.skillset/`; plan mode (the default) runs the
+ * survey alone and writes nothing.
+ */
+export async function adoptSkillset(
+  rootPath: string,
+  options: AdoptOptions = {}
+): Promise<AdoptReport> {
+  const { targets, write, ...buildOptions } = options;
+  const writeMode = write === true;
+  const resolvedRoot = resolve(rootPath);
+  // Captured before init scaffolds config: an existing .skillset/config.yaml
+  // means the repo was already adopted; adopt proceeds (init tolerates a valid
+  // pre-existing config) but the report says so honestly.
+  const alreadyAdopted = await exists(join(resolvedRoot, ".skillset/config.yaml"));
+
+  const init = await initSkillset({
+    cwd: resolvedRoot,
+    useGitRoot: false,
+    write: writeMode,
+    ...(targets === undefined ? {} : { targets }),
+  });
+
+  if (!writeMode) {
+    return {
+      alreadyAdopted,
+      baselines: init.baselines,
+      builtFiles: 0,
+      candidates: init.importCandidates,
+      cutover: [],
+      imports: [],
+      lintIssues: [],
+      ok: true,
+      rootPath: init.rootPath,
+      setupFiles: init.files,
+      surveySkips: init.surveySkips,
+      write: false,
+    };
+  }
+
+  const imports: AdoptImportResult[] = [];
+  const cutover: string[] = [];
+  for (const candidate of init.importCandidates) {
+    imports.push(await importCandidate(init.rootPath, candidate, cutover));
+  }
+
+  let lintIssues: readonly LintIssue[] = [];
+  let buildError: string | undefined;
+  try {
+    const graph = await loadBuildGraph(init.rootPath, buildOptions);
+    lintIssues = (await inspectSkillset(graph)).issues;
+  } catch (error) {
+    buildError = errorMessage(error);
+  }
+
+  let builtFiles = 0;
+  if (buildError === undefined) {
+    try {
+      builtFiles = (await buildSkillset(init.rootPath, { ...buildOptions, isolated: true })).length;
+    } catch (error) {
+      buildError = errorMessage(error);
+    }
+  }
+
+  const lintErrors = lintIssues.filter((issue) => issue.severity === "error");
+  const report: AdoptReport = {
+    alreadyAdopted,
+    baselines: init.baselines,
+    ...(buildError === undefined ? {} : { buildError }),
+    builtFiles,
+    candidates: init.importCandidates,
+    cutover,
+    imports,
+    lintIssues,
+    ok:
+      imports.every((result) => result.ok) &&
+      lintErrors.length === 0 &&
+      buildError === undefined,
+    rootPath: init.rootPath,
+    setupFiles: init.files,
+    surveySkips: init.surveySkips,
+    write: true,
+  };
+
+  const reportDir = join(init.rootPath, ADOPT_REPORT_DIR);
+  await mkdir(reportDir, { recursive: true });
+  await writeFile(
+    join(reportDir, "report.md"),
+    renderAdoptReportMarkdown(report, { rootPath: init.rootPath })
+  );
+  await writeFile(join(reportDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
+
+  return report;
+}
+
+/**
+ * Import one survey candidate. Failures are recorded on the result, never
+ * thrown: a single bad candidate must not abort the rest of the migration.
+ */
+async function importCandidate(
+  rootPath: string,
+  candidate: SetupImportCandidate,
+  cutover: string[]
+): Promise<AdoptImportResult> {
+  if (candidate.kind === "instructions") {
+    try {
+      const destination = await importInstructionFile(rootPath, candidate.path);
+      // The original instruction file stays in place; a live build would
+      // regenerate it from the imported source and hit the unmanaged-overwrite
+      // protection, so it belongs on the cutover list.
+      cutover.push(candidate.path);
+      return { candidate, destination, detail: destination, ok: true, units: [] };
+    } catch (error) {
+      return { candidate, detail: errorMessage(error), ok: false, units: [] };
+    }
+  }
+
+  try {
+    const batch = await importSources({
+      kind: candidate.kind,
+      rootPath,
+      sourcePath: join(rootPath, candidate.path),
+    });
+    const units = batch.imports.map((report) => {
+      const sourcePath = relative(rootPath, report.sourcePath).replaceAll("\\", "/");
+      return {
+        kind: report.kind,
+        name: report.name,
+        sourcePath: sourcePath.length === 0 ? "." : sourcePath,
+      };
+    });
+    return {
+      candidate,
+      detail: `${units.map((unit) => `${unit.kind} ${unit.name}`).join(", ")} (${batch.files} files)`,
+      ok: true,
+      units,
+    };
+  } catch (error) {
+    return { candidate, detail: errorMessage(error), ok: false, units: [] };
+  }
+}
+
+/**
+ * Minimal verbatim instructions import: copy the root instruction file into
+ * `.skillset/instructions/` under its lowercased name (`AGENTS.md` ->
+ * `agents.md`). The ADR's transform-on-adopt is a later slice; content copies
+ * byte-for-byte and never overwrites an existing destination.
+ */
+async function importInstructionFile(rootPath: string, sourceName: string): Promise<string> {
+  const destinationRelative = `${INSTRUCTIONS_DIR}/${sourceName.toLowerCase()}`;
+  const destination = join(rootPath, destinationRelative);
+  if (await exists(destination)) {
+    throw new Error(
+      `skillset: instructions import target already exists: ${destinationRelative}. ` +
+        "Adopt never overwrites; remove the existing file or merge by hand."
+    );
+  }
+  const content = await readFile(join(rootPath, sourceName));
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, content);
+  return destinationRelative;
+}
+
+export function renderAdoptReportMarkdown(
+  report: AdoptReport,
+  opts: { readonly rootPath: string }
+): string {
+  const lintErrors = report.lintIssues.filter((issue) => issue.severity === "error");
+  const lintWarnings = report.lintIssues.filter((issue) => issue.severity === "warn");
+  const succeeded = report.imports.filter((result) => result.ok);
+  const failed = report.imports.filter((result) => !result.ok);
+
+  const lines: string[] = ["# Skillset adoption report", ""];
+
+  lines.push("## Summary", "");
+  lines.push(`- root: \`${opts.rootPath}\``);
+  lines.push(`- result: ${report.ok ? "pass" : "fail"}`);
+  if (report.alreadyAdopted) {
+    lines.push("- note: the repo already had `.skillset/config.yaml`; adoption proceeded against the existing source tree");
+  }
+  lines.push(
+    `- imports: ${succeeded.length} succeeded, ${failed.length} failed`,
+    `- lint: ${lintErrors.length} error(s), ${lintWarnings.length} warning(s)`,
+    report.buildError === undefined
+      ? `- build (isolated): ${report.builtFiles} generated files`
+      : "- build (isolated): failed",
+    ""
+  );
+
+  lines.push("## Setup", "");
+  for (const file of report.setupFiles) {
+    lines.push(`- ${file.status === "create" ? "created" : "already present"}: \`${file.path}\``);
+  }
+  for (const baseline of report.baselines) {
+    if (baseline.status !== "create") continue;
+    lines.push(`- baseline: ${baseline.scope} ${baseline.version}`);
+  }
+  lines.push("");
+
+  lines.push("## Imported", "");
+  if (succeeded.length === 0) {
+    lines.push("Nothing imported.", "");
+  } else {
+    for (const result of succeeded) {
+      if (result.destination !== undefined) {
+        lines.push(`- ${result.candidate.kind}: \`${result.candidate.path}\` -> \`${result.destination}\` (verbatim copy)`);
+        continue;
+      }
+      lines.push(`- ${result.candidate.kind}: \`${result.candidate.path}\` -> ${result.detail}`);
+    }
+    lines.push("");
+  }
+
+  if (report.surveySkips.length > 0) {
+    lines.push("## Skipped surfaces", "");
+    for (const skip of report.surveySkips) {
+      lines.push(`- ${skip.surface} \`${skip.path}\`: ${skip.reason}`);
+    }
+    lines.push("");
+  }
+
+  if (failed.length > 0) {
+    lines.push("## Failed imports", "");
+    for (const result of failed) {
+      lines.push(`- ${result.candidate.kind} \`${result.candidate.path}\`: ${result.detail}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Lint", "");
+  if (report.lintIssues.length === 0) {
+    lines.push("No lint issues.", "");
+  } else {
+    for (const issue of lintErrors) {
+      lines.push(`- error \`${issue.path}\`: ${issue.code}: ${issue.message}`);
+    }
+    for (const issue of lintWarnings) {
+      lines.push(`- warning \`${issue.path}\`: ${issue.code}: ${issue.message}`);
+    }
+    lines.push(
+      "",
+      "Lint errors fail adoption and need source fixes; warnings are advisory.",
+      ""
+    );
+  }
+
+  lines.push("## Build (isolated)", "");
+  if (report.buildError === undefined) {
+    lines.push(
+      `Wrote ${report.builtFiles} generated files into the mirror under \`${ISOLATED_OUT_ROOT}/\`, laid out as the repo root would be. The live tree is untouched.`,
+      ""
+    );
+  } else {
+    lines.push("```", report.buildError.trimEnd(), "```", "");
+  }
+
+  lines.push("## Cutover", "");
+  lines.push(
+    `1. Review the generated mirror under \`${ISOLATED_OUT_ROOT}/\` against the originals.`
+  );
+  if (report.cutover.length > 0) {
+    lines.push("2. Remove or relocate these originals — a live build owns their paths:");
+    for (const path of report.cutover) {
+      lines.push(`   - \`${path}\``);
+    }
+  } else {
+    lines.push("2. No original paths need to move before a live build.");
+  }
+  lines.push(
+    "3. Run `skillset build --yes` to write live output.",
+    "",
+    "Until the originals move, live builds refuse to overwrite them as unmanaged files — that protection is the safety net; nothing is lost by building too early.",
+    ""
+  );
+
+  lines.push(
+    "## Next steps",
+    "",
+    "- `skillset lint`",
+    "- `skillset check --isolated`",
+    "- `skillset ci`",
+    ""
+  );
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -3,6 +3,7 @@ import { basename, dirname, resolve } from "node:path";
 
 import { changeCheck, type ChangeBump, type ChangeCheckReport } from "./change-entries";
 import { changeStatus, type ChangeStatusReport } from "./change-status";
+import { ADOPT_REPORT_DIR, adoptSkillset, type AdoptReport } from "./adopt";
 import {
   addChangeEntry,
   groupRef,
@@ -26,7 +27,7 @@ import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "./sou
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
 import type { BuildScope, CompileBuildMode, SkillsetOptions, TargetName } from "./types";
 
-type Command = "build" | "change" | "check" | "ci" | "create" | "diff" | "doctor" | "explain" | "hooks" | "import" | "init" | "lint" | "list" | "release" | "test";
+type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "diff" | "doctor" | "explain" | "hooks" | "import" | "init" | "lint" | "list" | "release" | "test";
 
 const USAGE = [
   "usage: skillset build [--yes|--dry-run] [--updated|--all] [--isolated] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
@@ -45,6 +46,7 @@ const USAGE = [
   "       skillset test [name] [--root <path>] [--source <dir>]",
   "       skillset hooks print --runner <lefthook|husky|pre-commit|git> [--pre-commit] [--pre-push]",
   "       skillset hooks print --target <claude|codex> --agent-runtime",
+  "       skillset adopt <path> [--yes|--dry-run] [--targets claude,codex] [--root <path>]",
   "       skillset init [path] [--yes|--dry-run] [--targets claude,codex] [--include agents,ci] [--name <name>] [--root <path>]",
   "       skillset create [path|--global] [--yes|--dry-run] [--targets claude,codex] [--include agents,ci] [--name <name>] [--root <path>]",
   "       skillset explain <path> [--root <path>] [--source <dir>]",
@@ -231,6 +233,21 @@ export async function runCli(
       console.log(`  warn: ${issue.path}: ${issue.code}: ${issue.message}`);
     }
     console.log(`skillset: linted ${result.checkedSkills} source skills`);
+    return;
+  }
+
+  if (command === "adopt") {
+    const writeMode = yes && !dryRun;
+    const report = await adoptSkillset(
+      importPath === undefined ? rootPath : resolve(rootPath, importPath),
+      {
+        ...(setupTargets === undefined ? {} : { targets: setupTargets }),
+        write: writeMode,
+      }
+    );
+    printAdoptReport(report, dryRun ? "dry run" : writeMode ? "written" : "write confirmation required");
+    if (!writeMode) console.log("skillset: rerun with --yes to adopt");
+    if (writeMode && !report.ok) process.exitCode = 1;
     return;
   }
 
@@ -612,6 +629,41 @@ function printImportReport(result: ImportReport): void {
   console.log(`  next: ${result.nextChecks.join(", ")}`);
 }
 
+function printAdoptReport(report: AdoptReport, reason: string): void {
+  console.log(`skillset: adopt ${report.rootPath} (${reason})`);
+  if (report.alreadyAdopted) {
+    console.log("  note: repo already has .skillset/config.yaml; adopting against existing source");
+  }
+  for (const file of report.setupFiles) {
+    console.log(`  ${file.status === "create" ? "+" : "="} ${file.path}`);
+  }
+  for (const candidate of report.candidates) {
+    console.log(`  ? import candidate ${candidate.kind} ${candidate.path}`);
+  }
+  for (const skip of report.surveySkips) {
+    console.log(`  ! skipped ${skip.surface} ${skip.path}: ${skip.reason}`);
+  }
+  if (!report.write) return;
+
+  for (const result of report.imports) {
+    const marker = result.ok ? "ok" : "FAIL";
+    console.log(`  ${marker} import ${result.candidate.kind}:${result.candidate.path}${result.ok ? ` -> ${result.detail}` : `: ${result.detail}`}`);
+  }
+  const lintErrors = report.lintIssues.filter((issue) => issue.severity === "error").length;
+  const lintWarnings = report.lintIssues.length - lintErrors;
+  console.log(`  ${lintErrors === 0 ? "ok" : "FAIL"} lint: ${lintErrors} error(s), ${lintWarnings} warning(s)`);
+  console.log(
+    report.buildError === undefined
+      ? `  ok build: wrote ${report.builtFiles} generated files under .skillset/build/out/`
+      : `  FAIL build: ${report.buildError.split("\n")[0]}`
+  );
+  if (report.cutover.length > 0) {
+    console.log(`  cutover: ${report.cutover.join(", ")} (see report)`);
+  }
+  console.log(`  report: ${ADOPT_REPORT_DIR}/report.md`);
+  console.log(`skillset: adopt ${report.ok ? "passed" : "found problems"}`);
+}
+
 function printSetupReport(result: SetupReport, reason: string): void {
   for (const file of result.files) {
     const marker = file.status === "create" ? "+" : "=";
@@ -658,6 +710,7 @@ function printSkillsetTest(report: SkillsetTestReport): void {
 function parseArgs(args: readonly string[]): ParsedArgs {
   const command = args[0];
   if (
+    command !== "adopt" &&
     command !== "build" &&
     command !== "change" &&
     command !== "check" &&
@@ -675,7 +728,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "test"
   ) {
     throw new Error(
-        "skillset: expected command build, change, check, ci, create, diff, doctor, explain, hooks, import, init, lint, list, release, or test\n" +
+        "skillset: expected command adopt, build, change, check, ci, create, diff, doctor, explain, hooks, import, init, lint, list, release, or test\n" +
         USAGE
     );
   }
@@ -770,7 +823,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     }
   }
 
-  if (command === "init" || command === "create") {
+  if (command === "adopt" || command === "init" || command === "create") {
     const rawPath = args[index];
     if (rawPath !== undefined && !rawPath.startsWith("--")) {
       importPath = rawPath;
@@ -960,6 +1013,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(ciReportPath === undefined ? {} : { reportPath: ciReportPath }),
     ...(changeSince === undefined ? {} : { since: changeSince }),
     yes,
+  });
+
+  validateAdoptFlags(command, {
+    ...(buildMode === undefined ? {} : { buildMode }),
+    ...(scopes === undefined ? {} : { scopes }),
   });
 
   validateIsolatedFlag(command, isolated);
@@ -1273,11 +1331,31 @@ function validateSetupFlags(
   if (command === "create" && setup.global && setup.path !== undefined) {
     throw new Error("skillset: create accepts either a path or --global, not both");
   }
+  if (command === "adopt") {
+    if (setup.global) throw new Error("skillset: --global is not supported with adopt");
+    if (setup.includes !== undefined) throw new Error("skillset: --include is not supported with adopt");
+    return;
+  }
   const hasSetupFlag = setup.global ||
     setup.includes !== undefined ||
     setup.targets !== undefined;
   if (hasSetupFlag && command !== "init" && command !== "create") {
     throw new Error("skillset: setup options are only supported with init or create");
+  }
+}
+
+function validateAdoptFlags(
+  command: Command,
+  adopt: {
+    readonly buildMode?: CompileBuildMode;
+    readonly scopes?: readonly BuildScope[];
+  }
+): void {
+  if (command !== "adopt") return;
+  if (adopt.buildMode !== undefined || adopt.scopes !== undefined) {
+    throw new Error(
+      "skillset: build mode and scope flags are not supported with adopt; adoption always builds the full projection isolated"
+    );
   }
 }
 

--- a/scripts/fixtures/__tests__/external.test.ts
+++ b/scripts/fixtures/__tests__/external.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, readdir } from "node:fs/promises";
+import { mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -108,15 +108,18 @@ test("runExternalRepo adopts a marketplace-shaped repo in place and reports roun
     ["purity", true],
   ]);
   expect(report.ok).toBe(true);
-  // The root AGENTS.md is recognized but import has no lowering for it yet:
-  // the harness defers it to adopt instead of failing or staying silent.
+  // The root AGENTS.md candidate now actually imports: adopt copies it
+  // verbatim into .skillset/instructions/ under its lowercased name.
   expect(
     report.stages.find(
       (stage) =>
         stage.stage === "import" &&
         stage.detail.includes("instructions:AGENTS.md")
     )?.detail
-  ).toContain("instructions candidate deferred to adopt");
+  ).toContain(".skillset/instructions/agents.md");
+  expect(
+    await readFile(join(clone, ".skillset/instructions/agents.md"), "utf8")
+  ).toBe("# Demo agents\n\nHandwritten instructions.\n");
   expect(report.survey.candidates).toEqual([
     { kind: "instructions", path: "AGENTS.md" },
     { kind: "plugin", path: "plugins/demo" },
@@ -162,7 +165,9 @@ test("runExternalRepo adopts a marketplace-shaped repo in place and reports roun
   expect(markdown).toContain(
     "- skipped commands `.claude/commands`: project-level commands have no portable source home yet"
   );
-  expect(markdown).toContain("instructions candidate deferred to adopt");
+  expect(markdown).toContain(
+    "instructions:AGENTS.md -> .skillset/instructions/agents.md"
+  );
   expect(markdown).toContain("### plugin demo");
 });
 

--- a/scripts/fixtures/external.ts
+++ b/scripts/fixtures/external.ts
@@ -1,18 +1,20 @@
 #!/usr/bin/env bun
 /**
  * Maintainer harness for external fixture repos: real published repos that
- * Skillset should be able to adopt (init + import), compile, and round-trip
- * into substantially similar generated output.
+ * `skillset adopt` should migrate cleanly, compile, and round-trip into
+ * substantially similar generated output.
  *
  * The committed manifest (fixtures/external/repos.yaml) pins each repo to an
  * exact commit. Clones live gitignored under fixtures/external/repos/ and are
- * never scanned as this repo's own source. Runs adopt each clone in place and
- * build with the isolated mirror (everything lands under .skillset/build/out/),
- * then write reports under .skillset/build/external/.
+ * never scanned as this repo's own source. Runs are a thin wrapper over the
+ * product command: each clone is adopted in place with adoptSkillset (survey,
+ * imports, lint, isolated build under .skillset/build/out/), then the harness
+ * checks purity and round-trips and writes reports under
+ * .skillset/build/external/.
  *
  *   bun scripts/fixtures/external.ts sync   [name]   # reset clones pristine at pinned refs
  *   bun scripts/fixtures/external.ts update [name]   # re-pin to upstream HEAD, then sync
- *   bun scripts/fixtures/external.ts run    [name]   # init -> import -> lint -> build -> purity -> round-trip report
+ *   bun scripts/fixtures/external.ts run    [name]   # adopt -> purity -> round-trip report
  *
  * Run failures (init/import/lint/build/purity errors) exit non-zero. The
  * purity stage is the hard invariant: after a run, `git status` in the clone
@@ -23,12 +25,10 @@
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
-import { buildSkillset, ISOLATED_OUT_ROOT } from "../../apps/skillset/src/build";
+import { adoptSkillset, type AdoptReport } from "../../apps/skillset/src/adopt";
+import { ISOLATED_OUT_ROOT } from "../../apps/skillset/src/build";
 import { gitSafeEnv } from "../../apps/skillset/src/git-env";
-import { importSources } from "../../apps/skillset/src/import";
-import { lintSkillset } from "../../apps/skillset/src/lint";
 import { compareStrings, validateSlug } from "../../apps/skillset/src/path";
-import { initSkillset } from "../../apps/skillset/src/setup";
 import type {
   SetupImportCandidate,
   SurveySkip,
@@ -307,10 +307,12 @@ async function cleanSkillsetLeftovers(clonePath: string): Promise<void> {
 }
 
 /**
- * Adopt one external repo clone in place: init the source scaffold, import
- * every detected candidate, lint, build with the isolated mirror (the
- * projection lands under .skillset/build/out/), verify the purity invariant,
- * and compare the original clone against the generated Claude projection.
+ * Adopt one external repo clone in place via the product command
+ * (`adoptSkillset`): survey, import every candidate (instructions included),
+ * lint, and build with the isolated mirror (the projection lands under
+ * .skillset/build/out/). The harness adds only what the product command does
+ * not own: the purity invariant and the round-trip comparison of the original
+ * clone against the generated Claude projection.
  */
 export async function runExternalRepo(
   name: string,
@@ -322,24 +324,23 @@ export async function runExternalRepo(
 
   await cleanSkillsetLeftovers(clonePath);
 
-  let candidates: readonly SetupImportCandidate[] = [];
   let survey: ExternalSurvey = { candidates: [], skips: [] };
+  let adopt: AdoptReport;
   try {
-    const init = await initSkillset({
-      cwd: clonePath,
-      targets,
-      useGitRoot: false,
-      write: true,
-    });
-    candidates = init.importCandidates;
-    survey = { candidates, skips: init.surveySkips };
-    stages.push({
-      detail: `${candidates.length} import candidate(s): ${candidates.map((candidate) => `${candidate.kind}:${candidate.path}`).join(", ") || "none"}`,
-      ok: candidates.length > 0,
-      stage: "init",
-    });
+    adopt = await adoptSkillset(clonePath, { targets, write: true });
   } catch (error) {
     stages.push({ detail: errorMessage(error), ok: false, stage: "init" });
+    return { name, ok: false, roundTrips, stages, survey };
+  }
+
+  const { candidates } = adopt;
+  survey = { candidates, skips: adopt.surveySkips };
+  stages.push({
+    detail: `${candidates.length} import candidate(s): ${candidates.map((candidate) => `${candidate.kind}:${candidate.path}`).join(", ") || "none"}`,
+    ok: candidates.length > 0,
+    stage: "init",
+  });
+  if (candidates.length === 0) {
     return { name, ok: false, roundTrips, stages, survey };
   }
 
@@ -348,75 +349,40 @@ export async function runExternalRepo(
     readonly name: string;
     readonly sourcePath: string;
   }[] = [];
-  for (const candidate of candidates) {
-    // Instruction files have no import lowering yet; adopt will lower them to
-    // .skillset/instructions/. Deferring keeps the run green and visible.
-    if (candidate.kind === "instructions") {
-      stages.push({
-        detail: `${candidate.kind}:${candidate.path}: instructions candidate deferred to adopt`,
-        ok: true,
-        stage: "import",
-      });
-      continue;
-    }
-    try {
-      const batch = await importSources({
-        kind: candidate.kind,
-        rootPath: clonePath,
-        sourcePath: join(clonePath, candidate.path),
-      });
-      for (const report of batch.imports) {
-        const sourcePath = relative(clonePath, report.sourcePath).replaceAll(
-          "\\",
-          "/"
-        );
-        imported.push({
-          kind: report.kind,
-          name: report.name,
-          sourcePath: sourcePath.length === 0 ? "." : sourcePath,
-        });
-      }
-      stages.push({
-        detail: `${candidate.kind}:${candidate.path} -> ${batch.imports.map((report) => `${report.kind} ${report.name}`).join(", ")} (${batch.files} files)`,
-        ok: true,
-        stage: "import",
-      });
-    } catch (error) {
-      stages.push({
-        detail: `${candidate.kind}:${candidate.path}: ${errorMessage(error)}`,
-        ok: false,
-        stage: "import",
-      });
-    }
-  }
-
-  if (imported.length === 0) {
-    return { name, ok: false, roundTrips, stages, survey };
-  }
-
-  // Partial import failures still run lint/build: they validate whatever did
-  // import, and the failed import stage already fails the overall run.
-  try {
-    const lint = await lintSkillset(clonePath);
+  for (const result of adopt.imports) {
+    const label = `${result.candidate.kind}:${result.candidate.path}`;
     stages.push({
-      detail: `linted ${lint.checkedSkills} source skills`,
-      ok: true,
-      stage: "lint",
+      detail: result.ok
+        ? `${label} -> ${result.detail}`
+        : `${label}: ${result.detail}`,
+      ok: result.ok,
+      stage: "import",
     });
-  } catch (error) {
-    stages.push({ detail: errorMessage(error), ok: false, stage: "lint" });
+    imported.push(...result.units);
   }
 
-  try {
-    const rendered = await buildSkillset(clonePath, { isolated: true });
-    stages.push({
-      detail: `wrote ${rendered.length} generated files under ${ISOLATED_OUT_ROOT}/`,
-      ok: true,
-      stage: "build",
-    });
-  } catch (error) {
-    stages.push({ detail: errorMessage(error), ok: false, stage: "build" });
-  }
+  const lintErrors = adopt.lintIssues.filter(
+    (issue) => issue.severity === "error"
+  );
+  stages.push({
+    detail:
+      lintErrors.length === 0
+        ? `${adopt.lintIssues.length} lint issue(s), 0 errors`
+        : `${lintErrors.length} lint error(s): ${lintErrors
+            .slice(0, 3)
+            .map((issue) => `${issue.path}: ${issue.code}`)
+            .join("; ")}`,
+    ok: lintErrors.length === 0,
+    stage: "lint",
+  });
+
+  stages.push({
+    detail:
+      adopt.buildError ??
+      `wrote ${adopt.builtFiles} generated files under ${ISOLATED_OUT_ROOT}/`,
+    ok: adopt.buildError === undefined,
+    stage: "build",
+  });
 
   try {
     const purity = await checkClonePurity(clonePath);


### PR DESCRIPTION
**`skillset adopt <path>`** — the one-action migration, composed exactly like `ci`: survey → import every candidate (plugins/skills via import; instructions copied verbatim) → lint (non-throwing) → `build --isolated` → migration report (md+json) under `.skillset/build/adopt/` with per-candidate results, honest skips, lint errors-vs-warnings, and an explicit **Cutover** section citing the unmanaged-overwrite protection as the safety net. Plan-first: without `--yes` it surveys only. Writes nothing outside `.skillset/`.

The external fixture harness is now a **thin wrapper over adopt** — fixture runs exercise the product command. Live run: 4 candidates imported (incl. both instruction files), 11 lint warnings / 0 errors, 253 files built isolated, purity green, round-trip 197/40/6 stable. Notable finding from the smoke run: with default `claude,codex` targets the repo correctly *fails* adopt (Claude plugin agents are unsupported in Codex v1) — honest report, exit 1; `--targets claude` passes.

Linear: https://linear.app/outfitter/issue/SET-63
Gates: `bun run check` ✓ · 382 tests ✓ · live fixture sync+run ✓ incl. purity · CLI smoke with report excerpts ✓

Top of the stack (on #36).