### PR TITLE
test(core): add consumer api coverage

### DIFF
--- a/packages/core/src/__tests__/consumer.test.ts
+++ b/packages/core/src/__tests__/consumer.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildSkillsetResult,
+  checkSkillsetResult,
+  diffSkillsetResult,
+} from "@skillset/core";
+
+const DEMO_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": `
+skillset:
+  name: core-consumer-root
+claude: true
+codex: false
+`,
+  ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+---
+
+Body.
+`,
+};
+
+describe("@skillset/core consumer API", () => {
+  it("supports a quiet preview-build-check loop through public result APIs", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+    const expectedOutput = ".claude/skills/demo/SKILL.md";
+    const cwd = process.cwd();
+    const previousExitCode = process.exitCode;
+    const calls: string[] = [];
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+
+    process.exitCode = undefined;
+    console.log = (...args: unknown[]) => {
+      calls.push(`log:${args.join(" ")}`);
+    };
+    console.warn = (...args: unknown[]) => {
+      calls.push(`warn:${args.join(" ")}`);
+    };
+
+    try {
+      const preview = await diffSkillsetResult(root);
+      expect(preview.operation).toBe("diff");
+      expect(preview.writes).toEqual({
+        deletedPaths: [],
+        mode: "read",
+        paths: [],
+        writtenPaths: [],
+      });
+      expect(preview.diagnostics).toEqual([]);
+      expect(preview.data.added).toContain(expectedOutput);
+      expect(await Bun.file(join(root, expectedOutput)).exists()).toBe(false);
+
+      const build = await buildSkillsetResult(root);
+      expect(build.operation).toBe("build");
+      expect(build.writes.mode).toBe("write");
+      expect(build.writes.paths).toContain(expectedOutput);
+      expect(build.diagnostics).toEqual([]);
+      expect(await Bun.file(join(root, expectedOutput)).exists()).toBe(true);
+
+      const checked = await checkSkillsetResult(root);
+      expect(checked.operation).toBe("check");
+      expect(checked.writes).toEqual({
+        deletedPaths: [],
+        mode: "read",
+        paths: [],
+        writtenPaths: [],
+      });
+      expect(checked.data.checkedFiles).toBe(build.data.length);
+      expect(checked.diagnostics).toEqual([]);
+
+      const clean = await diffSkillsetResult(root);
+      expect(clean.data).toEqual({ added: [], changed: [], missing: [], removed: [] });
+      expect(calls).toEqual([]);
+      expect(process.cwd()).toBe(cwd);
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      process.exitCode = previousExitCode;
+    }
+  });
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-core-consumer-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -4,6 +4,9 @@ describe("@skillset/core", () => {
   it("is importable as a private workspace package", async () => {
     const core = await import("@skillset/core");
 
+    expect(core.buildSkillsetResult).toBeFunction();
+    expect(core.checkSkillsetResult).toBeFunction();
     expect(core.diffSkillset).toBeFunction();
+    expect(core.diffSkillsetResult).toBeFunction();
   });
 });


### PR DESCRIPTION
## Summary
- Adds API-level consumer coverage for `@skillset/core`.
- Exercises a quiet preview/build/check loop through public result APIs instead of CLI output parsing.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- This is the consumer-facing safety net for the core boundary.
- Keep draft until the full stack CI is green.