### PR TITLE
feat(adopt): acquire git remotes before adoption

### DIFF
--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -2,9 +2,11 @@ import { expect, test } from "bun:test";
 import { mkdtemp, readdir, readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { ADOPT_REPORT_DIR, adoptSkillset, renderAdoptReportMarkdown } from "../adopt";
 import { ISOLATED_OUT_ROOT } from "../build";
+import { gitSafeEnv } from "../git-env";
 
 const AGENTS_CONTENT = "# Demo agents\n\nHandwritten instructions.\n";
 
@@ -33,6 +35,7 @@ test("adopt plan mode surveys only and writes nothing", async () => {
 
   expect(report.write).toBe(false);
   expect(report.ok).toBe(true);
+  expect(report.acquisition).toEqual({ input: root, kind: "path", rootPath: root });
   expect(report.alreadyAdopted).toBe(false);
   expect(report.candidates).toEqual([
     { kind: "instructions", path: "AGENTS.md" },
@@ -43,6 +46,36 @@ test("adopt plan mode surveys only and writes nothing", async () => {
   expect(report.builtFiles).toBe(0);
   expect(report.cutover).toEqual([]);
   expect(await walkFiles(root)).toEqual(before);
+});
+
+test("adopt accepts git remotes by shallow cloning before running the existing flow", async () => {
+  const source = await gitFixture(MARKETPLACE_FIXTURE);
+  const remote = pathToFileURL(source).href;
+
+  const report = await adoptSkillset(remote, { write: true });
+
+  expect(report.ok).toBe(true);
+  expect(report.rootPath).not.toBe(source);
+  expect(report.acquisition.kind).toBe("git");
+  if (report.acquisition.kind === "git") {
+    expect(report.acquisition.repo).toBe(remote);
+    expect(report.acquisition.rootPath).toBe(report.rootPath);
+    expect(report.acquisition.ref).toMatch(/^[0-9a-f]{40}$/);
+  }
+  expect(report.imports.map((result) => [result.candidate.kind, result.ok])).toEqual([
+    ["instructions", true],
+    ["plugin", true],
+  ]);
+
+  const markdown = await readFile(join(report.rootPath, ADOPT_REPORT_DIR, "report.md"), "utf8");
+  expect(markdown).toContain("## Acquisition");
+  expect(markdown).toContain("- source: git remote");
+  expect(markdown).toContain(`- repo: \`${remote}\``);
+
+  const cli = await runSkillsetCli("adopt", remote, "--yes");
+  expect(cli.exitCode).toBe(0);
+  expect(cli.stdout).toContain(`source: git ${remote} @ `);
+  expect(cli.stdout).toContain("adopt passed");
 });
 
 test("adopt write mode imports everything, builds the mirror, and writes the report", async () => {
@@ -256,6 +289,40 @@ async function fixture(files: Record<string, string>): Promise<string> {
     await Bun.write(join(root, path), content);
   }
   return root;
+}
+
+async function gitFixture(files: Record<string, string>): Promise<string> {
+  const root = await fixture(files);
+  await runGit(root, ["init"]);
+  await runGit(root, ["add", "."]);
+  await runGit(root, [
+    "-c",
+    "user.name=Skillset Test",
+    "-c",
+    "user.email=skillset@example.com",
+    "commit",
+    "-m",
+    "fixture",
+  ]);
+  return root;
+}
+
+async function runGit(cwd: string, args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn({
+    cmd: ["git", ...args],
+    cwd,
+    env: gitSafeEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`${stdout}${stderr}`.trim());
+  }
 }
 
 async function walkFiles(root: string): Promise<ReadonlySet<string>> {

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
 import {
@@ -9,6 +10,7 @@ import {
 
 import type { ReleaseBaselineEntry } from "./adoption";
 import { buildSkillset, ISOLATED_OUT_ROOT } from "./build";
+import { gitSafeEnv } from "./git-env";
 import { importSources } from "./import";
 import { inspectSkillset } from "./lint";
 import { loadBuildGraph } from "./resolver";
@@ -22,9 +24,24 @@ import type { LintIssue, SkillsetOptions, TargetName } from "./types";
 import { parseMarkdown } from "./yaml";
 
 export interface AdoptOptions extends SkillsetOptions {
+  readonly cwd?: string;
   readonly targets?: readonly TargetName[];
   readonly write?: boolean;
 }
+
+export type AdoptAcquisition =
+  | {
+      readonly input: string;
+      readonly kind: "path";
+      readonly rootPath: string;
+    }
+  | {
+      readonly input: string;
+      readonly kind: "git";
+      readonly ref: string;
+      readonly repo: string;
+      readonly rootPath: string;
+    };
 
 /** A plugin or skill landed in `.skillset/` by one candidate import. */
 export interface AdoptImportedUnit {
@@ -69,6 +86,7 @@ export interface TransformPreview {
 }
 
 export interface AdoptReport {
+  readonly acquisition: AdoptAcquisition;
   readonly alreadyAdopted: boolean;
   readonly baselines: readonly ReleaseBaselineEntry[];
   readonly buildError?: string;
@@ -111,12 +129,25 @@ const INSTRUCTIONS_DIR = ".skillset/instructions";
  * survey alone and writes nothing.
  */
 export async function adoptSkillset(
-  rootPath: string,
+  source: string,
+  options: AdoptOptions = {}
+): Promise<AdoptReport> {
+  const { cwd, targets, write, ...buildOptions } = options;
+  const acquisition = await acquireAdoptSource(source, cwd ?? process.cwd());
+  return adoptResolvedRoot(acquisition, {
+    ...buildOptions,
+    ...(targets === undefined ? {} : { targets }),
+    ...(write === undefined ? {} : { write }),
+  });
+}
+
+async function adoptResolvedRoot(
+  acquisition: AdoptAcquisition,
   options: AdoptOptions = {}
 ): Promise<AdoptReport> {
   const { targets, write, ...buildOptions } = options;
   const writeMode = write === true;
-  const resolvedRoot = resolve(rootPath);
+  const resolvedRoot = acquisition.rootPath;
   // Captured before init scaffolds config: an existing .skillset/config.yaml
   // means the repo was already adopted; adopt proceeds (init tolerates a valid
   // pre-existing config) but the report says so honestly.
@@ -131,6 +162,7 @@ export async function adoptSkillset(
 
   if (!writeMode) {
     return {
+      acquisition,
       alreadyAdopted,
       baselines: init.baselines,
       builtFiles: 0,
@@ -177,6 +209,7 @@ export async function adoptSkillset(
 
   const lintErrors = lintIssues.filter((issue) => issue.severity === "error");
   const report: AdoptReport = {
+    acquisition,
     alreadyAdopted,
     baselines: init.baselines,
     ...(buildError === undefined ? {} : { buildError }),
@@ -205,6 +238,45 @@ export async function adoptSkillset(
   await writeFile(join(reportDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
 
   return report;
+}
+
+async function acquireAdoptSource(source: string, cwd: string): Promise<AdoptAcquisition> {
+  const localPath = resolve(cwd, source);
+  if (await exists(localPath)) {
+    return { input: source, kind: "path", rootPath: localPath };
+  }
+
+  const clonePath = await mkdtemp(join(tmpdir(), "skillset-adopt-remote-"));
+  try {
+    await runGit(["clone", "--depth", "1", source, clonePath], cwd);
+    const ref = (await runGit(["-C", clonePath, "rev-parse", "HEAD"], cwd)).trim();
+    return { input: source, kind: "git", ref, repo: source, rootPath: clonePath };
+  } catch (error) {
+    await rm(clonePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+async function runGit(args: readonly string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn({
+    cmd: ["git", ...args],
+    cwd,
+    env: gitSafeEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    const detail = `${stdout}${stderr}`.trim();
+    throw new Error(
+      `skillset: git ${args[0] ?? "command"} failed${detail.length === 0 ? "" : `\n${detail}`}`
+    );
+  }
+  return stdout;
 }
 
 /**
@@ -380,6 +452,23 @@ export function renderAdoptReportMarkdown(
       : "- build (isolated): failed",
     ""
   );
+
+  lines.push("## Acquisition", "");
+  if (report.acquisition.kind === "git") {
+    lines.push(
+      "- source: git remote",
+      `- repo: \`${report.acquisition.repo}\``,
+      `- ref: \`${report.acquisition.ref}\``,
+      `- clone: \`${report.acquisition.rootPath}\``,
+      ""
+    );
+  } else {
+    lines.push(
+      "- source: local path",
+      `- input: \`${report.acquisition.input}\``,
+      ""
+    );
+  }
 
   lines.push("## Setup", "");
   for (const file of report.setupFiles) {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -239,8 +239,9 @@ export async function runCli(
   if (command === "adopt") {
     const writeMode = yes && !dryRun;
     const report = await adoptSkillset(
-      importPath === undefined ? rootPath : resolve(rootPath, importPath),
+      importPath === undefined ? rootPath : importPath,
       {
+        cwd: rootPath,
         ...(setupTargets === undefined ? {} : { targets: setupTargets }),
         write: writeMode,
       }
@@ -636,6 +637,9 @@ function printImportReport(result: ImportReport): void {
 
 function printAdoptReport(report: AdoptReport, reason: string): void {
   console.log(`skillset: adopt ${report.rootPath} (${reason})`);
+  if (report.acquisition.kind === "git") {
+    console.log(`  source: git ${report.acquisition.repo} @ ${report.acquisition.ref}`);
+  }
   if (report.alreadyAdopted) {
     console.log("  note: repo already has .skillset/config.yaml; adopting against existing source");
   }


### PR DESCRIPTION
## Context

Part of the one-action repo adoption stack. SET-66 teaches `skillset adopt` to accept git remotes directly, so users can point the adoption flow at a published repo without cloning it by hand first.

Linear: https://linear.app/outfitter/issue/SET-66/skillset-adopt-git-remote-acquire-remote-repos-before-running-the

## What Changed

- Added an acquisition step before adoption that preserves existing local-path behavior and treats non-existing source arguments as git remotes.
- Shallow-clones remotes to a Skillset-owned temp directory with `gitSafeEnv()` and records the cloned HEAD ref.
- Threads acquisition details through the adopt report and CLI output.
- Covers remote adoption in tests, including dry-run and write-mode CLI paths.

## Verification

- `bun run typecheck`
- `bun run test`
- `bun run check`
- `bun scripts/fixtures/external.ts sync && bun scripts/fixtures/external.ts run`
- Manual smoke: `skillset adopt file://...compound-engineering-plugin --targets claude --dry-run`

External fidelity baseline held for `compound-engineering`: `197 identical / 40 different / 6 original-only / 0 generated-only`.

## Risks

- Only git-clone-compatible remotes are in scope for this slice. Refresh/update behavior is intentionally deferred.
