### PR TITLE
feat(transforms): intent-keyed registry with evidence and adopt preview

### DIFF
--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -33,6 +33,7 @@
     "yaml": "^2.8.1"
   },
   "devDependencies": {
-    "@skillset/lint": "workspace:*"
+    "@skillset/lint": "workspace:*",
+    "@skillset/transforms": "workspace:*"
   }
 }

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -135,6 +135,45 @@ test("adopt fails on lint errors and the CLI exits nonzero", async () => {
   expect(result.stdout).toContain("adopt found problems");
 });
 
+test("adopt previews transforms in imported skill bodies without rewriting", async () => {
+  const skillBody =
+    "Skills live in .claude/skills/x today.\n\nPass $ARGUMENTS along, then ask @reviewer.\n";
+  const root = await fixture({
+    ".claude/skills/x/SKILL.md": `---\nname: x\ndescription: Transform preview fixture.\n---\n\n${skillBody}`,
+  });
+
+  const report = await adoptSkillset(root, { write: true });
+
+  const preview = report.transformPreviews.find(
+    (entry) => entry.path === ".skillset/skills/x/SKILL.md"
+  );
+  expect(preview).toBeDefined();
+  expect(
+    preview?.matches.map((match) => [match.intent, match.text, match.lowering, match.codexForm])
+  ).toEqual([
+    ["path.skills-dir", ".claude/skills", "bidirectional", ".agents/skills"],
+    ["dynamic.arguments", "$ARGUMENTS", "none", undefined],
+    ["invoke.subagent", "@reviewer", "to-codex", "the `reviewer` agent"],
+  ]);
+  expect(preview?.matches[1]?.reason).toContain("no templating");
+
+  // Preview only: the imported source is byte-identical to the original body.
+  expect(await readFile(join(root, ".skillset/skills/x/SKILL.md"), "utf8")).toContain(skillBody);
+
+  const markdown = renderAdoptReportMarkdown(report, { rootPath: root });
+  expect(markdown).toContain("## Transforms (preview)");
+  expect(markdown).toContain("`.claude/skills` -> `.agents/skills` (path.skills-dir)");
+  expect(markdown).toContain("No faithful Codex lowering:");
+  expect(markdown).toContain("`$ARGUMENTS` (dynamic.arguments)");
+
+  // No recognized constructs -> the section is omitted entirely.
+  const quietReport = await adoptSkillset(await fixture(MARKETPLACE_FIXTURE), { write: true });
+  expect(quietReport.transformPreviews).toEqual([]);
+  expect(renderAdoptReportMarkdown(quietReport, { rootPath: "ignored" })).not.toContain(
+    "## Transforms (preview)"
+  );
+});
+
 test("adopt CLI without --yes prints the survey and writes nothing", async () => {
   const root = await fixture(MARKETPLACE_FIXTURE);
   const before = await walkFiles(root);

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -1,5 +1,11 @@
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import {
+  lowerTransform,
+  recognizeTransforms,
+  type TransformMatch,
+} from "@skillset/transforms";
 
 import type { ReleaseBaselineEntry } from "./adoption";
 import { buildSkillset, ISOLATED_OUT_ROOT } from "./build";
@@ -13,6 +19,7 @@ import {
   type SurveySkip,
 } from "./setup";
 import type { LintIssue, SkillsetOptions, TargetName } from "./types";
+import { parseMarkdown } from "./yaml";
 
 export interface AdoptOptions extends SkillsetOptions {
   readonly targets?: readonly TargetName[];
@@ -36,6 +43,24 @@ export interface AdoptImportResult {
   readonly units: readonly AdoptImportedUnit[];
 }
 
+/** One recognized construct in an imported markdown file, preview only. */
+export interface TransformPreviewMatch {
+  /** Codex surface form a future transform slice would write, if faithful. */
+  readonly codexForm?: string;
+  readonly intent: string;
+  readonly lowering: TransformMatch["lowering"];
+  /** Why no faithful Codex lowering exists (`lowering: "none"` entries). */
+  readonly reason?: string;
+  readonly text: string;
+}
+
+/** Per-file transform recognition over content the import just landed. */
+export interface TransformPreview {
+  readonly matches: readonly TransformPreviewMatch[];
+  /** Repo-relative path of the imported file that was scanned. */
+  readonly path: string;
+}
+
 export interface AdoptReport {
   readonly alreadyAdopted: boolean;
   readonly baselines: readonly ReleaseBaselineEntry[];
@@ -54,6 +79,12 @@ export interface AdoptReport {
   readonly rootPath: string;
   readonly setupFiles: readonly SetupFile[];
   readonly surveySkips: readonly SurveySkip[];
+  /**
+   * Recognition-only preview of Claude-dialect constructs in imported
+   * markdown (skill bodies and instruction files). Nothing is rewritten;
+   * this is the report surface for the transform registry.
+   */
+  readonly transformPreviews: readonly TransformPreview[];
   readonly write: boolean;
 }
 
@@ -102,15 +133,18 @@ export async function adoptSkillset(
       rootPath: init.rootPath,
       setupFiles: init.files,
       surveySkips: init.surveySkips,
+      transformPreviews: [],
       write: false,
     };
   }
 
   const imports: AdoptImportResult[] = [];
   const cutover: string[] = [];
+  const previewSources: string[] = [];
   for (const candidate of init.importCandidates) {
-    imports.push(await importCandidate(init.rootPath, candidate, cutover));
+    imports.push(await importCandidate(init.rootPath, candidate, cutover, previewSources));
   }
+  const transformPreviews = await buildTransformPreviews(init.rootPath, previewSources);
 
   let lintIssues: readonly LintIssue[] = [];
   let buildError: string | undefined;
@@ -147,6 +181,7 @@ export async function adoptSkillset(
     rootPath: init.rootPath,
     setupFiles: init.files,
     surveySkips: init.surveySkips,
+    transformPreviews,
     write: true,
   };
 
@@ -168,7 +203,8 @@ export async function adoptSkillset(
 async function importCandidate(
   rootPath: string,
   candidate: SetupImportCandidate,
-  cutover: string[]
+  cutover: string[],
+  previewSources: string[]
 ): Promise<AdoptImportResult> {
   if (candidate.kind === "instructions") {
     try {
@@ -177,6 +213,7 @@ async function importCandidate(
       // regenerate it from the imported source and hit the unmanaged-overwrite
       // protection, so it belongs on the cutover list.
       cutover.push(candidate.path);
+      previewSources.push(destination);
       return { candidate, destination, detail: destination, ok: true, units: [] };
     } catch (error) {
       return { candidate, detail: errorMessage(error), ok: false, units: [] };
@@ -197,6 +234,14 @@ async function importCandidate(
         sourcePath: sourcePath.length === 0 ? "." : sourcePath,
       };
     });
+    for (const report of batch.imports) {
+      for (const file of report.copiedFiles) {
+        if (basename(file) !== "SKILL.md") continue;
+        previewSources.push(
+          relative(rootPath, join(report.targetPath, file)).replaceAll("\\", "/")
+        );
+      }
+    }
     return {
       candidate,
       detail: `${units.map((unit) => `${unit.kind} ${unit.name}`).join(", ")} (${batch.files} files)`,
@@ -227,6 +272,47 @@ async function importInstructionFile(rootPath: string, sourceName: string): Prom
   await mkdir(dirname(destination), { recursive: true });
   await writeFile(destination, content);
   return destinationRelative;
+}
+
+/**
+ * Recognition-only transform preview over the markdown the imports just
+ * landed: skill bodies (frontmatter stripped) and verbatim instruction
+ * files. Source content is read from the imported copies, never rewritten.
+ */
+async function buildTransformPreviews(
+  rootPath: string,
+  paths: readonly string[]
+): Promise<readonly TransformPreview[]> {
+  const previews: TransformPreview[] = [];
+  for (const path of paths) {
+    const raw = await readFile(join(rootPath, path), "utf8");
+    const body = basename(path) === "SKILL.md" ? markdownBody(raw, path) : raw;
+    const matches = recognizeTransforms(body, "claude");
+    if (matches.length === 0) continue;
+    previews.push({
+      matches: matches.map((match) => {
+        const codexForm = lowerTransform(match, "codex");
+        return {
+          ...(codexForm === undefined ? {} : { codexForm }),
+          intent: match.intent,
+          lowering: match.lowering,
+          ...(match.reason === undefined ? {} : { reason: match.reason }),
+          text: match.text,
+        };
+      }),
+      path,
+    });
+  }
+  return previews;
+}
+
+function markdownBody(raw: string, label: string): string {
+  try {
+    return parseMarkdown(raw, label).body;
+  } catch {
+    // Unparseable frontmatter still deserves a preview; scan the raw text.
+    return raw;
+  }
 }
 
 export function renderAdoptReportMarkdown(
@@ -312,6 +398,40 @@ export function renderAdoptReportMarkdown(
     );
   }
 
+  if (report.transformPreviews.length > 0) {
+    lines.push("## Transforms (preview)", "");
+    lines.push(
+      "Recognition only — adopt rewrote nothing. Codex forms show what a future transform slice would write.",
+      ""
+    );
+    for (const preview of report.transformPreviews) {
+      lines.push(`### \`${preview.path}\``, "");
+      const transformable = aggregatePreviewMatches(
+        preview.matches.filter((match) => match.lowering !== "none")
+      );
+      const blocked = aggregatePreviewMatches(
+        preview.matches.filter((match) => match.lowering === "none")
+      );
+      if (transformable.length > 0) {
+        lines.push("Transformable to Codex:", "");
+        for (const item of transformable) {
+          const target = item.codexForm === undefined ? "(no Codex form)" : inlineCode(item.codexForm);
+          lines.push(`- ${inlineCode(item.text)} -> ${target} (${item.intent}${countSuffix(item.count)})`);
+        }
+        lines.push("");
+      }
+      if (blocked.length > 0) {
+        lines.push("No faithful Codex lowering:", "");
+        for (const item of blocked) {
+          lines.push(
+            `- ${inlineCode(item.text)} (${item.intent}${countSuffix(item.count)}): ${item.reason ?? "no reason recorded"}`
+          );
+        }
+        lines.push("");
+      }
+    }
+  }
+
   lines.push("## Build (isolated)", "");
   if (report.buildError === undefined) {
     lines.push(
@@ -351,6 +471,35 @@ export function renderAdoptReportMarkdown(
   );
 
   return `${lines.join("\n").trimEnd()}\n`;
+}
+
+interface AggregatedPreviewMatch extends TransformPreviewMatch {
+  readonly count: number;
+}
+
+/** Collapse repeated (intent, text, codexForm) hits into one counted line. */
+function aggregatePreviewMatches(
+  matches: readonly TransformPreviewMatch[]
+): readonly AggregatedPreviewMatch[] {
+  const aggregated = new Map<string, AggregatedPreviewMatch>();
+  for (const match of matches) {
+    const key = `${match.intent} ${match.text} ${match.codexForm ?? ""}`;
+    const existing = aggregated.get(key);
+    aggregated.set(
+      key,
+      existing === undefined ? { ...match, count: 1 } : { ...existing, count: existing.count + 1 }
+    );
+  }
+  return [...aggregated.values()];
+}
+
+function countSuffix(count: number): string {
+  return count === 1 ? "" : `, x${count}`;
+}
+
+/** Inline code that survives constructs containing backticks (!`cmd`). */
+function inlineCode(text: string): string {
+  return text.includes("`") ? `\`\` ${text} \`\`` : `\`${text}\``;
 }
 
 function errorMessage(error: unknown): string {

--- a/bun.lock
+++ b/bun.lock
@@ -25,10 +25,15 @@
       },
       "devDependencies": {
         "@skillset/lint": "workspace:*",
+        "@skillset/transforms": "workspace:*",
       },
     },
     "packages/lint": {
       "name": "@skillset/lint",
+      "version": "0.0.0",
+    },
+    "packages/transforms": {
+      "name": "@skillset/transforms",
       "version": "0.0.0",
     },
   },
@@ -114,6 +119,8 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.69.0", "", { "os": "win32", "cpu": "x64" }, "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA=="],
 
     "@skillset/lint": ["@skillset/lint@workspace:packages/lint"],
+
+    "@skillset/transforms": ["@skillset/transforms@workspace:packages/transforms"],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@skillset/transforms",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/transforms/src/__tests__/engine.test.ts
+++ b/packages/transforms/src/__tests__/engine.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test";
+
+import { lowerTransform, recognizeTransforms } from "../index";
+
+test("recognizes claude constructs sorted by index", () => {
+  const body = "Read CLAUDE.md, then look in .claude/settings.json and pass $ARGUMENTS.";
+  const matches = recognizeTransforms(body, "claude");
+  expect(matches.map((match) => [match.intent, match.text])).toEqual([
+    ["doc.project-instructions", "CLAUDE.md"],
+    ["path.project-config-dir", ".claude/"],
+    ["dynamic.arguments", "$ARGUMENTS"],
+  ]);
+  expect(matches.map((match) => match.index)).toEqual(
+    [...matches].sort((a, b) => a.index - b.index).map((match) => match.index)
+  );
+});
+
+test(".claude/skills/foo yields only the skills-dir match", () => {
+  const matches = recognizeTransforms("Skills live in .claude/skills/foo today.", "claude");
+  expect(matches.map((match) => match.intent)).toEqual(["path.skills-dir"]);
+  expect(matches[0]?.text).toBe(".claude/skills");
+});
+
+test("~/.claude/ spans prefer the user entry; ~/.claude/skills the skills entry", () => {
+  expect(
+    recognizeTransforms("config: ~/.claude/settings.json", "claude").map((m) => m.intent)
+  ).toEqual(["path.user-config-dir"]);
+  const skills = recognizeTransforms("home skills: ~/.claude/skills/foo", "claude");
+  expect(skills.map((match) => [match.intent, match.text])).toEqual([
+    ["path.skills-dir", "~/.claude/skills"],
+  ]);
+});
+
+test("subagent mentions are conservative", () => {
+  const matches = recognizeTransforms("Ask @reviewer to take a pass.", "claude");
+  expect(matches.map((match) => [match.intent, match.text])).toEqual([
+    ["invoke.subagent", "@reviewer"],
+  ]);
+  // Emails (word char before @), short names, and uppercase do not match.
+  expect(recognizeTransforms("mail me at matt@example.com", "claude")).toEqual([]);
+  expect(recognizeTransforms("ping @ab quickly", "claude")).toEqual([]);
+  expect(recognizeTransforms("ping @Reviewer quickly", "claude")).toEqual([]);
+});
+
+test("@path mentions classify as file references, beating the agent-mention span", () => {
+  const matches = recognizeTransforms("Read @src/lib/types.ts and @./notes.md.", "claude");
+  expect(matches.map((match) => [match.intent, match.text])).toEqual([
+    ["reference.file-mention", "@src/lib/types.ts"],
+    ["reference.file-mention", "@./notes.md"],
+  ]);
+});
+
+test("lowerTransform produces codex forms for transformable matches", () => {
+  const lower = (body: string): ReadonlyArray<string | undefined> =>
+    recognizeTransforms(body, "claude").map((match) => lowerTransform(match, "codex"));
+
+  expect(lower(".claude/commands and ~/.claude/agents")).toEqual([".codex/", "~/.codex/"]);
+  expect(lower(".claude/skills/x and ~/.claude/skills")).toEqual([
+    ".agents/skills",
+    "~/.agents/skills",
+  ]);
+  expect(lower("see CLAUDE.md")).toEqual(["AGENTS.md"]);
+  expect(lower("Ask @reviewer first.")).toEqual(["the `reviewer` agent"]);
+  expect(lower("Use the Task tool with subagent_type 'code-reviewer' here.")).toEqual([
+    "Spawn the `code-reviewer` agent",
+  ]);
+});
+
+test("lowerTransform refuses no-faithful-lowering matches and wrong directions", () => {
+  const [argumentsMatch] = recognizeTransforms("pass $ARGUMENTS", "claude");
+  if (argumentsMatch === undefined) throw new Error("expected a match");
+  expect(argumentsMatch.lowering).toBe("none");
+  expect(argumentsMatch.reason).toContain("no templating");
+  expect(lowerTransform(argumentsMatch, "codex")).toBeUndefined();
+  expect(lowerTransform(argumentsMatch, "claude")).toBeUndefined();
+
+  const [mention] = recognizeTransforms("Ask @reviewer first.", "claude");
+  if (mention === undefined) throw new Error("expected a match");
+  expect(mention.lowering).toBe("to-codex");
+  expect(lowerTransform(mention, "claude")).toBeUndefined();
+});
+
+test("no-lowering dynamics are recognized, including inside code fences", () => {
+  const body = [
+    "```bash",
+    "run $1 with ${CLAUDE_PLUGIN_ROOT}/bin/tool",
+    "```",
+    "  !`git status`",
+  ].join("\n");
+  const intents = recognizeTransforms(body, "claude").map((match) => match.intent);
+  expect(intents).toEqual([
+    "dynamic.positional",
+    "dynamic.env-substitution",
+    "dynamic.pre-resolution",
+  ]);
+});
+
+test("codex dialect recognition works for the bidirectional entries", () => {
+  const matches = recognizeTransforms(
+    "AGENTS.md, .codex/config.toml, ~/.codex/, and .agents/skills/x",
+    "codex"
+  );
+  expect(matches.map((match) => match.intent)).toEqual([
+    "doc.project-instructions",
+    "path.project-config-dir",
+    "path.user-config-dir",
+    "path.skills-dir",
+  ]);
+});

--- a/packages/transforms/src/__tests__/entries.test.ts
+++ b/packages/transforms/src/__tests__/entries.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test";
+
+import {
+  builtinTransformEntries,
+  listTransformEntries,
+  recognizeTransforms,
+  registerTransformEntry,
+} from "../index";
+
+test("every built-in entry is registered, evidence-backed, and flagged correctly", () => {
+  expect(listTransformEntries()).toEqual(builtinTransformEntries);
+  expect(builtinTransformEntries.map((entry) => entry.intent)).toEqual([
+    "path.project-config-dir",
+    "path.user-config-dir",
+    "path.skills-dir",
+    "doc.project-instructions",
+    "invoke.subagent",
+    "dynamic.arguments",
+    "dynamic.positional",
+    "dynamic.env-substitution",
+    "dynamic.pre-resolution",
+    "reference.file-mention",
+  ]);
+
+  for (const entry of builtinTransformEntries) {
+    expect(entry.evidence.length).toBeGreaterThan(0);
+    for (const evidence of entry.evidence) {
+      expect(evidence.verified).toBe("2026-06-11");
+      expect(evidence.source.length).toBeGreaterThan(0);
+    }
+    if (entry.lowering === "none") {
+      expect(entry.reason).toBeDefined();
+    }
+    for (const form of Object.values(entry.forms)) {
+      expect(form.pattern.flags).toContain("g");
+      expect(form.pattern.flags).toContain("u");
+    }
+  }
+});
+
+test("transformable entries carry renderers on their target forms", () => {
+  for (const entry of builtinTransformEntries) {
+    if (entry.lowering === "bidirectional") {
+      expect(entry.forms.claude?.render).toBeDefined();
+      expect(entry.forms.codex?.render).toBeDefined();
+    }
+    if (entry.lowering === "to-codex") {
+      expect(entry.forms.codex?.render).toBeDefined();
+    }
+    if (entry.lowering === "none") {
+      for (const form of Object.values(entry.forms)) {
+        expect(form.render).toBeUndefined();
+      }
+    }
+  }
+});
+
+test("registry rejects duplicates, missing evidence, and unreasoned none-lowerings", () => {
+  const base = builtinTransformEntries[0];
+  if (base === undefined) throw new Error("expected built-in entries");
+  expect(() => registerTransformEntry(base)).toThrow("already registered");
+  expect(() =>
+    registerTransformEntry({
+      description: "x",
+      evidence: [],
+      forms: {},
+      intent: "test.no-evidence",
+      lowering: "bidirectional",
+    })
+  ).toThrow("no evidence");
+  expect(() =>
+    registerTransformEntry({
+      description: "x",
+      evidence: [{ source: "s", verified: "2026-06-11" }],
+      forms: {},
+      intent: "test.no-reason",
+      lowering: "none",
+    })
+  ).toThrow("needs a reason");
+  expect(() =>
+    registerTransformEntry({
+      description: "x",
+      evidence: [{ source: "s", verified: "2026-06-11" }],
+      forms: { claude: { pattern: /x/u } },
+      intent: "test.bad-flags",
+      lowering: "bidirectional",
+    })
+  ).toThrow("g and u flags");
+});
+
+test("dynamic recognizers stay aligned with skillset lint's CLAUDE_DYNAMIC_PATTERNS", () => {
+  // Mirrors apps/skillset/src/lint.ts; lint owns the codex-enabled gate,
+  // the registry only adds recognition. Keep both recognizing the same
+  // language — lint's patterns are the battle-tested reference.
+  const samples: ReadonlyArray<readonly [string, string]> = [
+    ["dynamic.arguments", "Run with $ARGUMENTS now"],
+    ["dynamic.arguments", "Run with $ARGUMENTS[0] now"],
+    ["dynamic.arguments", "Run with $ARGUMENTS.flag now"],
+    ["dynamic.positional", "echo $1"],
+    ["dynamic.positional", "echo $0 and $12"],
+    ["dynamic.env-substitution", "see ${CLAUDE_PLUGIN_ROOT}/bin"],
+    ["dynamic.pre-resolution", "context:\n  !`git status`\n"],
+  ];
+  for (const [intent, sample] of samples) {
+    const intents = recognizeTransforms(sample, "claude").map((match) => match.intent);
+    expect(intents).toContain(intent);
+  }
+
+  // Non-matches lint also ignores.
+  expect(recognizeTransforms("price is US$100 total", "claude")).toEqual([]);
+  expect(recognizeTransforms("${CODEX_HOME} is not a Claude var", "claude")).toEqual([]);
+  expect(recognizeTransforms("mid-line !`cmd` is not a placeholder", "claude")).toEqual([]);
+});

--- a/packages/transforms/src/__tests__/round-trip.test.ts
+++ b/packages/transforms/src/__tests__/round-trip.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+
+import { lowerTransform, recognizeTransforms } from "../index";
+import type { TransformDialect, TransformTarget } from "../types";
+
+/**
+ * Test-local rewrite helper. The product never rewrites content in this
+ * slice; this exists purely to assert the round-trip identity property on
+ * whole documents.
+ */
+function rewrite(body: string, from: TransformDialect, to: TransformTarget): string {
+  let out = "";
+  let cursor = 0;
+  for (const match of recognizeTransforms(body, from)) {
+    const lowered = lowerTransform(match, to);
+    if (lowered === undefined) continue;
+    out += body.slice(cursor, match.index) + lowered;
+    cursor = match.index + match.text.length;
+  }
+  return out + body.slice(cursor);
+}
+
+const CLAUDE_SAMPLE = [
+  "Project config sits in .claude/settings.json; user config in ~/.claude/config.",
+  "Skills live in .claude/skills/review and globally in ~/.claude/skills.",
+  "Read CLAUDE.md first, then docs/CLAUDE.md if present.",
+  "Commands: .claude/commands/x.md and agents in ~/.claude/agents/.",
+].join("\n");
+
+const CODEX_SAMPLE = [
+  "Project config sits in .codex/config.toml; user config in ~/.codex/config.",
+  "Skills live in .agents/skills/review and globally in ~/.agents/skills.",
+  "Read AGENTS.md first, then docs/AGENTS.md if present.",
+].join("\n");
+
+test("claude -> intent -> claude is the identity on bidirectional entries", () => {
+  expect(rewrite(CLAUDE_SAMPLE, "claude", "claude")).toBe(CLAUDE_SAMPLE);
+  for (const match of recognizeTransforms(CLAUDE_SAMPLE, "claude")) {
+    expect(lowerTransform(match, "claude")).toBe(match.text);
+  }
+});
+
+test("claude -> codex -> claude reproduces the input byte-for-byte", () => {
+  const codex = rewrite(CLAUDE_SAMPLE, "claude", "codex");
+  expect(codex).toBe(
+    [
+      "Project config sits in .codex/settings.json; user config in ~/.codex/config.",
+      "Skills live in .agents/skills/review and globally in ~/.agents/skills.",
+      "Read AGENTS.md first, then docs/AGENTS.md if present.",
+      "Commands: .codex/commands/x.md and agents in ~/.codex/agents/.",
+    ].join("\n")
+  );
+  expect(rewrite(codex, "codex", "claude")).toBe(CLAUDE_SAMPLE);
+});
+
+test("codex -> claude -> codex reproduces the input byte-for-byte", () => {
+  const claude = rewrite(CODEX_SAMPLE, "codex", "claude");
+  expect(rewrite(claude, "claude", "codex")).toBe(CODEX_SAMPLE);
+});
+
+test("subagent invocations render to codex prose (to-codex only)", () => {
+  const body = [
+    "First ask @code-reviewer for a pass.",
+    "Then use the Task tool with subagent_type 'doc-writer' for docs.",
+  ].join("\n");
+  const matches = recognizeTransforms(body, "claude");
+  expect(matches.map((match) => lowerTransform(match, "codex"))).toEqual([
+    "the `code-reviewer` agent",
+    "Spawn the `doc-writer` agent",
+  ]);
+  // No reverse path exists: claude is not a valid target for these matches.
+  for (const match of matches) {
+    expect(lowerTransform(match, "claude")).toBeUndefined();
+  }
+});

--- a/packages/transforms/src/engine.ts
+++ b/packages/transforms/src/engine.ts
@@ -1,0 +1,111 @@
+import { listTransformEntries, transformEntries } from "./registry";
+import type {
+  TransformDialect,
+  TransformEntry,
+  TransformMatch,
+  TransformTarget,
+} from "./types";
+
+interface Candidate {
+  readonly entry: TransformEntry;
+  readonly index: number;
+  /** Registration position; the deterministic tiebreak for equal spans. */
+  readonly order: number;
+  readonly text: string;
+}
+
+/**
+ * Recognize every registered construct of `dialect` in `body`.
+ *
+ * Overlapping spans never double-report: the longest match wins (then the
+ * earlier match, then registration order), which is what makes the
+ * skills-dir entries shadow the generic config-dir prefixes on
+ * `.claude/skills/...` spans. Code fences and inline code are scanned like
+ * any other text on purpose — for skills, dynamic constructs inside fences
+ * are usually the real usage. Results are sorted by index.
+ */
+export function recognizeTransforms(
+  body: string,
+  dialect: TransformDialect
+): readonly TransformMatch[] {
+  const candidates: Candidate[] = [];
+  let order = 0;
+  for (const entry of listTransformEntries()) {
+    const form = entry.forms[dialect];
+    if (form !== undefined) {
+      for (const match of execAll(form.pattern, body)) {
+        candidates.push({ entry, index: match.index, order, text: match[0] });
+      }
+    }
+    order += 1;
+  }
+
+  candidates.sort(
+    (a, b) => b.text.length - a.text.length || a.index - b.index || a.order - b.order
+  );
+
+  const kept: Candidate[] = [];
+  for (const candidate of candidates) {
+    const end = candidate.index + candidate.text.length;
+    const overlaps = kept.some(
+      (other) => candidate.index < other.index + other.text.length && other.index < end
+    );
+    if (!overlaps) kept.push(candidate);
+  }
+
+  return kept
+    .sort((a, b) => a.index - b.index)
+    .map(({ entry, index, text }) => ({
+      dialect,
+      index,
+      intent: entry.intent,
+      lowering: entry.lowering,
+      text,
+      ...(entry.reason === undefined ? {} : { reason: entry.reason }),
+    }));
+}
+
+/**
+ * Lower a recognized construct into `target`'s surface form. Returns
+ * `undefined` when no faithful lowering exists: `lowering: "none"` entries,
+ * a `to-codex` entry asked for a non-codex target, or a missing target
+ * form/renderer. Lowering into the match's own dialect is the identity.
+ */
+export function lowerTransform(
+  match: TransformMatch,
+  target: TransformTarget
+): string | undefined {
+  if (match.lowering === "none") return undefined;
+  if (match.lowering === "to-codex" && target !== "codex") return undefined;
+  if (target === match.dialect) return match.text;
+
+  const entry = transformEntries.get(match.intent);
+  const sourceForm = entry?.forms[match.dialect];
+  const render = entry?.forms[target]?.render;
+  if (entry === undefined || sourceForm === undefined || render === undefined) {
+    return undefined;
+  }
+
+  // Re-derive the canonical capture by re-running the source recognizer on
+  // the matched text alone; `^`/whitespace context guards hold at offset 0.
+  const exec = cloneWithoutGlobal(sourceForm.pattern).exec(match.text);
+  if (exec === null || exec[0] !== match.text) return undefined;
+  return render(exec);
+}
+
+/** Iterate all matches on a private clone so shared patterns stay stateless. */
+function execAll(pattern: RegExp, body: string): readonly RegExpExecArray[] {
+  const regex = new RegExp(pattern.source, pattern.flags);
+  const matches: RegExpExecArray[] = [];
+  let match = regex.exec(body);
+  while (match !== null) {
+    matches.push(match);
+    if (match[0].length === 0) regex.lastIndex += 1;
+    match = regex.exec(body);
+  }
+  return matches;
+}
+
+function cloneWithoutGlobal(pattern: RegExp): RegExp {
+  return new RegExp(pattern.source, pattern.flags.replaceAll(/[gy]/gu, ""));
+}

--- a/packages/transforms/src/entries/docs.ts
+++ b/packages/transforms/src/entries/docs.ts
@@ -1,0 +1,29 @@
+import type { TransformEntry } from "../types";
+
+/**
+ * Project instructions document name: `CLAUDE.md` <-> `AGENTS.md`.
+ * Word-boundary on both sides keeps `MY_CLAUDE.md` and `CLAUDE.mdx` out;
+ * path-qualified mentions (`docs/CLAUDE.md`) match the filename alone.
+ */
+export const projectInstructionsEntry: TransformEntry = {
+  description: "Repo-level agent instructions document name.",
+  evidence: [
+    {
+      note: "Codex reads project instructions from AGENTS.md, the role CLAUDE.md plays for Claude.",
+      source: "https://developers.openai.com/codex/guides/agents-md",
+      verified: "2026-06-11",
+    },
+  ],
+  forms: {
+    claude: {
+      pattern: /\bCLAUDE\.md\b/gu,
+      render: () => "CLAUDE.md",
+    },
+    codex: {
+      pattern: /\bAGENTS\.md\b/gu,
+      render: () => "AGENTS.md",
+    },
+  },
+  intent: "doc.project-instructions",
+  lowering: "bidirectional",
+};

--- a/packages/transforms/src/entries/dynamics.ts
+++ b/packages/transforms/src/entries/dynamics.ts
@@ -1,0 +1,98 @@
+import type { TransformEntry, TransformEvidence } from "../types";
+
+/**
+ * Shared target truth for Claude dynamic-context constructs: Codex skills
+ * have no templating, so these pass through as inert literal text, and
+ * OpenAI's own Claude importer rejects skills that use them
+ * (`has_unsupported_command_template_features`).
+ *
+ * Pattern parity: these recognizers are aligned with skillset's lint
+ * CLAUDE_DYNAMIC_PATTERNS (codes claude-arguments,
+ * claude-positional-argument, claude-env-substitution,
+ * claude-shell-placeholder in apps/skillset/src/lint.ts). Lint keeps owning
+ * the codex-enabled gate; this registry only adds recognition for adopt
+ * reporting.
+ */
+const DYNAMIC_EVIDENCE: readonly TransformEvidence[] = [
+  {
+    note: "Codex skills are static instruction files; no templating or substitution is documented.",
+    source: "https://developers.openai.com/codex/skills",
+    verified: "2026-06-11",
+  },
+  {
+    note: "OpenAI's Claude importer flags these constructs as has_unsupported_command_template_features and rejects the import.",
+    source: "https://github.com/openai/codex codex-rs/external-agent-migration/src/lib.rs (~L1181)",
+    verified: "2026-06-11",
+  },
+] as const;
+
+const NO_TEMPLATING_REASON =
+  "Codex skills have no templating: the construct passes through as inert literal text, " +
+  "and OpenAI's Claude importer rejects it (has_unsupported_command_template_features).";
+
+/** `$ARGUMENTS`, including indexed (`$ARGUMENTS[0]`) and dotted access. */
+export const dynamicArgumentsEntry: TransformEntry = {
+  description: "Claude $ARGUMENTS substitution.",
+  evidence: DYNAMIC_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /\$ARGUMENTS(?:\b|\[[^\]]+\]|\.[A-Za-z_][A-Za-z0-9_-]*)/gu,
+    },
+  },
+  intent: "dynamic.arguments",
+  lowering: "none",
+  reason: NO_TEMPLATING_REASON,
+};
+
+/**
+ * Positional arguments (`$0`, `$1`, ...). Matches lint's recognized language
+ * (`(^|[^\w$])\$[0-9]+\b`) expressed as a lookbehind so the reported text is
+ * the construct alone.
+ */
+export const dynamicPositionalEntry: TransformEntry = {
+  description: "Claude positional-argument substitution ($0/$1/...).",
+  evidence: DYNAMIC_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /(?<![\w$])\$[0-9]+\b/gu,
+    },
+  },
+  intent: "dynamic.positional",
+  lowering: "none",
+  reason: NO_TEMPLATING_REASON,
+};
+
+/** `${CLAUDE_*}` environment substitution. */
+export const dynamicEnvSubstitutionEntry: TransformEntry = {
+  description: "Claude ${CLAUDE_*} environment substitution.",
+  evidence: DYNAMIC_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /\$\{CLAUDE_[A-Z0-9_]+\}/gu,
+    },
+  },
+  intent: "dynamic.env-substitution",
+  lowering: "none",
+  reason: NO_TEMPLATING_REASON,
+};
+
+/**
+ * Pre-resolved shell placeholder: a line whose content (after leading
+ * whitespace) starts with !`cmd`. Beyond inertness, the semantics shift on
+ * Codex: the model may read a literal !`cmd` line as an instruction to run
+ * the command rather than as an already-resolved value.
+ */
+export const dynamicPreResolutionEntry: TransformEntry = {
+  description: "Claude pre-resolved shell-command placeholder (!`cmd`).",
+  evidence: DYNAMIC_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /(?<=^[ \t]*)!`[^`\n]+`/gmu,
+    },
+  },
+  intent: "dynamic.pre-resolution",
+  lowering: "none",
+  reason:
+    `${NO_TEMPLATING_REASON} Semantics also shift: the model may interpret a literal ` +
+    "!`cmd` line as an instruction to run the command.",
+};

--- a/packages/transforms/src/entries/index.ts
+++ b/packages/transforms/src/entries/index.ts
@@ -1,0 +1,43 @@
+import { registerTransformEntry } from "../registry";
+import type { TransformEntry } from "../types";
+import { projectInstructionsEntry } from "./docs";
+import {
+  dynamicArgumentsEntry,
+  dynamicEnvSubstitutionEntry,
+  dynamicPositionalEntry,
+  dynamicPreResolutionEntry,
+} from "./dynamics";
+import { projectConfigDirEntry, skillsDirEntry, userConfigDirEntry } from "./paths";
+import { fileMentionEntry } from "./references";
+import { subagentInvokeEntry } from "./subagents";
+
+/** Built-in entries, registered on package import. */
+export const builtinTransformEntries: readonly TransformEntry[] = [
+  projectConfigDirEntry,
+  userConfigDirEntry,
+  skillsDirEntry,
+  projectInstructionsEntry,
+  subagentInvokeEntry,
+  dynamicArgumentsEntry,
+  dynamicPositionalEntry,
+  dynamicEnvSubstitutionEntry,
+  dynamicPreResolutionEntry,
+  fileMentionEntry,
+];
+
+for (const entry of builtinTransformEntries) {
+  registerTransformEntry(entry);
+}
+
+export {
+  dynamicArgumentsEntry,
+  dynamicEnvSubstitutionEntry,
+  dynamicPositionalEntry,
+  dynamicPreResolutionEntry,
+  fileMentionEntry,
+  projectConfigDirEntry,
+  projectInstructionsEntry,
+  skillsDirEntry,
+  subagentInvokeEntry,
+  userConfigDirEntry,
+};

--- a/packages/transforms/src/entries/paths.ts
+++ b/packages/transforms/src/entries/paths.ts
@@ -1,0 +1,94 @@
+import type { TransformEntry } from "../types";
+
+const CONFIG_DIR_EVIDENCE = [
+  {
+    note: "Codex's project- and user-level configuration home is .codex/, the structural twin of Claude's .claude/.",
+    source: "https://developers.openai.com/codex/config-reference",
+    verified: "2026-06-11",
+  },
+] as const;
+
+const SKILLS_DIR_EVIDENCE = [
+  {
+    note: "Codex documents the cross-agent .agents/skills convention as the primary skill home.",
+    source: "https://developers.openai.com/codex/skills",
+    verified: "2026-06-11",
+  },
+  {
+    note: "The skill loader prefers .agents/skills and treats .codex/skills as a legacy location.",
+    source: "openai/codex codex-rs/core-skills/src/loader.rs (~L310-377)",
+    verified: "2026-06-11",
+  },
+] as const;
+
+/**
+ * Project-level config directory prefix: `.claude/` <-> `.codex/`.
+ *
+ * `.claude/skills` is deliberately NOT this entry's business — the skills
+ * directory lowers to `.agents/skills` (see `path.skills-dir`), and the
+ * engine's longest-match-first overlap dedupe guarantees the longer skills
+ * match wins over this generic prefix.
+ */
+export const projectConfigDirEntry: TransformEntry = {
+  description: "Project-level agent config directory prefix.",
+  evidence: CONFIG_DIR_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /\.claude\//gu,
+      render: () => ".claude/",
+    },
+    codex: {
+      pattern: /\.codex\//gu,
+      render: () => ".codex/",
+    },
+  },
+  intent: "path.project-config-dir",
+  lowering: "bidirectional",
+};
+
+/**
+ * User-level config directory prefix: `~/.claude/` <-> `~/.codex/`.
+ * Same skills exception as the project entry; overlap dedupe also keeps this
+ * entry ahead of `path.project-config-dir` on `~/.claude/...` spans because
+ * its match is longer.
+ */
+export const userConfigDirEntry: TransformEntry = {
+  description: "User-level agent config directory prefix.",
+  evidence: CONFIG_DIR_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /~\/\.claude\//gu,
+      render: () => "~/.claude/",
+    },
+    codex: {
+      pattern: /~\/\.codex\//gu,
+      render: () => "~/.codex/",
+    },
+  },
+  intent: "path.user-config-dir",
+  lowering: "bidirectional",
+};
+
+/**
+ * Skills directory: `.claude/skills` <-> `.agents/skills` and
+ * `~/.claude/skills` <-> `~/.agents/skills`. Codex's primary skill home is
+ * the cross-agent `.agents` convention, not `.codex/skills` (legacy).
+ *
+ * Canonical capture: group 1 is the optional `~/` user-home prefix.
+ */
+export const skillsDirEntry: TransformEntry = {
+  description: "Agent skills directory, lowered to the cross-agent .agents convention.",
+  evidence: SKILLS_DIR_EVIDENCE,
+  forms: {
+    claude: {
+      pattern: /(~\/)?\.claude\/skills\b/gu,
+      render: (match) => `${match[1] ?? ""}.claude/skills`,
+    },
+    codex: {
+      pattern: /(~\/)?\.agents\/skills\b/gu,
+      render: (match) => `${match[1] ?? ""}.agents/skills`,
+    },
+  },
+  intent: "path.skills-dir",
+  lowering: "bidirectional",
+};

--- a/packages/transforms/src/entries/references.ts
+++ b/packages/transforms/src/entries/references.ts
@@ -1,0 +1,36 @@
+import type { TransformEntry } from "../types";
+
+/**
+ * Claude `@<path>` file mention. Conservative recognizer: the @ must follow
+ * start-of-line or whitespace (excluding emails, whose @ follows a word
+ * character) and the target must look like a path — it starts with `/`,
+ * `./`, `../`, or `~/`, or it contains a `/`. Quotes, backticks, and
+ * brackets terminate the path, and trailing sentence punctuation backtracks
+ * out of the match.
+ */
+export const fileMentionEntry: TransformEntry = {
+  description: "Claude @<path> file mention.",
+  evidence: [
+    {
+      note: "Codex has no file-mention syntax in skill or instruction bodies; OpenAI's Claude importer rejects mentions as unsupported template features.",
+      source: "https://developers.openai.com/codex/skills",
+      verified: "2026-06-11",
+    },
+    {
+      note: "Importer rejection path for Claude dynamic constructs.",
+      source: "https://github.com/openai/codex codex-rs/external-agent-migration/src/lib.rs (~L1181)",
+      verified: "2026-06-11",
+    },
+  ],
+  forms: {
+    claude: {
+      pattern:
+        /(?<=^|\s)@((?:\.{1,2}\/|\/|~\/)[^\s`'"()[\]]+(?<![.,;:!?])|[\w.-]+\/[^\s`'"()[\]]+(?<![.,;:!?]))/gmu,
+    },
+  },
+  intent: "reference.file-mention",
+  lowering: "none",
+  reason:
+    "Claude file mentions have no Codex equivalent — the reference passes through as literal text, " +
+    "and OpenAI's Claude importer rejects skills that use them.",
+};

--- a/packages/transforms/src/entries/subagents.ts
+++ b/packages/transforms/src/entries/subagents.ts
@@ -1,0 +1,46 @@
+import type { TransformEntry } from "../types";
+
+/**
+ * Subagent invocation. Claude has two surface forms: an `@agent-name`
+ * mention and the explicit "use/run the Task tool with subagent_type 'name'"
+ * phrasing. Codex has no @agent mention syntax (the TUI's @ is file search),
+ * so the lowering is one-way prose: "Spawn the `name` agent" for the Task
+ * phrasing, "the `name` agent" for bare mentions.
+ *
+ * Conservative on purpose: @mentions only match after start-of-line or
+ * whitespace (which excludes emails, whose @ follows a word character) and
+ * names must look like agent slugs (`[a-z0-9][a-z0-9-]{2,}`).
+ *
+ * Canonical capture: group 1 = mention name, group 2 = Task-phrase name;
+ * exactly one is set per match.
+ */
+export const subagentInvokeEntry: TransformEntry = {
+  description: "Invocation of a named subagent.",
+  evidence: [
+    {
+      note: "Codex subagents are spawned by name in prose; there is no mention syntax.",
+      source: "https://developers.openai.com/codex/subagents",
+      verified: "2026-06-11",
+    },
+    {
+      note: "In the Codex TUI, @ triggers file search, not agent mentions.",
+      source: "https://developers.openai.com/codex/cli/slash-commands",
+      verified: "2026-06-11",
+    },
+  ],
+  forms: {
+    claude: {
+      pattern:
+        /(?<=^|\s)@([a-z0-9][a-z0-9-]{2,})\b|(?:[Uu]se|[Rr]un) the Task tool with subagent_type ['"`]?([a-z0-9][a-z0-9-]{2,})/gmu,
+    },
+    codex: {
+      pattern: /\bSpawn the `([a-z0-9][a-z0-9-]{2,})` agent\b/gu,
+      render: (match) =>
+        match[1] === undefined
+          ? `Spawn the \`${match[2] ?? ""}\` agent`
+          : `the \`${match[1]}\` agent`,
+    },
+  },
+  intent: "invoke.subagent",
+  lowering: "to-codex",
+};

--- a/packages/transforms/src/index.ts
+++ b/packages/transforms/src/index.ts
@@ -1,0 +1,23 @@
+export { lowerTransform, recognizeTransforms } from "./engine";
+export {
+  builtinTransformEntries,
+  dynamicArgumentsEntry,
+  dynamicEnvSubstitutionEntry,
+  dynamicPositionalEntry,
+  dynamicPreResolutionEntry,
+  fileMentionEntry,
+  projectConfigDirEntry,
+  projectInstructionsEntry,
+  skillsDirEntry,
+  subagentInvokeEntry,
+  userConfigDirEntry,
+} from "./entries";
+export { listTransformEntries, registerTransformEntry, transformEntries } from "./registry";
+export type {
+  TransformDialect,
+  TransformEntry,
+  TransformEvidence,
+  TransformForm,
+  TransformMatch,
+  TransformTarget,
+} from "./types";

--- a/packages/transforms/src/registry.ts
+++ b/packages/transforms/src/registry.ts
@@ -1,0 +1,32 @@
+import type { TransformEntry } from "./types";
+
+/**
+ * Explicit entry registry keyed by intent; no implicit discovery. Built-in
+ * entries register on package import (see ./entries). Registration order is
+ * the deterministic tiebreak the engine uses for equal-length overlaps.
+ */
+export const transformEntries = new Map<string, TransformEntry>();
+
+export const registerTransformEntry = (entry: TransformEntry): void => {
+  if (transformEntries.has(entry.intent)) {
+    throw new Error(`transform entry already registered: ${entry.intent}`);
+  }
+  if (entry.evidence.length === 0) {
+    throw new Error(`transform entry has no evidence: ${entry.intent}`);
+  }
+  if (entry.lowering === "none" && entry.reason === undefined) {
+    throw new Error(`transform entry with lowering "none" needs a reason: ${entry.intent}`);
+  }
+  for (const [dialect, form] of Object.entries(entry.forms)) {
+    if (!(form.pattern.flags.includes("g") && form.pattern.flags.includes("u"))) {
+      throw new Error(
+        `transform pattern for ${entry.intent} (${dialect}) must carry g and u flags`
+      );
+    }
+  }
+  transformEntries.set(entry.intent, entry);
+};
+
+export const listTransformEntries = (): readonly TransformEntry[] => [
+  ...transformEntries.values(),
+];

--- a/packages/transforms/src/types.ts
+++ b/packages/transforms/src/types.ts
@@ -1,0 +1,79 @@
+/** Source dialect a piece of authored content is written in. */
+export type TransformDialect = "claude" | "codex";
+
+/** Target a recognized construct can be lowered into. */
+export type TransformTarget = "claude" | "codex";
+
+/**
+ * Target-truth provenance for an entry. Every entry must cite where its
+ * mapping was verified and when, so registry maintenance is an evidence
+ * refresh rather than archaeology.
+ */
+export interface TransformEvidence {
+  /** Where the behavior was verified (docs URL, source file + lines). */
+  readonly source: string;
+  /** Verification date, ISO `YYYY-MM-DD`. */
+  readonly verified: string;
+  /** Optional clarification of what the source establishes. */
+  readonly note?: string;
+}
+
+/**
+ * One dialect's surface form of an intent.
+ *
+ * Capture-group contract: an entry's patterns across dialects must expose
+ * compatible capture groups — the groups are the entry's canonical payload
+ * (the "hub"). `render` receives an exec array produced by any dialect's
+ * pattern for the same entry and must rebuild this dialect's surface form
+ * from those groups alone.
+ */
+export interface TransformForm {
+  /** Recognizer for this dialect's surface form. Must carry `g` and `u` flags. */
+  readonly pattern: RegExp;
+  /**
+   * Produce this dialect's form from a canonical capture. Present only on
+   * forms that are a lowering target for the entry (transformable entries);
+   * `lowering: "none"` entries are recognized and reported, never rendered.
+   */
+  readonly render?: (match: RegExpExecArray) => string;
+}
+
+/**
+ * One portable concept, keyed by intent, with per-dialect surface forms.
+ * Data-first: entries carry no behavior beyond recognizers and renderers,
+ * so the registry stays inspectable and testable as plain data.
+ */
+export interface TransformEntry {
+  /** Stable intent key, e.g. `path.project-config-dir`. */
+  readonly intent: string;
+  /** What the portable concept is, in one sentence. */
+  readonly description: string;
+  /** Recognizers (and renderers, where transformable) per dialect. */
+  readonly forms: Partial<Record<TransformDialect, TransformForm>>;
+  /**
+   * `bidirectional`: claude <-> codex round-trips byte-for-byte.
+   * `to-codex`: claude lowers into codex prose; no codex -> claude path.
+   * `none`: recognized and reported only — no faithful lowering exists.
+   */
+  readonly lowering: "bidirectional" | "to-codex" | "none";
+  /** Why no faithful lowering exists. Required when `lowering` is `none`. */
+  readonly reason?: string;
+  /** Mandatory target-truth evidence backing the mapping. */
+  readonly evidence: readonly TransformEvidence[];
+}
+
+/** One recognized construct in a body of text. */
+export interface TransformMatch {
+  /** Intent key of the entry that recognized this span. */
+  readonly intent: string;
+  /** Dialect the text was recognized as. */
+  readonly dialect: TransformDialect;
+  /** Exact matched text. */
+  readonly text: string;
+  /** Offset of the match in the scanned body. */
+  readonly index: number;
+  /** Lowering capability inherited from the entry. */
+  readonly lowering: TransformEntry["lowering"];
+  /** Entry reason, present for `lowering: "none"` entries. */
+  readonly reason?: string;
+}


### PR DESCRIPTION
New private package **`@skillset/transforms`**: the intent-keyed (hub-and-spoke) registry as typed data, every entry carrying target-truth evidence verified 2026-06-11 against developers.openai.com/codex and openai/codex source. Transformable entries: path prefixes (including the `.agents/skills` asymmetry — Codex's skill home is NOT `.codex/skills`), `CLAUDE.md`→`AGENTS.md`, and subagent invocation phrasing. **No-faithful-lowering entries** (`$ARGUMENTS`, positionals, `${CLAUDE_*}`, `!`-pre-resolution, `@file`) carry reasons matching OpenAI's own importer behavior (their migration code rejects these; their prompts surface that supports $ARGUMENTS is deprecated). Engine: recognize/lower with longest-match-first overlap dedupe; round-trip identity (claude→intent→claude) is a tested property per bidirectional entry. Dynamic-construct patterns are parity-pinned to the battle-tested lint patterns by test.

First consumer: `skillset adopt` reports a per-file **transform preview** — live run against compound-engineering: 129 matches across 29 files, every intent firing. No content is rewritten yet (build-time application is the next slice).

Linear: https://linear.app/outfitter/issue/SET-64
Gates: `bun run check` ✓ · 400 tests ✓ · live fixture run ✓

Top of the stack (on #37).