### PR TITLE
feat(core): define operation result types

### DIFF
--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 
-import { diffSkillset } from "@skillset/core";
+import { diffSkillsetResult, type SkillsetDiagnostic, type SkillsetDiff } from "@skillset/core";
 
 import { changeCheck, type ChangeBump, type ChangeCheckReport } from "./change-entries";
 import { changeStatus, type ChangeStatusReport } from "./change-status";
@@ -102,7 +102,9 @@ export async function runCli(
 
   if (command === "build") {
     if (dryRun || !yes) {
-      const diff = await diffSkillset(rootPath, options);
+      const result = await diffSkillsetResult(rootPath, options);
+      printDiagnostics(result.diagnostics);
+      const { data: diff } = result;
       printDiffPlan(diff, dryRun ? "dry run" : "write confirmation required");
       if (!dryRun) console.log("skillset: rerun with --yes to write generated files");
       return;
@@ -303,7 +305,9 @@ export async function runCli(
   }
 
   if (command === "diff") {
-    const diff = await diffSkillset(rootPath, options);
+    const result = await diffSkillsetResult(rootPath, options);
+    printDiagnostics(result.diagnostics);
+    const { data: diff } = result;
     const total = diff.added.length + diff.changed.length + diff.missing.length + diff.removed.length;
     if (total === 0) {
       console.log("skillset: no generated changes");
@@ -600,7 +604,7 @@ function printReleaseApply(
   for (const file of files) console.log(`  ${file}`);
 }
 
-function printDiffPlan(diff: Awaited<ReturnType<typeof diffSkillset>>, reason: string): void {
+function printDiffPlan(diff: SkillsetDiff, reason: string): void {
   const total = diff.added.length + diff.changed.length + diff.missing.length + diff.removed.length;
   if (total === 0) {
     console.log(`skillset: no generated changes (${reason})`);
@@ -710,6 +714,15 @@ function printSetupReport(result: SetupReport, reason: string): void {
   ];
   console.log(`skillset: ${result.kind} ${details.join(", ")} (${reason})`);
   console.log(`  root: ${result.rootPath}`);
+}
+
+function printDiagnostics(diagnostics: readonly SkillsetDiagnostic[]): void {
+  for (const diagnostic of diagnostics) {
+    const location = diagnostic.path ?? diagnostic.outputPath;
+    const suffix = location === undefined ? "" : `: ${location}`;
+    const prefix = diagnostic.severity === "error" ? "error" : diagnostic.severity === "warning" ? "warning" : "info";
+    console.warn(`skillset: ${prefix}${suffix}: ${diagnostic.message}`);
+  }
 }
 
 function printSkillsetTest(report: SkillsetTestReport): void {

--- a/packages/core/src/__tests__/diff.test.ts
+++ b/packages/core/src/__tests__/diff.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { diffSkillset } from "@skillset/core";
+import { diffSkillset, diffSkillsetResult } from "@skillset/core";
 
 const DEMO_FIXTURE: Record<string, string> = {
   ".skillset/config.yaml": `
@@ -40,12 +40,29 @@ describe("diffSkillset", () => {
     };
 
     try {
-      const diff = await diffSkillset(root);
+      const result = await diffSkillsetResult(root);
+      const diff = result.data;
 
+      expect(result.ok).toBe(true);
+      expect(result.operation).toBe("diff");
+      expect(result.writes).toEqual({
+        deletedPaths: [],
+        mode: "read",
+        paths: [],
+        writtenPaths: [],
+      });
+      expect(result.loweringOutcomes).toEqual([]);
+      expect(result.diagnostics).toEqual([
+        expect.objectContaining({
+          code: "source-warning",
+          severity: "warning",
+        }),
+      ]);
       expect(diff.added).toContain(".claude/skills/demo/SKILL.md");
       expect(diff.changed).toEqual([]);
       expect(diff.missing).toEqual([]);
       expect(diff.removed).toEqual([]);
+      expect(await diffSkillset(root)).toEqual(diff);
       expect(await Bun.file(join(root, ".claude/skills/demo/SKILL.md")).exists()).toBe(false);
       expect(calls).toEqual([]);
       expect(process.exitCode).toBeUndefined();
@@ -54,6 +71,20 @@ describe("diffSkillset", () => {
       console.warn = originalWarn;
       process.exitCode = previousExitCode;
     }
+  });
+
+  it("throws invalid source config instead of hiding it in a successful result", async () => {
+    const root = await fixture({
+      ".skillset/config.yaml": `
+skillset:
+  name: invalid-core-diff-root
+compile:
+  targets:
+    - nope
+`,
+    });
+
+    await expect(diffSkillsetResult(root)).rejects.toThrow("unsupported target");
   });
 });
 

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -4,6 +4,7 @@ import { dirname, join, relative } from "node:path";
 import { compareStrings, resolveInside } from "./path";
 import { renderBuildGraph } from "./render";
 import { emitGraphWarnings, loadBuildGraph } from "./resolver";
+import { sourceWarningDiagnostic, type SkillsetOperationResult } from "./operation-result";
 import type { BuildGraph, BuildScope, CheckResult, RenderedFile, SkillsetOptions } from "./types";
 import { isJsonRecord, parseMarkdown } from "./yaml";
 
@@ -113,6 +114,8 @@ export interface SkillsetDiff {
   readonly removed: readonly string[];
 }
 
+export type SkillsetDiffResult = SkillsetOperationResult<SkillsetDiff>;
+
 /**
  * Compute the generated changes a build would make, without writing anything.
  * Backs `skillset diff` and `skillset doctor`.
@@ -121,6 +124,13 @@ export async function diffSkillset(
   rootPath: string,
   options: SkillsetOptions = {}
 ): Promise<SkillsetDiff> {
+  return (await diffSkillsetResult(rootPath, options)).data;
+}
+
+export async function diffSkillsetResult(
+  rootPath: string,
+  options: SkillsetOptions = {}
+): Promise<SkillsetDiffResult> {
   const graph = await loadBuildGraph(rootPath, options);
   const outPath = outPathMapper(options);
   const rendered = mirroredRenderedFiles(
@@ -156,11 +166,24 @@ export async function diffSkillset(
     if (!expected.has(path)) removed.push(path);
   }
 
-  return {
+  const diff = {
     added: [...added].sort(compareStrings),
     changed: [...changed].sort(compareStrings),
     missing: [...missing].sort(compareStrings),
     removed: [...removed].sort(compareStrings),
+  };
+  return {
+    data: diff,
+    diagnostics: graph.warnings.map(sourceWarningDiagnostic),
+    loweringOutcomes: [],
+    ok: true,
+    operation: "diff",
+    writes: {
+      deletedPaths: [],
+      mode: "read",
+      paths: [],
+      writtenPaths: [],
+    },
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,11 @@
-export { diffSkillset, type SkillsetDiff } from "./build";
+export { diffSkillset, diffSkillsetResult, type SkillsetDiff, type SkillsetDiffResult } from "./build";
+export type { SkillsetLoweringOutcome, SkillsetLoweringOutcomeStatus } from "./lowering-outcome";
+export type {
+  SkillsetDiagnostic,
+  SkillsetDiagnosticSeverity,
+  SkillsetOperation,
+  SkillsetOperationResult,
+  SkillsetWriteMode,
+  SkillsetWriteSummary,
+} from "./operation-result";
 export type { SkillsetOptions } from "./types";

--- a/packages/core/src/lowering-outcome.ts
+++ b/packages/core/src/lowering-outcome.ts
@@ -1,0 +1,20 @@
+import type { TargetName } from "./types";
+
+export type SkillsetLoweringOutcomeStatus =
+  | "degraded_notice"
+  | "emitted"
+  | "intentionally_skipped"
+  | "lossy"
+  | "metadata_only"
+  | "target_native"
+  | "unsupported";
+
+export interface SkillsetLoweringOutcome {
+  readonly diagnosticIds?: readonly string[];
+  readonly featureId: string;
+  readonly message?: string;
+  readonly outputPath?: string;
+  readonly sourcePath?: string;
+  readonly status: SkillsetLoweringOutcomeStatus;
+  readonly target?: TargetName;
+}

--- a/packages/core/src/operation-result.ts
+++ b/packages/core/src/operation-result.ts
@@ -1,0 +1,58 @@
+import type { SkillsetLoweringOutcome } from "./lowering-outcome";
+
+export type SkillsetOperation =
+  | "adopt"
+  | "build"
+  | "change"
+  | "check"
+  | "ci"
+  | "diff"
+  | "doctor"
+  | "explain"
+  | "import"
+  | "lint"
+  | "list"
+  | "release"
+  | "test";
+
+export type SkillsetDiagnosticSeverity = "error" | "info" | "warning";
+
+export interface SkillsetDiagnostic {
+  readonly code: string;
+  readonly featureId?: string;
+  readonly message: string;
+  readonly outputPath?: string;
+  readonly path?: string;
+  readonly severity: SkillsetDiagnosticSeverity;
+  readonly sourceUnit?: string;
+  readonly target?: string;
+}
+
+export type SkillsetWriteMode = "dry-run" | "read" | "write";
+
+export interface SkillsetWriteSummary {
+  /** Actual filesystem paths changed by the operation. Read and dry-run operations return an empty list. */
+  readonly mode: SkillsetWriteMode;
+  readonly paths: readonly string[];
+  /** Files or directories written by the operation. */
+  readonly writtenPaths: readonly string[];
+  /** Files or directories removed by the operation. */
+  readonly deletedPaths: readonly string[];
+}
+
+export interface SkillsetOperationResult<Data> {
+  readonly data: Data;
+  readonly diagnostics: readonly SkillsetDiagnostic[];
+  readonly loweringOutcomes: readonly SkillsetLoweringOutcome[];
+  readonly ok: boolean;
+  readonly operation: SkillsetOperation;
+  readonly writes: SkillsetWriteSummary;
+}
+
+export function sourceWarningDiagnostic(message: string): SkillsetDiagnostic {
+  return {
+    code: "source-warning",
+    message,
+    severity: "warning",
+  };
+}


### PR DESCRIPTION
## Summary
- Adds stable operation result and side-effect vocabulary for core APIs.
- Separates structured results from CLI printing so callers can consume compiler outcomes without stdout coupling.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- This branch underpins the CLI renderer and consumer API tests above it.
- Keep draft until the full stack CI is green.