### PR TITLE
feat(adopt): record source origin provenance

### DIFF
--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -71,6 +71,26 @@ test("adopt accepts git remotes by shallow cloning before running the existing f
   expect(markdown).toContain("## Acquisition");
   expect(markdown).toContain("- source: git remote");
   expect(markdown).toContain(`- repo: \`${remote}\``);
+  if (report.acquisition.kind === "git") {
+    const ref = report.acquisition.ref;
+    const pluginLock = JSON.parse(
+      await readFile(join(report.rootPath, ISOLATED_OUT_ROOT, "plugins-claude/.skillset.lock"), "utf8")
+    ) as {
+      items: readonly {
+        kind: string;
+        name: string;
+        sourceOrigin?: { path: string; ref?: string; repo?: string };
+      }[];
+    };
+    expect(pluginLock.items.find((item) => item.kind === "plugin" && item.name === "demo")?.sourceOrigin).toEqual({
+      path: "plugins/demo",
+      ref,
+      repo: remote,
+    });
+    const explain = await runSkillsetCli("explain", ".skillset/plugins/demo", "--root", report.rootPath);
+    expect(explain.exitCode).toBe(0);
+    expect(explain.stdout).toContain(`source origin: ${remote} @ ${ref} path plugins/demo`);
+  }
 
   const cli = await runSkillsetCli("adopt", remote, "--yes");
   expect(cli.exitCode).toBe(0);
@@ -94,11 +114,17 @@ test("adopt write mode imports everything, builds the mirror, and writes the rep
   expect(report.buildError).toBeUndefined();
   expect(report.cutover).toEqual(["AGENTS.md"]);
 
-  // Imported source lands in canonical .skillset/ homes; instructions copy verbatim.
+  // Imported source lands in canonical .skillset/ homes with source-origin metadata.
   expect(await readFile(join(root, ".skillset/config.yaml"), "utf8")).toContain("targets:");
   expect(await exists(join(root, ".skillset/plugins/demo/skillset.yaml"))).toBe(true);
-  expect(await readFile(join(root, ".skillset/instructions/agents.md"), "utf8")).toBe(
-    AGENTS_CONTENT
+  const importedInstructions = await readFile(join(root, ".skillset/instructions/agents.md"), "utf8");
+  expect(importedInstructions).toContain("skillset:\n  origin:\n    path: AGENTS.md");
+  expect(importedInstructions).toContain(AGENTS_CONTENT.trimEnd());
+  expect(await readFile(join(root, ".skillset/plugins/demo/skillset.yaml"), "utf8")).toContain(
+    "path: plugins/demo"
+  );
+  expect(await readFile(join(root, ".skillset/plugins/demo/skills/demo-skill/SKILL.md"), "utf8")).toContain(
+    "path: plugins/demo/skills/demo-skill/SKILL.md"
   );
 
   // The build is isolated: the projection lives in the mirror, not the live tree.
@@ -116,6 +142,10 @@ test("adopt write mode imports everything, builds the mirror, and writes the rep
     ok: boolean;
   };
   expect(json.ok).toBe(true);
+
+  const explain = await runSkillsetCli("explain", ".skillset/plugins/demo", "--root", root);
+  expect(explain.exitCode).toBe(0);
+  expect(explain.stdout).toContain("source origin: path plugins/demo");
 
   // Purity: adoption only ever creates paths under .skillset/.
   const added = [...(await walkFiles(root))].filter((path) => !before.has(path));
@@ -226,10 +256,12 @@ test("adopt leaves files with only no-lowering matches undeclared", async () => 
   );
   expect(preview?.dialectDeclared).toBe(false);
   expect(preview?.matches.every((match) => match.lowering === "none")).toBe(true);
-  // Nothing would translate, so the imported source stays byte-identical.
-  expect(await readFile(join(root, ".skillset/skills/args-only/SKILL.md"), "utf8")).toBe(
-    skillSource
-  );
+  // Nothing would translate, so no dialect is declared; source-origin metadata
+  // is still recorded and the body stays untouched.
+  const imported = await readFile(join(root, ".skillset/skills/args-only/SKILL.md"), "utf8");
+  expect(imported).not.toContain("dialect: claude");
+  expect(imported).toContain("path: .claude/skills/args-only/SKILL.md");
+  expect(imported).toContain("Pass $ARGUMENTS along.");
   expect(renderAdoptReportMarkdown(report, { rootPath: root })).not.toContain(
     "`dialect: claude` declared."
   );
@@ -246,7 +278,7 @@ test("adopt prepends a frontmatter block to transformable instruction imports", 
   );
   expect(preview?.dialectDeclared).toBe(true);
   expect(await readFile(join(root, ".skillset/instructions/claude.md"), "utf8")).toBe(
-    `---\ndialect: claude\n---\n\n${instructions}`
+    `---\ndialect: claude\nskillset:\n  origin:\n    path: CLAUDE.md\n---\n\n${instructions}`
   );
   expect(report.buildError).toBeUndefined();
 });

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -20,8 +20,8 @@ import {
   type SetupImportCandidate,
   type SurveySkip,
 } from "./setup";
-import type { LintIssue, SkillsetOptions, TargetName } from "./types";
-import { parseMarkdown } from "./yaml";
+import type { JsonRecord, LintIssue, SkillsetOptions, SourceOrigin, TargetName } from "./types";
+import { isJsonRecord, parseMarkdown, stringifyMarkdown } from "./yaml";
 
 export interface AdoptOptions extends SkillsetOptions {
   readonly cwd?: string;
@@ -183,7 +183,7 @@ async function adoptResolvedRoot(
   const cutover: string[] = [];
   const previewSources: string[] = [];
   for (const candidate of init.importCandidates) {
-    imports.push(await importCandidate(init.rootPath, candidate, cutover, previewSources));
+    imports.push(await importCandidate(init.rootPath, acquisition, candidate, cutover, previewSources));
   }
   // Dialect declaration must land before the graph loads: the isolated build
   // below is what translates the Codex projection of the marked files.
@@ -285,6 +285,7 @@ async function runGit(args: readonly string[], cwd: string): Promise<string> {
  */
 async function importCandidate(
   rootPath: string,
+  acquisition: AdoptAcquisition,
   candidate: SetupImportCandidate,
   cutover: string[],
   previewSources: string[]
@@ -292,6 +293,10 @@ async function importCandidate(
   if (candidate.kind === "instructions") {
     try {
       const destination = await importInstructionFile(rootPath, candidate.path);
+      await writeMarkdownSourceOrigin(
+        join(rootPath, destination),
+        sourceOriginFor(acquisition, candidate.path)
+      );
       // The original instruction file stays in place; a live build would
       // regenerate it from the imported source and hit the unmanaged-overwrite
       // protection, so it belongs on the cutover list.
@@ -307,6 +312,8 @@ async function importCandidate(
     const batch = await importSources({
       kind: candidate.kind,
       rootPath,
+      sourceOrigin: (sourcePath, copiedFile) =>
+        sourceOriginFor(acquisition, relativeOriginPath(rootPath, sourcePath, copiedFile)),
       sourcePath: join(rootPath, candidate.path),
     });
     const units = batch.imports.map((report) => {
@@ -337,10 +344,11 @@ async function importCandidate(
 }
 
 /**
- * Minimal verbatim instructions import: copy the root instruction file into
+ * Minimal instructions import: copy the root instruction body into
  * `.skillset/instructions/` under its lowercased name (`AGENTS.md` ->
- * `agents.md`). The ADR's transform-on-adopt is a later slice; content copies
- * byte-for-byte and never overwrites an existing destination.
+ * `agents.md`), adding source-only provenance metadata. The ADR's
+ * transform-on-adopt is a later slice; adopt never overwrites an existing
+ * destination.
  */
 async function importInstructionFile(rootPath: string, sourceName: string): Promise<string> {
   const destinationRelative = `${INSTRUCTIONS_DIR}/${sourceName.toLowerCase()}`;
@@ -355,6 +363,46 @@ async function importInstructionFile(rootPath: string, sourceName: string): Prom
   await mkdir(dirname(destination), { recursive: true });
   await writeFile(destination, content);
   return destinationRelative;
+}
+
+function sourceOriginFor(acquisition: AdoptAcquisition, path: string): SourceOrigin {
+  return acquisition.kind === "git"
+    ? { path, ref: acquisition.ref, repo: acquisition.repo }
+    : { path };
+}
+
+function relativeOriginPath(rootPath: string, sourcePath: string, copiedFile?: string): string {
+  const sourceFile = copiedFile === undefined
+    ? sourcePath
+    : basename(sourcePath) === copiedFile
+      ? sourcePath
+      : join(sourcePath, copiedFile);
+  const path = relative(rootPath, sourceFile).replaceAll("\\", "/");
+  return path.length === 0 ? "." : path;
+}
+
+async function writeMarkdownSourceOrigin(path: string, origin: SourceOrigin): Promise<void> {
+  const parts = parseMarkdown(await readFile(path, "utf8"), path);
+  await writeFile(path, stringifyMarkdown(withSkillsetOrigin(parts.frontmatter, origin), parts.body));
+}
+
+function withSkillsetOrigin(record: JsonRecord, origin: SourceOrigin): JsonRecord {
+  const existing = isJsonRecord(record.skillset) ? record.skillset : {};
+  return {
+    ...record,
+    skillset: {
+      ...existing,
+      origin: sourceOriginRecord(origin),
+    },
+  };
+}
+
+function sourceOriginRecord(origin: SourceOrigin): JsonRecord {
+  return {
+    path: origin.path,
+    ...(origin.ref === undefined ? {} : { ref: origin.ref }),
+    ...(origin.repo === undefined ? {} : { repo: origin.repo }),
+  };
 }
 
 /**
@@ -486,7 +534,7 @@ export function renderAdoptReportMarkdown(
   } else {
     for (const result of succeeded) {
       if (result.destination !== undefined) {
-        lines.push(`- ${result.candidate.kind}: \`${result.candidate.path}\` -> \`${result.destination}\` (verbatim copy)`);
+        lines.push(`- ${result.candidate.kind}: \`${result.candidate.path}\` -> \`${result.destination}\` (body copy with provenance metadata)`);
         continue;
       }
       lines.push(`- ${result.candidate.kind}: \`${result.candidate.path}\` -> ${result.detail}`);

--- a/apps/skillset/src/authoring.ts
+++ b/apps/skillset/src/authoring.ts
@@ -4,7 +4,7 @@ import { diffSkillset, scopedRenderedFiles, type SkillsetDiff } from "./build";
 import { inspectSkillset } from "./lint";
 import { renderBuildGraph } from "./render";
 import { loadBuildGraph } from "./resolver";
-import type { BuildGraph, GeneratedEntry, LintIssue, SkillsetOptions } from "./types";
+import type { BuildGraph, GeneratedEntry, LintIssue, SkillsetOptions, SourceOrigin } from "./types";
 import { isJsonRecord } from "./yaml";
 
 const textDecoder = new TextDecoder();
@@ -181,6 +181,7 @@ function collectLockItems(rendered: Awaited<ReturnType<typeof renderBuildGraph>>
               : []
           )
         : undefined;
+      const sourceOrigin = readSourceOrigin(rawItem.sourceOrigin);
       matches.push({
         sourcePath,
         outputPath: joinOutputRoot(outputRoot, outputPath),
@@ -198,6 +199,7 @@ function collectLockItems(rendered: Awaited<ReturnType<typeof renderBuildGraph>>
           ...(typeof rawItem.outputHash === "string" ? { outputHash: rawItem.outputHash } : {}),
           ...(preprocessDependencies === undefined ? {} : { preprocessDependencies }),
           ...(typeof rawItem.sourceHash === "string" ? { sourceHash: rawItem.sourceHash } : {}),
+          ...(sourceOrigin === undefined ? {} : { sourceOrigin }),
           ...(typeof rawItem.sourcePointer === "string" ? { sourcePointer: rawItem.sourcePointer } : {}),
           ...(transforms === undefined || transforms.length === 0 ? {} : { transforms }),
           ...(typeof rawItem.version === "string" ? { version: rawItem.version } : {}),
@@ -208,6 +210,15 @@ function collectLockItems(rendered: Awaited<ReturnType<typeof renderBuildGraph>>
     }
   }
   return matches;
+}
+
+function readSourceOrigin(value: unknown): SourceOrigin | undefined {
+  if (!isJsonRecord(value) || typeof value.path !== "string") return undefined;
+  return {
+    path: value.path,
+    ...(typeof value.ref === "string" ? { ref: value.ref } : {}),
+    ...(typeof value.repo === "string" ? { repo: value.repo } : {}),
+  };
 }
 
 function joinOutputRoot(outputRoot: string, file: string): string {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -25,7 +25,7 @@ import { applyRelease, planRelease, type ReleasePlanReport, type ReleaseSubcomma
 import { createSkillset, initSkillset, type SetupInclude, type SetupReport } from "./setup";
 import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "./source-unit-selector";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
-import type { BuildScope, CompileBuildMode, SkillsetOptions, TargetName } from "./types";
+import type { BuildScope, CompileBuildMode, SkillsetOptions, SourceOrigin, TargetName } from "./types";
 
 type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "diff" | "doctor" | "explain" | "hooks" | "import" | "init" | "lint" | "list" | "release" | "test";
 
@@ -344,6 +344,7 @@ export async function runCli(
       if (entry.validation !== undefined) console.log(`    validation: ${entry.validation}`);
       if (entry.feature !== undefined) console.log(`    feature: ${entry.feature}`);
       if (entry.origin !== undefined) console.log(`    origin: ${entry.origin}`);
+      if (entry.sourceOrigin !== undefined) console.log(`    source origin: ${formatSourceOrigin(entry.sourceOrigin)}`);
       if (entry.sourcePointer !== undefined) console.log(`    source pointer: ${entry.sourcePointer}`);
       if (entry.dependencies !== undefined && entry.dependencies.length > 0) {
         console.log(`    dependencies: ${entry.dependencies.join(", ")}`);
@@ -671,6 +672,13 @@ function printAdoptReport(report: AdoptReport, reason: string): void {
   }
   console.log(`  report: ${ADOPT_REPORT_DIR}/report.md`);
   console.log(`skillset: adopt ${report.ok ? "passed" : "found problems"}`);
+}
+
+function formatSourceOrigin(origin: SourceOrigin): string {
+  const remote = origin.repo === undefined || origin.ref === undefined
+    ? ""
+    : `${origin.repo} @ ${origin.ref} `;
+  return `${remote}path ${origin.path}`;
 }
 
 function printSetupReport(result: SetupReport, reason: string): void {

--- a/apps/skillset/src/import.ts
+++ b/apps/skillset/src/import.ts
@@ -5,8 +5,8 @@ import { basename, dirname, join, resolve } from "node:path";
 import { seedReleaseBaselines, type ReleaseBaselineEntry } from "./adoption";
 import { readSkillsetMetadata, readSkillsetName, readString } from "./config";
 import { compareStrings, resolveInside, validateSlug } from "./path";
-import type { JsonRecord } from "./types";
-import { isJsonRecord, parseMarkdown, parseYamlRecord, stringifyYaml } from "./yaml";
+import type { JsonRecord, SourceOrigin } from "./types";
+import { isJsonRecord, parseMarkdown, parseYamlRecord, stringifyMarkdown, stringifyYaml } from "./yaml";
 
 const DEFAULT_SOURCE_DIR = ".skillset";
 
@@ -57,6 +57,7 @@ export interface ImportOptions {
   readonly name?: string;
   readonly rootPath: string;
   readonly sourceDir?: string;
+  readonly sourceOrigin?: (sourcePath: string, copiedFile?: string) => SourceOrigin;
   readonly sourcePath: string;
 }
 
@@ -66,6 +67,7 @@ export interface ImportSourcesOptions {
   readonly provider?: ImportProvider;
   readonly rootPath: string;
   readonly sourceDir?: string;
+  readonly sourceOrigin?: (sourcePath: string, copiedFile?: string) => SourceOrigin;
   readonly sourcePath?: string;
 }
 
@@ -109,6 +111,7 @@ export async function importSources(options: ImportSourcesOptions): Promise<Impo
         sourcePath: item.sourcePath,
         ...(options.name === undefined ? {} : { name: options.name }),
         ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
+        ...(options.sourceOrigin === undefined ? {} : { sourceOrigin: options.sourceOrigin }),
       })
     );
   }
@@ -146,6 +149,9 @@ export async function importSource(options: ImportOptions): Promise<ImportReport
 
   try {
     const copiedFiles = await copyImportSource(sourcePath, stagingPath, options.kind, name);
+    if (options.sourceOrigin !== undefined) {
+      await stampImportedOrigins(stagingPath, sourcePath, copiedFiles, options.kind, options.sourceOrigin);
+    }
     const frontmatter = await readImportedFrontmatter(stagingPath, options.kind);
     const classification = classifyFrontmatter(frontmatter);
 
@@ -317,6 +323,52 @@ async function copyImportSource(
   }
 
   return copied.sort(compareStrings);
+}
+
+async function stampImportedOrigins(
+  targetPath: string,
+  sourcePath: string,
+  copiedFiles: readonly string[],
+  kind: SingularImportKind,
+  sourceOrigin: (sourcePath: string, copiedFile?: string) => SourceOrigin
+): Promise<void> {
+  if (kind === "plugin") {
+    await writeYamlSourceOrigin(join(targetPath, "skillset.yaml"), sourceOrigin(sourcePath));
+  }
+
+  for (const file of copiedFiles) {
+    if (basename(file) !== "SKILL.md") continue;
+    await writeMarkdownSourceOrigin(join(targetPath, file), sourceOrigin(sourcePath, file));
+  }
+}
+
+async function writeYamlSourceOrigin(path: string, origin: SourceOrigin): Promise<void> {
+  const config = parseYamlRecord(await readFile(path, "utf8"), path);
+  await writeFile(path, stringifyYaml(withSkillsetOrigin(config, origin)));
+}
+
+async function writeMarkdownSourceOrigin(path: string, origin: SourceOrigin): Promise<void> {
+  const parts = parseMarkdown(await readFile(path, "utf8"), path);
+  await writeFile(path, stringifyMarkdown(withSkillsetOrigin(parts.frontmatter, origin), parts.body));
+}
+
+function withSkillsetOrigin(record: JsonRecord, origin: SourceOrigin): JsonRecord {
+  const existing = isJsonRecord(record.skillset) ? record.skillset : {};
+  return {
+    ...record,
+    skillset: {
+      ...existing,
+      origin: sourceOriginRecord(origin),
+    },
+  };
+}
+
+function sourceOriginRecord(origin: SourceOrigin): JsonRecord {
+  return {
+    path: origin.path,
+    ...(origin.ref === undefined ? {} : { ref: origin.ref }),
+    ...(origin.repo === undefined ? {} : { repo: origin.repo }),
+  };
 }
 
 function relativeImportPath(sourceRoot: string, file: string, kind: SingularImportKind): string {

--- a/apps/skillset/src/render.ts
+++ b/apps/skillset/src/render.ts
@@ -45,6 +45,7 @@ import type {
   JsonValue,
   RenderedFile,
   SourceIslandFile,
+  SourceOrigin,
   SourcePlugin,
   SourcePluginFeature,
   SourceProjectAgent,
@@ -80,6 +81,7 @@ interface LockItem {
   readonly preprocessDependencies?: readonly string[];
   readonly skippedSkills?: readonly string[];
   readonly sourceHash: string;
+  readonly sourceOrigin?: SourceOrigin;
   readonly sourcePath: string;
   readonly sourcePointer?: string;
   readonly targetState?: string;
@@ -1232,6 +1234,7 @@ async function renderClaudeRules(
         outputRoot: CLAUDE_RULES_OUTPUT_ROOT,
         outputPath: targetFile,
         sourceHash: hashTextRule(rule),
+        ...(rule.sourceOrigin === undefined ? {} : { sourceOrigin: rule.sourceOrigin }),
         sourcePath: relative(graph.rootPath, rule.sourcePath),
       })
     );
@@ -1728,6 +1731,7 @@ function lockItemForPlugin(args: {
     outputPath: relative(args.outputRoot, args.file.path),
     skippedSkills,
     sourceHash: hashPluginSource(args.plugin, args.target, includedSkills, skippedSkills, dependencyHashSummaries),
+    ...(args.plugin.sourceOrigin === undefined ? {} : { sourceOrigin: args.plugin.sourceOrigin }),
     sourcePath: relative(args.graph.rootPath, args.plugin.path),
     targetState: skippedSkills.length === 0 ? "sync" : "intentionally-skipped",
     version: pluginVersion(args.graph, args.plugin),
@@ -1767,6 +1771,7 @@ function lockItemForRule(args: {
   readonly outputPath: string;
   readonly outputRoot: string;
   readonly sourceHash: string;
+  readonly sourceOrigin?: SourceOrigin;
   readonly sourcePath: string;
   readonly transforms?: readonly AppliedTransform[];
 }): LockItem {
@@ -1777,6 +1782,7 @@ function lockItemForRule(args: {
     outputHash: hashRenderedFiles(args.outputRoot, args.files),
     outputPath: relative(args.outputRoot, args.outputPath),
     sourceHash: args.sourceHash,
+    ...(args.sourceOrigin === undefined ? {} : { sourceOrigin: args.sourceOrigin }),
     sourcePath: args.sourcePath,
     ...(args.transforms === undefined || args.transforms.length === 0
       ? {}
@@ -1853,6 +1859,7 @@ async function lockItemForSkill(args: {
     outputHash: hashRenderedFiles(args.outputRoot, args.files),
     outputPath: files.find((file) => file.endsWith("/SKILL.md")) ?? files[0] ?? "",
     sourceHash: await hashSkillSource(args.sourceDir, args.skill.resources),
+    ...(args.skill.sourceOrigin === undefined ? {} : { sourceOrigin: args.skill.sourceOrigin }),
     sourcePath: relative(args.graph.rootPath, args.skill.sourcePath),
     ...(args.transforms.length === 0 ? {} : { transforms: args.transforms }),
     version: skillVersion(args.graph, args.plugin, args.skill),
@@ -1927,6 +1934,7 @@ function stripUndefinedLockItem(item: LockItem): JsonRecord {
     preprocessDependencies: item.preprocessDependencies === undefined ? undefined : [...item.preprocessDependencies],
     skippedSkills: item.skippedSkills === undefined ? undefined : [...item.skippedSkills],
     sourceHash: item.sourceHash,
+    sourceOrigin: item.sourceOrigin === undefined ? undefined : sourceOriginRecord(item.sourceOrigin),
     sourcePath: item.sourcePath,
     sourcePointer: item.sourcePointer,
     targetState: item.targetState,
@@ -1938,6 +1946,14 @@ function stripUndefinedLockItem(item: LockItem): JsonRecord {
     version: item.version,
   };
   return value;
+}
+
+function sourceOriginRecord(origin: SourceOrigin): JsonRecord {
+  return {
+    path: origin.path,
+    ...(origin.ref === undefined ? {} : { ref: origin.ref }),
+    ...(origin.repo === undefined ? {} : { repo: origin.repo }),
+  };
 }
 
 function hashPluginSource(

--- a/apps/skillset/src/resolver.ts
+++ b/apps/skillset/src/resolver.ts
@@ -26,6 +26,7 @@ import type {
   OutputSelection,
   SkillsetOptions,
   SourceDialect,
+  SourceOrigin,
   SourcePlugin,
   SourcePluginFeature,
   SourcePluginFeatureKey,
@@ -358,6 +359,8 @@ async function loadInstructions(
     const relativePath = relative(canonicalPath, sourcePath);
     const frontmatter = normalizeRuleFrontmatter(parts.frontmatter, sourcePath);
     await validateSupports(frontmatter.supports, { label: relative(rootPath, sourcePath), rootPath, warnings });
+    const metadata = readSkillsetMetadata(frontmatter, sourcePath);
+    const sourceOrigin = readSourceOrigin(metadata, sourcePath);
     const targets = resolveFeatureTargets(rootTargets, frontmatter, sourcePath, "instructions");
     const dialect = readDialect(frontmatter, relative(rootPath, sourcePath));
 
@@ -367,6 +370,7 @@ async function loadInstructions(
       frontmatter,
       id: relativePath.replace(/\.md$/, ""),
       relativePath,
+      ...(sourceOrigin === undefined ? {} : { sourceOrigin }),
       sourcePath: resolveInside(rootPath, relative(rootPath, sourcePath)),
       targets,
     });
@@ -443,6 +447,7 @@ async function loadPlugin(
   const metadata = readSkillsetMetadata(config, configPath);
   validateSchemaField(metadata, `${configPath}.skillset.schema`);
   validateVersionField(metadata, `${configPath}.skillset.version`);
+  const sourceOrigin = readSourceOrigin(metadata, configPath);
   const configuredId = readSkillsetName(metadata, id, configPath);
   validateSlug(configuredId, `skillset.name in ${configPath}`);
   if (configuredId !== id) {
@@ -479,7 +484,17 @@ async function loadPlugin(
     );
   }
 
-  return { configPath, dependencies, features, id, metadata, path: pluginPath, skills, targets };
+  return {
+    configPath,
+    dependencies,
+    features,
+    id,
+    metadata,
+    path: pluginPath,
+    skills,
+    ...(sourceOrigin === undefined ? {} : { sourceOrigin }),
+    targets,
+  };
 }
 
 async function loadPluginFeatures(
@@ -654,6 +669,7 @@ async function loadSkillsFromDirectory(
     if (metadata.version !== undefined) {
       throw new Error(`skillset: ${sourcePath} uses unsupported skillset.version; use top-level version`);
     }
+    const sourceOrigin = readSourceOrigin(metadata, sourcePath);
     const id = validateSlug(
       readString(parts.frontmatter, "name") ?? basename(dirname(sourcePath)),
       `skill id in ${sourcePath}`
@@ -677,6 +693,7 @@ async function loadSkillsFromDirectory(
       metadata,
       relativePath,
       resources,
+      ...(sourceOrigin === undefined ? {} : { sourceOrigin }),
       sourcePath: resolveInside(rootPath, relative(rootPath, sourcePath)),
       targets,
     });
@@ -766,6 +783,28 @@ async function collectFiles(root: string): Promise<string[]> {
   }
 
   return files;
+}
+
+function readSourceOrigin(metadata: JsonRecord, label: string): SourceOrigin | undefined {
+  const raw = metadata.origin;
+  if (raw === undefined) return undefined;
+  if (!isJsonRecord(raw)) {
+    throw new Error(`skillset: expected ${label}.skillset.origin to be an object`);
+  }
+  const path = readString(raw, "path");
+  if (path === undefined) {
+    throw new Error(`skillset: expected ${label}.skillset.origin.path`);
+  }
+  const repo = readString(raw, "repo");
+  const ref = readString(raw, "ref");
+  if ((repo === undefined) !== (ref === undefined)) {
+    throw new Error(`skillset: ${label}.skillset.origin must set repo and ref together`);
+  }
+  return {
+    path,
+    ...(ref === undefined ? {} : { ref }),
+    ...(repo === undefined ? {} : { repo }),
+  };
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/apps/skillset/src/types.ts
+++ b/apps/skillset/src/types.ts
@@ -70,6 +70,7 @@ export interface SourceSkill {
   readonly metadata: JsonRecord;
   readonly relativePath: string;
   readonly resources: readonly SourceResource[];
+  readonly sourceOrigin?: SourceOrigin;
   readonly sourcePath: string;
   readonly targets: Readonly<Record<TargetName, ResolvedTarget>>;
 }
@@ -98,6 +99,7 @@ export interface SourcePlugin {
   readonly metadata: JsonRecord;
   readonly path: string;
   readonly skills: readonly SourceSkill[];
+  readonly sourceOrigin?: SourceOrigin;
   readonly targets: Readonly<Record<TargetName, ResolvedTarget>>;
 }
 
@@ -120,6 +122,7 @@ export interface SourceRule {
   readonly frontmatter: JsonRecord;
   readonly id: string;
   readonly relativePath: string;
+  readonly sourceOrigin?: SourceOrigin;
   readonly sourcePath: string;
   readonly targets: Readonly<Record<TargetName, ResolvedTarget>>;
 }
@@ -188,6 +191,12 @@ export interface AppliedTransform {
   readonly intent: string;
 }
 
+export interface SourceOrigin {
+  readonly path: string;
+  readonly ref?: string;
+  readonly repo?: string;
+}
+
 export interface GeneratedEntry {
   readonly dependencies?: readonly string[];
   readonly feature?: string;
@@ -198,6 +207,7 @@ export interface GeneratedEntry {
   readonly outputRoot: string;
   readonly preprocessDependencies?: readonly string[];
   readonly sourceHash?: string;
+  readonly sourceOrigin?: SourceOrigin;
   readonly sourcePath: string;
   readonly sourcePointer?: string;
   readonly target: string;

--- a/scripts/fixtures/__tests__/external.test.ts
+++ b/scripts/fixtures/__tests__/external.test.ts
@@ -108,8 +108,8 @@ test("runExternalRepo adopts a marketplace-shaped repo in place and reports roun
     ["purity", true],
   ]);
   expect(report.ok).toBe(true);
-  // The root AGENTS.md candidate now actually imports: adopt copies it
-  // verbatim into .skillset/instructions/ under its lowercased name.
+  // The root AGENTS.md candidate now actually imports: adopt copies the body
+  // into .skillset/instructions/ and adds source-origin metadata.
   expect(
     report.stages.find(
       (stage) =>
@@ -117,9 +117,9 @@ test("runExternalRepo adopts a marketplace-shaped repo in place and reports roun
         stage.detail.includes("instructions:AGENTS.md")
     )?.detail
   ).toContain(".skillset/instructions/agents.md");
-  expect(
-    await readFile(join(clone, ".skillset/instructions/agents.md"), "utf8")
-  ).toBe("# Demo agents\n\nHandwritten instructions.\n");
+  const importedAgents = await readFile(join(clone, ".skillset/instructions/agents.md"), "utf8");
+  expect(importedAgents).toContain("skillset:\n  origin:\n    path: AGENTS.md");
+  expect(importedAgents).toContain("# Demo agents\n\nHandwritten instructions.");
   expect(report.survey.candidates).toEqual([
     { kind: "instructions", path: "AGENTS.md" },
     { kind: "plugin", path: "plugins/demo" },


### PR DESCRIPTION
## Context

Part of the one-action repo adoption stack. SET-67 records where adopted source came from so future adoption refresh and explainability work has durable provenance.

Linear: https://linear.app/outfitter/issue/SET-67/record-origin-provenance-for-adopted-source-and-surface-it-through

## What Changed

- Added `sourceOrigin` as a distinct concept from existing feature `origin` metadata.
- Stamps adopted source with `skillset.origin` metadata before graph resolution and release baseline seeding.
- Carries source origin into plugin, skill, and Claude rule lock entries.
- Surfaces source origin through `skillset explain` from lock provenance.
- Keeps local path adoption path-only and remote adoption as `{ repo, ref, path }`.

## Verification

- `bun run typecheck`
- `bun test apps/skillset/src/__tests__/adopt.test.ts`
- `bun test scripts/fixtures/__tests__/external.test.ts`
- `bun run test`
- `bun run check`
- `bun scripts/fixtures/external.ts sync && bun scripts/fixtures/external.ts run`
- Manual smoke: remote-style `file://` adopt of `compound-engineering-plugin`, followed by `skillset explain .skillset/plugins/compound-engineering` and lock inspection for `sourceOrigin`.

External fidelity baseline held for `compound-engineering`: `197 identical / 40 different / 6 original-only / 0 generated-only`.

## Risks

- Concatenated Codex `AGENTS.md` lock entries do not record a single `sourceOrigin` because they can aggregate multiple instruction sources. Individual Claude rule lock entries do carry it.
