### PR TITLE
feat(core): collect lowering outcomes

### DIFF
--- a/packages/core/src/__tests__/diff.test.ts
+++ b/packages/core/src/__tests__/diff.test.ts
@@ -51,7 +51,14 @@ describe("diffSkillset", () => {
         paths: [],
         writtenPaths: [],
       });
-      expect(result.loweringOutcomes).toEqual([]);
+      expect(result.loweringOutcomes).toContainEqual(
+        expect.objectContaining({
+          featureId: "standalone-skills",
+          sourceUnit: "skill:demo",
+          status: "emitted",
+          target: "claude",
+        })
+      );
       expect(result.diagnostics).toEqual([
         expect.objectContaining({
           code: "source-warning",

--- a/packages/core/src/__tests__/lowering-outcome-build.test.ts
+++ b/packages/core/src/__tests__/lowering-outcome-build.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildSkillsetResult,
+  diffSkillsetResult,
+  SkillsetLoweringError,
+  type SkillsetLoweringOutcome,
+} from "@skillset/core";
+
+const OUTCOME_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": `
+skillset:
+  name: outcome-root
+  marketplace:
+    name: outcome-market
+claude: true
+codex: true
+`,
+  ".skillset/skills/repo-skill/SKILL.md": `
+---
+name: repo-skill
+description: Repo skill.
+---
+
+Use the repo skill.
+`,
+  ".skillset/instructions/root.md": `
+---
+description: Root instructions.
+---
+
+Keep generated output deterministic.
+`,
+  ".skillset/src/agents/reviewer.md": `
+---
+name: reviewer
+description: Reviews code.
+skills:
+  - repo-skill
+---
+
+Review diffs carefully.
+`,
+  ".skillset/src/codex/rules/deny.rules": `
+match = "rm -rf"
+decision = "deny"
+`,
+  ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+  description: Alpha plugin.
+dependencies:
+  plugins:
+    - name: external-tools
+      range: ^2.1.0
+      marketplace: acme
+mcp: true
+`,
+  ".skillset/plugins/alpha/.app.json": `
+{"apps":[]}
+`,
+  ".skillset/plugins/alpha/.lsp.json": `
+{"servers":[]}
+`,
+  ".skillset/plugins/alpha/.mcp.json": `
+{
+  "mcpServers": {
+    "alpha": { "command": "node" }
+  }
+}
+`,
+  ".skillset/plugins/alpha/README.md": `
+# Alpha
+`,
+  ".skillset/plugins/alpha/assets/icon.txt": `
+icon
+`,
+  ".skillset/plugins/alpha/commands/run.md": `
+# Run
+`,
+  ".skillset/plugins/alpha/hooks/hooks.json": `
+{
+  "hooks": {
+    "SessionStart": []
+  }
+}
+`,
+  ".skillset/plugins/alpha/monitors/monitors.json": `
+{"monitors":[]}
+`,
+  ".skillset/plugins/alpha/output-styles/focused.md": `
+# Focused
+`,
+  ".skillset/plugins/alpha/scripts/setup.sh": `
+#!/usr/bin/env bash
+echo setup
+`,
+  ".skillset/plugins/alpha/skills/plugin-skill/SKILL.md": `
+---
+name: plugin-skill
+description: Plugin skill.
+tool_intent:
+  allow:
+    read:
+      - docs/**
+---
+
+Use the plugin skill.
+`,
+  ".skillset/plugins/alpha/src/index.js": `
+export const alpha = true;
+`,
+  ".skillset/plugins/alpha/themes/dark.json": `
+{"name":"dark"}
+`,
+  ".skillset/plugins/beta/skillset.yaml": `
+skillset:
+  name: beta
+  description: Beta plugin.
+codex: false
+`,
+  ".skillset/plugins/beta/bin/tool": `
+#!/usr/bin/env bash
+echo beta
+`,
+  ".skillset/plugins/beta/agents/reviewer.md": `
+# Plugin Reviewer
+
+Review plugin output.
+`,
+  ".skillset/plugins/beta/skills/plugin-skill/SKILL.md": `
+---
+name: beta-skill
+description: Beta skill.
+---
+
+Use the beta plugin skill.
+`,
+};
+
+describe("build lowering outcomes", () => {
+  it("reports emitted, pass-through, transformed, unsupported, and scoped outcomes", async () => {
+    const root = await fixture(OUTCOME_FIXTURE);
+
+    const preview = await diffSkillsetResult(root);
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "standalone-skills",
+        outputs: expect.arrayContaining([
+          expect.objectContaining({ path: ".claude/skills/repo-skill/SKILL.md" }),
+        ]),
+        sourceUnit: "skill:repo-skill",
+        status: "emitted",
+        target: "claude",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-skills",
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "emitted",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "project-instructions",
+        sourceUnit: "instruction:AGENTS.md",
+        status: "transformed",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "project-agents",
+        sourceUnit: "agent:reviewer",
+        status: "transformed",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "target-native-islands",
+        sourceUnit: "codex.rules:rules/deny.rules",
+        status: "target_native",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-mcp",
+        sourceUnit: "plugin.alpha.feature:mcp",
+        status: "target_native",
+        target: "claude",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-bin",
+        outputs: expect.arrayContaining([
+          expect.objectContaining({ path: "plugins-claude/plugins/beta/bin/tool" }),
+        ]),
+        sourceUnit: "plugin.beta.feature:bin",
+        status: "target_native",
+        target: "claude",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-hooks",
+        outputs: expect.arrayContaining([
+          expect.objectContaining({ path: "plugins-codex/plugins/alpha/hooks/hooks.json" }),
+        ]),
+        sourceUnit: "plugin.alpha.feature:hooks",
+        status: "target_native",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-apps",
+        sourceUnit: "plugin.alpha.feature:app",
+        status: "target_native",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "dependencies",
+        sourceUnit: "plugin.alpha.feature:dependencies",
+        status: "emitted",
+        target: "claude",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "dependencies",
+        reason: expect.stringContaining("Codex"),
+        sourceUnit: "plugin.alpha.feature:dependencies",
+        status: "degraded",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "tool-intent",
+        outputs: expect.arrayContaining([
+          expect.objectContaining({ path: "plugins-claude/plugins/alpha/skills/plugin-skill/SKILL.md" }),
+        ]),
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "transformed",
+        target: "claude",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "tool-intent",
+        outputs: expect.arrayContaining([
+          expect.objectContaining({ path: "plugins-codex/plugins/alpha/skills/plugin-skill/.skillset.tools.yaml" }),
+        ]),
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "metadata_only",
+        target: "codex",
+      })
+    );
+    expect(preview.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-agents",
+        outputs: expect.arrayContaining([
+          expect.objectContaining({ path: "plugins-claude/plugins/beta/agents/reviewer.md" }),
+        ]),
+        sourceUnit: "plugin.beta.feature:agents",
+        status: "target_native",
+        target: "claude",
+      })
+    );
+    const companionExpectations = [
+      {
+        featureId: "plugin-readme",
+        path: "plugins-claude/plugins/alpha/README.md",
+        sourceUnit: "plugin.alpha.feature:readme",
+        target: "claude",
+      },
+      {
+        featureId: "plugin-assets",
+        path: "plugins-codex/plugins/alpha/assets/icon.txt",
+        sourceUnit: "plugin.alpha.feature:assets",
+        target: "codex",
+      },
+      {
+        featureId: "plugin-scripts",
+        path: "plugins-codex/plugins/alpha/scripts/setup.sh",
+        sourceUnit: "plugin.alpha.feature:scripts",
+        target: "codex",
+      },
+      {
+        featureId: "plugin-src",
+        path: "plugins-codex/plugins/alpha/src/index.js",
+        sourceUnit: "plugin.alpha.feature:src",
+        target: "codex",
+      },
+      {
+        featureId: "plugin-commands",
+        path: "plugins-claude/plugins/alpha/commands/run.md",
+        sourceUnit: "plugin.alpha.feature:commands",
+        target: "claude",
+      },
+      {
+        featureId: "plugin-lsp-servers",
+        path: "plugins-claude/plugins/alpha/.lsp.json",
+        sourceUnit: "plugin.alpha.feature:lsp-servers",
+        target: "claude",
+      },
+      {
+        featureId: "plugin-output-styles",
+        path: "plugins-claude/plugins/alpha/output-styles/focused.md",
+        sourceUnit: "plugin.alpha.feature:output-styles",
+        target: "claude",
+      },
+      {
+        featureId: "plugin-themes",
+        path: "plugins-claude/plugins/alpha/themes/dark.json",
+        sourceUnit: "plugin.alpha.feature:themes",
+        target: "claude",
+      },
+      {
+        featureId: "plugin-monitors",
+        path: "plugins-claude/plugins/alpha/monitors/monitors.json",
+        sourceUnit: "plugin.alpha.feature:monitors",
+        target: "claude",
+      },
+    ] as const;
+    for (const expected of companionExpectations) {
+      expect(preview.loweringOutcomes).toContainEqual(
+        expect.objectContaining({
+          featureId: expected.featureId,
+          outputs: expect.arrayContaining([expect.objectContaining({ path: expected.path })]),
+          sourceUnit: expected.sourceUnit,
+          status: "target_native",
+          target: expected.target,
+        })
+      );
+    }
+
+    const scoped = await diffSkillsetResult(root, { scopes: ["repo"] });
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-skills",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "intentionally_skipped",
+        target: "claude",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "standalone-skills",
+        sourceUnit: "skill:repo-skill",
+        status: "emitted",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-hooks",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.feature:hooks",
+        status: "intentionally_skipped",
+        target: "codex",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-apps",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.feature:app",
+        status: "intentionally_skipped",
+        target: "codex",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "dependencies",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.feature:dependencies",
+        status: "intentionally_skipped",
+        target: "codex",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "tool-intent",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "intentionally_skipped",
+        target: "codex",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "tool-intent",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "intentionally_skipped",
+        target: "claude",
+      })
+    );
+    expect(scoped.loweringOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-commands",
+        policy: "scope:excluded",
+        sourceUnit: "plugin.alpha.feature:commands",
+        status: "intentionally_skipped",
+        target: "claude",
+      })
+    );
+
+    const build = await buildSkillsetResult(root);
+    expect(build.loweringOutcomes.map(outcomeKey)).toEqual(preview.loweringOutcomes.map(outcomeKey));
+  });
+
+  it("records isolated output paths relative to the isolated projection root", async () => {
+    const root = await fixture(OUTCOME_FIXTURE);
+    const preview = await diffSkillsetResult(root, { isolated: true });
+    const outputPaths = preview.loweringOutcomes.flatMap((outcome) =>
+      (outcome.outputs ?? []).map((output) => output.path)
+    );
+
+    expect(outputPaths).toContain(".skillset/build/out/.claude/skills/repo-skill/SKILL.md");
+    expect(outputPaths.some((path) => path.startsWith(root))).toBe(false);
+  });
+
+  it("exposes resolver-level unsupported decisions on thrown lowering errors", async () => {
+    const agentRoot = await fixture({
+      ...OUTCOME_FIXTURE,
+      ".skillset/plugins/alpha/agents/reviewer.md": `
+# Plugin Reviewer
+
+Review plugin output.
+`,
+    });
+    await expectUnsupportedOutcome(agentRoot, {
+      featureId: "plugin-agents",
+      reason: "Codex plugin documentation does not include a plugin agents component.",
+      sourceUnit: "plugin.alpha.feature:agents",
+    });
+
+    const binRoot = await fixture({
+      ...OUTCOME_FIXTURE,
+      ".skillset/plugins/alpha/bin/tool": `
+#!/usr/bin/env bash
+echo alpha
+`,
+    });
+    await expectUnsupportedOutcome(binRoot, {
+      featureId: "plugin-bin",
+      reason: "Codex plugins do not expose a documented plugin-local bin contract.",
+      sourceUnit: "plugin.alpha.feature:bin",
+    });
+  });
+});
+
+function outcomeKey(outcome: SkillsetLoweringOutcome): string {
+  return `${outcome.sourceUnit}\0${outcome.target ?? ""}\0${outcome.featureId}\0${outcome.status}`;
+}
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-lowering-build-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}
+
+async function expectUnsupportedOutcome(
+  root: string,
+  expected: Pick<SkillsetLoweringOutcome, "featureId" | "reason" | "sourceUnit">
+): Promise<void> {
+  try {
+    await diffSkillsetResult(root);
+    throw new Error("expected diffSkillsetResult to reject");
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillsetLoweringError);
+    const outcomes = (error as SkillsetLoweringError).loweringOutcomes;
+    expect(outcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: expected.featureId,
+        policy: "unsupported:error",
+        reason: expected.reason,
+        sourceUnit: expected.sourceUnit,
+        status: "unsupported",
+        target: "codex",
+      })
+    );
+  }
+}

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path";
 
 import { compareStrings, resolveInside } from "./path";
+import { collectLoweringOutcomes } from "./lowering-outcome-collector";
 import { renderBuildGraph } from "./render";
 import { loadBuildGraph } from "./resolver";
 import {
@@ -10,6 +11,7 @@ import {
   type SkillsetOperationResult,
   type SkillsetWriteSummary,
 } from "./operation-result";
+import type { SkillsetLoweringOutcome } from "./lowering-outcome";
 import type { BuildGraph, BuildScope, CheckResult, RenderedFile, SkillsetOptions } from "./types";
 import { isJsonRecord, parseMarkdown } from "./yaml";
 
@@ -85,10 +87,14 @@ export async function buildSkillsetResult(
   const graph = await loadBuildGraph(rootPath, options);
   const diagnostics = [...graph.warnings.map(sourceWarningDiagnostic)];
   const outPath = outPathMapper(options);
-  const rendered = mirroredRenderedFiles(
-    scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
-    outPath
-  );
+  const allRendered = await renderBuildGraph(graph);
+  const scopedRendered = scopedRenderedFiles(graph, allRendered, options.scopes);
+  const loweringOutcomes = collectLoweringOutcomes(graph, allRendered, {
+    includedPaths: new Set(scopedRendered.map((file) => file.path)),
+    mapOutputPath: outPath,
+    scopes: options.scopes,
+  });
+  const rendered = mirroredRenderedFiles(scopedRendered, outPath);
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
   const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
   const includeWorkspaceLock = includesProjectScope(options.scopes);
@@ -116,7 +122,7 @@ export async function buildSkillsetResult(
     );
 
     const writtenPaths = await writeRenderedFiles(rootPath, rendered);
-    return buildResult(rendered, diagnostics, writeSummary(writtenPaths, [
+    return buildResult(rendered, diagnostics, loweringOutcomes, writeSummary(writtenPaths, [
       ...deletedOutputRoots,
       ...deletedWorkspaceFiles,
     ]));
@@ -126,7 +132,7 @@ export async function buildSkillsetResult(
   const deletedPaths = await removeStaleGeneratedFiles(rootPath, actualPaths, expectedPaths);
   const writtenPaths = await writeChangedRenderedFiles(rootPath, rendered, actualPaths);
 
-  return buildResult(rendered, diagnostics, writeSummary(writtenPaths, deletedPaths));
+  return buildResult(rendered, diagnostics, loweringOutcomes, writeSummary(writtenPaths, deletedPaths));
 }
 
 export interface SkillsetDiff {
@@ -156,10 +162,14 @@ export async function diffSkillsetResult(
   const graph = await loadBuildGraph(rootPath, options);
   const diagnostics = [...graph.warnings.map(sourceWarningDiagnostic)];
   const outPath = outPathMapper(options);
-  const rendered = mirroredRenderedFiles(
-    scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
-    outPath
-  );
+  const allRendered = await renderBuildGraph(graph);
+  const scopedRendered = scopedRenderedFiles(graph, allRendered, options.scopes);
+  const loweringOutcomes = collectLoweringOutcomes(graph, allRendered, {
+    includedPaths: new Set(scopedRendered.map((file) => file.path)),
+    mapOutputPath: outPath,
+    scopes: options.scopes,
+  });
+  const rendered = mirroredRenderedFiles(scopedRendered, outPath);
   diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
@@ -199,7 +209,7 @@ export async function diffSkillsetResult(
   return {
     data: diff,
     diagnostics,
-    loweringOutcomes: [],
+    loweringOutcomes,
     ok: true,
     operation: "diff",
     writes: {
@@ -227,10 +237,14 @@ export async function checkSkillsetResult(
   const graph = await loadBuildGraph(rootPath, options);
   const diagnostics = [...graph.warnings.map(sourceWarningDiagnostic)];
   const outPath = outPathMapper(options);
-  const rendered = mirroredRenderedFiles(
-    scopedRenderedFiles(graph, await renderBuildGraph(graph), options.scopes),
-    outPath
-  );
+  const allRendered = await renderBuildGraph(graph);
+  const scopedRendered = scopedRenderedFiles(graph, allRendered, options.scopes);
+  const loweringOutcomes = collectLoweringOutcomes(graph, allRendered, {
+    includedPaths: new Set(scopedRendered.map((file) => file.path)),
+    mapOutputPath: outPath,
+    scopes: options.scopes,
+  });
+  const rendered = mirroredRenderedFiles(scopedRendered, outPath);
   diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
@@ -271,7 +285,7 @@ export async function checkSkillsetResult(
   return {
     data: { checkedFiles: rendered.length },
     diagnostics,
-    loweringOutcomes: [],
+    loweringOutcomes,
     ok: true,
     operation: "check",
     writes: {
@@ -286,12 +300,13 @@ export async function checkSkillsetResult(
 function buildResult(
   rendered: readonly RenderedFile[],
   diagnostics: readonly SkillsetDiagnostic[],
+  loweringOutcomes: readonly SkillsetLoweringOutcome[],
   writes: SkillsetWriteSummary
 ): SkillsetBuildResult {
   return {
     data: rendered,
     diagnostics,
-    loweringOutcomes: [],
+    loweringOutcomes,
     ok: true,
     operation: "build",
     writes,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export {
 export {
   LOWERING_OUTCOME_SCHEMA,
   LOWERING_OUTCOME_STATUS_VALUES,
+  SkillsetLoweringError,
   assertLoweringOutcome,
   defineLoweringOutcome,
   normalizeLoweringOutcome,

--- a/packages/core/src/lowering-outcome-collector.ts
+++ b/packages/core/src/lowering-outcome-collector.ts
@@ -1,0 +1,588 @@
+import { existsSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { readString, isOutputSelected } from "./config";
+import { getSkillsetFeature } from "./feature-registry";
+import {
+  defineLoweringOutcome,
+  type SkillsetLoweringOutcome,
+  type SkillsetLoweringOutcomeStatus,
+  type SkillsetLoweringPolicy,
+} from "./lowering-outcome";
+import { compareStrings } from "./path";
+import { readClaudeNativeToolRules } from "./skill-policy";
+import {
+  selectorForInstruction,
+  selectorForPluginConfig,
+  selectorForPluginFeature,
+  selectorForPluginSkill,
+  selectorForProjectAgent,
+  selectorForStandaloneSkill,
+  selectorForTargetNativeIsland,
+} from "./source-unit-selector";
+import type { BuildGraph, BuildScope, JsonRecord, RenderedFile, SourceSkill, TargetName } from "./types";
+import { isJsonRecord } from "./yaml";
+
+const LOCK_FILE = ".skillset.lock";
+const TARGETS: readonly TargetName[] = ["claude", "codex"];
+
+type OutputPathMapper = (path: string) => string;
+
+interface CollectLoweringOutcomesOptions {
+  readonly includedPaths: ReadonlySet<string>;
+  readonly mapOutputPath?: OutputPathMapper;
+  readonly scopes?: readonly BuildScope[] | undefined;
+}
+
+interface RenderedLock {
+  readonly items: readonly RenderedLockItem[];
+  readonly outputRoot: string;
+  readonly target: TargetName | "workspace";
+}
+
+interface RenderedLockItem {
+  readonly dependencies?: readonly string[];
+  readonly feature?: string;
+  readonly files: readonly string[];
+  readonly kind: string;
+  readonly name: string;
+  readonly outputPath: string;
+  readonly plugin?: string;
+  readonly sourcePath: string;
+  readonly targetState?: string;
+  readonly transforms?: readonly JsonRecord[];
+  readonly validation?: string;
+}
+
+export function collectLoweringOutcomes(
+  graph: BuildGraph,
+  rendered: readonly RenderedFile[],
+  options: CollectLoweringOutcomesOptions
+): readonly SkillsetLoweringOutcome[] {
+  const mapOutputPath = options.mapOutputPath ?? ((path: string) => path);
+  const outcomes: SkillsetLoweringOutcome[] = [];
+  const assignedOutputPaths = new Set<string>();
+
+  for (const lockFile of rendered.filter((file) => file.path.endsWith(`/${LOCK_FILE}`) || file.path === LOCK_FILE)) {
+    const lock = parseRenderedLock(lockFile);
+    for (const item of lock.items) {
+      const outputPaths = outputPathsForLockItem(lock.outputRoot, item);
+      for (const path of outputPaths) assignedOutputPaths.add(path);
+      outcomes.push(outcomeForLockItem(graph, lock, item, outputPaths, options.includedPaths, mapOutputPath));
+      outcomes.push(...featureOutcomesForLockItem(graph, lock, item, outputPaths, options.includedPaths, mapOutputPath));
+    }
+  }
+
+  for (const file of rendered) {
+    if (assignedOutputPaths.has(file.path) || file.path.endsWith(`/${LOCK_FILE}`) || file.path === LOCK_FILE) {
+      continue;
+    }
+    const outcome = outcomeForCompanionFile(graph, file, options.includedPaths.has(file.path), mapOutputPath);
+    if (outcome !== undefined) outcomes.push(outcome);
+  }
+
+  outcomes.push(...unsupportedPluginFeatureOutcomes(graph, options.scopes));
+
+  return outcomes.sort((left, right) =>
+    compareStrings(
+      `${left.sourceUnit}\0${left.target ?? ""}\0${left.featureId}\0${left.status}\0${left.sourcePath ?? ""}`,
+      `${right.sourceUnit}\0${right.target ?? ""}\0${right.featureId}\0${right.status}\0${right.sourcePath ?? ""}`
+    )
+  );
+}
+
+function parseRenderedLock(file: RenderedFile): RenderedLock {
+  const parsed = JSON.parse(new TextDecoder().decode(file.content)) as unknown;
+  if (!isJsonRecord(parsed)) {
+    throw new Error(`skillset: generated lock ${file.path} cannot produce lowering outcomes`);
+  }
+  const outputRoot = stringField(parsed, "outputRoot");
+  const target = stringField(parsed, "target");
+  const rawItems = parsed.items;
+  if (!Array.isArray(rawItems)) {
+    throw new Error(`skillset: generated lock ${file.path} cannot produce lowering outcomes`);
+  }
+  return {
+    items: rawItems.map((item) => parseRenderedLockItem(file.path, item)),
+    outputRoot,
+    target: target === "claude" || target === "codex" ? target : "workspace",
+  };
+}
+
+function parseRenderedLockItem(lockPath: string, raw: unknown): RenderedLockItem {
+  if (!isJsonRecord(raw)) {
+    throw new Error(`skillset: generated lock ${lockPath} has an invalid item`);
+  }
+  const dependencies = optionalStringArrayField(raw, "dependencies");
+  const feature = optionalStringField(raw, "feature");
+  const plugin = optionalStringField(raw, "plugin");
+  const targetState = optionalStringField(raw, "targetState");
+  const transforms = jsonRecordArrayField(raw, "transforms");
+  const validation = optionalStringField(raw, "validation");
+  return {
+    ...(dependencies === undefined ? {} : { dependencies }),
+    ...(feature === undefined ? {} : { feature }),
+    files: stringArrayField(raw, "files"),
+    kind: stringField(raw, "kind"),
+    name: stringField(raw, "name"),
+    outputPath: stringField(raw, "outputPath"),
+    ...(plugin === undefined ? {} : { plugin }),
+    sourcePath: stringField(raw, "sourcePath"),
+    ...(targetState === undefined ? {} : { targetState }),
+    ...(transforms === undefined ? {} : { transforms }),
+    ...(validation === undefined ? {} : { validation }),
+  };
+}
+
+function outcomeForLockItem(
+  graph: BuildGraph,
+  lock: RenderedLock,
+  item: RenderedLockItem,
+  outputPaths: readonly string[],
+  includedPaths: ReadonlySet<string>,
+  mapOutputPath: OutputPathMapper
+): SkillsetLoweringOutcome {
+  const target = targetForLockItem(graph, lock, item, outputPaths);
+  const featureId = featureIdForLockItem(item);
+  const baseStatus = statusForLockItem(item, target);
+  const isIncluded = outputPaths.some((path) => includedPaths.has(path));
+  const status: SkillsetLoweringOutcomeStatus = isIncluded ? baseStatus : "intentionally_skipped";
+  const policy: SkillsetLoweringPolicy | undefined = isIncluded ? undefined : "scope:excluded";
+  const reason = isIncluded ? reasonForStatus(featureId, target, status) : "excluded by build scope";
+  const evidence = evidenceFor(featureId, target);
+
+  return defineLoweringOutcome({
+    ...(evidence === undefined ? {} : { evidence }),
+    featureId,
+    ...(isIncluded ? { outputs: outputPaths.map((path) => ({ kind: item.kind, path: mapOutputPath(path) })) } : {}),
+    ...(policy === undefined ? {} : { policy }),
+    ...(reason === undefined ? {} : { reason }),
+    sourcePath: item.sourcePath,
+    sourceUnit: sourceUnitForLockItem(item, target),
+    status,
+    ...(target === undefined ? {} : { target }),
+  });
+}
+
+function outcomeForCompanionFile(
+  graph: BuildGraph,
+  file: RenderedFile,
+  isIncluded: boolean,
+  mapOutputPath: OutputPathMapper
+): SkillsetLoweringOutcome | undefined {
+  const companion = companionForPath(graph, file.path);
+  if (companion === undefined) return undefined;
+  const plugin = graph.plugins.find((candidate) => candidate.id === companion.pluginId);
+  const sourcePath = plugin === undefined
+    ? undefined
+    : normalizePath(relative(graph.rootPath, join(plugin.path, companion.sourceRelativePath)));
+  const evidence = evidenceFor(companion.featureId, companion.target);
+  return defineLoweringOutcome({
+    ...(evidence === undefined ? {} : { evidence }),
+    featureId: companion.featureId,
+    ...(isIncluded ? { outputs: [{ kind: "companion", path: mapOutputPath(file.path) }] } : {}),
+    ...(isIncluded ? {} : { policy: "scope:excluded" as const, reason: "excluded by build scope" }),
+    ...(sourcePath === undefined ? {} : { sourcePath }),
+    sourceUnit: selectorForPluginFeature(companion.pluginId, companion.featureKey),
+    status: isIncluded ? "target_native" : "intentionally_skipped",
+    target: companion.target,
+  });
+}
+
+function featureOutcomesForLockItem(
+  graph: BuildGraph,
+  lock: RenderedLock,
+  item: RenderedLockItem,
+  outputPaths: readonly string[],
+  includedPaths: ReadonlySet<string>,
+  mapOutputPath: OutputPathMapper
+): readonly SkillsetLoweringOutcome[] {
+  const target = targetForLockItem(graph, lock, item, outputPaths);
+  const outcomes: SkillsetLoweringOutcome[] = [];
+
+  if (item.kind === "plugin" && item.dependencies !== undefined && item.dependencies.length > 0) {
+    outcomes.push(
+      featureOutcome({
+        featureId: "dependencies",
+        isIncluded: outputPaths.some((path) => includedPaths.has(path)),
+        mapOutputPath,
+        outputKind: item.kind,
+        outputPaths,
+        sourcePath: item.sourcePath,
+        sourceUnit: selectorForPluginFeature(item.name, "dependencies"),
+        status: target === "codex" ? "degraded" : "emitted",
+        target,
+      })
+    );
+  }
+
+  const claudeToolIntentOutputPaths =
+    target === "claude" && skillHasClaudeToolIntent(graph, item)
+      ? outputPaths.filter((path) => path.endsWith("/SKILL.md") || path === "SKILL.md")
+      : [];
+  if (claudeToolIntentOutputPaths.length > 0) {
+    outcomes.push(
+      featureOutcome({
+        featureId: "tool-intent",
+        isIncluded: claudeToolIntentOutputPaths.some((path) => includedPaths.has(path)),
+        mapOutputPath,
+        outputKind: "metadata",
+        outputPaths: claudeToolIntentOutputPaths,
+        sourcePath: item.sourcePath,
+        sourceUnit: sourceUnitForLockItem(item, target),
+        status: "transformed",
+        target,
+      })
+    );
+  }
+
+  const toolIntentOutputPaths = outputPaths.filter((path) => path.endsWith("/.skillset.tools.yaml"));
+  if (toolIntentOutputPaths.length > 0) {
+    outcomes.push(
+      featureOutcome({
+        featureId: "tool-intent",
+        isIncluded: toolIntentOutputPaths.some((path) => includedPaths.has(path)),
+        mapOutputPath,
+        outputKind: "metadata",
+        outputPaths: toolIntentOutputPaths,
+        sourcePath: item.sourcePath,
+        sourceUnit: sourceUnitForLockItem(item, target),
+        status: "metadata_only",
+        target,
+      })
+    );
+  }
+
+  return outcomes;
+}
+
+function skillHasClaudeToolIntent(graph: BuildGraph, item: RenderedLockItem): boolean {
+  const skill = sourceSkillForLockItem(graph, item);
+  if (skill === undefined) return false;
+  const rules = readClaudeNativeToolRules(skill.frontmatter, skill.targets.claude.options, item.sourcePath);
+  return rules.allow.length > 0 || rules.deny.length > 0;
+}
+
+function sourceSkillForLockItem(graph: BuildGraph, item: RenderedLockItem): SourceSkill | undefined {
+  if (item.kind === "standalone-skill") {
+    return graph.standaloneSkills.find((skill) => skill.id === item.name);
+  }
+  if (item.kind !== "plugin-skill" || item.plugin === undefined) return undefined;
+  return graph.plugins
+    .find((plugin) => plugin.id === item.plugin)
+    ?.skills.find((skill) => skill.id === item.name);
+}
+
+function featureOutcome(args: {
+  readonly featureId: string;
+  readonly isIncluded: boolean;
+  readonly mapOutputPath: OutputPathMapper;
+  readonly outputKind: string;
+  readonly outputPaths: readonly string[];
+  readonly sourcePath: string;
+  readonly sourceUnit: string;
+  readonly status: SkillsetLoweringOutcomeStatus;
+  readonly target: TargetName | undefined;
+}): SkillsetLoweringOutcome {
+  const status: SkillsetLoweringOutcomeStatus = args.isIncluded ? args.status : "intentionally_skipped";
+  const evidence = evidenceFor(args.featureId, args.target);
+  const reason = args.isIncluded ? reasonForStatus(args.featureId, args.target, status) : "excluded by build scope";
+
+  return defineLoweringOutcome({
+    ...(evidence === undefined ? {} : { evidence }),
+    featureId: args.featureId,
+    ...(args.isIncluded
+      ? { outputs: args.outputPaths.map((path) => ({ kind: args.outputKind, path: args.mapOutputPath(path) })) }
+      : {}),
+    ...(args.isIncluded ? {} : { policy: "scope:excluded" as const }),
+    ...(reason === undefined ? {} : { reason }),
+    sourcePath: args.sourcePath,
+    sourceUnit: args.sourceUnit,
+    status,
+    ...(args.target === undefined ? {} : { target: args.target }),
+  });
+}
+
+function unsupportedPluginFeatureOutcomes(
+  graph: BuildGraph,
+  scopes: readonly BuildScope[] | undefined
+): readonly SkillsetLoweringOutcome[] {
+  if (scopes !== undefined && !scopes.includes("plugins")) return [];
+  const outcomes: SkillsetLoweringOutcome[] = [];
+  for (const plugin of graph.plugins) {
+    if (!pluginTargetSelected(graph, plugin.id, "codex")) continue;
+    const pluginPath = normalizePath(relative(graph.rootPath, plugin.path));
+
+    for (const feature of plugin.features) {
+      if (feature.key !== "bin") continue;
+      const featureId = "plugin-bin";
+      const evidence = evidenceFor(featureId, "codex");
+      outcomes.push(
+        defineLoweringOutcome({
+          ...(evidence === undefined ? {} : { evidence }),
+          featureId,
+          policy: "unsupported:skip",
+          reason: requiredReasonForStatus(featureId, "codex", "unsupported"),
+          sourcePath: normalizePath(relative(graph.rootPath, feature.sourcePath)),
+          sourceUnit: selectorForPluginFeature(plugin.id, feature.key),
+          status: "unsupported",
+          target: "codex",
+        })
+      );
+    }
+
+    const agentsPath = join(plugin.path, "agents");
+    if (!existsSync(agentsPath)) continue;
+    const featureId = "plugin-agents";
+    const evidence = evidenceFor(featureId, "codex");
+    outcomes.push(
+      defineLoweringOutcome({
+        ...(evidence === undefined ? {} : { evidence }),
+        featureId,
+        policy: "unsupported:skip",
+        reason: requiredReasonForStatus(featureId, "codex", "unsupported"),
+        sourcePath: `${pluginPath}/agents`,
+        sourceUnit: selectorForPluginFeature(plugin.id, "agents"),
+        status: "unsupported",
+        target: "codex",
+      })
+    );
+  }
+  return outcomes;
+}
+
+function outputPathsForLockItem(outputRoot: string, item: RenderedLockItem): readonly string[] {
+  const files = item.files.length > 0 ? item.files : [item.outputPath];
+  return files.map((file) => joinOutputPath(outputRoot, file)).sort(compareStrings);
+}
+
+function joinOutputPath(outputRoot: string, path: string): string {
+  return normalizePath(outputRoot === "." ? path : join(outputRoot, path));
+}
+
+function featureIdForLockItem(item: RenderedLockItem): string {
+  if (item.kind === "standalone-skill") return "standalone-skills";
+  if (item.kind === "plugin-skill") return "plugin-skills";
+  if (item.kind === "plugin") return "plugin-manifests";
+  if (item.kind === "rule") return "project-instructions";
+  if (item.kind === "project-agent") return "project-agents";
+  if (item.kind === "island") return "target-native-islands";
+  if (item.kind === "changelog") return "releases";
+  if (item.kind === "plugin-feature" && item.feature === "mcp") return "plugin-mcp";
+  if (item.kind === "plugin-feature" && item.feature === "bin") return "plugin-bin";
+  return item.feature ?? item.kind;
+}
+
+function sourceUnitForLockItem(item: RenderedLockItem, target: TargetName | undefined): string {
+  if (item.kind === "standalone-skill") return selectorForStandaloneSkill(item.name);
+  if (item.kind === "plugin-skill" && item.plugin !== undefined) {
+    return selectorForPluginSkill(item.plugin, item.name);
+  }
+  if (item.kind === "plugin") return selectorForPluginConfig(item.name);
+  if (item.kind === "plugin-feature" && item.plugin !== undefined && item.feature !== undefined) {
+    return selectorForPluginFeature(item.plugin, item.feature);
+  }
+  if (item.kind === "rule") return selectorForInstruction(item.name);
+  if (item.kind === "project-agent") return selectorForProjectAgent(item.name);
+  if (item.kind === "island") return sourceUnitForIsland(item, target);
+  return item.sourcePath;
+}
+
+function sourceUnitForIsland(item: RenderedLockItem, target: TargetName | undefined): string {
+  const [nameTarget, owner, ...relativeParts] = item.name.split(":");
+  const islandTarget = target ?? (nameTarget === "claude" || nameTarget === "codex" ? nameTarget : undefined);
+  if (islandTarget === undefined) return item.sourcePath;
+  const relativePath = relativeParts.join(":") || item.outputPath;
+  if (owner !== undefined && owner !== "project") {
+    return selectorForTargetNativeIsland(islandTarget, `plugin:${owner}`, relativePath);
+  }
+  return selectorForTargetNativeIsland(islandTarget, "project", relativePath);
+}
+
+function statusForLockItem(item: RenderedLockItem, target: TargetName | undefined): SkillsetLoweringOutcomeStatus {
+  if (item.kind === "changelog") return "metadata_only";
+  if (item.kind === "island" || item.kind === "plugin-feature") return "target_native";
+  if (item.kind === "rule") return "transformed";
+  if (item.kind === "project-agent" && target === "codex") return "transformed";
+  if (item.transforms !== undefined && item.transforms.length > 0) return "transformed";
+  if (item.validation === "opaque-copy") return "target_native";
+  return "emitted";
+}
+
+function targetForLockItem(
+  graph: BuildGraph,
+  lock: RenderedLock,
+  item: RenderedLockItem,
+  outputPaths: readonly string[]
+): TargetName | undefined {
+  if (lock.target !== "workspace") return lock.target;
+  if (item.kind === "rule" && outputPaths.some((path) => path === "AGENTS.md" || path.endsWith("/AGENTS.md"))) {
+    return "codex";
+  }
+  for (const path of outputPaths) {
+    const target = targetForOutputPath(graph, path);
+    if (target !== undefined) return target;
+  }
+  return undefined;
+}
+
+function targetForOutputPath(graph: BuildGraph, path: string): TargetName | undefined {
+  for (const target of TARGETS) {
+    if (isInsideOutputRoot(path, graph.root.outputs.plugins[target])) return target;
+    if (isInsideOutputRoot(path, graph.root.outputs.skills[target])) return target;
+    if (isInsideOutputRoot(path, targetProjectRoot(graph, target))) return target;
+  }
+  return undefined;
+}
+
+function companionForPath(
+  graph: BuildGraph,
+  path: string
+):
+  | {
+      readonly featureId: string;
+      readonly featureKey: string;
+      readonly pluginId: string;
+      readonly sourceRelativePath: string;
+      readonly target: TargetName;
+    }
+  | undefined {
+  for (const target of TARGETS) {
+    const outputRoot = graph.root.outputs.plugins[target];
+    const prefix = `${outputRoot}/plugins/`;
+    if (!path.startsWith(prefix)) continue;
+    const rest = path.slice(prefix.length);
+    const separator = rest.indexOf("/");
+    if (separator < 0) continue;
+    const pluginId = rest.slice(0, separator);
+    const pluginPath = rest.slice(separator + 1);
+    if (pluginPath === "README.md") {
+      return { featureId: "plugin-readme", featureKey: "readme", pluginId, sourceRelativePath: "README.md", target };
+    }
+    if (pluginPath === ".app.json") {
+      return { featureId: "plugin-apps", featureKey: "app", pluginId, sourceRelativePath: ".app.json", target };
+    }
+    if (target === "claude" && pluginPath === ".lsp.json") {
+      return { featureId: "plugin-lsp-servers", featureKey: "lsp-servers", pluginId, sourceRelativePath: ".lsp.json", target };
+    }
+    if (target === "claude" && isCompanionPath(pluginPath, "commands")) {
+      return { featureId: "plugin-commands", featureKey: "commands", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (pluginPath === "hooks/hooks.json" || pluginPath.startsWith("hooks/")) {
+      return { featureId: "plugin-hooks", featureKey: "hooks", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (target === "claude" && isCompanionPath(pluginPath, "agents")) {
+      return { featureId: "plugin-agents", featureKey: "agents", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (target === "claude" && isCompanionPath(pluginPath, "output-styles")) {
+      return { featureId: "plugin-output-styles", featureKey: "output-styles", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (target === "claude" && isCompanionPath(pluginPath, "themes")) {
+      return { featureId: "plugin-themes", featureKey: "themes", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (target === "claude" && isCompanionPath(pluginPath, "monitors")) {
+      return { featureId: "plugin-monitors", featureKey: "monitors", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (isCompanionPath(pluginPath, "assets")) {
+      return { featureId: "plugin-assets", featureKey: "assets", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (isCompanionPath(pluginPath, "scripts")) {
+      return { featureId: "plugin-scripts", featureKey: "scripts", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (isCompanionPath(pluginPath, "src")) {
+      return { featureId: "plugin-src", featureKey: "src", pluginId, sourceRelativePath: pluginPath, target };
+    }
+  }
+  return undefined;
+}
+
+function isCompanionPath(path: string, topLevelPath: string): boolean {
+  return path === topLevelPath || path.startsWith(`${topLevelPath}/`);
+}
+
+function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
+  return readString(graph.root.targets[target].options, "projectRoot") ?? (target === "claude" ? ".claude" : ".codex");
+}
+
+function pluginTargetSelected(graph: BuildGraph, pluginId: string, target: TargetName): boolean {
+  const plugin = graph.plugins.find((candidate) => candidate.id === pluginId);
+  return plugin !== undefined && plugin.targets[target].enabled && isOutputSelected(graph.root.outputs.targetOutputs[target].plugins, pluginId);
+}
+
+function evidenceFor(featureId: string, target: TargetName | undefined) {
+  const feature = getSkillsetFeature(featureId);
+  if (feature === undefined) return undefined;
+  if (target === undefined) return feature.evidence.length === 0 ? undefined : feature.evidence;
+  return feature.targetSupport[target].evidence ?? (feature.evidence.length === 0 ? undefined : feature.evidence);
+}
+
+function reasonForStatus(
+  featureId: string,
+  target: TargetName | undefined,
+  status: SkillsetLoweringOutcomeStatus
+): string | undefined {
+  if (status !== "degraded" && status !== "lossy" && status !== "unsupported" && status !== "failed") {
+    return undefined;
+  }
+  if (target === undefined) return undefined;
+  return getSkillsetFeature(featureId)?.targetSupport[target].reason;
+}
+
+function requiredReasonForStatus(
+  featureId: string,
+  target: TargetName,
+  status: SkillsetLoweringOutcomeStatus
+): string {
+  const reason = reasonForStatus(featureId, target, status);
+  if (reason === undefined) {
+    throw new Error(`skillset: feature registry ${featureId} ${target} ${status} support requires a reason`);
+  }
+  return reason;
+}
+
+function isInsideOutputRoot(path: string, outputRoot: string): boolean {
+  return path === outputRoot || path.startsWith(`${outputRoot}/`);
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function stringField(record: JsonRecord, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string") throw new Error(`skillset: expected generated lock ${key} to be a string`);
+  return value;
+}
+
+function optionalStringField(record: JsonRecord, key: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error(`skillset: expected generated lock ${key} to be a string`);
+  return value;
+}
+
+function stringArrayField(record: JsonRecord, key: string): readonly string[] {
+  const value = record[key];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`skillset: expected generated lock ${key} to be a string array`);
+  }
+  return [...value];
+}
+
+function optionalStringArrayField(record: JsonRecord, key: string): readonly string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`skillset: expected generated lock ${key} to be a string array`);
+  }
+  return [...value];
+}
+
+function jsonRecordArrayField(record: JsonRecord, key: string): readonly JsonRecord[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || !value.every(isJsonRecord)) {
+    throw new Error(`skillset: expected generated lock ${key} to be an object array`);
+  }
+  return [...value];
+}

--- a/packages/core/src/lowering-outcome.ts
+++ b/packages/core/src/lowering-outcome.ts
@@ -57,6 +57,16 @@ export type SkillsetLoweringOutcomeInput = Omit<SkillsetLoweringOutcome, "schema
   readonly schema?: typeof LOWERING_OUTCOME_SCHEMA;
 };
 
+export class SkillsetLoweringError extends Error {
+  readonly loweringOutcomes: readonly SkillsetLoweringOutcome[];
+
+  constructor(message: string, loweringOutcomes: readonly SkillsetLoweringOutcome[]) {
+    super(message);
+    this.name = "SkillsetLoweringError";
+    this.loweringOutcomes = loweringOutcomes.map(normalizeLoweringOutcome);
+  }
+}
+
 export function defineLoweringOutcome(
   input: SkillsetLoweringOutcomeInput
 ): SkillsetLoweringOutcome {

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -16,9 +16,16 @@ import {
   validateConfigDocument,
 } from "./config";
 import { readPluginDependencies, validatePluginDependencyGraph } from "./dependencies";
+import { getSkillsetFeature } from "./feature-registry";
+import {
+  SkillsetLoweringError,
+  defineLoweringOutcome,
+  type SkillsetLoweringOutcome,
+} from "./lowering-outcome";
 import { compareStrings, resolveInside, validateSlug } from "./path";
 import { readReleaseState } from "./release-state";
 import { readSkillResources } from "./resources";
+import { selectorForPluginFeature } from "./source-unit-selector";
 import { validateSupports } from "./supports";
 import type {
   BuildGraph,
@@ -472,9 +479,15 @@ async function loadPlugin(
     );
   }
   if (targets.codex.enabled && outputIncludes(codexPluginSelection, id) && (await exists(join(pluginPath, "agents")))) {
-    throw new Error(
-      `skillset: plugin ${id} has Claude plugin agents, but Codex plugins do not support plugin agents in v1; set codex: false for the plugin or move project agents to ${sourceDir}/src/agents`
-    );
+    const message = `skillset: plugin ${id} has Claude plugin agents, but Codex plugins do not support plugin agents in v1; set codex: false for the plugin or move project agents to ${sourceDir}/src/agents`;
+    throw unsupportedPluginFeatureError({
+      featureId: "plugin-agents",
+      featureKey: "agents",
+      message,
+      pluginId: id,
+      rootPath,
+      sourcePath: join(pluginPath, "agents"),
+    });
   }
 
   return {
@@ -559,9 +572,15 @@ async function loadPluginFeature(
   }
 
   if (key === "bin" && targets.codex.enabled && outputIncludes(codexPluginSelection, pluginId)) {
-    throw new Error(
-      `skillset: plugin ${pluginId} feature bin is Claude-only in v1; set bin: false, set codex: false for the plugin, or remove Codex plugin output selection`
-    );
+    const message = `skillset: plugin ${pluginId} feature bin is Claude-only in v1; set bin: false, set codex: false for the plugin, or remove Codex plugin output selection`;
+    throw unsupportedPluginFeatureError({
+      featureId: "plugin-bin",
+      featureKey: key,
+      message,
+      pluginId,
+      rootPath,
+      sourcePath,
+    });
   }
   const stats = await stat(sourcePath);
   if (key === "mcp" && !stats.isFile()) {
@@ -582,6 +601,51 @@ async function loadPluginFeature(
 
 function pluginFeatureTargetPath(key: SourcePluginFeatureKey): string {
   return key === "mcp" ? ".mcp.json" : "bin";
+}
+
+function unsupportedPluginFeatureError(args: {
+  readonly featureId: string;
+  readonly featureKey: string;
+  readonly message: string;
+  readonly pluginId: string;
+  readonly rootPath: string;
+  readonly sourcePath: string;
+}): SkillsetLoweringError {
+  return new SkillsetLoweringError(args.message, [
+    unsupportedPluginFeatureOutcome({
+      featureId: args.featureId,
+      featureKey: args.featureKey,
+      message: args.message,
+      pluginId: args.pluginId,
+      rootPath: args.rootPath,
+      sourcePath: args.sourcePath,
+    }),
+  ]);
+}
+
+function unsupportedPluginFeatureOutcome(args: {
+  readonly featureId: string;
+  readonly featureKey: string;
+  readonly message: string;
+  readonly pluginId: string;
+  readonly rootPath: string;
+  readonly sourcePath: string;
+}): SkillsetLoweringOutcome {
+  const support = getSkillsetFeature(args.featureId)?.targetSupport.codex;
+  const reason = support?.reason;
+  if (reason === undefined) {
+    throw new Error(`skillset: feature registry ${args.featureId} codex unsupported support requires a reason`);
+  }
+  return defineLoweringOutcome({
+    ...(support?.evidence === undefined ? {} : { evidence: support.evidence }),
+    featureId: args.featureId,
+    policy: "unsupported:error",
+    reason,
+    sourcePath: relative(args.rootPath, args.sourcePath),
+    sourceUnit: selectorForPluginFeature(args.pluginId, args.featureKey),
+    status: "unsupported",
+    target: "codex",
+  });
 }
 
 async function resolveRepoSourcePointer(


### PR DESCRIPTION
## Summary
- Instruments build and render paths to collect lowering outcomes.
- Records emitted/transformed/pass-through/unsupported decisions, including registry-backed unsupported reasons.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- Review fixes included requiring resolver fallback reasons from the registry and using canonical monitor activation fixtures.
- Keep draft until the full stack CI is green.