### PR TITLE
test(fixtures): expand external adoption corpus

### DIFF
--- a/fixtures/external/repos.yaml
+++ b/fixtures/external/repos.yaml
@@ -5,3 +5,11 @@ repos:
     repo: https://github.com/EveryInc/compound-engineering-plugin
     ref: 4719dc509fdc45656a830e3ed6060f674e206076
     notes: "Multi-surface Claude plugin repo: .claude-plugin manifest, .claude and .agents trees, nested plugins/ directory."
+  - name: browserbase-claude-code-plugin
+    repo: https://github.com/browserbase/claude-code-plugin
+    ref: b399af34a1b1cc365d1e1c0089823c4fa5e10ea5
+    notes: "Small root Claude plugin repo with bundled MCP/config surfaces and no project instructions."
+  - name: claude-review-loop
+    repo: https://github.com/hamelsmu/claude-review-loop
+    ref: 244f4c7bc15e98552af7cc5a67e70dfcdea9ab12
+    notes: "Nested marketplace-style Claude plugin under plugins/review-loop."


### PR DESCRIPTION
## Context

Part of the one-action repo adoption stack. SET-68 expands the external fixture corpus beyond the original single pinned repo so adoption quality is checked against more real published Claude plugin shapes.

Linear: https://linear.app/outfitter/issue/SET-68/expand-the-external-adoption-fixture-corpus-beyond-one-pinned

## What Changed

- Added `browserbase/claude-code-plugin` pinned at `b399af34a1b1cc365d1e1c0089823c4fa5e10ea5`.
- Added `hamelsmu/claude-review-loop` pinned at `244f4c7bc15e98552af7cc5a67e70dfcdea9ab12`.
- Kept both entries Claude-only by default, matching the current verified fixture target.

## Verification

- Candidate probes against temp clones for several public repos; only clean passers were added.
- `bun scripts/fixtures/external.ts sync && bun scripts/fixtures/external.ts run`
- `bun run check`
- Pre-push hook reran `skillset ci` and `bun run check` successfully during `gt submit`.

Round-trip baselines:

- `compound-engineering` stayed `197 identical / 40 different / 6 original-only / 0 generated-only`.
- `browserbase-claude-code-plugin`: `6 identical / 1 different / 7 original-only / 0 generated-only`.
- `review-loop`: `5 identical / 1 different / 1 original-only / 0 generated-only`.

## Risks

- The new repos are pinned to full SHAs; future upstream drift only enters the harness through an explicit fixture update.
