### PR TITLE
refactor(cli): isolate core result rendering

### DIFF
--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 
 import { expect, test } from "bun:test";
 
-import { buildSkillset, checkSkillset, diffSkillset } from "../build";
+import { buildSkillset, buildSkillsetResult, checkSkillset, diffSkillset, diffSkillsetResult } from "../build";
 import { changeStatus, collectSourceInventory } from "../change-status";
 import { doctorSkillset, explainPath } from "../authoring";
 import { importSource, importSources } from "../import";
@@ -992,6 +992,10 @@ Body.
   expect(written.exitCode).toBe(0);
   expect(written.stdout).toContain("wrote");
   expect(await Bun.file(join(root, ".claude/skills/demo/SKILL.md")).exists()).toBe(true);
+
+  const unchanged = await runSkillsetCli("build", "--root", root, "--yes");
+  expect(unchanged.exitCode).toBe(0);
+  expect(unchanged.stdout).toContain("wrote 0 generated files");
 });
 
 test("SET-25: CLI help succeeds before command validation", async () => {
@@ -4566,7 +4570,7 @@ paths:
   expect(agents).toContain("Second by name.");
 });
 
-test("SET-7: build warns when a generated AGENTS.md exceeds Codex's size limit", async () => {
+test("SET-7: build reports when a generated AGENTS.md exceeds Codex's size limit", async () => {
   const big = `# Big\n\n${"- padding line to grow the instruction file\n".repeat(900)}`;
   const root = await contractFixture({
     ".skillset/config.yaml": `
@@ -4578,19 +4582,15 @@ codex: true
     ".skillset/instructions/big.md": big,
   });
 
-  const warnings: string[] = [];
-  const original = console.warn;
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args.map(String).join(" "));
-  };
-  try {
-    await buildSkillset(root);
-  } finally {
-    console.warn = original;
-  }
+  const result = await buildSkillsetResult(root);
+  const warnings = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+  const preview = await diffSkillsetResult(root);
+  const previewWarnings = preview.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
 
-  expect(warnings.join("\n")).toContain("project_doc_max_bytes");
-  expect(warnings.join("\n")).toContain("AGENTS.md");
+  expect(warnings).toContain("project_doc_max_bytes");
+  expect(warnings).toContain("AGENTS.md");
+  expect(previewWarnings).toContain("project_doc_max_bytes");
+  expect(previewWarnings).toContain("AGENTS.md");
 });
 
 // SET-15: shared-resource and script authoring diagnostics.

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 
-import { diffSkillsetResult, type SkillsetDiagnostic, type SkillsetDiff } from "@skillset/core";
+import { buildSkillsetResult, checkSkillsetResult, diffSkillsetResult } from "@skillset/core";
 
 import { changeCheck, type ChangeBump, type ChangeCheckReport } from "./change-entries";
 import { changeStatus, type ChangeStatusReport } from "./change-status";
@@ -18,8 +18,8 @@ import {
   type ChangeSubcommand,
 } from "./change-workflow";
 import { doctorSkillset, explainPath, listGeneratedEntries } from "./authoring";
-import { buildSkillset, checkSkillset } from "./build";
 import { ciSkillset, hasDrift, renderCiReportMarkdown, type CiReport } from "./ci";
+import { printDiagnostics, printDiffPlan } from "./cli-renderers";
 import { renderHookPrint, type HookPrintSubcommand, type HookRunner } from "./hook-guardrails";
 import { importSources, type ImportKind, type ImportProvider, type ImportReport } from "./import";
 import { lintSkillset } from "./lint";
@@ -109,8 +109,12 @@ export async function runCli(
       if (!dryRun) console.log("skillset: rerun with --yes to write generated files");
       return;
     }
-    const rendered = await buildSkillset(rootPath, options);
-    console.log(`skillset: wrote ${rendered.length} generated files`);
+    const result = await buildSkillsetResult(rootPath, options);
+    printDiagnostics(result.diagnostics);
+    console.log(`skillset: wrote ${result.writes.writtenPaths.length} generated files`);
+    if (result.writes.deletedPaths.length > 0) {
+      console.log(`skillset: removed ${result.writes.deletedPaths.length} stale generated files`);
+    }
     return;
   }
 
@@ -402,8 +406,9 @@ export async function runCli(
     return;
   }
 
-  const result = await checkSkillset(rootPath, options);
-  console.log(`skillset: checked ${result.checkedFiles} generated files`);
+  const result = await checkSkillsetResult(rootPath, options);
+  printDiagnostics(result.diagnostics);
+  console.log(`skillset: checked ${result.data.checkedFiles} generated files`);
 }
 
 export function reportCliError(error: unknown): void {
@@ -604,21 +609,6 @@ function printReleaseApply(
   for (const file of files) console.log(`  ${file}`);
 }
 
-function printDiffPlan(diff: SkillsetDiff, reason: string): void {
-  const total = diff.added.length + diff.changed.length + diff.missing.length + diff.removed.length;
-  if (total === 0) {
-    console.log(`skillset: no generated changes (${reason})`);
-    return;
-  }
-  for (const path of diff.added) console.log(`  + ${path}`);
-  for (const path of diff.changed) console.log(`  ~ ${path}`);
-  for (const path of diff.missing) console.log(`  ! ${path}`);
-  for (const path of diff.removed) console.log(`  - ${path}`);
-  console.log(
-    `skillset: planned ${diff.added.length} added, ${diff.changed.length} changed, ${diff.missing.length} missing, ${diff.removed.length} removed (${reason})`
-  );
-}
-
 function printImportReport(result: ImportReport): void {
   console.log(`skillset: imported ${result.kind} ${result.name} (${result.files} files)`);
   console.log(`  target: ${result.targetPath}`);
@@ -714,15 +704,6 @@ function printSetupReport(result: SetupReport, reason: string): void {
   ];
   console.log(`skillset: ${result.kind} ${details.join(", ")} (${reason})`);
   console.log(`  root: ${result.rootPath}`);
-}
-
-function printDiagnostics(diagnostics: readonly SkillsetDiagnostic[]): void {
-  for (const diagnostic of diagnostics) {
-    const location = diagnostic.path ?? diagnostic.outputPath;
-    const suffix = location === undefined ? "" : `: ${location}`;
-    const prefix = diagnostic.severity === "error" ? "error" : diagnostic.severity === "warning" ? "warning" : "info";
-    console.warn(`skillset: ${prefix}${suffix}: ${diagnostic.message}`);
-  }
 }
 
 function printSkillsetTest(report: SkillsetTestReport): void {

--- a/apps/skillset/src/cli-renderers.ts
+++ b/apps/skillset/src/cli-renderers.ts
@@ -1,0 +1,25 @@
+import type { SkillsetDiagnostic, SkillsetDiff } from "@skillset/core";
+
+export function printDiagnostics(diagnostics: readonly SkillsetDiagnostic[]): void {
+  for (const diagnostic of diagnostics) {
+    const location = diagnostic.path ?? diagnostic.outputPath;
+    const suffix = location === undefined ? "" : `: ${location}`;
+    const prefix = diagnostic.severity === "error" ? "error" : diagnostic.severity === "warning" ? "warning" : "info";
+    console.warn(`skillset: ${prefix}${suffix}: ${diagnostic.message}`);
+  }
+}
+
+export function printDiffPlan(diff: SkillsetDiff, reason: string): void {
+  const total = diff.added.length + diff.changed.length + diff.missing.length + diff.removed.length;
+  if (total === 0) {
+    console.log(`skillset: no generated changes (${reason})`);
+    return;
+  }
+  for (const path of diff.added) console.log(`  + ${path}`);
+  for (const path of diff.changed) console.log(`  ~ ${path}`);
+  for (const path of diff.missing) console.log(`  ! ${path}`);
+  for (const path of diff.removed) console.log(`  - ${path}`);
+  console.log(
+    `skillset: planned ${diff.added.length} added, ${diff.changed.length} changed, ${diff.missing.length} missing, ${diff.removed.length} removed (${reason})`
+  );
+}

--- a/apps/skillset/src/lint.ts
+++ b/apps/skillset/src/lint.ts
@@ -10,7 +10,7 @@ import {
   findUndeclaredResourceLinks,
   isScriptTargetPath,
 } from "./resources";
-import { emitGraphWarnings, loadBuildGraph } from "./resolver";
+import { loadBuildGraph } from "./resolver";
 import {
   readAllowedTools,
   readClaudeNativeToolRules,
@@ -61,7 +61,6 @@ export async function lintSkillset(
   options: SkillsetOptions = {}
 ): Promise<LintResult> {
   const graph = await loadBuildGraph(rootPath, options);
-  emitGraphWarnings(graph);
   const result = await inspectBuildGraph(graph);
 
   const errors = result.issues.filter((issue) => issue.severity === "error");

--- a/packages/core/src/__tests__/build-result.test.ts
+++ b/packages/core/src/__tests__/build-result.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildSkillsetResult } from "@skillset/core";
+
+const DEMO_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": `
+skillset:
+  name: core-build-root
+claude: true
+codex: false
+`,
+  ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+---
+
+Body.
+`,
+};
+
+describe("buildSkillsetResult", () => {
+  it("reports actual writes and deletions instead of planned managed paths", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+    const expectedOutput = ".claude/skills/demo/SKILL.md";
+    const staleOutput = ".claude/skills/stale/SKILL.md";
+
+    const first = await buildSkillsetResult(root);
+
+    expect(first.writes.writtenPaths).toContain(expectedOutput);
+    expect(first.writes.deletedPaths).toEqual([]);
+    expect(first.writes.paths).toEqual(first.writes.writtenPaths);
+
+    const second = await buildSkillsetResult(root);
+
+    expect(second.writes).toEqual({
+      deletedPaths: [],
+      mode: "write",
+      paths: [],
+      writtenPaths: [],
+    });
+
+    await Bun.write(join(root, staleOutput), "stale\n");
+    const third = await buildSkillsetResult(root);
+
+    expect(third.writes.writtenPaths).toEqual([]);
+    expect(third.writes.deletedPaths).toEqual([staleOutput]);
+    expect(third.writes.paths).toEqual([staleOutput]);
+  });
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-core-build-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -3,8 +3,13 @@ import { dirname, join, relative } from "node:path";
 
 import { compareStrings, resolveInside } from "./path";
 import { renderBuildGraph } from "./render";
-import { emitGraphWarnings, loadBuildGraph } from "./resolver";
-import { sourceWarningDiagnostic, type SkillsetOperationResult } from "./operation-result";
+import { loadBuildGraph } from "./resolver";
+import {
+  sourceWarningDiagnostic,
+  type SkillsetDiagnostic,
+  type SkillsetOperationResult,
+  type SkillsetWriteSummary,
+} from "./operation-result";
 import type { BuildGraph, BuildScope, CheckResult, RenderedFile, SkillsetOptions } from "./types";
 import { isJsonRecord, parseMarkdown } from "./yaml";
 
@@ -45,24 +50,40 @@ const textDecoder = new TextDecoder();
  */
 const CODEX_AGENTS_MAX_BYTES = 32 * 1024;
 
-function warnLargeInstructionFiles(rendered: readonly RenderedFile[]): void {
+function diagnoseLargeInstructionFiles(rendered: readonly RenderedFile[]): readonly SkillsetDiagnostic[] {
+  const diagnostics: SkillsetDiagnostic[] = [];
   for (const file of rendered) {
     if (file.path !== "AGENTS.md" && !file.path.endsWith("/AGENTS.md")) continue;
     if (file.content.byteLength <= CODEX_AGENTS_MAX_BYTES) continue;
-    console.warn(
-      `skillset: generated ${file.path} is ${file.content.byteLength} bytes, over Codex's default ` +
+    diagnostics.push({
+      code: "codex-agents-size",
+      message:
+        `generated ${file.path} is ${file.content.byteLength} bytes, over Codex's default ` +
         `project_doc_max_bytes (${CODEX_AGENTS_MAX_BYTES}); Codex silently truncates beyond it. ` +
-        "Split instructions across nested directories or raise project_doc_max_bytes."
-    );
+        "Split instructions across nested directories or raise project_doc_max_bytes.",
+      outputPath: file.path,
+      severity: "warning",
+      target: "codex",
+    });
   }
+  return diagnostics;
 }
+
+export type SkillsetBuildResult = SkillsetOperationResult<readonly RenderedFile[]>;
 
 export async function buildSkillset(
   rootPath: string,
   options: SkillsetOptions = {}
 ): Promise<readonly RenderedFile[]> {
+  return (await buildSkillsetResult(rootPath, options)).data;
+}
+
+export async function buildSkillsetResult(
+  rootPath: string,
+  options: SkillsetOptions = {}
+): Promise<SkillsetBuildResult> {
   const graph = await loadBuildGraph(rootPath, options);
-  emitGraphWarnings(graph);
+  const diagnostics = [...graph.warnings.map(sourceWarningDiagnostic)];
   const outPath = outPathMapper(options);
   const rendered = mirroredRenderedFiles(
     scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
@@ -71,11 +92,11 @@ export async function buildSkillset(
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
   const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
   const includeWorkspaceLock = includesProjectScope(options.scopes);
-  warnLargeInstructionFiles(rendered);
+  diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expectedPaths = new Set(rendered.map((file) => file.path));
   const previousWorkspaceManagedPaths = includeWorkspaceLock ? await readWorkspaceManagedPaths(rootPath, outPath) : new Set<string>();
   const previousManagedPaths = await readManagedPaths(rootPath, liveOutputRoots, includeWorkspaceLock, outPath);
-  await warnMissingManagedOutputs(rootPath, rendered, previousManagedPaths);
+  diagnostics.push(...await diagnoseMissingManagedOutputs(rootPath, rendered, previousManagedPaths));
 
   await assertNoUnmanagedWorkspaceOverwrites(
     rootPath,
@@ -85,26 +106,27 @@ export async function buildSkillset(
   );
 
   if (graph.root.compile.build === "all") {
-    for (const outputRoot of outputRoots) {
-      await rm(resolveInside(rootPath, outputRoot), { force: true, recursive: true });
-    }
+    const deletedOutputRoots = await removeOutputRoots(rootPath, outputRoots);
 
-    await removeStaleWorkspaceManagedFiles(
+    const deletedWorkspaceFiles = await removeStaleWorkspaceManagedFiles(
       rootPath,
       outputRoots,
       previousWorkspaceManagedPaths,
       expectedPaths
     );
 
-    await writeRenderedFiles(rootPath, rendered);
-    return rendered;
+    const writtenPaths = await writeRenderedFiles(rootPath, rendered);
+    return buildResult(rendered, diagnostics, writeSummary(writtenPaths, [
+      ...deletedOutputRoots,
+      ...deletedWorkspaceFiles,
+    ]));
   }
 
   const actualPaths = new Set(await listGeneratedFiles(rootPath, outputRoots, rendered, includeWorkspaceLock, outPath));
-  await removeStaleGeneratedFiles(rootPath, actualPaths, expectedPaths);
-  await writeChangedRenderedFiles(rootPath, rendered, actualPaths);
+  const deletedPaths = await removeStaleGeneratedFiles(rootPath, actualPaths, expectedPaths);
+  const writtenPaths = await writeChangedRenderedFiles(rootPath, rendered, actualPaths);
 
-  return rendered;
+  return buildResult(rendered, diagnostics, writeSummary(writtenPaths, deletedPaths));
 }
 
 export interface SkillsetDiff {
@@ -132,11 +154,13 @@ export async function diffSkillsetResult(
   options: SkillsetOptions = {}
 ): Promise<SkillsetDiffResult> {
   const graph = await loadBuildGraph(rootPath, options);
+  const diagnostics = [...graph.warnings.map(sourceWarningDiagnostic)];
   const outPath = outPathMapper(options);
   const rendered = mirroredRenderedFiles(
     scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
     outPath
   );
+  diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
   const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
@@ -174,7 +198,7 @@ export async function diffSkillsetResult(
   };
   return {
     data: diff,
-    diagnostics: graph.warnings.map(sourceWarningDiagnostic),
+    diagnostics,
     loweringOutcomes: [],
     ok: true,
     operation: "diff",
@@ -191,14 +215,23 @@ export async function checkSkillset(
   rootPath: string,
   options: SkillsetOptions = {}
 ): Promise<CheckResult> {
+  return (await checkSkillsetResult(rootPath, options)).data;
+}
+
+export type SkillsetCheckResult = SkillsetOperationResult<CheckResult>;
+
+export async function checkSkillsetResult(
+  rootPath: string,
+  options: SkillsetOptions = {}
+): Promise<SkillsetCheckResult> {
   const graph = await loadBuildGraph(rootPath, options);
-  emitGraphWarnings(graph);
+  const diagnostics = [...graph.warnings.map(sourceWarningDiagnostic)];
   const outPath = outPathMapper(options);
   const rendered = mirroredRenderedFiles(
     scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
     outPath
   );
-  warnLargeInstructionFiles(rendered);
+  diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
   const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
@@ -235,37 +268,75 @@ export async function checkSkillset(
     throw new Error(`skillset: generated output is not current\n${failures.join("\n")}`);
   }
 
-  return { checkedFiles: rendered.length };
+  return {
+    data: { checkedFiles: rendered.length },
+    diagnostics,
+    loweringOutcomes: [],
+    ok: true,
+    operation: "check",
+    writes: {
+      deletedPaths: [],
+      mode: "read",
+      paths: [],
+      writtenPaths: [],
+    },
+  };
 }
 
-async function warnMissingManagedOutputs(
+function buildResult(
+  rendered: readonly RenderedFile[],
+  diagnostics: readonly SkillsetDiagnostic[],
+  writes: SkillsetWriteSummary
+): SkillsetBuildResult {
+  return {
+    data: rendered,
+    diagnostics,
+    loweringOutcomes: [],
+    ok: true,
+    operation: "build",
+    writes,
+  };
+}
+
+async function diagnoseMissingManagedOutputs(
   rootPath: string,
   rendered: readonly RenderedFile[],
   previousManagedPaths: ReadonlySet<string>
-): Promise<void> {
+): Promise<readonly SkillsetDiagnostic[]> {
+  const diagnostics: SkillsetDiagnostic[] = [];
   for (const file of rendered) {
     if (!previousManagedPaths.has(file.path)) continue;
     if (await exists(resolveInside(rootPath, file.path))) continue;
-    console.warn(`skillset: managed output is missing and will be regenerated: ${file.path}`);
+    diagnostics.push({
+      code: "managed-output-missing",
+      message: `managed output is missing and will be regenerated: ${file.path}`,
+      outputPath: file.path,
+      severity: "warning",
+    });
   }
+  return diagnostics;
 }
 
 async function writeRenderedFiles(
   rootPath: string,
   rendered: readonly RenderedFile[]
-): Promise<void> {
+): Promise<readonly string[]> {
+  const writtenPaths: string[] = [];
   for (const file of rendered) {
     const outputPath = resolveInside(rootPath, file.path);
     await mkdir(dirname(outputPath), { recursive: true });
     await writeFile(outputPath, file.content);
+    writtenPaths.push(file.path);
   }
+  return writtenPaths.sort(compareStrings);
 }
 
 async function writeChangedRenderedFiles(
   rootPath: string,
   rendered: readonly RenderedFile[],
   actualPaths: ReadonlySet<string>
-): Promise<void> {
+): Promise<readonly string[]> {
+  const writtenPaths: string[] = [];
   for (const file of rendered) {
     const outputPath = resolveInside(rootPath, file.path);
     if (actualPaths.has(file.path)) {
@@ -274,18 +345,23 @@ async function writeChangedRenderedFiles(
     }
     await mkdir(dirname(outputPath), { recursive: true });
     await writeFile(outputPath, file.content);
+    writtenPaths.push(file.path);
   }
+  return writtenPaths.sort(compareStrings);
 }
 
 async function removeStaleGeneratedFiles(
   rootPath: string,
   actualPaths: ReadonlySet<string>,
   expectedPaths: ReadonlySet<string>
-): Promise<void> {
+): Promise<readonly string[]> {
+  const deletedPaths: string[] = [];
   for (const path of actualPaths) {
     if (expectedPaths.has(path)) continue;
     await rm(resolveInside(rootPath, path), { force: true });
+    deletedPaths.push(path);
   }
+  return deletedPaths.sort(compareStrings);
 }
 
 async function listOutputFiles(
@@ -345,12 +421,46 @@ async function removeStaleWorkspaceManagedFiles(
   outputRoots: readonly string[],
   previousManagedPaths: ReadonlySet<string>,
   expectedPaths: ReadonlySet<string>
-): Promise<void> {
+): Promise<readonly string[]> {
+  const deletedPaths: string[] = [];
   for (const path of previousManagedPaths) {
     if (isInsideAnyOutputRoot(path, outputRoots)) continue;
     if (expectedPaths.has(path)) continue;
     await rm(resolveInside(rootPath, path), { force: true });
+    deletedPaths.push(path);
   }
+  return deletedPaths.sort(compareStrings);
+}
+
+async function removeOutputRoots(
+  rootPath: string,
+  outputRoots: readonly string[]
+): Promise<readonly string[]> {
+  const deletedPaths: string[] = [];
+  for (const outputRoot of outputRoots) {
+    const absolutePath = resolveInside(rootPath, outputRoot);
+    if (await exists(absolutePath)) deletedPaths.push(outputRoot);
+    await rm(absolutePath, { force: true, recursive: true });
+  }
+  return deletedPaths.sort(compareStrings);
+}
+
+function writeSummary(
+  writtenPaths: readonly string[],
+  deletedPaths: readonly string[]
+): SkillsetWriteSummary {
+  const written = [...writtenPaths].sort(compareStrings);
+  const deleted = [...deletedPaths].sort(compareStrings);
+  return {
+    deletedPaths: deleted,
+    mode: "write",
+    paths: sortedUnique([...written, ...deleted]),
+    writtenPaths: written,
+  };
+}
+
+function sortedUnique(paths: readonly string[]): readonly string[] {
+  return [...new Set(paths)].sort(compareStrings);
 }
 
 async function assertNoUnmanagedWorkspaceOverwrites(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,13 @@
-export { diffSkillset, diffSkillsetResult, type SkillsetDiff, type SkillsetDiffResult } from "./build";
+export {
+  buildSkillsetResult,
+  checkSkillsetResult,
+  diffSkillset,
+  diffSkillsetResult,
+  type SkillsetBuildResult,
+  type SkillsetCheckResult,
+  type SkillsetDiff,
+  type SkillsetDiffResult,
+} from "./build";
 export type { SkillsetLoweringOutcome, SkillsetLoweringOutcomeStatus } from "./lowering-outcome";
 export type {
   SkillsetDiagnostic,

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -321,13 +321,6 @@ function validateProjectAgentCollisions(agents: readonly SourceProjectAgent[]): 
   }
 }
 
-/** Emit non-fatal source warnings collected during load. */
-export function emitGraphWarnings(graph: BuildGraph): void {
-  for (const warning of graph.warnings) {
-    console.warn(`skillset: ${warning}`);
-  }
-}
-
 /**
  * Load source instructions. Source lives in `.skillset/instructions/`. Generated
  * output is unchanged: Claude lowers to `.claude/rules/`, Codex lowers to


### PR DESCRIPTION
## Summary
- Refactors `apps/skillset` toward a thin CLI client over core result objects.
- Centralizes command result rendering while preserving existing user-facing command behavior.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- Includes the fixed dry-run/diff diagnostic handling from review.
- Keep draft until the full stack CI is green.