### PR TITLE
feat(core): seed feature registry entries

### DIFF
--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -11,7 +11,53 @@ import {
   type SkillsetFeatureEntry,
 } from "../feature-registry";
 
+const SEEDED_FEATURE_IDS = [
+  "changes",
+  "dependencies",
+  "future-companion-source-pointers",
+  "plugin-agents",
+  "plugin-apps",
+  "plugin-bin",
+  "plugin-hooks",
+  "plugin-manifests",
+  "plugin-mcp",
+  "plugin-skills",
+  "project-agents",
+  "project-instructions",
+  "releases",
+  "resources",
+  "standalone-skills",
+  "supports",
+  "target-native-islands",
+  "tool-intent",
+  "workflows",
+];
+
 describe("feature registry", () => {
+  it("ships the current feature seed in deterministic order with docs and evidence", () => {
+    const features = listSkillsetFeatures();
+
+    expect(features.map((entry) => entry.id)).toEqual(SEEDED_FEATURE_IDS);
+    for (const feature of features) {
+      expect(feature.docs.length).toBeGreaterThan(0);
+      expect(feature.evidence.length).toBeGreaterThan(0);
+      expect(feature.targetSupport.claude).toBeDefined();
+      expect(feature.targetSupport.codex).toBeDefined();
+    }
+  });
+
+  it("keeps current target support claims conservative", () => {
+    expect(getSkillsetFeature("plugin-bin")?.targetSupport.codex).toEqual({
+      reason: "Codex plugins do not expose a documented plugin-local bin contract.",
+      status: "unsupported",
+    });
+    expect(getSkillsetFeature("dependencies")?.targetSupport.codex.status).toBe("degraded");
+    expect(getSkillsetFeature("supports")?.targetSupport.claude.status).toBe("metadata_only");
+    expect(getSkillsetFeature("project-agents")?.targetSupport.codex.status).toBe("transformed");
+    expect(listSkillsetFeaturesByTarget("claude").map((entry) => entry.id)).not.toContain("changes");
+    expect(listSkillsetFeaturesByTarget("codex").map((entry) => entry.id)).not.toContain("workflows");
+  });
+
   it("sorts entries, looks up by id, and filters target-applicable features", () => {
     const registry = defineFeatureRegistry([
       feature({

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -77,7 +77,276 @@ export interface SkillsetFeatureEntry {
 
 export type SkillsetFeatureRegistry = readonly SkillsetFeatureEntry[];
 
-export const skillsetFeatureRegistry = defineFeatureRegistry([]);
+export const skillsetFeatureRegistry = defineFeatureRegistry([
+  feature({
+    docs: ["docs/features/changes.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-34/35/36 change status and entry coverage")],
+    id: "changes",
+    kind: "change-management",
+    loweringOwner: "apps/skillset/src/change-entries.ts",
+    sourceShape: ".skillset/changes/pending/*.yaml and .skillset/changes/history/*.jsonl",
+    status: "implemented",
+    summary: "Tracks source-unit changes, evidence hashes, pending entries, and applied history.",
+    targetSupport: notTargetRuntime(),
+    title: "Changes",
+    validationOwner: "apps/skillset/src/change-entries.ts",
+  }),
+  feature({
+    docs: ["docs/features/dependencies.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-40 dependency lowering tests")],
+    id: "dependencies",
+    kind: "metadata",
+    loweringOwner: "packages/core/src/dependencies.ts",
+    sourceShape: "plugin skillset.yaml dependencies",
+    status: "implemented",
+    summary: "Declares plugin dependencies and lowers target-specific install/awareness behavior.",
+    targetSupport: {
+      claude: { status: "native" },
+      codex: { note: "Codex gets generated dependency notices rather than a native plugin dependency resolver.", status: "degraded" },
+    },
+    title: "Dependencies",
+    validationOwner: "packages/core/src/dependencies.ts",
+  }),
+  feature({
+    docs: ["docs/features/feature-source-pointers.md", "docs/features/mcp-servers.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-26 MCP pointer coverage")],
+    id: "plugin-mcp",
+    kind: "plugin-component",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "plugin mcp/source pointer or conventional .mcp.json",
+    status: "implemented",
+    summary: "Copies validated plugin MCP server definitions into Claude and Codex plugin outputs.",
+    targetSupport: bothTargets("native"),
+    title: "Plugin MCP Servers",
+    validationOwner: "packages/core/src/resources.ts",
+  }),
+  feature({
+    docs: ["docs/features/apps.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "Codex app manifest companion-path coverage")],
+    id: "plugin-apps",
+    kind: "target-native",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "plugin codex/.app.json target-native companion file",
+    status: "implemented",
+    summary: "Passes Codex app manifests through as target-native plugin companion files.",
+    targetSupport: {
+      claude: { status: "not_applicable" },
+      codex: { status: "pass_through" },
+    },
+    title: "Codex Plugin Apps",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/executables.md", "docs/features/feature-source-pointers.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-26 bin pointer coverage")],
+    id: "plugin-bin",
+    kind: "plugin-component",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "plugin bin/source pointer or conventional bin/",
+    status: "implemented",
+    summary: "Copies Claude plugin-root executable helpers while failing loudly for Codex-enabled plugin output.",
+    targetSupport: {
+      claude: { status: "pass_through" },
+      codex: { reason: "Codex plugins do not expose a documented plugin-local bin contract.", status: "unsupported" },
+    },
+    title: "Plugin Bin",
+    validationOwner: "packages/core/src/resources.ts",
+  }),
+  feature({
+    docs: ["docs/features/hooks.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-2 hook companion-path coverage")],
+    id: "plugin-hooks",
+    kind: "target-native",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "plugin hooks/hooks.json",
+    status: "implemented",
+    summary: "Copies plugin hook declarations with broad Claude validation and strict Codex validation.",
+    targetSupport: bothTargets("pass_through"),
+    title: "Plugin Hooks",
+    validationOwner: "packages/core/src/hooks.ts",
+  }),
+  feature({
+    docs: ["docs/features/plugins.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "plugin boundary and manifest coverage")],
+    id: "plugin-manifests",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/plugins/<plugin>/skillset.yaml",
+    status: "implemented",
+    summary: "Projects plugin metadata and component wiring into target-native plugin manifests.",
+    targetSupport: bothTargets("native"),
+    title: "Plugin Manifests",
+    validationOwner: "packages/core/src/config.ts",
+  }),
+  feature({
+    docs: ["docs/features/plugins.md", "docs/features/skills.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "plugin skill rendering coverage")],
+    id: "plugin-skills",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/plugins/<plugin>/skills/<skill>/SKILL.md",
+    status: "implemented",
+    summary: "Preserves plugin-scoped skills inside each target plugin boundary.",
+    targetSupport: bothTargets("native"),
+    title: "Plugin Skills",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/agents.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "Codex plugin-agent failure coverage")],
+    id: "plugin-agents",
+    kind: "target-native",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "plugin target-native agents/",
+    status: "implemented",
+    summary: "Allows Claude plugin agents as target-native companion files and rejects Codex plugin agents.",
+    targetSupport: {
+      claude: { status: "pass_through" },
+      codex: { reason: "Codex plugin documentation does not include a plugin agents component.", status: "unsupported" },
+    },
+    title: "Plugin Agents",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/instructions.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-5 instruction lowering coverage")],
+    id: "project-instructions",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/instructions/**/*.md",
+    status: "implemented",
+    summary: "Lowers project instructions to Claude rules and directory-local Codex AGENTS.md files.",
+    targetSupport: bothTargets("transformed"),
+    title: "Project Instructions",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/agents.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "portable project agent coverage")],
+    id: "project-agents",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/src/agents/*.md",
+    status: "implemented",
+    summary: "Lowers portable project agents to Claude Markdown agents and Codex TOML agents.",
+    targetSupport: {
+      claude: { status: "native" },
+      codex: { status: "transformed" },
+    },
+    title: "Project Agents",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/releases.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-38 release apply coverage")],
+    id: "releases",
+    kind: "change-management",
+    loweringOwner: "apps/skillset/src/release.ts",
+    sourceShape: ".skillset/releases/*.jsonl, .skillset/release-state.json, generated changelogs",
+    status: "implemented",
+    summary: "Applies pending changes into versions, release history, changelogs, and generated metadata.",
+    targetSupport: bothTargets("metadata_only"),
+    title: "Releases",
+    validationOwner: "apps/skillset/src/release.ts",
+  }),
+  feature({
+    docs: ["docs/features/resources.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "shared resource rendering coverage")],
+    id: "resources",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "skill resources frontmatter and .skillset/shared/",
+    status: "implemented",
+    summary: "Copies declared skill resources and validates links to shared resource declarations.",
+    targetSupport: bothTargets("native"),
+    title: "Resources",
+    validationOwner: "packages/core/src/resources.ts",
+  }),
+  feature({
+    docs: ["docs/features/skills.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "standalone skill rendering coverage")],
+    id: "standalone-skills",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/skills/<skill>/SKILL.md",
+    status: "implemented",
+    summary: "Projects standalone repo skills into configured target skill roots.",
+    targetSupport: bothTargets("native"),
+    title: "Standalone Skills",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/supports.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-39 supports coverage")],
+    id: "supports",
+    kind: "metadata",
+    loweringOwner: "apps/skillset/src/change-status.ts",
+    sourceShape: "supports frontmatter metadata",
+    status: "implemented",
+    summary: "Records compatibility claims as source-significant metadata without target-frontmatter leakage.",
+    targetSupport: bothTargets("metadata_only"),
+    title: "Supports",
+    validationOwner: "packages/core/src/supports.ts",
+  }),
+  feature({
+    docs: ["docs/features/target-native-islands.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "target-native island coverage")],
+    id: "target-native-islands",
+    kind: "target-native",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: ".skillset/src/<target>/** and plugin-local target-native subdirs",
+    status: "implemented",
+    summary: "Mirrors explicitly target-owned files only to their intended provider output.",
+    targetSupport: bothTargets("pass_through"),
+    title: "Target-Native Islands",
+    validationOwner: "packages/core/src/resolver.ts",
+  }),
+  feature({
+    docs: ["docs/features/tool-intent.md"],
+    evidence: [test("apps/skillset/src/__tests__/skillset.test.ts", "tool policy lowering coverage")],
+    id: "tool-intent",
+    kind: "source",
+    loweringOwner: "packages/core/src/render.ts",
+    sourceShape: "skill tool_intent frontmatter",
+    status: "implemented",
+    summary: "Normalizes tool policy intent into Claude allowed-tools fields and Codex metadata sidecars.",
+    targetSupport: {
+      claude: { status: "native" },
+      codex: { status: "metadata_only" },
+    },
+    title: "Tool Intent",
+    validationOwner: "packages/core/src/skill-policy.ts",
+  }),
+  feature({
+    docs: ["docs/features/apps.md", "docs/features/hooks.md", "docs/features/commands.md", "docs/features/settings.md"],
+    evidence: [docs("docs/target-surfaces.md")],
+    id: "future-companion-source-pointers",
+    kind: "plugin-component",
+    loweringOwner: "future",
+    sourceShape: "future apps.source/hooks.source/commands.source/settings.source style feature keys",
+    status: "planned",
+    summary: "Reserved space for future companion-file source pointers beyond current MCP and bin feature keys.",
+    targetSupport: {
+      claude: { status: "planned" },
+      codex: { status: "planned" },
+    },
+    title: "Future Companion Source Pointers",
+    validationOwner: "future",
+  }),
+  feature({
+    docs: ["docs/features/ci.md", "docs/features/build-scopes.md"],
+    evidence: [test("apps/skillset/src/__tests__/ci.test.ts", "CI and build-scope coverage")],
+    id: "workflows",
+    kind: "workflow",
+    loweringOwner: "apps/skillset/src/cli-core.ts",
+    sourceShape: "skillset CLI workflows such as build, check, ci, test, init, and create",
+    status: "implemented",
+    summary: "Provides repo-local workflow commands without lowering them into target runtime artifacts.",
+    targetSupport: notTargetRuntime(),
+    title: "Workflows",
+    validationOwner: "apps/skillset/src/cli-core.ts",
+  }),
+]);
 
 export function defineFeatureRegistry(
   entries: readonly SkillsetFeatureEntry[]
@@ -134,4 +403,27 @@ function assertFeatureStatusVocabulary(entries: readonly SkillsetFeatureEntry[])
       }
     }
   }
+}
+
+function feature(entry: SkillsetFeatureEntry): SkillsetFeatureEntry {
+  return entry;
+}
+
+function bothTargets(status: SkillsetTargetSupportStatus): Readonly<Record<TargetName, SkillsetTargetSupport>> {
+  return {
+    claude: { status },
+    codex: { status },
+  };
+}
+
+function notTargetRuntime(): Readonly<Record<TargetName, SkillsetTargetSupport>> {
+  return bothTargets("not_applicable");
+}
+
+function docs(ref: string): SkillsetFeatureEvidence {
+  return { kind: "docs", ref };
+}
+
+function test(ref: string, note: string): SkillsetFeatureEvidence {
+  return { kind: "test", note, ref };
 }


### PR DESCRIPTION
## Summary
- Seeds registry entries for the current Skillset source and target surfaces.
- Gives the compiler a concrete feature inventory that later lowering/conformance work can reference.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- This branch is the registry data layer for the capability and lowering branches above it.
- Keep draft until the full stack CI is green.