### PR TITLE
feat(core): introduce feature registry

### DIFF
--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  FEATURE_STATUS_VALUES,
+  TARGET_SUPPORT_STATUS_VALUES,
+  assertFeatureIdsUnique,
+  defineFeatureRegistry,
+  getSkillsetFeature,
+  listSkillsetFeatures,
+  listSkillsetFeaturesByTarget,
+  type SkillsetFeatureEntry,
+} from "../feature-registry";
+
+describe("feature registry", () => {
+  it("sorts entries, looks up by id, and filters target-applicable features", () => {
+    const registry = defineFeatureRegistry([
+      feature({
+        id: "project-instructions",
+        targetSupport: {
+          claude: { status: "native" },
+          codex: { status: "native" },
+        },
+      }),
+      feature({
+        id: "plugin-bin",
+        targetSupport: {
+          claude: { status: "pass_through" },
+          codex: { reason: "Codex plugins do not expose a plugin-local bin contract.", status: "unsupported" },
+        },
+      }),
+      feature({
+        id: "change-state",
+        kind: "change-management",
+        targetSupport: {
+          claude: { status: "not_applicable" },
+          codex: { status: "not_applicable" },
+        },
+      }),
+    ]);
+
+    expect(listSkillsetFeatures(registry).map((entry) => entry.id)).toEqual([
+      "change-state",
+      "plugin-bin",
+      "project-instructions",
+    ]);
+    expect(getSkillsetFeature("plugin-bin", registry)?.targetSupport.claude.status).toBe("pass_through");
+    expect(getSkillsetFeature("missing", registry)).toBeUndefined();
+    expect(listSkillsetFeaturesByTarget("claude", registry).map((entry) => entry.id)).toEqual([
+      "plugin-bin",
+      "project-instructions",
+    ]);
+    expect(listSkillsetFeaturesByTarget("codex", registry).map((entry) => entry.id)).toEqual([
+      "plugin-bin",
+      "project-instructions",
+    ]);
+  });
+
+  it("rejects duplicate ids and unknown vocabulary", () => {
+    const duplicate = feature({ id: "same" });
+
+    expect(() => assertFeatureIdsUnique([duplicate, duplicate])).toThrow("duplicate feature registry id same");
+    expect(() =>
+      defineFeatureRegistry([
+        feature({ id: "bad-status", status: "invented" as SkillsetFeatureEntry["status"] }),
+      ])
+    ).toThrow("unknown feature registry status invented");
+    expect(() =>
+      defineFeatureRegistry([
+        feature({
+          id: "bad-target-status",
+          targetSupport: {
+            claude: { status: "native" },
+            codex: { status: "magical" as SkillsetFeatureEntry["targetSupport"]["codex"]["status"] },
+          },
+        }),
+      ])
+    ).toThrow("unknown target support status magical");
+  });
+
+  it("requires reasons for unsupported and lossy target states", () => {
+    expect(() =>
+      defineFeatureRegistry([
+        feature({
+          id: "unsupported-without-reason",
+          targetSupport: {
+            claude: { status: "native" },
+            codex: { status: "unsupported" },
+          },
+        }),
+      ])
+    ).toThrow("unsupported support requires a reason");
+
+    expect(() =>
+      defineFeatureRegistry([
+        feature({
+          id: "lossy-without-reason",
+          targetSupport: {
+            claude: { status: "lossy" },
+            codex: { status: "native" },
+          },
+        }),
+      ])
+    ).toThrow("lossy support requires a reason");
+  });
+
+  it("pins the status vocabularies", () => {
+    expect(FEATURE_STATUS_VALUES).toEqual([
+      "deferred",
+      "future",
+      "implemented",
+      "planned",
+      "reserved",
+      "unsupported",
+    ]);
+    expect(TARGET_SUPPORT_STATUS_VALUES).toEqual([
+      "degraded",
+      "externally_managed",
+      "future",
+      "lossy",
+      "metadata_only",
+      "native",
+      "not_applicable",
+      "pass_through",
+      "planned",
+      "transformed",
+      "unsupported",
+    ]);
+  });
+});
+
+function feature(overrides: Partial<SkillsetFeatureEntry> & { readonly id: string }): SkillsetFeatureEntry {
+  return {
+    docs: ["docs/features/README.md"],
+    evidence: [{ kind: "test", ref: "packages/core/src/__tests__/feature-registry.test.ts" }],
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/**",
+    status: "implemented",
+    summary: `${overrides.id} summary.`,
+    targetSupport: {
+      claude: { status: "native" },
+      codex: { status: "native" },
+    },
+    title: overrides.id,
+    validationOwner: "packages/core/src/resolver.ts",
+    ...overrides,
+  };
+}

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -1,0 +1,137 @@
+import { compareStrings } from "./path";
+import type { TargetName } from "./types";
+
+export type SkillsetFeatureId = string;
+
+export const FEATURE_STATUS_VALUES = [
+  "deferred",
+  "future",
+  "implemented",
+  "planned",
+  "reserved",
+  "unsupported",
+] as const;
+
+export type SkillsetFeatureStatus = (typeof FEATURE_STATUS_VALUES)[number];
+
+export const TARGET_SUPPORT_STATUS_VALUES = [
+  "degraded",
+  "externally_managed",
+  "future",
+  "lossy",
+  "metadata_only",
+  "native",
+  "not_applicable",
+  "pass_through",
+  "planned",
+  "transformed",
+  "unsupported",
+] as const;
+
+export type SkillsetTargetSupportStatus = (typeof TARGET_SUPPORT_STATUS_VALUES)[number];
+
+export type SkillsetFeatureKind =
+  | "adoption"
+  | "change-management"
+  | "metadata"
+  | "plugin-component"
+  | "source"
+  | "target-native"
+  | "workflow";
+
+export type SkillsetEvidenceKind =
+  | "assumption"
+  | "docs"
+  | "external-docs"
+  | "fixture"
+  | "source"
+  | "test";
+
+export interface SkillsetFeatureEvidence {
+  readonly kind: SkillsetEvidenceKind;
+  readonly note?: string;
+  readonly ref: string;
+  readonly verifiedAt?: string;
+}
+
+export interface SkillsetTargetSupport {
+  readonly evidence?: readonly SkillsetFeatureEvidence[];
+  readonly note?: string;
+  readonly reason?: string;
+  readonly status: SkillsetTargetSupportStatus;
+}
+
+export interface SkillsetFeatureEntry {
+  readonly docs: readonly string[];
+  readonly evidence: readonly SkillsetFeatureEvidence[];
+  readonly id: SkillsetFeatureId;
+  readonly kind: SkillsetFeatureKind;
+  readonly loweringOwner: string;
+  readonly sourceShape: string;
+  readonly status: SkillsetFeatureStatus;
+  readonly summary: string;
+  readonly targetSupport: Readonly<Record<TargetName, SkillsetTargetSupport>>;
+  readonly title: string;
+  readonly validationOwner: string;
+}
+
+export type SkillsetFeatureRegistry = readonly SkillsetFeatureEntry[];
+
+export const skillsetFeatureRegistry = defineFeatureRegistry([]);
+
+export function defineFeatureRegistry(
+  entries: readonly SkillsetFeatureEntry[]
+): SkillsetFeatureRegistry {
+  assertFeatureIdsUnique(entries);
+  assertFeatureStatusVocabulary(entries);
+  return [...entries].sort((left, right) => compareStrings(left.id, right.id));
+}
+
+export function listSkillsetFeatures(
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): SkillsetFeatureRegistry {
+  return registry;
+}
+
+export function getSkillsetFeature(
+  id: SkillsetFeatureId,
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): SkillsetFeatureEntry | undefined {
+  return registry.find((entry) => entry.id === id);
+}
+
+export function listSkillsetFeaturesByTarget(
+  target: TargetName,
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): SkillsetFeatureRegistry {
+  return registry.filter((entry) => entry.targetSupport[target].status !== "not_applicable");
+}
+
+export function assertFeatureIdsUnique(entries: readonly SkillsetFeatureEntry[]): void {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.id)) throw new Error(`skillset: duplicate feature registry id ${entry.id}`);
+    seen.add(entry.id);
+  }
+}
+
+function assertFeatureStatusVocabulary(entries: readonly SkillsetFeatureEntry[]): void {
+  const featureStatuses = new Set<string>(FEATURE_STATUS_VALUES);
+  const targetStatuses = new Set<string>(TARGET_SUPPORT_STATUS_VALUES);
+  for (const entry of entries) {
+    if (!featureStatuses.has(entry.status)) {
+      throw new Error(`skillset: unknown feature registry status ${entry.status} for ${entry.id}`);
+    }
+    for (const target of ["claude", "codex"] as const satisfies readonly TargetName[]) {
+      const support = entry.targetSupport[target];
+      if (!targetStatuses.has(support.status)) {
+        throw new Error(
+          `skillset: unknown target support status ${support.status} for ${entry.id} ${target}`
+        );
+      }
+      if ((support.status === "lossy" || support.status === "unsupported") && support.reason === undefined) {
+        throw new Error(`skillset: ${entry.id} ${target} ${support.status} support requires a reason`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces the minimal typed feature registry module.
- Defines stable vocabulary for feature identifiers, target support, evidence, and support reasons.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- Registry validation is intentionally conservative so unsupported/lossy claims require reasons.
- Keep draft until the full stack CI is green.