### PR TITLE
feat(render): translate claude-dialect source for codex projections

### DIFF
--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -135,7 +135,7 @@ test("adopt fails on lint errors and the CLI exits nonzero", async () => {
   expect(result.stdout).toContain("adopt found problems");
 });
 
-test("adopt previews transforms in imported skill bodies without rewriting", async () => {
+test("adopt previews transforms and declares dialect on transformable imports", async () => {
   const skillBody =
     "Skills live in .claude/skills/x today.\n\nPass $ARGUMENTS along, then ask @reviewer.\n";
   const root = await fixture({
@@ -157,11 +157,16 @@ test("adopt previews transforms in imported skill bodies without rewriting", asy
   ]);
   expect(preview?.matches[1]?.reason).toContain("no templating");
 
-  // Preview only: the imported source is byte-identical to the original body.
-  expect(await readFile(join(root, ".skillset/skills/x/SKILL.md"), "utf8")).toContain(skillBody);
+  // Transformable matches present -> the imported frontmatter declares the
+  // dialect; the body itself is byte-identical to the original.
+  expect(preview?.dialectDeclared).toBe(true);
+  const imported = await readFile(join(root, ".skillset/skills/x/SKILL.md"), "utf8");
+  expect(imported).toStartWith("---\ndialect: claude\n");
+  expect(imported).toContain(skillBody);
 
   const markdown = renderAdoptReportMarkdown(report, { rootPath: root });
   expect(markdown).toContain("## Transforms (preview)");
+  expect(markdown).toContain("`dialect: claude` declared.");
   expect(markdown).toContain("`.claude/skills` -> `.agents/skills` (path.skills-dir)");
   expect(markdown).toContain("No faithful Codex lowering:");
   expect(markdown).toContain("`$ARGUMENTS` (dynamic.arguments)");
@@ -172,6 +177,45 @@ test("adopt previews transforms in imported skill bodies without rewriting", asy
   expect(renderAdoptReportMarkdown(quietReport, { rootPath: "ignored" })).not.toContain(
     "## Transforms (preview)"
   );
+});
+
+test("adopt leaves files with only no-lowering matches undeclared", async () => {
+  const skillSource =
+    "---\nname: args-only\ndescription: Only dynamic context.\n---\n\nPass $ARGUMENTS along.\n";
+  const root = await fixture({
+    ".claude/skills/args-only/SKILL.md": skillSource,
+  });
+
+  const report = await adoptSkillset(root, { write: true });
+
+  const preview = report.transformPreviews.find(
+    (entry) => entry.path === ".skillset/skills/args-only/SKILL.md"
+  );
+  expect(preview?.dialectDeclared).toBe(false);
+  expect(preview?.matches.every((match) => match.lowering === "none")).toBe(true);
+  // Nothing would translate, so the imported source stays byte-identical.
+  expect(await readFile(join(root, ".skillset/skills/args-only/SKILL.md"), "utf8")).toBe(
+    skillSource
+  );
+  expect(renderAdoptReportMarkdown(report, { rootPath: root })).not.toContain(
+    "`dialect: claude` declared."
+  );
+});
+
+test("adopt prepends a frontmatter block to transformable instruction imports", async () => {
+  const instructions = "# Conventions\n\nKeep CLAUDE.md current.\n";
+  const root = await fixture({ "CLAUDE.md": instructions });
+
+  const report = await adoptSkillset(root, { write: true });
+
+  const preview = report.transformPreviews.find(
+    (entry) => entry.path === ".skillset/instructions/claude.md"
+  );
+  expect(preview?.dialectDeclared).toBe(true);
+  expect(await readFile(join(root, ".skillset/instructions/claude.md"), "utf8")).toBe(
+    `---\ndialect: claude\n---\n\n${instructions}`
+  );
+  expect(report.buildError).toBeUndefined();
 });
 
 test("adopt CLI without --yes prints the survey and writes nothing", async () => {

--- a/apps/skillset/src/__tests__/dialect.test.ts
+++ b/apps/skillset/src/__tests__/dialect.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildSkillset } from "../build";
+import { parseMarkdown } from "../yaml";
+
+const SKILL_BODY = [
+  "Skills live in .claude/skills/x and config in ~/.claude/foo.",
+  "",
+  "Read CLAUDE.md first, then ask @helper to verify.",
+  "",
+  "Use $ARGUMENTS verbatim.",
+].join("\n");
+
+const DIALECT_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": `
+skillset:
+  name: dialect-root
+claude: true
+codex: true
+`,
+  ".skillset/skills/x/SKILL.md": `---
+name: x
+description: Claude-dialect skill.
+dialect: claude
+---
+
+${SKILL_BODY}
+`,
+  ".skillset/skills/y/SKILL.md": `---
+name: y
+description: Portable skill with the same body.
+---
+
+${SKILL_BODY}
+`,
+};
+
+const TRANSLATED_BODY = [
+  "Skills live in .agents/skills/x and config in ~/.codex/foo.",
+  "",
+  "Read AGENTS.md first, then ask the `helper` agent to verify.",
+  "",
+  "Use $ARGUMENTS verbatim.",
+].join("\n");
+
+test("dialect: claude lowers the codex skill projection and only that projection", async () => {
+  const root = await fixture(DIALECT_FIXTURE);
+  await buildSkillset(root);
+
+  // Codex projection: transformable constructs lowered, $ARGUMENTS untouched.
+  const codex = await readFile(join(root, ".agents/skills/x/SKILL.md"), "utf8");
+  expect(parseMarkdown(codex, "codex skill").body.trim()).toBe(TRANSLATED_BODY);
+
+  // Claude projection: byte-identical to the source body.
+  const claude = await readFile(join(root, ".claude/skills/x/SKILL.md"), "utf8");
+  expect(parseMarkdown(claude, "claude skill").body.trim()).toBe(SKILL_BODY);
+  expect(claude).toContain(".claude/skills/x");
+  expect(claude).not.toContain(".agents/skills/x");
+
+  // The source-only dialect key never reaches generated frontmatter.
+  expect(codex).not.toContain("dialect: claude");
+  expect(claude).not.toContain("dialect: claude");
+
+  // Codex lock entry records applied transforms, sorted by intent.
+  const codexLock = JSON.parse(
+    await readFile(join(root, ".agents/skills/.skillset.lock"), "utf8")
+  ) as { items: readonly { name: string; transforms?: readonly unknown[] }[] };
+  const codexItem = codexLock.items.find((item) => item.name === "x");
+  expect(codexItem?.transforms).toEqual([
+    { count: 1, intent: "doc.project-instructions" },
+    { count: 1, intent: "invoke.subagent" },
+    { count: 1, intent: "path.skills-dir" },
+    { count: 1, intent: "path.user-config-dir" },
+  ]);
+
+  // Claude lock entry carries no transforms; neither does the untranslated skill.
+  const claudeLock = JSON.parse(
+    await readFile(join(root, ".claude/skills/.skillset.lock"), "utf8")
+  ) as { items: readonly { name: string; transforms?: readonly unknown[] }[] };
+  expect(claudeLock.items.find((item) => item.name === "x")?.transforms).toBeUndefined();
+  expect(codexLock.items.find((item) => item.name === "y")?.transforms).toBeUndefined();
+
+  // No declaration, no translation: the portable skill keeps its body as-is.
+  const portableCodex = await readFile(join(root, ".agents/skills/y/SKILL.md"), "utf8");
+  expect(parseMarkdown(portableCodex, "portable codex skill").body.trim()).toBe(SKILL_BODY);
+});
+
+test("unknown dialect values fail the build loudly", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml": "skillset:\n  name: dialect-bad\nclaude: true\n",
+    ".skillset/skills/x/SKILL.md": `---
+name: x
+description: Bad dialect.
+dialect: codex
+---
+
+Body.
+`,
+  });
+
+  await expect(buildSkillset(root)).rejects.toThrow(
+    'declares unsupported dialect "codex"; only "claude" is supported'
+  );
+});
+
+test("dialect: claude instructions translate AGENTS.md but not .claude/rules", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: dialect-rules
+claude: true
+codex: true
+`,
+    ".skillset/instructions/conventions.md": `---
+dialect: claude
+---
+
+Keep CLAUDE.md current; agents live under .claude/agents.
+`,
+  });
+  await buildSkillset(root);
+
+  const agents = await readFile(join(root, "AGENTS.md"), "utf8");
+  expect(agents).toContain("Keep AGENTS.md current; agents live under .codex/agents.");
+  expect(agents).not.toContain("CLAUDE.md current");
+
+  const rule = await readFile(join(root, ".claude/rules/conventions.md"), "utf8");
+  expect(rule).toBe("Keep CLAUDE.md current; agents live under .claude/agents.\n");
+
+  const workspaceLock = JSON.parse(await readFile(join(root, ".skillset.lock"), "utf8")) as {
+    items: readonly { name: string; transforms?: readonly unknown[] }[];
+  };
+  expect(workspaceLock.items.find((item) => item.name === "AGENTS.md")?.transforms).toEqual([
+    { count: 1, intent: "doc.project-instructions" },
+    { count: 1, intent: "path.project-config-dir" },
+  ]);
+
+  const rulesLock = JSON.parse(
+    await readFile(join(root, ".claude/rules/.skillset.lock"), "utf8")
+  ) as { items: readonly { transforms?: readonly unknown[] }[] };
+  expect(rulesLock.items.every((item) => item.transforms === undefined)).toBe(true);
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dialect-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), content);
+  }
+  return root;
+}

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -56,6 +56,13 @@ export interface TransformPreviewMatch {
 
 /** Per-file transform recognition over content the import just landed. */
 export interface TransformPreview {
+  /**
+   * Whether adopt declared `dialect: claude` in the imported file's
+   * frontmatter. Set when at least one match has a faithful Codex lowering;
+   * files with only no-lowering matches stay unmarked (nothing would
+   * translate).
+   */
+  readonly dialectDeclared: boolean;
   readonly matches: readonly TransformPreviewMatch[];
   /** Repo-relative path of the imported file that was scanned. */
   readonly path: string;
@@ -80,9 +87,11 @@ export interface AdoptReport {
   readonly setupFiles: readonly SetupFile[];
   readonly surveySkips: readonly SurveySkip[];
   /**
-   * Recognition-only preview of Claude-dialect constructs in imported
-   * markdown (skill bodies and instruction files). Nothing is rewritten;
-   * this is the report surface for the transform registry.
+   * Per-file preview of Claude-dialect constructs in imported markdown
+   * (skill bodies and instruction files). Bodies are never rewritten; when a
+   * file has at least one transformable match, adopt declares
+   * `dialect: claude` in its frontmatter so the build translates its Codex
+   * projection.
    */
   readonly transformPreviews: readonly TransformPreview[];
   readonly write: boolean;
@@ -144,6 +153,8 @@ export async function adoptSkillset(
   for (const candidate of init.importCandidates) {
     imports.push(await importCandidate(init.rootPath, candidate, cutover, previewSources));
   }
+  // Dialect declaration must land before the graph loads: the isolated build
+  // below is what translates the Codex projection of the marked files.
   const transformPreviews = await buildTransformPreviews(init.rootPath, previewSources);
 
   let lintIssues: readonly LintIssue[] = [];
@@ -275,9 +286,12 @@ async function importInstructionFile(rootPath: string, sourceName: string): Prom
 }
 
 /**
- * Recognition-only transform preview over the markdown the imports just
- * landed: skill bodies (frontmatter stripped) and verbatim instruction
- * files. Source content is read from the imported copies, never rewritten.
+ * Transform preview over the markdown the imports just landed: skill bodies
+ * (frontmatter stripped) and verbatim instruction files. Bodies are never
+ * rewritten; when a file has at least one transformable match, adopt
+ * declares `dialect: claude` in its frontmatter so the build's Codex
+ * projection lowers it through the transform engine. Files with only
+ * no-lowering matches stay unmarked — nothing would translate.
  */
 async function buildTransformPreviews(
   rootPath: string,
@@ -289,7 +303,12 @@ async function buildTransformPreviews(
     const body = basename(path) === "SKILL.md" ? markdownBody(raw, path) : raw;
     const matches = recognizeTransforms(body, "claude");
     if (matches.length === 0) continue;
+    const transformable = matches.some((match) => match.lowering !== "none");
+    const dialectDeclared = transformable
+      ? await declareClaudeDialect(join(rootPath, path))
+      : false;
     previews.push({
+      dialectDeclared,
       matches: matches.map((match) => {
         const codexForm = lowerTransform(match, "codex");
         return {
@@ -304,6 +323,27 @@ async function buildTransformPreviews(
     });
   }
   return previews;
+}
+
+/**
+ * Declare `dialect: claude` in an imported file's frontmatter. Skills carry
+ * frontmatter already (the key slots in after the opening `---`);
+ * instruction files imported verbatim usually have none, so a minimal block
+ * is prepended. Unparseable frontmatter is left alone — adopt must not
+ * compound an import problem — and an existing `dialect` key is respected.
+ */
+async function declareClaudeDialect(path: string): Promise<boolean> {
+  const raw = await readFile(path, "utf8");
+  try {
+    if (parseMarkdown(raw, path).frontmatter.dialect !== undefined) return true;
+  } catch {
+    return false;
+  }
+  const updated = /^---\r?\n/.test(raw)
+    ? raw.replace(/^---\r?\n/, (open) => `${open}dialect: claude\n`)
+    : `---\ndialect: claude\n---\n\n${raw}`;
+  await writeFile(path, updated);
+  return true;
 }
 
 function markdownBody(raw: string, label: string): string {
@@ -401,11 +441,14 @@ export function renderAdoptReportMarkdown(
   if (report.transformPreviews.length > 0) {
     lines.push("## Transforms (preview)", "");
     lines.push(
-      "Recognition only — adopt rewrote nothing. Codex forms show what a future transform slice would write.",
+      "Bodies are untouched. Files with transformable constructs were marked `dialect: claude`; the build lowers their Codex projection through these forms.",
       ""
     );
     for (const preview of report.transformPreviews) {
       lines.push(`### \`${preview.path}\``, "");
+      if (preview.dialectDeclared) {
+        lines.push("`dialect: claude` declared.", "");
+      }
       const transformable = aggregatePreviewMatches(
         preview.matches.filter((match) => match.lowering !== "none")
       );

--- a/apps/skillset/src/authoring.ts
+++ b/apps/skillset/src/authoring.ts
@@ -174,6 +174,13 @@ function collectLockItems(rendered: Awaited<ReturnType<typeof renderBuildGraph>>
       const dependencies = Array.isArray(rawItem.dependencies)
         ? rawItem.dependencies.filter((value): value is string => typeof value === "string")
         : undefined;
+      const transforms = Array.isArray(rawItem.transforms)
+        ? rawItem.transforms.flatMap((value) =>
+            isJsonRecord(value) && typeof value.intent === "string" && typeof value.count === "number"
+              ? [{ count: value.count, intent: value.intent }]
+              : []
+          )
+        : undefined;
       matches.push({
         sourcePath,
         outputPath: joinOutputRoot(outputRoot, outputPath),
@@ -192,6 +199,7 @@ function collectLockItems(rendered: Awaited<ReturnType<typeof renderBuildGraph>>
           ...(preprocessDependencies === undefined ? {} : { preprocessDependencies }),
           ...(typeof rawItem.sourceHash === "string" ? { sourceHash: rawItem.sourceHash } : {}),
           ...(typeof rawItem.sourcePointer === "string" ? { sourcePointer: rawItem.sourcePointer } : {}),
+          ...(transforms === undefined || transforms.length === 0 ? {} : { transforms }),
           ...(typeof rawItem.version === "string" ? { version: rawItem.version } : {}),
           ...(typeof rawItem.targetState === "string" ? { targetState: rawItem.targetState } : {}),
           ...(typeof rawItem.validation === "string" ? { validation: rawItem.validation } : {}),

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -350,6 +350,11 @@ export async function runCli(
       if (entry.preprocessDependencies !== undefined && entry.preprocessDependencies.length > 0) {
         console.log(`    preprocess dependencies: ${entry.preprocessDependencies.join(", ")}`);
       }
+      if (entry.transforms !== undefined && entry.transforms.length > 0) {
+        console.log(
+          `    transforms: ${entry.transforms.map((transform) => `${transform.intent} x${transform.count}`).join(", ")}`
+        );
+      }
       if (entry.sourceHash !== undefined) console.log(`    source hash: ${entry.sourceHash}`);
       if (entry.outputHash !== undefined) console.log(`    output hash: ${entry.outputHash}`);
     }

--- a/apps/skillset/src/config.ts
+++ b/apps/skillset/src/config.ts
@@ -35,6 +35,7 @@ const SOURCE_ONLY_KEYS = new Set([
   "codex",
   "defaults",
   "dependencies",
+  "dialect",
   "implicit_invocation",
   "mcp",
   "model",

--- a/apps/skillset/src/render.ts
+++ b/apps/skillset/src/render.ts
@@ -3,6 +3,8 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { basename, dirname, join, relative } from "node:path";
 
+import { lowerTransform, recognizeTransforms } from "@skillset/transforms";
+
 import {
   isOutputSelected,
   mergeRecords,
@@ -37,6 +39,7 @@ import {
   validateGeneratedStructuredOutput,
 } from "./structured-output";
 import type {
+  AppliedTransform,
   BuildGraph,
   JsonRecord,
   JsonValue,
@@ -80,8 +83,39 @@ interface LockItem {
   readonly sourcePath: string;
   readonly sourcePointer?: string;
   readonly targetState?: string;
+  /** Build-time dialect transforms applied to this item, sorted by intent. */
+  readonly transforms?: readonly AppliedTransform[];
   readonly validation?: "opaque-copy" | "structured";
   readonly version?: string;
+}
+
+interface TranslatedBody {
+  readonly text: string;
+  readonly transforms: readonly AppliedTransform[];
+}
+
+/**
+ * Lower a Claude-dialect body into Codex surface forms. Every recognized
+ * construct with a faithful Codex lowering (bidirectional or to-codex) is
+ * replaced in place; replacements apply last-to-first by index so earlier
+ * spans stay valid. `lowering: "none"` constructs pass through untouched —
+ * lint owns those. Returns the applied intents with occurrence counts,
+ * sorted by intent, for lock provenance.
+ */
+function translateClaudeDialect(body: string): TranslatedBody {
+  const matches = recognizeTransforms(body, "claude");
+  const counts = new Map<string, number>();
+  let text = body;
+  for (const match of [...matches].reverse()) {
+    const lowered = lowerTransform(match, "codex");
+    if (lowered === undefined) continue;
+    text = `${text.slice(0, match.index)}${lowered}${text.slice(match.index + match.text.length)}`;
+    counts.set(match.intent, (counts.get(match.intent) ?? 0) + 1);
+  }
+  const transforms = [...counts.entries()]
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([intent, count]) => ({ count, intent }));
+  return { text, transforms };
 }
 
 interface LockRoot {
@@ -495,11 +529,12 @@ async function renderPluginSkillFiles(
   );
   const rendered: RenderedFile[] = [];
   const renderedRelativeFiles = new Set<string>();
+  const skillMarkdown = await renderSkillMarkdown(graph, plugin, skill, target);
   pushSkillRenderedFile(
     rendered,
     textFile(
       targetSkillFile,
-      await renderSkillMarkdown(graph, plugin, skill, target),
+      skillMarkdown.content,
       relative(graph.rootPath, skill.sourcePath)
     ),
     targetSkillDir,
@@ -552,6 +587,7 @@ async function renderPluginSkillFiles(
       plugin,
       skill,
       sourceDir,
+      transforms: skillMarkdown.transforms,
     })
   );
 
@@ -875,11 +911,12 @@ async function renderStandaloneSkill(
   );
   const rendered: RenderedFile[] = [];
   const renderedRelativeFiles = new Set<string>();
+  const skillMarkdown = await renderSkillMarkdown(graph, undefined, skill, target);
   pushSkillRenderedFile(
     rendered,
     textFile(
       targetSkillFile,
-      await renderSkillMarkdown(graph, undefined, skill, target),
+      skillMarkdown.content,
       relative(graph.rootPath, skill.sourcePath)
     ),
     targetSkillDir,
@@ -931,6 +968,7 @@ async function renderStandaloneSkill(
       outputRoot,
       skill,
       sourceDir,
+      transforms: skillMarkdown.transforms,
     })
   );
 
@@ -984,12 +1022,18 @@ function normalizeRenderedRelativePath(path: string): string {
   return path.replaceAll("\\", "/");
 }
 
+interface RenderedSkillMarkdown {
+  readonly content: string;
+  /** Dialect transforms applied to the body (codex projections only). */
+  readonly transforms: readonly AppliedTransform[];
+}
+
 async function renderSkillMarkdown(
   graph: BuildGraph,
   plugin: SourcePlugin | undefined,
   skill: SourceSkill,
   target: TargetName
-): Promise<string> {
+): Promise<RenderedSkillMarkdown> {
   const metadata = skill.metadata;
   const targetOptions = skill.targets[target].options;
   const base = mergeRecords(stripSourceFrontmatter(skill.frontmatter, skill.sourcePath), {
@@ -1042,11 +1086,21 @@ async function renderSkillMarkdown(
   const body = dependencyNotice === undefined
     ? preprocessedBody
     : `${dependencyNotice}\n\n${preprocessedBody}`;
-  return renderValidatedMarkdown(
-    frontmatter,
-    rewriteResourceLinks(body, skill.resources, skill.sourcePath),
-    `${relative(graph.rootPath, skill.sourcePath)} -> ${target}`
-  );
+  const linkedBody = rewriteResourceLinks(body, skill.resources, skill.sourcePath);
+  // Claude-dialect source lowers through the transform engine for the codex
+  // projection only; the claude projection stays byte-identical to source.
+  const translated =
+    target === "codex" && skill.dialect === "claude"
+      ? translateClaudeDialect(linkedBody)
+      : { text: linkedBody, transforms: [] };
+  return {
+    content: renderValidatedMarkdown(
+      frontmatter,
+      translated.text,
+      `${relative(graph.rootPath, skill.sourcePath)} -> ${target}`
+    ),
+    transforms: translated.transforms,
+  };
 }
 
 function renderClaudeSkillPolicy(skill: SourceSkill, targetOptions: JsonRecord): JsonRecord {
@@ -1201,9 +1255,10 @@ async function renderCodexAgentsFiles(
 
   const rendered: RenderedFile[] = [];
   for (const [destination, rules] of [...destinations.entries()].sort(([left], [right]) => compareStrings(left, right))) {
+    const markdown = await renderCodexAgentsMarkdown(graph, rules, destination);
     const file = textFile(
       destination,
-      await renderCodexAgentsMarkdown(graph, rules, destination),
+      markdown.content,
       `${graph.sourceDir}/${graph.instructionsDir}`
     );
     rendered.push(file);
@@ -1216,6 +1271,7 @@ async function renderCodexAgentsFiles(
         outputPath: destination,
         sourceHash: hashRules(rules),
         sourcePath: `${graph.sourceDir}/${graph.instructionsDir}`,
+        transforms: markdown.transforms,
       })
     );
   }
@@ -1233,13 +1289,23 @@ async function renderCodexAgentsMarkdown(
   graph: BuildGraph,
   rules: readonly SourceRule[],
   outputPath: string
-): Promise<string> {
+): Promise<{ readonly content: string; readonly transforms: readonly AppliedTransform[] }> {
   // Each concatenated source gets a deterministic boundary comment naming its
   // source instruction path. Comments carry the path only — source-only
   // frontmatter never reaches the generated AGENTS.md. Ordering follows the
-  // already-sorted rule list, so concatenation is stable.
-  const sections = rules
-    .map(async (rule) => ({ rule, body: await renderRuleBody(graph, rule, outputPath) }));
+  // already-sorted rule list, so concatenation is stable. Claude-dialect
+  // sources lower through the transform engine for this codex projection;
+  // the .claude/rules projection of the same sources stays untouched.
+  const counts = new Map<string, number>();
+  const sections = rules.map(async (rule) => {
+    const body = await renderRuleBody(graph, rule, outputPath);
+    if (rule.dialect !== "claude") return { rule, body };
+    const translated = translateClaudeDialect(body);
+    for (const transform of translated.transforms) {
+      counts.set(transform.intent, (counts.get(transform.intent) ?? 0) + transform.count);
+    }
+    return { rule, body: translated.text };
+  });
   const resolvedSections = await Promise.all(sections);
   const renderedSections = resolvedSections
     .filter((section) => section.body.length > 0)
@@ -1247,12 +1313,16 @@ async function renderCodexAgentsMarkdown(
       (section) =>
         `<!-- source: ${relative(graph.rootPath, section.rule.sourcePath)} -->\n${section.body}`
     );
-  return [
+  const content = [
     `<!-- Generated by ${GENERATED_BY} from ${graph.sourceDir}/${graph.instructionsDir}. Do not edit directly. -->`,
     "",
     renderedSections.join("\n\n"),
     "",
   ].join("\n");
+  const transforms = [...counts.entries()]
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([intent, count]) => ({ count, intent }));
+  return { content, transforms };
 }
 
 async function codexRuleDestinations(
@@ -1698,6 +1768,7 @@ function lockItemForRule(args: {
   readonly outputRoot: string;
   readonly sourceHash: string;
   readonly sourcePath: string;
+  readonly transforms?: readonly AppliedTransform[];
 }): LockItem {
   return {
     files: args.files.map((file) => relative(args.outputRoot, file.path)).sort(),
@@ -1707,6 +1778,9 @@ function lockItemForRule(args: {
     outputPath: relative(args.outputRoot, args.outputPath),
     sourceHash: args.sourceHash,
     sourcePath: args.sourcePath,
+    ...(args.transforms === undefined || args.transforms.length === 0
+      ? {}
+      : { transforms: args.transforms }),
     version: rootVersion(args.graph),
   };
 }
@@ -1766,6 +1840,7 @@ async function lockItemForSkill(args: {
   readonly plugin?: SourcePlugin;
   readonly skill: SourceSkill;
   readonly sourceDir: string;
+  readonly transforms: readonly AppliedTransform[];
 }): Promise<LockItem> {
   const files = args.files
     .map((file) => relative(args.outputRoot, file.path))
@@ -1779,6 +1854,7 @@ async function lockItemForSkill(args: {
     outputPath: files.find((file) => file.endsWith("/SKILL.md")) ?? files[0] ?? "",
     sourceHash: await hashSkillSource(args.sourceDir, args.skill.resources),
     sourcePath: relative(args.graph.rootPath, args.skill.sourcePath),
+    ...(args.transforms.length === 0 ? {} : { transforms: args.transforms }),
     version: skillVersion(args.graph, args.plugin, args.skill),
     ...(args.plugin === undefined ? {} : { plugin: args.plugin.id }),
   };
@@ -1854,6 +1930,10 @@ function stripUndefinedLockItem(item: LockItem): JsonRecord {
     sourcePath: item.sourcePath,
     sourcePointer: item.sourcePointer,
     targetState: item.targetState,
+    transforms:
+      item.transforms === undefined
+        ? undefined
+        : item.transforms.map(({ count, intent }) => ({ count, intent })),
     validation: item.validation,
     version: item.version,
   };

--- a/apps/skillset/src/resolver.ts
+++ b/apps/skillset/src/resolver.ts
@@ -25,6 +25,7 @@ import type {
   JsonRecord,
   OutputSelection,
   SkillsetOptions,
+  SourceDialect,
   SourcePlugin,
   SourcePluginFeature,
   SourcePluginFeatureKey,
@@ -358,9 +359,11 @@ async function loadInstructions(
     const frontmatter = normalizeRuleFrontmatter(parts.frontmatter, sourcePath);
     await validateSupports(frontmatter.supports, { label: relative(rootPath, sourcePath), rootPath, warnings });
     const targets = resolveFeatureTargets(rootTargets, frontmatter, sourcePath, "instructions");
+    const dialect = readDialect(frontmatter, relative(rootPath, sourcePath));
 
     rules.push({
       body: parts.body,
+      ...(dialect === undefined ? {} : { dialect }),
       frontmatter,
       id: relativePath.replace(/\.md$/, ""),
       relativePath,
@@ -373,6 +376,20 @@ async function loadInstructions(
     rules: rules.sort((left, right) => compareStrings(left.relativePath, right.relativePath)),
     instructionsDir: INSTRUCTIONS_DIR,
   };
+}
+
+/**
+ * Read the source-only `dialect` frontmatter key. Only `claude` is supported;
+ * any other value fails the build loudly so a typo never silently skips
+ * translation. Absent means portable source (no translation).
+ */
+function readDialect(frontmatter: JsonRecord, label: string): SourceDialect | undefined {
+  const value = frontmatter.dialect;
+  if (value === undefined) return undefined;
+  if (value === "claude") return "claude";
+  throw new Error(
+    `skillset: ${label} declares unsupported dialect ${JSON.stringify(value)}; only "claude" is supported`
+  );
 }
 
 function normalizeRuleFrontmatter(frontmatter: SourceRule["frontmatter"], label: string): SourceRule["frontmatter"] {
@@ -650,8 +667,11 @@ async function loadSkillsFromDirectory(
       sharedPath: resolveInside(rootPath, join(sourceDir, "shared")),
     });
 
+    const dialect = readDialect(parts.frontmatter, relative(rootPath, sourcePath));
+
     skills.push({
       body: parts.body,
+      ...(dialect === undefined ? {} : { dialect }),
       frontmatter: parts.frontmatter,
       id,
       metadata,

--- a/apps/skillset/src/types.ts
+++ b/apps/skillset/src/types.ts
@@ -55,8 +55,16 @@ export interface PluginConfig {
   readonly targets: Readonly<Record<TargetName, ResolvedTarget>>;
 }
 
+/**
+ * Source dialect a skill or instruction body is authored in. Source-only:
+ * declared in frontmatter, stripped from generated output. Absent means
+ * portable (no build-time translation).
+ */
+export type SourceDialect = "claude";
+
 export interface SourceSkill {
   readonly body: string;
+  readonly dialect?: SourceDialect;
   readonly frontmatter: JsonRecord;
   readonly id: string;
   readonly metadata: JsonRecord;
@@ -108,6 +116,7 @@ export interface StandaloneSkill extends SourceSkill {}
 
 export interface SourceRule {
   readonly body: string;
+  readonly dialect?: SourceDialect;
   readonly frontmatter: JsonRecord;
   readonly id: string;
   readonly relativePath: string;
@@ -170,6 +179,15 @@ export interface RenderedFile {
   readonly sourcePath?: string;
 }
 
+/**
+ * One applied build-time dialect transform on a generated file: the intent
+ * key from the transform registry and how many spans it lowered.
+ */
+export interface AppliedTransform {
+  readonly count: number;
+  readonly intent: string;
+}
+
 export interface GeneratedEntry {
   readonly dependencies?: readonly string[];
   readonly feature?: string;
@@ -184,6 +202,7 @@ export interface GeneratedEntry {
   readonly sourcePointer?: string;
   readonly target: string;
   readonly targetState?: string;
+  readonly transforms?: readonly AppliedTransform[];
   readonly validation?: string;
   readonly version?: string;
 }


### PR DESCRIPTION
The dialect-source half of the transform decision: skills and instructions may declare `dialect: claude`, and their **Codex projections** pass through the transform engine (paths including the `.agents/skills` asymmetry, `CLAUDE.md`→`AGENTS.md`, subagent phrasing) while **Claude projections stay byte-identical** (round-trip identity verified). Applied transforms land in lock provenance (`transforms: [{intent, count}]`) and surface through `skillset explain`. `adopt` declares the dialect automatically on imported files whose preview found transformable constructs — live run marked 18 compound-engineering files, with claude-side round-trip numbers exactly unchanged (197/40/6) and purity green. No-faithful-lowering constructs (`$ARGUMENTS` etc.) remain untouched and lint-governed.

Note from the live run: codex projections aren't in the fixture mirror because the manifest pins `targets: [claude]` (their skills use $ARGUMENTS → codex lint correctly errors; Claude plugin agents reject codex plugins in v1) — translation was verified end-to-end in a scratch root with codex enabled (excerpt in commit/Linear).

Linear: https://linear.app/outfitter/issue/SET-65
Gates: `bun run check` ✓ · 405 tests ✓ · live fixture sync+run ✓ · this repo's generated output zero-diff ✓

Top of the stack (on #38).