### PR TITLE
feat(core): define lowering outcome schema

### DIFF
--- a/packages/core/src/__tests__/lowering-outcome.test.ts
+++ b/packages/core/src/__tests__/lowering-outcome.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  LOWERING_OUTCOME_SCHEMA,
+  LOWERING_OUTCOME_STATUS_VALUES,
+  defineLoweringOutcome,
+  serializeLoweringOutcome,
+  type SkillsetLoweringOutcome,
+} from "@skillset/core";
+
+describe("lowering outcomes", () => {
+  it("normalizes to a stable JSON shape with sorted nested arrays", () => {
+    const outcome = defineLoweringOutcome({
+      diagnostics: [
+        { code: "z-warning", path: ".skillset/src/z.md" },
+        { code: "a-warning", message: "First." },
+      ],
+      evidence: [
+        { kind: "test", ref: "b.test.ts" },
+        { kind: "external-docs", ref: "https://example.com/docs", verifiedAt: "2026-06-12" },
+      ],
+      featureId: "project-instructions",
+      outputs: [
+        { kind: "rule", path: ".claude/rules/b.md" },
+        { kind: "agents", path: "AGENTS.md" },
+      ],
+      policy: "default",
+      sourcePath: ".skillset/instructions/root.md",
+      sourceUnit: "instructions:root",
+      status: "transformed",
+      target: "codex",
+    });
+
+    expect(serializeLoweringOutcome(outcome)).toBe(`{
+  "schema": "${LOWERING_OUTCOME_SCHEMA}",
+  "sourceUnit": "instructions:root",
+  "sourcePath": ".skillset/instructions/root.md",
+  "featureId": "project-instructions",
+  "target": "codex",
+  "status": "transformed",
+  "policy": "default",
+  "outputs": [
+    {
+      "kind": "rule",
+      "path": ".claude/rules/b.md"
+    },
+    {
+      "kind": "agents",
+      "path": "AGENTS.md"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "a-warning",
+      "message": "First."
+    },
+    {
+      "code": "z-warning",
+      "path": ".skillset/src/z.md"
+    }
+  ],
+  "evidence": [
+    {
+      "kind": "external-docs",
+      "ref": "https://example.com/docs",
+      "verifiedAt": "2026-06-12"
+    },
+    {
+      "kind": "test",
+      "ref": "b.test.ts"
+    }
+  ]
+}
+`);
+  });
+
+  it("does not require output paths for source-only or skipped outcomes", () => {
+    const outcome = defineLoweringOutcome({
+      featureId: "supports",
+      policy: "scope:excluded",
+      sourcePath: ".skillset/skills/demo/SKILL.md",
+      sourceUnit: "skill:demo",
+      status: "intentionally_skipped",
+    });
+
+    expect(outcome.outputs).toBeUndefined();
+    expect(outcome.target).toBeUndefined();
+    expect(serializeLoweringOutcome(outcome)).toContain('"status": "intentionally_skipped"');
+  });
+
+  it("can represent multiple outputs from one source unit", () => {
+    const outcome = defineLoweringOutcome({
+      featureId: "plugin-manifests",
+      outputs: [
+        { path: "plugins-claude/plugins/acme/.claude-plugin/plugin.json" },
+        { path: "plugins-codex/plugins/acme/.codex-plugin/plugin.json" },
+      ],
+      sourcePath: ".skillset/plugins/acme/skillset.yaml",
+      sourceUnit: "plugin:acme",
+      status: "emitted",
+    });
+
+    expect(outcome.outputs?.map((output) => output.path)).toEqual([
+      "plugins-claude/plugins/acme/.claude-plugin/plugin.json",
+      "plugins-codex/plugins/acme/.codex-plugin/plugin.json",
+    ]);
+  });
+
+  it("rejects invalid schemas, statuses, missing identity, and incomplete evidence", () => {
+    expect(() =>
+      defineLoweringOutcome({
+        featureId: "project-instructions",
+        schema: "wrong" as typeof LOWERING_OUTCOME_SCHEMA,
+        sourceUnit: "instructions:root",
+        status: "emitted",
+      })
+    ).toThrow("unsupported lowering outcome schema wrong");
+    expect(() =>
+      defineLoweringOutcome({
+        featureId: "project-instructions",
+        sourceUnit: "instructions:root",
+        status: "magical" as SkillsetLoweringOutcome["status"],
+      })
+    ).toThrow("unknown lowering outcome status magical");
+    expect(() =>
+      defineLoweringOutcome({
+        featureId: "",
+        sourceUnit: "instructions:root",
+        status: "emitted",
+      })
+    ).toThrow("featureId is required");
+    expect(() =>
+      defineLoweringOutcome({
+        featureId: "project-instructions",
+        sourceUnit: "",
+        status: "emitted",
+      })
+    ).toThrow("sourceUnit is required");
+    expect(() =>
+      defineLoweringOutcome({
+        featureId: "project-instructions",
+        sourceUnit: "instructions:root",
+        status: "unsupported",
+      })
+    ).toThrow("unsupported status requires a reason");
+    expect(() =>
+      defineLoweringOutcome({
+        evidence: [{ kind: "external-docs", ref: "https://example.com/docs" }],
+        featureId: "project-instructions",
+        sourceUnit: "instructions:root",
+        status: "emitted",
+      })
+    ).toThrow("external docs evidence requires verifiedAt");
+  });
+
+  it("pins the outcome status vocabulary", () => {
+    expect(LOWERING_OUTCOME_STATUS_VALUES).toEqual([
+      "degraded",
+      "emitted",
+      "externally_managed",
+      "failed",
+      "intentionally_skipped",
+      "lossy",
+      "metadata_only",
+      "target_native",
+      "transformed",
+      "unsupported",
+    ]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,20 @@ export {
   type SkillsetDiff,
   type SkillsetDiffResult,
 } from "./build";
-export type { SkillsetLoweringOutcome, SkillsetLoweringOutcomeStatus } from "./lowering-outcome";
+export {
+  LOWERING_OUTCOME_SCHEMA,
+  LOWERING_OUTCOME_STATUS_VALUES,
+  assertLoweringOutcome,
+  defineLoweringOutcome,
+  normalizeLoweringOutcome,
+  serializeLoweringOutcome,
+  type SkillsetLoweringDiagnosticRef,
+  type SkillsetLoweringOutcome,
+  type SkillsetLoweringOutcomeInput,
+  type SkillsetLoweringOutcomeStatus,
+  type SkillsetLoweringOutput,
+  type SkillsetLoweringPolicy,
+} from "./lowering-outcome";
 export type {
   SkillsetDiagnostic,
   SkillsetDiagnosticSeverity,

--- a/packages/core/src/lowering-outcome.ts
+++ b/packages/core/src/lowering-outcome.ts
@@ -1,20 +1,169 @@
+import { compareStrings } from "./path";
+import type { SkillsetFeatureEvidence } from "./feature-registry";
 import type { TargetName } from "./types";
 
-export type SkillsetLoweringOutcomeStatus =
-  | "degraded_notice"
-  | "emitted"
-  | "intentionally_skipped"
-  | "lossy"
-  | "metadata_only"
-  | "target_native"
-  | "unsupported";
+export const LOWERING_OUTCOME_SCHEMA = "skillset-lowering-outcome@1";
+
+export const LOWERING_OUTCOME_STATUS_VALUES = [
+  "degraded",
+  "emitted",
+  "externally_managed",
+  "failed",
+  "intentionally_skipped",
+  "lossy",
+  "metadata_only",
+  "target_native",
+  "transformed",
+  "unsupported",
+] as const;
+
+export type SkillsetLoweringOutcomeStatus = (typeof LOWERING_OUTCOME_STATUS_VALUES)[number];
+
+export type SkillsetLoweringPolicy =
+  | "default"
+  | "scope:excluded"
+  | "target:disabled"
+  | "unsupported:error"
+  | "unsupported:force"
+  | "unsupported:skip"
+  | "unsupported:warn";
+
+export interface SkillsetLoweringOutput {
+  readonly kind?: string;
+  readonly path: string;
+}
+
+export interface SkillsetLoweringDiagnosticRef {
+  readonly code: string;
+  readonly message?: string;
+  readonly path?: string;
+}
 
 export interface SkillsetLoweringOutcome {
-  readonly diagnosticIds?: readonly string[];
+  readonly diagnostics?: readonly SkillsetLoweringDiagnosticRef[];
+  readonly evidence?: readonly SkillsetFeatureEvidence[];
   readonly featureId: string;
-  readonly message?: string;
-  readonly outputPath?: string;
+  readonly outputs?: readonly SkillsetLoweringOutput[];
+  readonly policy?: SkillsetLoweringPolicy;
+  readonly reason?: string;
+  readonly schema: typeof LOWERING_OUTCOME_SCHEMA;
   readonly sourcePath?: string;
+  readonly sourceUnit: string;
   readonly status: SkillsetLoweringOutcomeStatus;
   readonly target?: TargetName;
+}
+
+export type SkillsetLoweringOutcomeInput = Omit<SkillsetLoweringOutcome, "schema"> & {
+  readonly schema?: typeof LOWERING_OUTCOME_SCHEMA;
+};
+
+export function defineLoweringOutcome(
+  input: SkillsetLoweringOutcomeInput
+): SkillsetLoweringOutcome {
+  const outcome = normalizeLoweringOutcome({
+    ...input,
+    schema: input.schema ?? LOWERING_OUTCOME_SCHEMA,
+  });
+  assertLoweringOutcome(outcome);
+  return outcome;
+}
+
+export function normalizeLoweringOutcome(
+  outcome: SkillsetLoweringOutcome
+): SkillsetLoweringOutcome {
+  return {
+    schema: outcome.schema,
+    sourceUnit: outcome.sourceUnit,
+    ...(outcome.sourcePath === undefined ? {} : { sourcePath: outcome.sourcePath }),
+    featureId: outcome.featureId,
+    ...(outcome.target === undefined ? {} : { target: outcome.target }),
+    status: outcome.status,
+    ...(outcome.reason === undefined ? {} : { reason: outcome.reason }),
+    ...(outcome.policy === undefined ? {} : { policy: outcome.policy }),
+    ...(outcome.outputs === undefined ? {} : { outputs: normalizeOutputs(outcome.outputs) }),
+    ...(outcome.diagnostics === undefined ? {} : { diagnostics: normalizeDiagnostics(outcome.diagnostics) }),
+    ...(outcome.evidence === undefined ? {} : { evidence: normalizeEvidence(outcome.evidence) }),
+  };
+}
+
+export function serializeLoweringOutcome(outcome: SkillsetLoweringOutcome): string {
+  return `${JSON.stringify(normalizeLoweringOutcome(outcome), null, 2)}\n`;
+}
+
+export function assertLoweringOutcome(outcome: SkillsetLoweringOutcome): void {
+  if (outcome.schema !== LOWERING_OUTCOME_SCHEMA) {
+    throw new Error(`skillset: unsupported lowering outcome schema ${outcome.schema}`);
+  }
+  if (outcome.sourceUnit.trim().length === 0) {
+    throw new Error("skillset: lowering outcome sourceUnit is required");
+  }
+  if (outcome.featureId.trim().length === 0) {
+    throw new Error("skillset: lowering outcome featureId is required");
+  }
+  if (!new Set<string>(LOWERING_OUTCOME_STATUS_VALUES).has(outcome.status)) {
+    throw new Error(`skillset: unknown lowering outcome status ${outcome.status}`);
+  }
+  if ((outcome.status === "degraded" || outcome.status === "failed" || outcome.status === "lossy" || outcome.status === "unsupported") && outcome.reason === undefined) {
+    throw new Error(`skillset: lowering outcome ${outcome.status} status requires a reason`);
+  }
+  for (const output of outcome.outputs ?? []) {
+    if (output.path.trim().length === 0) {
+      throw new Error("skillset: lowering outcome output path is required");
+    }
+  }
+  for (const diagnostic of outcome.diagnostics ?? []) {
+    if (diagnostic.code.trim().length === 0) {
+      throw new Error("skillset: lowering outcome diagnostic code is required");
+    }
+  }
+  for (const evidence of outcome.evidence ?? []) {
+    if (evidence.ref.trim().length === 0) {
+      throw new Error("skillset: lowering outcome evidence ref is required");
+    }
+    if (evidence.kind === "external-docs" && evidence.verifiedAt === undefined) {
+      throw new Error("skillset: lowering outcome external docs evidence requires verifiedAt");
+    }
+  }
+}
+
+function normalizeOutputs(outputs: readonly SkillsetLoweringOutput[]): readonly SkillsetLoweringOutput[] {
+  return [...outputs]
+    .map((output) => ({
+      ...(output.kind === undefined ? {} : { kind: output.kind }),
+      path: output.path,
+    }))
+    .sort((left, right) => compareStrings(`${left.path}\0${left.kind ?? ""}`, `${right.path}\0${right.kind ?? ""}`));
+}
+
+function normalizeDiagnostics(
+  diagnostics: readonly SkillsetLoweringDiagnosticRef[]
+): readonly SkillsetLoweringDiagnosticRef[] {
+  return [...diagnostics]
+    .map((diagnostic) => ({
+      code: diagnostic.code,
+      ...(diagnostic.message === undefined ? {} : { message: diagnostic.message }),
+      ...(diagnostic.path === undefined ? {} : { path: diagnostic.path }),
+    }))
+    .sort((left, right) =>
+      compareStrings(
+        `${left.code}\0${left.path ?? ""}\0${left.message ?? ""}`,
+        `${right.code}\0${right.path ?? ""}\0${right.message ?? ""}`
+      )
+    );
+}
+
+function normalizeEvidence(evidence: readonly SkillsetFeatureEvidence[]): readonly SkillsetFeatureEvidence[] {
+  return [...evidence]
+    .map((item) => ({
+      kind: item.kind,
+      ref: item.ref,
+      ...(item.verifiedAt === undefined ? {} : { verifiedAt: item.verifiedAt }),
+      ...(item.note === undefined ? {} : { note: item.note }),
+    }))
+    .sort((left, right) =>
+      compareStrings(
+        `${left.kind}\0${left.ref}\0${left.verifiedAt ?? ""}\0${left.note ?? ""}`,
+        `${right.kind}\0${right.ref}\0${right.verifiedAt ?? ""}\0${right.note ?? ""}`
+      )
+    );
 }


### PR DESCRIPTION
## Summary
- Adds the lowering outcome data model and stable JSON shape.
- Represents emitted, transformed, pass-through, unsupported, skipped, and source-only outcomes consistently.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- This branch provides the schema consumed by build/render instrumentation.
- Keep draft until the full stack CI is green.