### PR TITLE
feat(test): add activation probe assets

### DIFF
--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1403,6 +1403,223 @@ Demo body.
   expect(await fileExists(join(root, secondLatest.runPath, "report.md"))).toBe(true);
 });
 
+test("SET-112: skillset test compiles activation probes into run and latest assets", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: activation-root
+tests:
+  activation:
+    source: repo:.skillset
+    targets:
+      - claude
+      - codex
+    activation:
+      - name: fixture guidance
+        prompt: Help me inspect this Skillset fixture setup.
+        expect:
+          skill: demo
+    assertions:
+      - build
+claude: true
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Demo body.
+`,
+  });
+
+  const result = await runSkillsetCli("test", "activation", "--root", root);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("activation probes: 1");
+  expect(result.stdout).toContain("activation:");
+  expect(await fileExists(join(root, ".skillset/build/tests/latest/activation/claude/fixture-guidance.md"))).toBe(true);
+  expect(await fileExists(join(root, ".skillset/build/tests/latest/activation/codex/fixture-guidance.md"))).toBe(true);
+  const claudeProbe = await readFile(join(root, ".skillset/build/tests/latest/activation/claude/fixture-guidance.md"), "utf8");
+  expect(claudeProbe).toContain("Manual Claude activation probe");
+  expect(claudeProbe).toContain("- skill: demo");
+  const codexProbe = await readFile(join(root, ".skillset/build/tests/latest/activation/codex/probes.json"), "utf8");
+  expect(codexProbe).toContain("manual-shimmed");
+  expect(codexProbe).toContain("fixture-guidance");
+});
+
+test("SET-112: activation probes reject empty prompts and duplicate output names", async () => {
+  const emptyPromptRoot = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: empty-prompt-root
+tests:
+  activation:
+    source: repo:.skillset
+    activation:
+      - prompt: " "
+        expect:
+          skill: demo
+    assertions:
+      - build
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Demo body.
+`,
+  });
+  const emptyPrompt = await runSkillsetCli("test", "activation", "--root", emptyPromptRoot);
+  expect(emptyPrompt.exitCode).toBe(1);
+  expect(emptyPrompt.stderr).toContain("prompt is required");
+
+  const duplicateRoot = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: duplicate-probe-root
+tests:
+  activation:
+    source: repo:.skillset
+    activation:
+      - name: Demo probe
+        prompt: First prompt.
+        expect:
+          skill: first
+      - name: demo-probe
+        prompt: Second prompt.
+        expect:
+          skill: second
+    assertions:
+      - build
+claude: true
+codex: false
+`,
+    ".skillset/skills/first/SKILL.md": `
+---
+name: first
+description: First.
+---
+
+First body.
+`,
+    ".skillset/skills/second/SKILL.md": `
+---
+name: second
+description: Second.
+---
+
+Second body.
+`,
+  });
+  const duplicate = await runSkillsetCli("test", "activation", "--root", duplicateRoot);
+  expect(duplicate.exitCode).toBe(1);
+  expect(duplicate.stderr).toContain("duplicate activation probe output name");
+  expect(await fileExists(join(duplicateRoot, ".skillset/build/tests/runs"))).toBe(false);
+
+  const emptyTargetsRoot = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: empty-targets-root
+tests:
+  activation:
+    source: repo:.skillset
+    activation:
+      - name: empty targets
+        prompt: Probe prompt.
+        targets: []
+        expect:
+          skill: demo
+    assertions:
+      - build
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Demo body.
+`,
+  });
+  const emptyTargets = await runSkillsetCli("test", "activation", "--root", emptyTargetsRoot);
+  expect(emptyTargets.exitCode).toBe(1);
+  expect(emptyTargets.stderr).toContain("targets to include at least one target");
+  expect(await fileExists(join(emptyTargetsRoot, ".skillset/build/tests/runs"))).toBe(false);
+});
+
+test("SET-112: activation probes require expected units to be emitted for the target", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: missing-activation-root
+tests:
+  activation:
+    source: repo:.skillset
+    targets:
+      - claude
+    activation:
+      - name: missing skill
+        prompt: Probe prompt.
+        expect:
+          skill: missing
+    assertions:
+      - build
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Demo body.
+`,
+  });
+
+  const result = await runSkillsetCli("test", "activation", "--root", root);
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("activation expected skill missing was not emitted for target claude");
+  expect(await fileExists(join(root, ".skillset/build/tests/runs"))).toBe(false);
+});
+
+test("SET-112: test declarations are root-owned and rejected in plugin config", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: root-owned-tests
+claude: true
+codex: false
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+tests:
+  ignored:
+    source: repo:.skillset
+    assertions:
+      - build
+`,
+    ".skillset/plugins/alpha/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Demo body.
+`,
+  });
+
+  await expect(buildSkillset(root)).rejects.toThrow("unsupported top-level key tests");
+});
+
 test("SET-50: skillset test reports failed assertions without touching live outputs", async () => {
   const root = await contractFixture({
     ".skillset/config.yaml": `

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -797,6 +797,8 @@ function printSkillsetTest(report: SkillsetTestReport): void {
   console.log(`  latest: ${report.latestPath}`);
   console.log(`  report: ${report.reportPath}`);
   console.log(`  generated files: ${report.generatedFiles}`);
+  console.log(`  activation probes: ${report.activationProbes}`);
+  if (report.activationPath !== undefined) console.log(`  activation: ${report.activationPath}`);
 }
 
 function parseArgs(args: readonly string[]): ParsedArgs {

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -6,8 +6,9 @@ import { tmpdir } from "node:os";
 import { buildSkillset, diffSkillset } from "./build";
 import { readCompileTargets, readString, resolveTargets, targetNames } from "./config";
 import { compareStrings, resolveInside } from "./path";
+import { loadBuildGraph } from "./resolver";
 import { renderValidatedJson } from "./structured-output";
-import type { JsonRecord, JsonValue, SkillsetOptions, TargetName } from "./types";
+import type { BuildGraph, JsonRecord, JsonValue, SkillsetOptions, TargetName } from "./types";
 import { isJsonRecord, parseYamlRecord } from "./yaml";
 
 const DEFAULT_SOURCE_DIR = ".skillset";
@@ -15,6 +16,8 @@ const TEST_BUILD_DIR = "build/tests";
 const TEST_SCHEMA = 1;
 
 export interface SkillsetTestReport {
+  readonly activationPath?: string;
+  readonly activationProbes: number;
   readonly assertions: readonly SkillsetTestAssertionResult[];
   readonly generatedFiles: number;
   readonly latestPath: string;
@@ -37,6 +40,7 @@ export interface SkillsetTestAssertionResult {
 }
 
 interface TestDeclaration {
+  readonly activationProbes: readonly ActivationProbe[];
   readonly assertions: readonly TestAssertion[];
   readonly name: string;
   readonly source: string;
@@ -48,6 +52,18 @@ type TestAssertion =
   | { readonly kind: "exists"; readonly path: string }
   | { readonly kind: "contains"; readonly path: string; readonly text: string }
   | { readonly kind: "noDrift" };
+
+interface ActivationProbe {
+  readonly expect: ActivationExpectation;
+  readonly name: string;
+  readonly prompt: string;
+  readonly targets: readonly TargetName[];
+}
+
+interface ActivationExpectation {
+  readonly kind: "agent" | "plugin" | "skill";
+  readonly name: string;
+}
 
 export async function runSkillsetTest(
   rootPath: string,
@@ -103,14 +119,26 @@ export async function runSkillsetTest(
         assertions.push(await runAssertion(stagingWorkspacePath, assertion, buildOptions));
       }
     }
+    if (assertions.every((assertion) => assertion.ok)) {
+      await validateActivationExpectations(stagingWorkspacePath, declaration, buildOptions);
+    }
 
     await mkdir(runPath, { recursive: true });
     await cp(stagingWorkspacePath, workspacePath, { recursive: true });
+    const activationPath = await writeActivationProbes(runPath, declaration);
 
     const ok = assertions.every((assertion) => assertion.ok);
     const reportPath = join(runPath, "report.json");
     const reportMarkdownPath = join(runPath, "report.md");
     const latestPath = join(buildRoot, "latest");
+    const activationReport = activationPath === undefined
+      ? {}
+      : {
+        activation: {
+          path: relative(rootPath, activationPath),
+          probes: declaration.activationProbes.length,
+        },
+      };
     const report: JsonRecord = {
       assertions: assertions.map(assertionRecord),
       generatedFiles,
@@ -120,6 +148,7 @@ export async function runSkillsetTest(
       schemaVersion: TEST_SCHEMA,
       source: declaration.source,
       targets: [...declaration.targets],
+      ...activationReport,
       workspacePath: relative(rootPath, workspacePath),
     };
 
@@ -129,6 +158,8 @@ export async function runSkillsetTest(
 
     return {
       assertions,
+      ...(activationPath === undefined ? {} : { activationPath: relative(rootPath, activationPath) }),
+      activationProbes: declaration.activationProbes.length,
       generatedFiles,
       latestPath: relative(rootPath, latestPath),
       name: declaration.name,
@@ -174,7 +205,7 @@ function readTestObject(
   defaultTargets: readonly TargetName[]
 ): TestDeclaration {
   for (const key of Object.keys(record)) {
-    if (key !== "assertions" && key !== "assert" && key !== "output" && key !== "source" && key !== "targets") {
+    if (key !== "activation" && key !== "assertions" && key !== "assert" && key !== "output" && key !== "source" && key !== "targets") {
       throw new Error(`skillset: unsupported test key ${key} in ${label}`);
     }
   }
@@ -183,6 +214,8 @@ function readTestObject(
 
   const targets = readTargets(record.targets, `${label}.targets`, defaultTargets);
   const assertions = readAssertions(record.assertions ?? record.assert, `${label}.assertions`);
+  const activationProbes = readActivationProbes(record.activation, `${label}.activation`, targets);
+  validateActivationProbeNames(activationProbes, targets);
   const output = record.output;
   if (output !== undefined) {
     if (!isJsonRecord(output)) throw new Error(`skillset: expected ${label}.output to be an object`);
@@ -195,12 +228,13 @@ function readTestObject(
     }
   }
 
-  return { assertions, name, source, targets };
+  return { activationProbes, assertions, name, source, targets };
 }
 
 function readTargets(value: JsonValue | undefined, label: string, defaultTargets: readonly TargetName[]): readonly TargetName[] {
   if (value === undefined) return defaultTargets;
   if (!Array.isArray(value)) throw new Error(`skillset: expected ${label} to be a string array`);
+  if (value.length === 0) throw new Error(`skillset: expected ${label} to include at least one target`);
   const enabled = new Set(defaultTargets);
   const seen = new Set<TargetName>();
   for (const target of value) {
@@ -248,6 +282,73 @@ function readAssertion(value: JsonValue, label: string): TestAssertion {
   }
 
   throw new Error(`skillset: expected ${label} to be build, noDrift, exists, or contains`);
+}
+
+function readActivationProbes(
+  value: JsonValue | undefined,
+  label: string,
+  defaultTargets: readonly TargetName[]
+): readonly ActivationProbe[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`skillset: expected ${label} to be an array`);
+  return value.map((item, index) => readActivationProbe(item, `${label}[${index}]`, defaultTargets));
+}
+
+function readActivationProbe(
+  value: JsonValue,
+  label: string,
+  defaultTargets: readonly TargetName[]
+): ActivationProbe {
+  if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "expect" && key !== "name" && key !== "prompt" && key !== "targets") {
+      throw new Error(`skillset: unsupported activation key ${key} in ${label}`);
+    }
+  }
+  const prompt = readString(value, "prompt");
+  if (prompt === undefined) throw new Error(`skillset: ${label}.prompt is required`);
+  const expect = readActivationExpectation(value.expect, `${label}.expect`);
+  const targets = readTargets(value.targets, `${label}.targets`, defaultTargets);
+  const configuredName = readString(value, "name");
+  return {
+    expect,
+    name: configuredName ?? activationProbeName(expect),
+    prompt,
+    targets,
+  };
+}
+
+function readActivationExpectation(value: JsonValue | undefined, label: string): ActivationExpectation {
+  if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
+  const entries = (["agent", "plugin", "skill"] as const)
+    .map((kind) => ({ kind, name: readString(value, kind) }))
+    .filter((entry): entry is ActivationExpectation => entry.name !== undefined);
+  if (entries.length !== 1) {
+    throw new Error(`skillset: ${label} must name exactly one of agent, plugin, or skill`);
+  }
+  const [entry] = entries;
+  if (entry === undefined) throw new Error(`skillset: ${label} must name exactly one of agent, plugin, or skill`);
+  return entry;
+}
+
+function activationProbeName(expect: ActivationExpectation): string {
+  return `${expect.kind}-${expect.name}`;
+}
+
+function validateActivationProbeNames(
+  probes: readonly ActivationProbe[],
+  targets: readonly TargetName[]
+): void {
+  for (const target of targets) {
+    const names = new Set<string>();
+    for (const probe of probes.filter((candidate) => candidate.targets.includes(target))) {
+      const name = slugifyProbeName(probe.name);
+      if (names.has(name)) {
+        throw new Error(`skillset: duplicate activation probe output name ${JSON.stringify(name)} for target ${target}`);
+      }
+      names.add(name);
+    }
+  }
 }
 
 function assertionRecord(assertion: SkillsetTestAssertionResult): JsonRecord {
@@ -304,6 +405,131 @@ async function runAssertion(
   return { kind: "build", ok: true };
 }
 
+async function validateActivationExpectations(
+  workspacePath: string,
+  declaration: TestDeclaration,
+  options: SkillsetOptions
+): Promise<void> {
+  if (declaration.activationProbes.length === 0) return;
+  const graph = await loadBuildGraph(workspacePath, options);
+  for (const probe of declaration.activationProbes) {
+    for (const target of probe.targets) {
+      const candidates = activationExpectationCandidatePaths(graph, target, probe.expect);
+      const matched = await Promise.all(candidates.map(async (path) => pathExists(resolveInside(workspacePath, path))));
+      if (matched.some(Boolean)) continue;
+      throw new Error(`skillset: activation expected ${probe.expect.kind} ${probe.expect.name} was not emitted for target ${target}`);
+    }
+  }
+}
+
+function activationExpectationCandidatePaths(
+  graph: BuildGraph,
+  target: TargetName,
+  expect: ActivationExpectation
+): readonly string[] {
+  if (expect.kind === "plugin") {
+    const manifestDirectory = target === "claude" ? ".claude-plugin" : ".codex-plugin";
+    return [`${graph.root.outputs.plugins[target]}/plugins/${expect.name}/${manifestDirectory}/plugin.json`];
+  }
+
+  if (expect.kind === "agent") {
+    const projectRoot = targetProjectRoot(graph, target);
+    return graph.projectAgents
+      .filter((agent) => agent.name === expect.name || agent.outputName === expect.name)
+      .map((agent) => join(projectRoot, "agents", `${agent.outputName}.${target === "claude" ? "md" : "toml"}`));
+  }
+
+  return [
+    ...graph.standaloneSkills
+      .filter((skill) => skill.id === expect.name)
+      .map((skill) => join(graph.root.outputs.skills[target], dirname(skill.relativePath), "SKILL.md")),
+    ...graph.plugins.flatMap((plugin) =>
+      plugin.skills
+        .filter((skill) => skill.id === expect.name)
+        .map((skill) => join(graph.root.outputs.plugins[target], "plugins", plugin.id, dirname(skill.relativePath), "SKILL.md"))
+    ),
+  ];
+}
+
+function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
+  return readString(graph.root.targets[target].options, "projectRoot") ?? (target === "claude" ? ".claude" : ".codex");
+}
+
+async function writeActivationProbes(
+  runPath: string,
+  declaration: TestDeclaration
+): Promise<string | undefined> {
+  if (declaration.activationProbes.length === 0) return undefined;
+  const activationRoot = join(runPath, "activation");
+  for (const target of declaration.targets) {
+    const probes = declaration.activationProbes.filter((probe) => probe.targets.includes(target));
+    if (probes.length === 0) continue;
+    const targetRoot = join(activationRoot, target);
+    await mkdir(targetRoot, { recursive: true });
+    const records = probes.map((probe) => activationProbeRecord(probe, target));
+    await writeFile(join(targetRoot, "probes.json"), renderValidatedJson({
+      probes: records,
+      schemaVersion: TEST_SCHEMA,
+      target,
+    }, `activation ${target} probes`), "utf8");
+    for (const record of records) {
+      const name = typeof record.name === "string" ? record.name : "probe";
+      await writeFile(join(targetRoot, `${name}.md`), renderActivationProbeMarkdown(record), "utf8");
+    }
+  }
+  return activationRoot;
+}
+
+function activationProbeRecord(probe: ActivationProbe, target: TargetName): JsonRecord {
+  return {
+    expect: {
+      [probe.expect.kind]: probe.expect.name,
+    },
+    harness: activationHarness(target),
+    name: slugifyProbeName(probe.name),
+    prompt: probe.prompt,
+    status: target === "claude" ? "manual-native" : "manual-shimmed",
+    target,
+  };
+}
+
+function activationHarness(target: TargetName): string {
+  if (target === "claude") {
+    return "Manual Claude activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.";
+  }
+  return "Manual Codex activation probe. Use generated Codex output or plugin-eval tooling when available; compatibility shims should be reported explicitly.";
+}
+
+function renderActivationProbeMarkdown(record: JsonRecord): string {
+  const expect = isJsonRecord(record.expect)
+    ? Object.entries(record.expect).map(([kind, name]) => `- ${kind}: ${name}`).join("\n")
+    : "- unknown";
+  return [
+    `# Activation Probe ${record.name}`,
+    "",
+    `Target: ${record.target}`,
+    `Status: ${record.status}`,
+    "",
+    "## Prompt",
+    "",
+    String(record.prompt ?? ""),
+    "",
+    "## Expected Activation",
+    "",
+    expect,
+    "",
+    "## Harness",
+    "",
+    String(record.harness ?? ""),
+    "",
+  ].join("\n");
+}
+
+function slugifyProbeName(value: string): string {
+  const slug = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "probe";
+}
+
 async function refreshLatest(
   buildRoot: string,
   runPath: string,
@@ -335,6 +561,7 @@ function renderMarkdownReport(report: JsonRecord): string {
     `Run: ${report.runId}`,
     `Source: ${report.source}`,
     `Generated files: ${report.generatedFiles}`,
+    `Activation probes: ${activationProbeCount(report)}`,
     "",
     "## Assertions",
     "",
@@ -347,6 +574,13 @@ function renderMarkdownReport(report: JsonRecord): string {
     lines.push(`- ${mark}: ${assertion.kind}${path}${detail}`);
   }
   return `${lines.join("\n").trimEnd()}\n`;
+}
+
+function activationProbeCount(report: JsonRecord): number {
+  const activation = report.activation;
+  if (!isJsonRecord(activation)) return 0;
+  const probes = activation.probes;
+  return typeof probes === "number" && Number.isFinite(probes) ? probes : 0;
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -6,6 +6,7 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 
 ## Initial Pages
 
+- [Activation Probes](tests-and-evals.md#activation-probes): target-aware manual harness prompts generated inside `skillset test` runs.
 - [Agents](agents.md): portable project agents, Claude plugin agents, Codex project agents, and skill-local Codex policy boundaries.
 - [Apps](apps.md): Codex plugin `.app.json` pass-through and why there is no v1 `apps.source` feature key.
 - [Build Scopes](build-scopes.md): build mode, destination scopes, dry-run safety, diff/list/explain behavior, and lock semantics.
@@ -56,7 +57,7 @@ Unsupported and lossy lowering must fail loudly by default. Softer outcomes such
 
 ## Registry Shape
 
-Each feature page uses the same registry-oriented fields, even though the registry is not implemented as code yet:
+Each feature page uses the same registry-oriented fields. The current typed seed lives in `packages/core/src/feature-registry.ts`; feature pages remain the reader-facing explanation for those registry facts:
 
 | Field | Purpose |
 | --- | --- |
@@ -68,7 +69,7 @@ Each feature page uses the same registry-oriented fields, even though the regist
 | Provenance | Lock entries, hashes, warnings, skipped output, target state, and explain/doctor surfaces. |
 | Evidence | Provider docs, ADRs, Linear issues, tests, and fixtures that justify the current status. |
 
-Future schema generation can turn these fields into typed data, but SET-28 does not introduce a generator, runtime registry, or new compiler behavior. When that registry becomes code, it belongs in `@skillset/core`; the CLI should render registry-backed facts rather than own feature semantics.
+Future schema generation can turn these fields into richer generated docs, but the registry source of truth belongs in `@skillset/core`; the CLI should render registry-backed facts rather than own feature semantics.
 
 ## Future-Only Features
 

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -49,8 +49,8 @@ Runtime support records live in the feature registry as `runtimeSupport` rows. A
 | --- | --- | --- |
 | Build target | A provider projection Skillset can lower directly. | `claude`, `codex` |
 | Runtime adapter | A concrete runtime or harness that can consume a projection or compatibility shim. | `claude-code`, `codex-cli`, `codex-app` |
-| Distribution surface | A repo, marketplace, extension root, or package shape a projection may be synced into. | Future `distributions.*` config |
-| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Future activation probes |
+| Distribution surface | A repo, marketplace, extension root, or package shape a projection may be synced into. | Implemented `distributions.*` plan config; sync/publish remains future |
+| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation probe assets under `skillset test`; runtime execution remains future |
 
 The test: adding a runtime must not make `compile.targets` accept a new value. It should add evidence and support records first, then a specific adapter or distribution flow only when the target behavior is proven.
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -60,6 +60,40 @@ The first assertion vocabulary is deliberately small: `build` means the isolated
 
 Release state and inline versions are observable, not migrated, by deterministic tests. A test may assert the version that build emits after release state is applied, but it must not rewrite source `version` fields or start the SET-43 migration from inline versions to release-state-only authoring.
 
+## Activation Probes
+
+Activation probes are a first layer above deterministic build assertions and below evals. They answer “can a target harness notice or invoke the expected skill, agent, or plugin?” They do not judge answer quality, call a model, install a plugin, trust global runtime config, or mutate live build roots.
+
+Root test declarations can include lightweight activation probes:
+
+```yaml
+tests:
+  activation:
+    source: repo:.skillset
+    targets:
+      - claude
+      - codex
+    activation:
+      - name: fixture guidance
+        prompt: Help me inspect this Skillset fixture setup.
+        expect:
+          skill: skillset-repo-test-fixtures
+    assertions:
+      - build
+```
+
+Each probe requires `prompt` and `expect`. The v1 `expect` object must name exactly one of `skill`, `agent`, or `plugin`. Probe `targets` can narrow to enabled test targets; absent probe targets inherit the enclosing test targets. Empty target arrays fail. Before a retained run is written, Skillset verifies that the expected unit was emitted for every selected target in the isolated workspace, so typos and target-disabled units fail without creating partial run directories. Probe assets are generated under the retained test run:
+
+```text
+.skillset/build/tests/runs/<run-id>/activation/<target>/
+  probes.json
+  <probe-name>.md
+```
+
+`latest/` receives the same activation directory when the run refreshes. Claude probes are emitted as manual native harness prompts. Codex probes are emitted as manual shim-aware prompts because Codex can follow generated loading instructions, but Skillset should not pretend that every Claude-style activation signal is target-enforced in Codex. Future Codex plugin-eval integration can consume the same `probes.json` shape once that runner boundary is proven.
+
+Edge cases stay explicit: multiple matching skills should be disambiguated in the expected selector, target-native islands may need target-specific probes, missing plugin dependencies should appear as activation setup failures rather than build successes, and compatibility shims should be reported as shims in the generated probe material.
+
 ## Compiler Determinism and Adapter Conformance
 
 The compiler verification lane is narrower than `skillset test` and much narrower than evals. It proves that the same source projects to the same generated artifacts, lockfiles, reports, and structured outcomes when built in clean roots. It is an internal and core-library-facing determinism proof, not a user-authored scenario format.

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../feature-registry";
 
 const SEEDED_FEATURE_IDS = [
+  "activation-probes",
   "changes",
   "dependencies",
   "distributions",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,8 +18,8 @@ const TARGET_NAMES: readonly TargetName[] = ["claude", "codex"];
 export type FeatureSurface = "agents" | "instructions" | "plugins" | "skills";
 
 const DEFAULT_SURFACES = new Set<FeatureSurface>(["agents", "instructions", "plugins", "skills"]);
-const CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "defaults", "dependencies", "skillset", "supports", "tests"]);
-const ROOT_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "compile", "distributions"]);
+const CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "defaults", "dependencies", "skillset", "supports"]);
+const ROOT_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "compile", "distributions", "tests"]);
 const COMPILE_BUILD_MODES = new Set<CompileBuildMode>(["updated", "all"]);
 const COMPILE_UNSUPPORTED_POLICIES = new Set<CompileUnsupportedPolicy>([
   "error",

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -108,6 +108,19 @@ export type SkillsetFeatureRegistry = readonly SkillsetFeatureEntry[];
 
 export const skillsetFeatureRegistry = defineFeatureRegistry([
   feature({
+    docs: ["docs/features/tests-and-evals.md"],
+    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-112 activation probe coverage")],
+    id: "activation-probes",
+    kind: "workflow",
+    loweringOwner: "apps/skillset/src/test-runner.ts",
+    sourceShape: ".skillset/config.yaml tests.<name>.activation[]",
+    status: "implemented",
+    summary: "Compiles target-aware manual activation probe assets inside isolated test runs.",
+    targetSupport: notTargetRuntime(),
+    title: "Activation Probes",
+    validationOwner: "apps/skillset/src/test-runner.ts",
+  }),
+  feature({
     docs: ["docs/features/changes.md"],
     evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-34/35/36 change status and entry coverage")],
     id: "changes",


### PR DESCRIPTION
## Context

This top slice gives Skillset a concrete activation-probe asset path for dogfooding and future eval/test harness work. It intentionally generates probe assets inside Skillset test runs rather than installing anything into live Claude or Codex runtime locations.

## What changed

- Adds root-owned `tests.<name>.activation[]` configuration for declared activation probes.
- Generates target-specific probe JSON and Markdown assets under `.skillset/build/tests/runs/<run-id>/activation/<target>/`, with a `latest/` mirror.
- Validates empty target lists, duplicate probe output names, and expected emitted entities before writing retained run output.
- Derives candidate skill/project/plugin paths from the build graph so probes point at the right target-native files.
- Documents activation probes in the tests/evals feature guide and updates runtime feature registry wording.

## Verification

- `bun run check` passed locally: 452 tests, typecheck, Ultracite doctor, lint, generated-output check.
- Manual smoke: `bun ./apps/skillset/src/cli.ts test --root .` passed, generated 51 files, and reported 0 activation probes for the current repo config.
- `skillset-ci` passed during the Graphite pre-push gate.
- GitHub CI is green for this PR: `check` and `skillset-ci`.

## Review notes

- Initial review found partial-run and validation risks around duplicate probe outputs, empty targets, plugin-local `tests`, and unvalidated expectations; all were fixed here.
- Tests now assert invalid activation configs do not leave partial `.skillset/build/tests/runs` output behind.
- Final local verifier Noether reported no P0-P3 findings and scored the stack 5/5.
