### PR TITLE
test(fixtures): add superpowers external fixture

### DIFF
--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -3552,6 +3552,35 @@ Use $ARGUMENTS and ${"${CLAUDE_SKILL_DIR}"} to prepare context.
   await expect(lintSkillset(root)).rejects.toThrow("codex-claude-dynamic-context");
 });
 
+test("lint ignores shell positional arguments inside fenced examples", async () => {
+  const root = await fixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: test-root
+claude: true
+codex: true
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+`,
+    ".skillset/plugins/alpha/skills/shell-example/SKILL.md": `
+---
+name: shell-example
+description: Shows a shell example.
+---
+
+Use this shell snippet as an example:
+
+~~~bash
+git log --oneline | awk '{print $1}'
+~~~
+`,
+  });
+
+  await expect(lintSkillset(root)).resolves.toMatchObject({ issues: [] });
+});
+
 test("lint checks Codex-enabled standalone skills", async () => {
   const root = await fixture({
     ".skillset/config.yaml": `

--- a/apps/skillset/src/lint.ts
+++ b/apps/skillset/src/lint.ts
@@ -55,6 +55,8 @@ const CLAUDE_DYNAMIC_PATTERNS: readonly DynamicPattern[] = [
     pattern: /(^|\n)\s*!`[^`\n]+`/,
   },
 ];
+const FENCE_PATTERN = /^\s*(?:```|~~~)/u;
+const INLINE_CODE_PATTERN = /`[^`]*`/gu;
 
 export async function lintSkillset(
   rootPath: string,
@@ -293,14 +295,15 @@ function lintSkill(graph: BuildGraph, skill: SourceSkill): readonly LintIssue[] 
 
   issues.push(...lintCodexAllowedTools(graph, skill));
 
-  const matches = CLAUDE_DYNAMIC_PATTERNS.filter(({ pattern }) => pattern.test(skill.body));
+  const searchableBody = maskMarkdownCodeRegions(skill.body);
+  const matches = CLAUDE_DYNAMIC_PATTERNS.filter(({ pattern }) => pattern.test(searchableBody));
   if (matches.length === 0) return issues;
 
   const path = relative(graph.rootPath, skill.sourcePath);
   const labels = matches.map((match) => match.label).join(", ");
   issues.push({
     code: "codex-claude-dynamic-context",
-        severity: "error",
+    severity: "error",
     path,
     message:
       `${path} uses Claude dynamic context (${labels}) while Codex output is enabled. ` +
@@ -308,6 +311,21 @@ function lintSkill(graph: BuildGraph, skill: SourceSkill): readonly LintIssue[] 
   });
 
   return issues;
+}
+
+function maskMarkdownCodeRegions(body: string): string {
+  let inFence = false;
+  return body
+    .split(/\r?\n/u)
+    .map((line) => {
+      if (FENCE_PATTERN.test(line)) {
+        inFence = !inFence;
+        return "";
+      }
+      if (inFence) return "";
+      return line.replace(INLINE_CODE_PATTERN, "");
+    })
+    .join("\n");
 }
 
 function lintToolEscapes(graph: BuildGraph, skill: SourceSkill): readonly LintIssue[] {

--- a/fixtures/external/repos.yaml
+++ b/fixtures/external/repos.yaml
@@ -13,3 +13,8 @@ repos:
     repo: https://github.com/hamelsmu/claude-review-loop
     ref: 244f4c7bc15e98552af7cc5a67e70dfcdea9ab12
     notes: "Nested marketplace-style Claude plugin under plugins/review-loop."
+  - name: superpowers
+    repo: https://github.com/obra/superpowers
+    ref: 6fd4507659784c351abbd2bc264c7162cfd386dc
+    targets: [claude, codex]
+    notes: "Large multi-agent plugin repo with Claude and Codex manifests, shared skills, hooks, assets, scripts, and repo-level instructions."

--- a/packages/core/src/__tests__/normalized-output-tree.test.ts
+++ b/packages/core/src/__tests__/normalized-output-tree.test.ts
@@ -117,15 +117,23 @@ describe("normalized output trees", () => {
     ]);
   });
 
-  it("rejects output symlinks instead of silently ignoring them", async () => {
-    const root = await fixture({
+  it("records symlink targets as explicit comparison entries", async () => {
+    const left = await fixture({
       "target.txt": "target\n",
     });
-    await symlink("target.txt", join(root, "linked.txt"));
+    await symlink("target.txt", join(left, "linked.txt"));
+    const right = await fixture({
+      "linked.txt": "target.txt",
+      "target.txt": "target\n",
+    });
 
-    await expect(readNormalizedOutputTree(root)).rejects.toThrow(
-      "normalized output tree does not support symlinks: linked.txt"
-    );
+    const tree = await readNormalizedOutputTree(left);
+    expect(entry(tree.entries, "linked.txt").kind).toBe("symlink");
+    expect(new TextDecoder().decode(entry(tree.entries, "linked.txt").bytes)).toBe("target.txt");
+
+    const comparison = await compareNormalizedOutputTrees(left, right);
+    expect(comparison.different).toEqual(["linked.txt"]);
+    expect(formatNormalizedTreeComparison(comparison)).toContain("symlink/bytes content differs");
   });
 });
 

--- a/packages/core/src/normalized-output-tree.ts
+++ b/packages/core/src/normalized-output-tree.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { lstat, readdir, readFile, readlink, stat } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 
 import { compareStrings } from "./path";
@@ -7,6 +7,7 @@ import type { JsonValue } from "./types";
 import { isJsonRecord, parseYamlRecord, stringifyYaml, stripUndefinedValue } from "./yaml";
 
 const DEFAULT_STRUCTURED_JSON_BASENAMES = new Set([".skillset.lock"]);
+type NormalizedContentKind = "bytes" | "json" | "yaml";
 
 export interface NormalizedOutputTreeOptions {
   readonly excludePathPrefixes?: readonly string[];
@@ -18,7 +19,7 @@ export interface NormalizedOutputTreeOptions {
 
 export interface NormalizedOutputTreeEntry {
   readonly bytes: Uint8Array;
-  readonly kind: "bytes" | "json" | "yaml";
+  readonly kind: "bytes" | "json" | "symlink" | "yaml";
   readonly path: string;
 }
 
@@ -50,7 +51,14 @@ export async function readNormalizedOutputTree(
   const paths = await collectRelativeFiles(rootPath, options);
   const entries: NormalizedOutputTreeEntry[] = [];
   for (const path of paths) {
-    const bytes = await readFile(join(rootPath, path));
+    const absolutePath = join(rootPath, path);
+    if ((await lstat(absolutePath)).isSymbolicLink()) {
+      const bytes = new TextEncoder().encode(normalizePath(await readlink(absolutePath)));
+      assertNoForbiddenSubstrings(path, bytes, options);
+      entries.push({ bytes, kind: "symlink", path });
+      continue;
+    }
+    const bytes = await readFile(absolutePath);
     entries.push(normalizeOutputTreeEntry(path, bytes, options));
   }
   return {
@@ -91,7 +99,7 @@ export function compareNormalizedOutputTreeEntries(
       differences.push({ detail: "only in left tree", kind: "left-only", path });
       continue;
     }
-    if (bytesEqual(leftEntry.bytes, rightEntry.bytes)) {
+    if (leftEntry.kind === rightEntry.kind && bytesEqual(leftEntry.bytes, rightEntry.bytes)) {
       identical.push(path);
       continue;
     }
@@ -154,7 +162,7 @@ function normalizeStructuredBytes(
 function structuredKindForPath(
   path: string,
   options: NormalizedOutputTreeOptions
-): NormalizedOutputTreeEntry["kind"] {
+): NormalizedContentKind {
   if ((options.structuredYamlPaths ?? []).includes(path)) return "yaml";
   if ((options.structuredJsonPaths ?? []).includes(path) || DEFAULT_STRUCTURED_JSON_BASENAMES.has(basename(path))) {
     return "json";
@@ -178,7 +186,7 @@ async function collectRelativeFiles(
       } else if (entry.isFile()) {
         paths.push(relativePath);
       } else if (entry.isSymbolicLink()) {
-        throw new Error(`skillset: normalized output tree does not support symlinks: ${relativePath}`);
+        paths.push(relativePath);
       }
     }
   };


### PR DESCRIPTION
## Context

Adds [`obra/superpowers`](https://github.com/obra/superpowers) as a real external adoption fixture. It is a stronger stress case than the current Claude-only examples because the pinned upstream repo carries Claude and Codex plugin manifests, a shared skills tree, hooks, assets, scripts, repo-level agent instructions, and other agent target surfaces.

The first run did useful work immediately: it exposed a symlinked `AGENTS.md -> CLAUDE.md` that the normalized tree comparator could not represent, then a false-positive Codex portability lint error from shell example text inside a fenced code block.

## What Changed

- Pinned `superpowers` in `fixtures/external/repos.yaml` at `6fd4507659784c351abbd2bc264c7162cfd386dc` with `targets: [claude, codex]`.
- Taught normalized output tree comparison to model symlinks as explicit `symlink` entries using the link target as normalized bytes, instead of failing or following them silently.
- Kept symlink drift visible by requiring the entry kind to match during comparison.
- Narrowed the Codex dynamic-context lint scan so fenced code blocks and inline code are masked before checking prose for Claude dynamic constructs.
- Added regression coverage for shell `$1` inside fenced examples.

## Verification

- `bun scripts/fixtures/external.ts run superpowers`
  - init: 3 import candidates (`instructions:AGENTS.md`, `instructions:CLAUDE.md`, `plugin:.`)
  - import: plugin `superpowers` with 177 files
  - lint: 0 issues, 0 errors
  - build: 119 generated files under `.skillset/build/out/`
  - purity: no dirty paths outside `.skillset/`
  - round-trip report: 41 identical, 15 different, 91 original-only, 0 generated-only
- `bun test packages/core/src/__tests__/normalized-output-tree.test.ts apps/skillset/src/__tests__/skillset.test.ts`
- `bun test scripts/fixtures/__tests__/external.test.ts`
- `bun run check`
- Graphite submit pre-push hooks: `skillset-ci` and `check` both passed

## Notes

The external round-trip comparison remains report-only. The `superpowers` report has expected original-only files because the upstream repository includes docs, tests, and non-Skillset target/plugin metadata that are not currently represented in generated Skillset output.
