### PR TITLE
docs: define feature registry contract

### DIFF
--- a/docs/adrs/decision-map.json
+++ b/docs/adrs/decision-map.json
@@ -94,6 +94,11 @@
           "fromPath": "docs/adrs/0000-source-first-loadouts.md"
         },
         {
+          "context": "- [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md) - provider selection and unsupported-policy boundary.",
+          "from": "20260604",
+          "fromPath": "docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"
+        },
+        {
           "context": "- [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md) - provider selection and target-specific config boundaries.",
           "from": "20260604",
           "fromPath": "docs/adrs/drafts/20260604-first-class-sets.md"

--- a/docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md
+++ b/docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md
@@ -3,329 +3,144 @@ slug: feature-reference-and-schema-registry
 title: Feature Reference and Schema Registry
 status: draft
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-14
 owners: ['[galligan](https://github.com/galligan)']
-depends_on: [0]
+depends_on: [0, 1]
 ---
 
 # ADR: Feature Reference and Schema Registry
 
-Proposal for a feature-by-feature documentation and schema layer for Skillset.
-
-## Status
-
-Proposed. This document describes a documentation/tooling direction, not an implemented compiler contract.
-
 ## Context
 
-Skillset is starting to cover a large surface area: skills, plugin manifests, rules/instructions, hooks, MCP servers, apps, resources, tool intent, agents, commands, executables, themes, monitors, LSP servers, settings, marketplace metadata, and target-specific escape hatches.
+Skillset covers a broad and growing source surface: skills, plugin manifests, instructions, hooks, MCP servers, apps, resources, tool intent, agents, commands, executables, themes, monitors, LSP servers, supports metadata, dependencies, distributions, tests, release state, target-native islands, and future runtime adapters. The compiler cannot keep that surface honest with prose alone.
 
-Today that knowledge is spread across tenets, layout docs, target-surface matrices, code, tests, and generated output. That makes it too easy for a feature to drift in one of three ways:
+The pressure is not just documentation completeness. A feature can drift in several ways:
 
 - The docs say a source feature lowers to a target, but the compiler does not.
 - The compiler supports a target feature, but the docs do not explain the target nuance or unsupported cases.
-- A near-match feature, such as Claude subagents versus Codex agent-like surfaces, is accidentally treated as portable because the names are similar.
+- A near-match feature is accidentally treated as portable because Claude and Codex use similar words for different behavior.
+- A diagnostic correctly rejects source, but the rejection is not traceable to the feature contract it protects.
+- A fixture proves emitted bytes, but not the target-support claim those bytes are supposed to represent.
 
-Skillset needs a durable feature reference that explains authoring, target lowering, support status, schemas, diagnostics, and examples in one place.
+Skillset needs a typed feature registry that is intentionally smaller than a public plugin system and stricter than a hand-written support matrix. It should be the internal authority for feature capability claims, docs ownership, adapter evidence, validation ownership, and future conformance checks.
 
 ## Decision
 
-Create a feature-reference layer for Skillset docs and evolve it toward a schema-backed feature registry. The reference should explain each source feature, target lowering, support status, diagnostics, examples, and lock provenance. The schema registry should eventually separate portable feature schemas from Claude and Codex adapter schemas so target support can rev independently.
+Skillset maintains a typed feature registry in `@skillset/core` and a manual reader-facing feature reference under `docs/features/`. The registry records static feature capability; lowering outcomes record per-build facts.
 
-## Goals
+The keeper sentence is: the feature registry says what Skillset claims a feature can do; lowering outcomes say what a build actually did.
 
-- Give authors one index of Skillset features.
-- Give each feature a focused page that explains how to write it in source and how it compiles for Claude and Codex.
-- Make target support explicit: implemented, portable, target-native, metadata-only, planned, reserved, deferred, unsupported, lossy, and future.
-- Capture nuances within features, such as `SKILL.md` frontmatter keys, path-scoped instruction frontmatter, hook handler compatibility, and MCP server policy.
-- Let future docs tables be generated from schemas or a feature registry so support flips do not require hand-updating several places.
-- Separate portable feature schemas from Claude and Codex adapter schemas so target support can evolve independently.
+### Registry Purpose
 
-## Non-goals
+The registry is the typed version of Skillset's support matrix. Each entry names a feature, its source shape, current maturity, target support, evidence, docs, lowering owner, and validation owner.
 
-- Do not build a full docs generator before the reference shape is proven.
-- Do not make unsupported target features look portable just because they appear in the reference.
-- Do not replace ADRs. ADRs still record decisions; feature docs describe the current authoring and lowering contract.
-- Do not move activation or trust into `skillset build`. The reference may document hooks, MCP servers, apps, and executables, but build still emits definitions only.
-- Do not implement a settings suggestion/review workflow in v1. Target-native settings may be documented and copied only when explicitly authored and scoped by a later issue; live user/project config mutation is out of scope.
-- Do not introduce shared model/reasoning alias profiles in v1. Use target-native fields such as Claude `model` / `effort` and Codex `model` / `model_reasoning_effort`.
-- Do not introduce first-class `sets` for grouped marketplaces or bundles in v1. CLI scopes and typed entity selectors remain separate.
-- Do not generate `docs/features` from a runtime schema in v1. Manual feature docs come first; registry-backed generation is future work.
+The registry is allowed to answer:
 
-## Documentation Shape
+- What stable feature id should docs, diagnostics, locks, outcomes, reports, and tests use?
+- Is the feature implemented, planned, reserved, deferred, future-only, or unsupported as a Skillset source feature?
+- Can Claude represent this feature, and by what support shape?
+- Can Codex represent this feature, and by what support shape?
+- Which source file or module owns lowering?
+- Which source file or module owns validation?
+- What docs, source, tests, fixtures, or external provider docs justify the claim?
 
-Add a generated-or-manual feature reference section:
+The registry is not allowed to become a dumping ground for every target file, every CLI flag, every generated path, or every runtime activation result. Those details can reference registry entries, but the registry row should stay compact enough to read and review.
 
-```text
-docs/
-  features/
-    README.md
-    skills.md
-    instructions.md
-    plugins.md
-    plugin-metadata.md
-    resources.md
-    tool-intent.md
-    hooks.md
-    mcp-servers.md
-    apps.md
-    agents.md
-    commands.md
-    executables.md
-    output-styles.md
-    themes.md
-    monitors.md
-    lsp-servers.md
-    settings.md
-```
-
-The index should group features by support shape:
-
-- **Portable**: same intent and faithful target lowering.
-- **Near match**: similar target concepts that need careful intent modeling.
-- **Target-native**: supported for one target only.
-- **Metadata-only**: preserved for provenance, not enforced by the target.
-- **Reserved / deferred / future**: named or understood, but not emitted yet.
-- **Unsupported / lossy**: cannot lower faithfully for an enabled target without explicit scoping, diagnostics, and provenance.
-
-## Feature Page Template
-
-Each page should follow the same shape:
-
-```markdown
-# <Feature Name>
-
-## Status
-
-Short support summary.
-
-## Authoring
-
-How this is written in `.skillset/src` or source config.
-
-## Schema
-
-Source keys, frontmatter keys, path conventions, aliases, and defaults.
-
-## Target Lowering
-
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-
-## Examples
-
-Small source example plus generated Claude/Codex snippets.
-
-## Diagnostics
-
-What lint/build/check should warn or fail on.
-
-## Provenance
-
-What should be recorded in `.skillset.lock`.
-
-## Open Questions
-
-Known target drift, missing docs evidence, or deferred design calls.
-```
-
-This keeps the page useful for both humans and future generator templates.
-
-## Schema Registry
-
-Once the manual shape is stable, introduce a feature registry that can drive docs, diagnostics, and adapter checks.
-
-Possible source:
-
-```text
-packages/core/src/schema/
-  features/
-    skills.schema.json
-    hooks.schema.json
-    mcp-servers.schema.json
-  targets/
-    claude.schema.json
-    codex.schema.json
-```
-
-or a typed registry if TypeScript is easier to maintain:
-
-```ts
-export const features = [
-  {
-    id: "skills",
-    title: "Skills",
-    source: {
-      paths: [".skillset/src/skills/<name>/SKILL.md"],
-      schema: "SkillSource",
-    },
-    targets: {
-      claude: {
-        status: "implemented",
-        outputs: ["skills/<name>/SKILL.md"],
-        adapterSchema: "ClaudeSkill",
-      },
-      codex: {
-        status: "implemented",
-        outputs: ["skills/<name>/SKILL.md", "agents/openai.yaml"],
-        adapterSchema: "CodexSkill",
-      },
-    },
-    docs: {
-      page: "docs/features/skills.md",
-      order: 10,
-    },
-  },
-] as const;
-```
-
-The registry should include:
-
-- Feature id, title, and maturity.
-- Source paths, source keys, and aliases.
-- Target support status per provider.
-- Target output paths and manifest fields.
-- Validation ownership: portable resolver, Claude adapter, Codex adapter.
-- Live-doc verification source/date for target surfaces.
-- Lock provenance fields.
-- Example fixture names or golden tests.
-
-## Adapter Separation
-
-The registry suggests a cleaner compiler split:
-
-```text
-packages/core/src/
-  features/
-    skills/
-    hooks/
-    mcp-servers/
-    instructions/
-  targets/
-    claude/
-      schema.ts
-      manifest.ts
-      lower.ts
-      validate.ts
-    codex/
-      schema.ts
-      manifest.ts
-      lower.ts
-      validate.ts
-```
-
-The portable feature layer answers: "What did the author mean?"
-
-The target adapter layer answers: "Can this target represent that meaning, and what native files should be emitted?"
-
-Adapter schemas can rev independently. For example, Claude could add a new plugin component without changing the portable source schema immediately, while Codex could add a new app or hook shape without pretending Claude has the same feature.
-
-## Support Vocabulary
-
-Use one support vocabulary everywhere:
-
-| Status | Meaning |
-| --- | --- |
-| `implemented` | Parsed, validated, rendered, tested, and documented. |
-| `portable` | Authored once because enabled targets can represent the same intent faithfully. |
-| `target_native` | Supported only through one target's native source or adapter path. |
-| `metadata_only` | Captured in generated metadata or lock provenance, but not target-enforced. |
-| `planned` | Accepted design with no parser/render support yet. |
-| `reserved` | Recognized vocabulary that fails until provenance and behavior exist. |
-| `deferred` | Intentionally not emitted; documented reason. |
-| `unsupported` | Cannot lower to an enabled target without explicit target scoping or unsupported policy. |
-| `lossy` | A possible lowering would drop target meaning or behavior; fail unless a future ADR defines visible provenance. |
-| `future` | Outside the v1 contract but tracked as a possible later design. |
-
-This vocabulary should match `docs/target-surfaces.md`, compiler diagnostics, and eventually generated feature pages.
-
-## Example: Agents / Subagents
-
-The feature-reference model is especially useful for non-portable concepts.
-
-Claude:
-
-- Has project/user `.claude/agents/*.md` subagent Markdown files.
-- Has plugin `agents/` subagent Markdown files.
-- Has project/user subagent behavior.
-- Exposes agent-related plugin settings and status-line options.
-
-Codex:
-
-- Has skills, plugins, hooks, MCP servers, apps, and skill-local `agents/openai.yaml` policy.
-- Has project/user `.codex/agents/*.toml` custom agents.
-- Does not document a plugin `agents/` equivalent.
-
-Feature page guidance:
-
-- Document project-scoped agents as planned portable source where target semantics are close enough and validation can stay target-specific.
-- Document Claude plugin `agents/` as target-native.
-- Document Codex project agents and skill-local `agents/openai.yaml` separately so project role behavior is not confused with per-skill policy.
-- Mark Codex plugin `agents/` as unsupported/deferred until Codex documents a plugin component.
-- Make `compile.unsupported` fail if a Claude-only plugin-agent source is compiled for Codex without explicit target scoping or visible unsupported provenance.
-
-## Target Boundary Examples
-
-Codex `AGENTS.md` and Codex `.rules` should not share a feature page as if they were equivalent. `AGENTS.md` is project guidance prose discovered from repo directories. `.rules` files are command execution policy under active Codex config-layer `rules/` directories. Lowering instruction Markdown into `.rules` would be lossy and should fail; mirroring explicitly authored Codex `.rules` through a target-native source island is a separate feature.
-
-Claude plugin-root `bin/` and `settings.json` are now documented target-native components. `bin/` can become a feature-key/source-pointer surface for executable helpers. `settings.json` must remain separate from live user/project settings mutation: Skillset may document or copy explicitly authored plugin settings in a future adapter slice, but v1 does not suggest, install, or mutate runtime config.
-
-## Example: Skills Frontmatter
-
-The skills page should drill into subfeatures:
-
-- Identity: `name`, `skillset.name`, directory-derived ids.
-- Description fields: `title`, `summary`, `description`.
-- Version fields: source schema version versus product version.
-- Resources: `resources.references`, `resources.scripts`, `resources.assets`, external `from` pointers if adopted.
-- Invocation policy: `implicit_invocation`.
-- Tool policy: `tool_intent`, `allowed_tools`, and target-native escapes.
-- Target toggles: `claude: false`, `codex: false`, and target-specific blocks.
-
-Each subfeature can have a row in the target-lowering table, plus examples and diagnostics.
-
-## Tooling Path
-
-Phase 1: Manual feature docs
-
-- Create `docs/features/README.md`.
-- Add initial pages for `skills`, `instructions`, `plugins`, `hooks`, `mcp-servers`, `apps`, `agents`, and `executables`.
-- Link existing `docs/target-surfaces.md` rows to feature pages.
-
-Phase 2: Registry-backed support tables
-
-- Introduce a typed feature registry.
-- Generate the support matrix portions of `docs/features/README.md` and each feature's target-lowering table.
-- Keep prose manual around generated tables.
-
-Phase 3: Compiler integration
-
-- Use the registry for diagnostics, `skillset explain`, `skillset doctor`, and `.skillset.lock` provenance.
-- Require each implemented feature to point to tests and docs.
-
-Phase 4: Adapter versioning
-
-- Add explicit Claude and Codex adapter schema versions.
-- Record adapter versions in generated lockfiles.
-- Let adapter support move independently from portable source schema support.
+### Feature Reference
+
+`docs/features/` remains the human-readable explanation layer. Feature pages describe how authors write source, how enabled targets lower it, which diagnostics apply, what provenance exists, and what is intentionally unsupported.
+
+The docs are manual in v1. Future generated tables can come from the typed registry only after the page shape has proven stable. Generated docs are a convenience, not the core contract.
+
+### Capability Status Is Static
+
+Feature capability status is static. It describes what Skillset believes it can support in general. It does not prove that a particular build emitted, skipped, degraded, or rejected a particular source unit.
+
+The registry has three related vocabularies:
+
+| Vocabulary | Scope | Example values |
+| --- | --- | --- |
+| Feature entry status | Whether Skillset owns the feature at all. | `implemented`, `planned`, `reserved`, `deferred`, `future`, `unsupported` |
+| Target support status | Whether a target can represent the feature. | `native`, `pass_through`, `transformed`, `metadata_only`, `degraded`, `externally_managed`, `not_applicable`, `unsupported`, `lossy` |
+| Runtime support status | Whether a runtime/harness/distribution can activate or observe the feature. | same values as target support, including `shimmed` |
+
+Lowering outcome statuses are separate. A target support row that says `native` usually produces an `emitted` outcome when source is built. A target support row that says `pass_through` usually produces a `target_native` outcome. A target support row that says `unsupported` may produce `unsupported`, `intentionally_skipped`, or no outcome when the source unit is not in scope.
+
+### Markdown Is Not The Core IR
+
+Markdown files are input and output formats, not Skillset's core intermediate representation. This is true even when Markdown is the user-authored source format.
+
+This means:
+
+- Source `SKILL.md` is parsed into a Skillset source skill with frontmatter, body, resources, target toggles, preprocessing settings, and normalized target options.
+- Generated `SKILL.md` is a target artifact, not a source truth or IR node.
+- `CLAUDE.md`-style files when imported or carried through target-native source, generated Claude rules, and generated Claude agent Markdown are Claude-native artifacts.
+- Generated `AGENTS.md` files are Codex-native project guidance artifacts.
+- Target-native islands may intentionally copy Markdown, TOML, JSON, YAML, binary files, or unknown sidecars, but opaque target-owned files are still recorded as target-native output, not portable IR.
+
+The core representation is the resolved source graph plus typed feature entries, target support rows, lowering outcomes, diagnostics, locks, and operation results. Those facts can serialize to Markdown, JSON, YAML, TOML, or target-specific directories, but the serialization does not define the semantic contract.
+
+The test: if changing a generated filename would not change the author's source intent, the filename is not the IR. If changing a source feature row would change validation, lowering, or support claims, that row is part of the contract.
+
+### Adapter Evidence
+
+Adapter support claims require evidence without overpromising runtime behavior. Evidence may be:
+
+- `docs`: Skillset docs or ADRs that define the source contract.
+- `source`: compiler modules that parse, validate, lower, or report the feature.
+- `test`: tests that prove the feature behavior or registry guard.
+- `fixture`: fixture cases that exercise target output or adoption behavior.
+- `external-docs`: provider docs with a verification date.
+- `assumption`: an explicit bounded assumption that should be replaced by stronger evidence before the feature graduates.
+
+External provider docs prove that a target surface exists; they do not prove Skillset's lowering is correct. Source and tests prove Skillset behavior; they do not prove provider runtime activation. Runtime support and activation probes must stay separate from compile-target support.
+
+### Boundary With Adapters
+
+The registry describes capabilities across adapters, but it is not a public adapter API. Claude and Codex adapter code can evolve internally, and future targets such as Cursor, Gemini, Devin, Droid, or OpenCode can add registry rows or runtime support records without making adopters learn a new plugin system.
+
+The portable feature layer answers, "What did the author mean?" The target adapter layer answers, "Can this target represent that meaning, and what native files should be emitted?" The runtime support layer answers, "Can a runtime, distribution, or harness activate or observe it?"
+
+### Diagnostics And Conformance
+
+Diagnostics should reference feature ids where useful, but readable error messages remain primary. A user should see what is wrong and how to fix it; a machine-readable feature id is supporting evidence for tooling and conformance.
+
+Conformance checks should consume the registry and lowering outcomes together. A registry row that says `degraded` should produce a visible degraded outcome when that source feature is built for the target. A row that says `unsupported` should produce an unsupported outcome, a clear lowering error, or an intentionally skipped outcome with policy provenance. Silent omission is not a valid conformance result.
+
+## Non-Goals
+
+This ADR does not define a public adapter plugin API, generate all feature docs from schemas, reverse-sync generated output into source, mutate provider runtime config, implement graph mutation, or require Trails adoption. It also does not turn target Markdown files into canonical source truth.
+
+Settings suggestions, grouped sets, model/reasoning aliases, global managed installs, richer runtime activation, generated docs, public adapters, and full schema generation remain separate decisions.
 
 ## Consequences
 
-The feature reference gives authors and agents one place to understand what Skillset supports and why. If the registry later drives generated tables, `lint`, `doctor`, and `explain`, support changes can become less dependent on manually synchronized prose.
+### Positive
 
-The tradeoff is a larger documentation surface and eventual schema maintenance burden. The first slice should stay manual until the page shape proves itself.
+The registry gives future implementation branches a stable place to attach diagnostics, drift checks, feature inspection, lowering outcomes, and conformance fixtures. It also gives docs a way to say "this is target-native" or "this is degraded" without burying that truth in a prose paragraph.
 
-## Open Questions
+Separating capability status from lowering outcomes keeps build reports honest. A feature can be generally supported while a particular source unit is skipped by scope, and a feature can be generally degraded without every build producing degraded output.
 
-- Should the first feature docs be manually authored before introducing any schema generator?
-- Should feature schemas be JSON Schema files, TypeScript registry objects, or both?
-- Should target adapters own their schemas entirely, or should shared feature schemas include target sections?
-- How much of `docs/target-surfaces.md` should remain once feature pages exist?
-- Should `skillset lint` include a "docs coverage" check for implemented features?
-- Should unsupported-target diagnostics link directly to feature docs?
+Treating Markdown as serialization rather than IR protects the source-first model. The compiler can continue to use Markdown where it is ergonomic while still validating source intent through typed records and registry evidence.
+
+### Tradeoffs
+
+The registry creates another contract to maintain. A feature implementation now needs docs, tests, evidence, and registry rows to stay aligned. That is work, but it is cheaper than discovering target drift through runtime surprises.
+
+The first registry is typed TypeScript rather than generated JSON Schema. That keeps the v1 implementation small and close to the compiler, but it means external consumers should treat the root API as pre-release until a public schema story is explicitly accepted.
+
+### Risks
+
+A registry can become stale if checks do not verify references and evidence. SET-77 owns drift checks for docs, tests, fixtures, and support claims.
+
+Registry ids can make diagnostics look machine-first. SET-76 must keep human-readable messages primary and add feature ids as structured context, not as replacements for explanations.
 
 ## References
 
 - [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md) - baseline source-first compiler doctrine.
-- [Tenets](../../tenets.md) - source-first, lower-intent, and drift-visible principles.
-- [Target Surface Evidence Matrix](../../target-surfaces.md) - current compact support matrix that feature pages could extend or generate from.
+- [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md) - provider selection and unsupported-policy boundary.
+- [Feature Reference](../../features/README.md) - reader-facing feature index and vocabulary.
+- [Feature Registry](../../features/feature-registry.md) - feature-facing documentation for the typed registry contract.
+- [Lowering Outcomes and Loss Ledger](20260614-lowering-outcomes-and-loss-ledger.md) - per-build outcome vocabulary that stays separate from registry capability status.
+- [Deterministic Projection and Adapter Conformance](20260613-deterministic-projection-and-adapter-conformance.md) - conformance model that consumes registry support and lowering outcomes together.
+- [Target Surface Evidence Matrix](../../target-surfaces.md) - compact target evidence matrix that feature pages expand.

--- a/docs/adrs/drafts/README.md
+++ b/docs/adrs/drafts/README.md
@@ -13,7 +13,7 @@ Draft map: `docs/adrs/drafts/decision-map.json`; numbered map: `docs/adrs/decisi
 - [Changelog and Version Bump Workflow](20260604-changelog-and-versioning.md)
   - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md)
 - [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md)
-  - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md)
+  - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md)
 - [First-Class Sets](20260604-first-class-sets.md)
   - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md), [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md), [Global / XDG Managed Installs and Sync](20260604-global-xdg-managed-installs-and-sync.md), [Reviewed Settings Suggestions](20260604-reviewed-settings-suggestions.md)
 - [Global / XDG Managed Installs and Sync](20260604-global-xdg-managed-installs-and-sync.md)

--- a/docs/adrs/drafts/decision-map.json
+++ b/docs/adrs/drafts/decision-map.json
@@ -55,7 +55,7 @@
     },
     {
       "created": "2026-06-04",
-      "depends_on": ["0"],
+      "depends_on": ["0", "1"],
       "inbound": [
         {
           "context": "- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - tracks first-class sets as future-only and keeps scopes/selectors separate.",
@@ -93,6 +93,11 @@
           "fromPath": "docs/adrs/drafts/20260614-lowering-outcomes-and-loss-ledger.md"
         },
         {
+          "context": "See [Feature Reference and Schema Registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) for the ADR-level decision.",
+          "from": "feature-registry",
+          "fromPath": "docs/features/feature-registry.md"
+        },
+        {
           "context": "- [Feature registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) - schema-backed support and evidence direction.",
           "from": "runtime-adapters",
           "fromPath": "docs/features/runtime-adapters.md"
@@ -105,7 +110,7 @@
       "status": "draft",
       "superseded_by": null,
       "title": "Feature Reference and Schema Registry",
-      "updated": "2026-06-04"
+      "updated": "2026-06-14"
     },
     {
       "created": "2026-06-04",
@@ -430,6 +435,11 @@
       ],
       "inbound": [
         {
+          "context": "- [Deterministic Projection and Adapter Conformance](20260613-deterministic-projection-and-adapter-conformance.md) - conformance model that consumes registry support and lowering outcomes together.",
+          "from": "20260604",
+          "fromPath": "docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"
+        },
+        {
           "context": "- [Deterministic Projection and Adapter Conformance](20260613-deterministic-projection-and-adapter-conformance.md) - uses lowering outcomes with the feature registry for adapter conformance.",
           "from": "20260614",
           "fromPath": "docs/adrs/drafts/20260614-lowering-outcomes-and-loss-ledger.md"
@@ -464,6 +474,11 @@
         "deterministic-projection-and-adapter-conformance"
       ],
       "inbound": [
+        {
+          "context": "- [Lowering Outcomes and Loss Ledger](20260614-lowering-outcomes-and-loss-ledger.md) - per-build outcome vocabulary that stays separate from registry capability status.",
+          "from": "20260604",
+          "fromPath": "docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"
+        },
         {
           "context": "See [Lowering Outcomes and Loss Ledger](../adrs/drafts/20260614-lowering-outcomes-and-loss-ledger.md) for the ADR-level decision.",
           "from": "lowering-outcomes",

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,6 +17,7 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 - [Distributions](distributions.md): post-build distribution planning, destination reports, and build/distribution/activation boundaries.
 - [Executables](executables.md): Claude plugin `bin/` conventional discovery, `bin.source`, and Codex unsupported diagnostics.
 - [Feature Source Pointers](feature-source-pointers.md): direct feature-key source pointers, conventional discovery, and future component ownership.
+- [Feature Registry](feature-registry.md): typed support matrix for feature ids, target capability claims, docs, evidence, lowering owners, and validation owners.
 - [Hook Guardrails](hook-guardrails.md): Git hook-runner snippets and optional agent-runtime nudges for change/release checks.
 - [Hooks](hooks.md): hook definition emission, canonical source paths, target validation, and activation boundaries.
 - [Instructions](instructions.md): `.skillset/instructions` lowering to Claude rules and Codex `AGENTS.md`, preprocessing, and collision safety.

--- a/docs/features/feature-registry.md
+++ b/docs/features/feature-registry.md
@@ -1,0 +1,91 @@
+# Feature Registry
+
+Feature id: `feature-registry`
+
+Related vocabulary: [Feature Reference Vocabulary](README.md#feature-reference-vocabulary)
+
+The feature registry is Skillset's typed support matrix. It records the features Skillset knows about, what source shape they use, whether each target can represent them, which module owns lowering, which module owns validation, and what evidence supports those claims.
+
+The registry is internal compiler infrastructure, not a public plugin system. It exists so docs, diagnostics, lowering outcomes, drift checks, and future conformance tests can use the same feature ids and support vocabulary.
+
+See [Feature Reference and Schema Registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) for the ADR-level decision.
+
+## Current Boundary
+
+The current seed lives in `packages/core/src/feature-registry.ts`. It is a typed registry because the compiler already runs in TypeScript and the first goal is to keep local support claims reviewable.
+
+Each entry records:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable feature id used by docs, diagnostics, lowering outcomes, reports, and future conformance checks. |
+| `title` | Reader-facing feature name. |
+| `summary` | One-sentence feature description. |
+| `kind` | Broad feature family such as source, metadata, workflow, plugin component, target-native, adoption, or change management. |
+| `status` | Feature entry status: implemented, planned, reserved, deferred, future, or unsupported. |
+| `sourceShape` | Source path, config key, frontmatter key, or generated fact shape that defines the feature. |
+| `targetSupport` | Per-target capability records for Claude and Codex. |
+| `runtimeSupport` | Optional runtime, distribution, or harness support records. |
+| `loweringOwner` | Module or workflow that owns lowering/reporting behavior. |
+| `validationOwner` | Module or workflow that owns validation behavior. |
+| `docs` | Reader-facing docs that explain the feature. |
+| `evidence` | Docs, source, tests, fixtures, external docs, or bounded assumptions supporting the claim. |
+
+The registry row should stay compact. Detailed authoring examples, generated-output snippets, and caveats belong on feature pages.
+
+## Capability Vs Outcome
+
+Registry target support is static capability. Lowering outcomes are build facts.
+
+For example:
+
+- `dependencies` has Claude target support `native` and Codex target support `degraded`.
+- A particular build can emit the Claude dependency surface and generate a degraded Codex awareness notice.
+- If the build scope excludes plugins, the same source may produce `intentionally_skipped` outcomes instead.
+
+This separation keeps docs from overpromising and keeps build reports from pretending skipped or degraded output is native support.
+
+## Markdown Is Serialization
+
+Skillset uses Markdown because skills, rules, agents, and instructions are authored and consumed as Markdown in target ecosystems. Markdown is still not the core IR.
+
+Source `SKILL.md` is parsed into a source skill record. Generated `SKILL.md` is a target artifact. `CLAUDE.md`-style files when imported or carried through target-native source, Claude rules, Claude agent files, and Codex `AGENTS.md` files are target-native projections. Target-native islands can copy opaque files, but those files remain target-owned output.
+
+The core contract is the resolved source graph plus typed feature entries, target support rows, lowering outcomes, diagnostics, locks, and operation results.
+
+## Evidence
+
+Evidence should be strong enough for the claim:
+
+| Evidence kind | Use |
+| --- | --- |
+| `docs` | Skillset docs or ADRs that define the contract. |
+| `source` | Compiler modules that implement parsing, lowering, validation, or reporting. |
+| `test` | Tests proving behavior, schema guards, or drift checks. |
+| `fixture` | Fixture cases proving generated output or adoption behavior. |
+| `external-docs` | Provider docs with verification dates for target surfaces. |
+| `assumption` | Explicit bounded assumption to replace with stronger evidence before graduation. |
+
+External docs prove that a target surface exists. They do not prove Skillset's lowering is correct or that a runtime activation path works. Runtime support and activation probes stay separate from compile-target support.
+
+## Diagnostics
+
+Diagnostics should eventually carry stable feature ids where useful, but user-facing messages must remain readable. A message like `skillset: Codex plugins do not support plugin-local bin/ helpers` is better than a bare `plugin-bin unsupported`; the feature id belongs in structured output, lock/report evidence, or a suffix where it helps agents inspect the issue.
+
+## Provenance
+
+Feature ids can appear in lowering outcomes, `.skillset.lock`, reports, doctor/explain output, and conformance fixtures. They should not be injected into ordinary generated target files by default.
+
+## Future Work
+
+- SET-76 connects diagnostics to feature ids without making messages machine-only.
+- SET-77 adds drift checks for docs, tests, fixtures, and evidence refs.
+- SET-78 exposes capability inspection through authoring CLI surfaces.
+- SET-82 through SET-86 persist outcomes, render them through diagnostics, gate policies, add matrix fixtures, and migrate warnings onto outcome codes.
+
+## Evidence
+
+- [Feature Reference and Schema Registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) defines the decision.
+- `packages/core/src/feature-registry.ts` defines the current typed registry.
+- `packages/core/src/__tests__/feature-registry.test.ts` pins registry ids, vocabulary, evidence expectations, and guard behavior.
+- [Lowering Outcomes](lowering-outcomes.md) explains the separate build-result ledger.

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -21,6 +21,7 @@ const SEEDED_FEATURE_IDS = [
   "changes",
   "dependencies",
   "distributions",
+  "feature-registry",
   "future-companion-source-pointers",
   "lowering-outcomes",
   "output-safety",

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -171,6 +171,23 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     validationOwner: "packages/core/src/config.ts",
   }),
   feature({
+    docs: ["docs/features/feature-registry.md"],
+    evidence: [
+      docs("docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"),
+      source("packages/core/src/feature-registry.ts"),
+      test("packages/core/src/__tests__/feature-registry.test.ts", "registry ids, vocabulary, evidence, and guard coverage"),
+    ],
+    id: "feature-registry",
+    kind: "workflow",
+    loweringOwner: "packages/core/src/feature-registry.ts",
+    sourceShape: "typed feature entries in packages/core/src/feature-registry.ts",
+    status: "implemented",
+    summary: "Records feature ids, target capability claims, docs, evidence, lowering owners, and validation owners.",
+    targetSupport: notTargetRuntime(),
+    title: "Feature Registry",
+    validationOwner: "packages/core/src/feature-registry.ts",
+  }),
+  feature({
     docs: ["docs/features/lowering-outcomes.md"],
     evidence: [
       docs("docs/adrs/drafts/20260614-lowering-outcomes-and-loss-ledger.md"),


### PR DESCRIPTION
## Context

The lowering outcome work needs a stable feature registry so diagnostics and adapter capability claims can point at named source/target surfaces instead of free-form prose.

## Changes

- Documents the feature registry contract, including feature ids, adapter support claims, evidence, and conservative target vocabulary.
- Anchors how diagnostics should reference registry entries in later branches.
- Keeps registry docs aligned with the source-first compiler model.

## Verification

- Local pre-push gate passed during `gt submit`: package build, 474 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check`.
- Registry implementation branches above this PR were reviewed against this contract.

## Risks

- Documentation-only branch. Main risk is future registry growth drifting from the documented vocabulary; follow-up implementation tests now guard the seed.
