### PR TITLE
feat(core): add deterministic projection runner

### DIFF
--- a/packages/core/src/__tests__/deterministic-projection.test.ts
+++ b/packages/core/src/__tests__/deterministic-projection.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  assertDeterministicProjection,
+  formatDeterministicProjectionReport,
+  ISOLATED_OUT_ROOT,
+  runDeterministicProjection,
+} from "@skillset/core";
+
+const DEMO_CONFIG = `
+skillset:
+  name: deterministic-root
+claude: true
+codex: false
+`;
+const DEMO_SKILL = `
+---
+name: demo
+description: Demo.
+---
+
+Body.
+`;
+const DEMO_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": DEMO_CONFIG,
+  ".skillset/skills/demo/SKILL.md": DEMO_SKILL,
+};
+
+describe("deterministic projection runner", () => {
+  it("proves the kitchen-sink fixture projects deterministically without live output writes", async () => {
+    const root = join(process.cwd(), "fixtures/kitchen-sink");
+
+    const report = await assertDeterministicProjection(root);
+
+    expect(report.ok).toBe(true);
+    expect(report.outputComparison.equal).toBe(true);
+    expect(report.resultComparison.equal).toBe(true);
+    expect(report.runs[0].generatedFiles).toBeGreaterThan(0);
+    expect(report.runs[1].generatedFiles).toBe(report.runs[0].generatedFiles);
+    expect(await exists(join(root, ISOLATED_OUT_ROOT))).toBe(false);
+  });
+
+  it("proves the self-hosted .skillset source selection deterministically", async () => {
+    const report = await runDeterministicProjection(process.cwd(), {
+      keepTemp: true,
+      sourcePaths: [".skillset"],
+    });
+    try {
+      expect(report.ok).toBe(true);
+      expect(report.outputComparison.identical).toContain("plugins-claude/plugins/skillset/.claude-plugin/plugin.json");
+      expect(report.outputComparison.identical).toContain("plugins-codex/plugins/skillset/.codex-plugin/plugin.json");
+      expect(await exists(join(report.runs[0].outputRoot, "plugins-claude/plugins/skillset/.claude-plugin/plugin.json"))).toBe(true);
+    } finally {
+      await rm(report.tempRootPath, { force: true, recursive: true });
+    }
+  });
+
+  it("reports path-level differences for deliberately unstable output", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+
+    const report = await runDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        if (run.name === "right") {
+          await Bun.write(join(run.outputRoot, "unstable.txt"), "right-only\n");
+        }
+      },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.outputComparison.rightOnly).toEqual(["unstable.txt"]);
+    expect(formatDeterministicProjectionReport(report)).toContain("right-only: unstable.txt");
+    await expect(assertDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        if (run.name === "right") {
+          await Bun.write(join(run.outputRoot, "unstable.txt"), "right-only\n");
+        }
+      },
+    })).rejects.toThrow("unstable.txt");
+  });
+
+  it("fails when generated output leaks a temp workspace path", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+
+    await expect(runDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        await Bun.write(join(run.outputRoot, "leak.txt"), `workspace=${run.workspacePath}\n`);
+      },
+    })).rejects.toThrow("contains forbidden value");
+  });
+
+  it("fails when generated output leaks the shared temp runner root", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+
+    await expect(runDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        await Bun.write(join(run.outputRoot, "leak.txt"), `tempRoot=${dirname(dirname(run.workspacePath))}\n`);
+      },
+    })).rejects.toThrow("contains forbidden value");
+  });
+
+  it("rejects source symlinks instead of copying external state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-deterministic-projection-"));
+    const external = await mkdtemp(join(tmpdir(), "skillset-deterministic-external-"));
+    await Bun.write(join(external, "config.yaml"), `${DEMO_CONFIG.trim()}\n`);
+    await Bun.write(join(root, ".skillset/skills/demo/SKILL.md"), `${DEMO_SKILL.trim()}\n`);
+    await symlink(join(external, "config.yaml"), join(root, ".skillset/config.yaml"));
+
+    await expect(runDeterministicProjection(root)).rejects.toThrow(
+      "deterministic projection source does not support symlinks: .skillset/config.yaml"
+    );
+  });
+
+  it("rejects empty source selections before running a projection", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+
+    await expect(runDeterministicProjection(root, {
+      sourcePaths: [],
+    })).rejects.toThrow("requires at least one source path");
+  });
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-deterministic-projection-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}
+
+async function exists(path: string): Promise<boolean> {
+  return Bun.file(path).exists();
+}

--- a/packages/core/src/deterministic-projection.ts
+++ b/packages/core/src/deterministic-projection.ts
@@ -1,0 +1,266 @@
+import { cp, lstat, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+
+import {
+  buildSkillsetResult,
+  ISOLATED_OUT_ROOT,
+  type SkillsetBuildResult,
+} from "./build";
+import { compareStrings, resolveInside } from "./path";
+import {
+  compareNormalizedOutputTreeEntries,
+  compareNormalizedOutputTrees,
+  formatNormalizedTreeComparison,
+  type NormalizedOutputTreeEntry,
+  type NormalizedTreeComparison,
+  type NormalizedOutputTreeOptions,
+} from "./normalized-output-tree";
+import type { JsonRecord, JsonValue, SkillsetOptions } from "./types";
+import { stringifyJson } from "./yaml";
+
+const DEFAULT_SOURCE_PATHS = ["."] as const;
+const DEFAULT_COPY_EXCLUDED_PATHS = [
+  ".agents",
+  ".claude",
+  ".codex",
+  ".git",
+  ".skillset/build",
+  "node_modules",
+  "plugins-claude",
+  "plugins-codex",
+] as const;
+
+const textEncoder = new TextEncoder();
+
+export type DeterministicProjectionRunName = "left" | "right";
+
+export interface DeterministicProjectionRunContext {
+  readonly build: SkillsetBuildResult;
+  readonly name: DeterministicProjectionRunName;
+  readonly outputRoot: string;
+  readonly workspacePath: string;
+}
+
+export interface DeterministicProjectionOptions {
+  /**
+   * Relative source paths to copy into each clean temp workspace. Defaults to
+   * the whole root, excluding generated/runtime-heavy paths.
+   */
+  readonly sourcePaths?: readonly string[];
+  /** Skillset build options applied to both temp-root projections. */
+  readonly buildOptions?: SkillsetOptions;
+  /** Extra output-tree comparison options. */
+  readonly comparisonOptions?: NormalizedOutputTreeOptions;
+  /** Test/conformance hook that may inspect or perturb a temp projection. */
+  readonly afterProjection?: (run: DeterministicProjectionRunContext) => Promise<void> | void;
+  /** Keep the temp runner root on disk for local debugging. */
+  readonly keepTemp?: boolean;
+  /** Parent directory for the runner's temp root; the runner creates a child. */
+  readonly tempParentPath?: string;
+}
+
+export interface DeterministicProjectionRunSummary {
+  readonly generatedFiles: number;
+  readonly name: DeterministicProjectionRunName;
+  readonly outputRoot: string;
+  readonly workspacePath: string;
+}
+
+export interface DeterministicProjectionReport {
+  readonly ok: boolean;
+  readonly outputComparison: NormalizedTreeComparison;
+  readonly resultComparison: NormalizedTreeComparison;
+  readonly runs: readonly [
+    DeterministicProjectionRunSummary,
+    DeterministicProjectionRunSummary,
+  ];
+  readonly tempRootPath: string;
+}
+
+export async function runDeterministicProjection(
+  rootPath: string,
+  options: DeterministicProjectionOptions = {}
+): Promise<DeterministicProjectionReport> {
+  const resolvedRootPath = resolve(rootPath);
+  const tempRootPath = await createTempRoot(options.tempParentPath);
+  try {
+    const left = await runProjection(resolvedRootPath, tempRootPath, "left", options);
+    const right = await runProjection(resolvedRootPath, tempRootPath, "right", options);
+    const forbiddenSubstrings = [
+      tempRootPath,
+      left.workspacePath,
+      right.workspacePath,
+      ...(options.comparisonOptions?.forbiddenSubstrings ?? []),
+    ];
+    const outputComparison = await compareNormalizedOutputTrees(
+      left.outputRoot,
+      right.outputRoot,
+      {
+        ...options.comparisonOptions,
+        forbiddenSubstrings,
+      }
+    );
+    const resultComparison = compareProjectionResults(left, right, forbiddenSubstrings);
+    return {
+      ok: outputComparison.equal && resultComparison.equal,
+      outputComparison,
+      resultComparison,
+      runs: [runSummary(left), runSummary(right)],
+      tempRootPath,
+    };
+  } finally {
+    if (options.keepTemp !== true) {
+      await rm(tempRootPath, { force: true, recursive: true });
+    }
+  }
+}
+
+export async function assertDeterministicProjection(
+  rootPath: string,
+  options: DeterministicProjectionOptions = {}
+): Promise<DeterministicProjectionReport> {
+  const report = await runDeterministicProjection(rootPath, options);
+  if (!report.ok) throw new Error(formatDeterministicProjectionReport(report));
+  return report;
+}
+
+export function formatDeterministicProjectionReport(
+  report: DeterministicProjectionReport,
+  limit = 20
+): string {
+  if (report.ok) {
+    const generated = report.runs.map((run) => run.generatedFiles).join(" / ");
+    return `deterministic projection matched (${generated} generated files)`;
+  }
+  const sections = ["skillset: deterministic projection differed"];
+  if (!report.outputComparison.equal) {
+    sections.push(formatNormalizedTreeComparison(report.outputComparison, limit));
+  }
+  if (!report.resultComparison.equal) {
+    sections.push("operation result summary differed");
+    sections.push(formatNormalizedTreeComparison(report.resultComparison, limit));
+  }
+  return sections.join("\n");
+}
+
+async function runProjection(
+  rootPath: string,
+  tempRootPath: string,
+  name: DeterministicProjectionRunName,
+  options: DeterministicProjectionOptions
+): Promise<DeterministicProjectionRunContext> {
+  const workspacePath = join(tempRootPath, name, "workspace");
+  await copySourceSelection(rootPath, workspacePath, options.sourcePaths ?? DEFAULT_SOURCE_PATHS);
+  const build = await buildSkillsetResult(workspacePath, {
+    ...options.buildOptions,
+    buildMode: "all",
+    isolated: true,
+  });
+  const run = {
+    build,
+    name,
+    outputRoot: join(workspacePath, ISOLATED_OUT_ROOT),
+    workspacePath,
+  };
+  await options.afterProjection?.(run);
+  return run;
+}
+
+async function copySourceSelection(
+  rootPath: string,
+  workspacePath: string,
+  sourcePaths: readonly string[]
+): Promise<void> {
+  await mkdir(workspacePath, { recursive: true });
+  const normalizedSourcePaths = sourcePaths.map(normalizeRelativePath).sort(compareStrings);
+  if (normalizedSourcePaths.length === 0) {
+    throw new Error("skillset: deterministic projection requires at least one source path");
+  }
+  for (const sourcePath of normalizedSourcePaths) {
+    const source = sourcePath === "." ? rootPath : resolveInside(rootPath, sourcePath);
+    const target = sourcePath === "." ? workspacePath : join(workspacePath, sourcePath);
+    await mkdir(dirname(target), { recursive: true });
+    await cp(source, target, {
+      filter: (path) => shouldCopyPath(rootPath, path),
+      recursive: true,
+    });
+  }
+}
+
+async function shouldCopyPath(rootPath: string, path: string): Promise<boolean> {
+  const relativePath = normalizePath(relative(rootPath, path));
+  if (relativePath === "") return true;
+  if ((await lstat(path)).isSymbolicLink()) {
+    throw new Error(`skillset: deterministic projection source does not support symlinks: ${relativePath}`);
+  }
+  return !DEFAULT_COPY_EXCLUDED_PATHS.some(
+    (excluded) => relativePath === excluded || relativePath.startsWith(`${excluded}/`)
+  );
+}
+
+async function createTempRoot(tempParentPath: string | undefined): Promise<string> {
+  const parent = tempParentPath === undefined ? tmpdir() : resolve(tempParentPath);
+  await mkdir(parent, { recursive: true });
+  return mkdtemp(join(parent, "skillset-projection-"));
+}
+
+function compareProjectionResults(
+  left: DeterministicProjectionRunContext,
+  right: DeterministicProjectionRunContext,
+  forbiddenSubstrings: readonly string[]
+): NormalizedTreeComparison {
+  return compareNormalizedOutputTreeEntries(
+    [projectionResultEntry(left, forbiddenSubstrings)],
+    [projectionResultEntry(right, forbiddenSubstrings)]
+  );
+}
+
+function projectionResultEntry(
+  run: DeterministicProjectionRunContext,
+  forbiddenSubstrings: readonly string[]
+): NormalizedOutputTreeEntry {
+  const content = stringifyJson(buildResultSummary(run.build));
+  for (const forbidden of forbiddenSubstrings) {
+    if (content.includes(forbidden)) {
+      throw new Error(`skillset: deterministic projection result for ${run.name} contains forbidden value ${forbidden}`);
+    }
+  }
+  return {
+    bytes: textEncoder.encode(content),
+    kind: "json",
+    path: "operation-result.json",
+  };
+}
+
+function buildResultSummary(result: SkillsetBuildResult): JsonRecord {
+  return {
+    diagnostics: result.diagnostics as unknown as JsonValue,
+    generatedPaths: result.data.map((file) => file.path).sort(compareStrings),
+    loweringOutcomes: result.loweringOutcomes as unknown as JsonValue,
+    operation: result.operation,
+    writes: result.writes as unknown as JsonValue,
+  };
+}
+
+function runSummary(run: DeterministicProjectionRunContext): DeterministicProjectionRunSummary {
+  return {
+    generatedFiles: run.build.data.length,
+    name: run.name,
+    outputRoot: run.outputRoot,
+    workspacePath: run.workspacePath,
+  };
+}
+
+function normalizeRelativePath(path: string): string {
+  const normalized = normalizePath(path.trim());
+  if (normalized.length === 0 || normalized === ".") return ".";
+  if (normalized.startsWith("/") || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`skillset: deterministic projection source path ${JSON.stringify(path)} must stay inside the root`);
+  }
+  return normalized.replace(/\/+$/u, "");
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,11 +3,22 @@ export {
   checkSkillsetResult,
   diffSkillset,
   diffSkillsetResult,
+  ISOLATED_OUT_ROOT,
   type SkillsetBuildResult,
   type SkillsetCheckResult,
   type SkillsetDiff,
   type SkillsetDiffResult,
 } from "./build";
+export {
+  assertDeterministicProjection,
+  formatDeterministicProjectionReport,
+  runDeterministicProjection,
+  type DeterministicProjectionOptions,
+  type DeterministicProjectionReport,
+  type DeterministicProjectionRunContext,
+  type DeterministicProjectionRunName,
+  type DeterministicProjectionRunSummary,
+} from "./deterministic-projection";
 export {
   LOWERING_OUTCOME_SCHEMA,
   LOWERING_OUTCOME_STATUS_VALUES,


### PR DESCRIPTION
## Summary
- Adds the deterministic temporary-root projection runner.
- Proves kitchen-sink and self-hosted source projections can run deterministically without touching live outputs.

## Verification
- `bun run check` locally: 439 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check` all green.
- `bun run hooks:pre-push` locally green.
- Lease-protected branch push ran the full Lefthook pre-push gate for each updated stack branch.
- Subagent review loop completed: Socrates 4/5, Maxwell 4.6/5, Kierkegaard 4/5. P2+ findings were fixed; reasonable P3s were fixed where scoped.

## Notes
- Runner tests cover unstable output diffs, temp-path leak detection, source symlink rejection, and empty source selection rejection.
- Keep draft until GitHub CI for this head finishes green.