### PR TITLE
feat(core): persist lowering outcomes in reports

### DIFF
--- a/.agents/skills/.skillset.lock
+++ b/.agents/skills/.skillset.lock
@@ -50,6 +50,115 @@
       "version": "0.1.2"
     }
   ],
+  "loweringOutcomes": [
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "standalone skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "standalone-skills",
+      "outputs": [
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/SKILL.md"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/assets/adr-management.md"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/__tests__/promote-rewrite.test.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/adr.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/cli.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/decision-map.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/discovery.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/frontmatter.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/git.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/index.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/paths.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-adrs/scripts/lib/references.ts"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-adrs/SKILL.md",
+      "sourceUnit": "skill:skillset-adrs",
+      "status": "emitted",
+      "target": "codex"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "standalone skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "standalone-skills",
+      "outputs": [
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-codex-development/SKILL.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-codex-development/SKILL.md",
+      "sourceUnit": "skill:skillset-codex-development",
+      "status": "emitted",
+      "target": "codex"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "standalone skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "standalone-skills",
+      "outputs": [
+        {
+          "kind": "standalone-skill",
+          "path": ".agents/skills/skillset-repo-test-fixtures/SKILL.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-repo-test-fixtures/SKILL.md",
+      "sourceUnit": "skill:skillset-repo-test-fixtures",
+      "status": "emitted",
+      "target": "codex"
+    }
+  ],
   "outputRoot": ".agents/skills",
   "schemaVersion": 1,
   "selectedTargets": [

--- a/.claude/rules/.skillset.lock
+++ b/.claude/rules/.skillset.lock
@@ -15,6 +15,29 @@
       "version": "0.1.1"
     }
   ],
+  "loweringOutcomes": [
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "SET-5 instruction lowering coverage",
+          "ref": "apps/skillset/src/__tests__/contract.test.ts"
+        }
+      ],
+      "featureId": "project-instructions",
+      "outputs": [
+        {
+          "kind": "rule",
+          "path": ".claude/rules/fixtures.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/instructions/fixtures.md",
+      "sourceUnit": "instruction:fixtures",
+      "status": "transformed",
+      "target": "claude"
+    }
+  ],
   "outputRoot": ".claude/rules",
   "schemaVersion": 1,
   "selectedTargets": [

--- a/.claude/skills/.skillset.lock
+++ b/.claude/skills/.skillset.lock
@@ -50,6 +50,115 @@
       "version": "0.1.2"
     }
   ],
+  "loweringOutcomes": [
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "standalone skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "standalone-skills",
+      "outputs": [
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/SKILL.md"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/assets/adr-management.md"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/__tests__/promote-rewrite.test.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/adr.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/cli.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/decision-map.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/discovery.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/frontmatter.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/git.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/index.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/paths.ts"
+        },
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-adrs/scripts/lib/references.ts"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-adrs/SKILL.md",
+      "sourceUnit": "skill:skillset-adrs",
+      "status": "emitted",
+      "target": "claude"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "standalone skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "standalone-skills",
+      "outputs": [
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-claude-development/SKILL.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-claude-development/SKILL.md",
+      "sourceUnit": "skill:skillset-claude-development",
+      "status": "emitted",
+      "target": "claude"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "standalone skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "standalone-skills",
+      "outputs": [
+        {
+          "kind": "standalone-skill",
+          "path": ".claude/skills/skillset-repo-test-fixtures/SKILL.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-repo-test-fixtures/SKILL.md",
+      "sourceUnit": "skill:skillset-repo-test-fixtures",
+      "status": "emitted",
+      "target": "claude"
+    }
+  ],
   "outputRoot": ".claude/skills",
   "schemaVersion": 1,
   "selectedTargets": [

--- a/.skillset.lock
+++ b/.skillset.lock
@@ -97,6 +97,68 @@
       "version": "0.1.1"
     }
   ],
+  "loweringOutcomes": [
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "SET-38 release apply coverage",
+          "ref": "apps/skillset/src/__tests__/contract.test.ts"
+        }
+      ],
+      "featureId": "releases",
+      "outputs": [
+        {
+          "kind": "changelog",
+          "path": ".skillset/plugins/skillset/CHANGELOG.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/plugins/skillset/skillset.yaml",
+      "sourceUnit": ".skillset/plugins/skillset/skillset.yaml",
+      "status": "metadata_only"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "SET-38 release apply coverage",
+          "ref": "apps/skillset/src/__tests__/contract.test.ts"
+        }
+      ],
+      "featureId": "releases",
+      "outputs": [
+        {
+          "kind": "changelog",
+          "path": ".skillset/skills/skillset-codex-development/CHANGELOG.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-codex-development/SKILL.md",
+      "sourceUnit": ".skillset/skills/skillset-codex-development/SKILL.md",
+      "status": "metadata_only"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "SET-38 release apply coverage",
+          "ref": "apps/skillset/src/__tests__/contract.test.ts"
+        }
+      ],
+      "featureId": "releases",
+      "outputs": [
+        {
+          "kind": "changelog",
+          "path": ".skillset/skills/skillset-repo-test-fixtures/CHANGELOG.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/skills/skillset-repo-test-fixtures/SKILL.md",
+      "sourceUnit": ".skillset/skills/skillset-repo-test-fixtures/SKILL.md",
+      "status": "metadata_only"
+    }
+  ],
   "outputRoot": ".",
   "schemaVersion": 1,
   "selectedTargets": [

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -136,12 +136,29 @@ test("adopt write mode imports everything, builds the mirror, and writes the rep
   expect(markdown).toBe(renderAdoptReportMarkdown(report, { rootPath: root }));
   expect(markdown).toContain("## Summary");
   expect(markdown).toContain("## Cutover");
+  expect(markdown).toContain("### Lowering outcomes");
+  expect(markdown).toContain("codex emitted:");
   expect(markdown).toContain("`AGENTS.md`");
   expect(markdown).toContain("unmanaged");
   const json = JSON.parse(await readFile(join(root, ADOPT_REPORT_DIR, "report.json"), "utf8")) as {
+    loweringOutcomes: readonly {
+      featureId: string;
+      sourceUnit: string;
+      status: string;
+      target?: string;
+    }[];
     ok: boolean;
   };
   expect(json.ok).toBe(true);
+  expect(json.loweringOutcomes).toContainEqual(
+    expect.objectContaining({
+      featureId: "plugin-skills",
+      sourceUnit: "plugin.demo.skill:demo-skill",
+      status: "emitted",
+      target: "codex",
+    })
+  );
+  expect(JSON.stringify(json.loweringOutcomes)).not.toContain(root);
 
   const explain = await runSkillsetCli("explain", ".skillset/plugins/demo", "--root", root);
   expect(explain.exitCode).toBe(0);

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -7,19 +7,15 @@ import {
   recognizeTransforms,
   type TransformMatch,
 } from "@skillset/transforms";
+import type { SkillsetLoweringOutcome } from "@skillset/core";
 
 import type { ReleaseBaselineEntry } from "./adoption";
-import { buildSkillset, ISOLATED_OUT_ROOT } from "./build";
+import { buildSkillsetResult, ISOLATED_OUT_ROOT } from "./build";
 import { gitSafeEnv } from "./git-env";
 import { importSources } from "./import";
 import { inspectSkillset } from "./lint";
 import { loadBuildGraph } from "./resolver";
-import {
-  initSkillset,
-  type SetupFile,
-  type SetupImportCandidate,
-  type SurveySkip,
-} from "./setup";
+import { initSkillset, type SetupFile, type SetupImportCandidate, type SurveySkip } from "./setup";
 import type { JsonRecord, LintIssue, SkillsetOptions, SourceOrigin, TargetName } from "./types";
 import { isJsonRecord, parseMarkdown, stringifyMarkdown } from "./yaml";
 
@@ -100,6 +96,7 @@ export interface AdoptReport {
   readonly cutover: readonly string[];
   readonly imports: readonly AdoptImportResult[];
   readonly lintIssues: readonly LintIssue[];
+  readonly loweringOutcomes: readonly SkillsetLoweringOutcome[];
   readonly ok: boolean;
   readonly rootPath: string;
   readonly setupFiles: readonly SetupFile[];
@@ -170,6 +167,7 @@ async function adoptResolvedRoot(
       cutover: [],
       imports: [],
       lintIssues: [],
+      loweringOutcomes: [],
       ok: true,
       rootPath: init.rootPath,
       setupFiles: init.files,
@@ -199,9 +197,12 @@ async function adoptResolvedRoot(
   }
 
   let builtFiles = 0;
+  let loweringOutcomes: readonly SkillsetLoweringOutcome[] = [];
   if (buildError === undefined) {
     try {
-      builtFiles = (await buildSkillset(init.rootPath, { ...buildOptions, isolated: true })).length;
+      const build = await buildSkillsetResult(init.rootPath, { ...buildOptions, isolated: true });
+      builtFiles = build.data.length;
+      loweringOutcomes = build.loweringOutcomes;
     } catch (error) {
       buildError = errorMessage(error);
     }
@@ -218,6 +219,7 @@ async function adoptResolvedRoot(
     cutover,
     imports,
     lintIssues,
+    loweringOutcomes,
     ok:
       imports.every((result) => result.ok) &&
       lintErrors.length === 0 &&
@@ -498,6 +500,7 @@ export function renderAdoptReportMarkdown(
     report.buildError === undefined
       ? `- build (isolated): ${report.builtFiles} generated files`
       : "- build (isolated): failed",
+    `- lowering outcomes: ${report.loweringOutcomes.length}`,
     ""
   );
 
@@ -618,6 +621,19 @@ export function renderAdoptReportMarkdown(
       `Wrote ${report.builtFiles} generated files into the mirror under \`${ISOLATED_OUT_ROOT}/\`, laid out as the repo root would be. The live tree is untouched.`,
       ""
     );
+    lines.push("### Lowering outcomes", "");
+    if (report.loweringOutcomes.length === 0) {
+      lines.push("No lowering outcomes recorded.", "");
+    } else {
+      for (const summary of summarizeLoweringOutcomes(report.loweringOutcomes)) {
+        lines.push(`- ${summary}`);
+      }
+      lines.push("");
+      lines.push(
+        "Full structured lowering outcomes are in `report.json` and in the isolated `.skillset.lock` files.",
+        ""
+      );
+    }
   } else {
     lines.push("```", report.buildError.trimEnd(), "```", "");
   }
@@ -655,6 +671,19 @@ export function renderAdoptReportMarkdown(
 
 interface AggregatedPreviewMatch extends TransformPreviewMatch {
   readonly count: number;
+}
+
+function summarizeLoweringOutcomes(
+  outcomes: readonly SkillsetLoweringOutcome[]
+): readonly string[] {
+  const counts = new Map<string, number>();
+  for (const outcome of outcomes) {
+    const key = `${outcome.target ?? "workspace"} ${outcome.status}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, count]) => `${key}: ${count}`);
 }
 
 /** Collapse repeated (intent, text, codexForm) hits into one counted line. */

--- a/docs/features/lowering-outcomes.md
+++ b/docs/features/lowering-outcomes.md
@@ -12,7 +12,7 @@ See [Lowering Outcomes and Loss Ledger](../adrs/drafts/20260614-lowering-outcome
 
 ## Current Boundary
 
-The current core schema is `skillset-lowering-outcome@1`. Outcome records are produced by `@skillset/core` and are intended for build results, future lock/report surfaces, `doctor`, `explain`, and adapter conformance tests. They are not written into ordinary generated `SKILL.md`, `CLAUDE.md`, `AGENTS.md`, plugin manifest, hook, MCP, app, or resource files by default.
+The current core schema is `skillset-lowering-outcome@1`. Outcome records are produced by `@skillset/core` and are persisted in structured operation results, generated `.skillset.lock` files, and adopt reports. Future `doctor`, `explain`, and adapter conformance surfaces should read the same ledger instead of inventing parallel diagnostics. Outcomes are not written into ordinary generated `SKILL.md`, `CLAUDE.md`, `AGENTS.md`, plugin manifest, hook, MCP, app, or resource files by default.
 
 | Field | Meaning |
 | --- | --- |
@@ -85,7 +85,7 @@ The default posture is error. `warn`, `skip`, and `force` are reserved escape ha
 
 ## Provenance
 
-Outcome provenance belongs in structured operation results today and future `.skillset.lock`, reports, `doctor`, and `explain` surfaces. Generated target files stay clean by default. Debug sentinels or source markers in target files are a future opt-in, not a default generated-output contract.
+Outcome provenance belongs in structured operation results, generated `.skillset.lock` files, and `.skillset/build/adopt/report.json` today. Adopt Markdown reports render a compact count summary and point readers at the structured JSON and isolated lockfiles. Generated target files stay clean by default. Debug sentinels or source markers in target files are a future opt-in, not a default generated-output contract.
 
 ## Evidence
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -230,7 +230,7 @@ metadata:
   generated: skillset@0.1.0
 ```
 
-Each `.skillset.lock` records emitted versions and hashes, plus root normalized build metadata such as `buildMode`, `selectedTargets`, and whether generated Skillset skill metadata was emitted. Plugin lock entries also include `includedSkills`, `skippedSkills`, and `targetState`; a target with skipped source skills uses `targetState: intentionally-skipped` so target-specific version bumps are visible even when that target's manifest and skills stay byte-for-byte unchanged. `skillset check` reports version drift directly when generated plugin manifest `version` or generated skill `metadata.version` is stale.
+Each `.skillset.lock` records emitted versions and hashes, plus root normalized build metadata such as `buildMode`, `selectedTargets`, and whether generated Skillset skill metadata was emitted. Locks also carry `loweringOutcomes` for the source units represented by that lock, using the `skillset-lowering-outcome@1` schema so emitted, transformed, target-native, degraded, skipped, unsupported, and failed lowering facts survive beyond console output. Plugin lock entries include `includedSkills`, `skippedSkills`, and `targetState`; a target with skipped source skills uses `targetState: intentionally-skipped` so target-specific version bumps are visible even when that target's manifest and skills stay byte-for-byte unchanged. `skillset check` reports version drift directly when generated plugin manifest `version` or generated skill `metadata.version` is stale.
 
 ## Instructions
 

--- a/packages/core/src/__tests__/lowering-outcome-build.test.ts
+++ b/packages/core/src/__tests__/lowering-outcome-build.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -419,17 +419,61 @@ describe("build lowering outcomes", () => {
 
     const build = await buildSkillsetResult(root);
     expect(build.loweringOutcomes.map(outcomeKey)).toEqual(preview.loweringOutcomes.map(outcomeKey));
+
+    const codexLock = await readJson(join(root, "plugins-codex/.skillset.lock"));
+    const codexOutcomes = codexLock.loweringOutcomes as SkillsetLoweringOutcome[];
+    expect(codexOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "plugin-skills",
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "emitted",
+        target: "codex",
+      })
+    );
+    expect(codexOutcomes).toContainEqual(
+      expect.objectContaining({
+        featureId: "dependencies",
+        sourceUnit: "plugin.alpha.feature:dependencies",
+        status: "degraded",
+        target: "codex",
+      })
+    );
+    expect(codexOutcomes).not.toContainEqual(
+      expect.objectContaining({
+        target: "claude",
+      })
+    );
+
+    const codexSkill = await readFile(join(root, "plugins-codex/plugins/alpha/skills/plugin-skill/SKILL.md"), "utf8");
+    expect(codexSkill).not.toContain("loweringOutcomes");
+    expect(JSON.stringify(codexLock)).not.toContain(root);
   });
 
   it("records isolated output paths relative to the isolated projection root", async () => {
     const root = await fixture(OUTCOME_FIXTURE);
-    const preview = await diffSkillsetResult(root, { isolated: true });
+    const preview = await buildSkillsetResult(root, { isolated: true });
     const outputPaths = preview.loweringOutcomes.flatMap((outcome) =>
       (outcome.outputs ?? []).map((output) => output.path)
     );
 
     expect(outputPaths).toContain(".skillset/build/out/.claude/skills/repo-skill/SKILL.md");
     expect(outputPaths.some((path) => path.startsWith(root))).toBe(false);
+
+    const isolatedLock = await readJson(join(root, ".skillset/build/out/plugins-codex/.skillset.lock"));
+    const isolatedOutcomes = isolatedLock.loweringOutcomes as SkillsetLoweringOutcome[];
+    expect(isolatedOutcomes).toContainEqual(
+      expect.objectContaining({
+        outputs: expect.arrayContaining([
+          expect.objectContaining({
+            path: ".skillset/build/out/plugins-codex/plugins/alpha/skills/plugin-skill/SKILL.md",
+          }),
+        ]),
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        status: "emitted",
+        target: "codex",
+      })
+    );
+    expect(JSON.stringify(isolatedLock)).not.toContain(root);
   });
 
   it("exposes resolver-level unsupported decisions on thrown lowering errors", async () => {
@@ -472,6 +516,10 @@ async function fixture(files: Record<string, string>): Promise<string> {
     await Bun.write(join(root, path), `${content.trim()}\n`);
   }
   return root;
+}
+
+async function readJson(path: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
 }
 
 async function expectUnsupportedOutcome(

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -11,6 +11,7 @@ import {
 } from "./output-safety";
 import { renderBuildGraph } from "./render";
 import { loadBuildGraph } from "./resolver";
+import { renderValidatedJson } from "./structured-output";
 import {
   sourceWarningDiagnostic,
   type SkillsetDiagnostic,
@@ -18,7 +19,7 @@ import {
   type SkillsetWriteSummary,
 } from "./operation-result";
 import type { SkillsetLoweringOutcome } from "./lowering-outcome";
-import type { BuildGraph, BuildScope, CheckResult, RenderedFile, SkillsetOptions } from "./types";
+import type { BuildGraph, BuildScope, CheckResult, JsonRecord, JsonValue, RenderedFile, SkillsetOptions } from "./types";
 import { isJsonRecord, parseMarkdown } from "./yaml";
 
 /** Mirror root for isolated builds; the full projection lands under it. */
@@ -48,6 +49,7 @@ function mirroredOutputRoots(outputRoots: readonly string[], outPath: OutPath): 
 }
 
 const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
 
 /**
  * Codex truncates AGENTS.md content beyond `project_doc_max_bytes` (32 KiB by
@@ -98,7 +100,10 @@ export async function buildSkillsetResult(
     mapOutputPath: outPath,
     scopes: options.scopes,
   });
-  const rendered = mirroredRenderedFiles(scopedRendered, outPath);
+  const rendered = withPersistedLoweringOutcomes(
+    mirroredRenderedFiles(scopedRendered, outPath),
+    loweringOutcomes
+  );
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
   const outputRoots = mirroredOutputRoots(liveOutputRoots, outPath);
   const includeWorkspaceLock = includesProjectScope(options.scopes);
@@ -162,7 +167,10 @@ export async function diffSkillsetResult(
     mapOutputPath: outPath,
     scopes: options.scopes,
   });
-  const rendered = mirroredRenderedFiles(scopedRendered, outPath);
+  const rendered = withPersistedLoweringOutcomes(
+    mirroredRenderedFiles(scopedRendered, outPath),
+    loweringOutcomes
+  );
   diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
@@ -240,7 +248,10 @@ export async function checkSkillsetResult(
     mapOutputPath: outPath,
     scopes: options.scopes,
   });
-  const rendered = mirroredRenderedFiles(scopedRendered, outPath);
+  const rendered = withPersistedLoweringOutcomes(
+    mirroredRenderedFiles(scopedRendered, outPath),
+    loweringOutcomes
+  );
   diagnostics.push(...diagnoseLargeInstructionFiles(rendered));
   const expected = new Map(rendered.map((file) => [file.path, file.content]));
   const liveOutputRoots = scopedOutputRoots(graph, options.scopes);
@@ -308,6 +319,84 @@ function buildResult(
     operation: "build",
     writes,
   };
+}
+
+function withPersistedLoweringOutcomes(
+  rendered: readonly RenderedFile[],
+  loweringOutcomes: readonly SkillsetLoweringOutcome[]
+): readonly RenderedFile[] {
+  if (loweringOutcomes.length === 0) return rendered;
+  return rendered.map((file) => {
+    if (!isLockFilePath(file.path)) return file;
+    const lock = parseLockFile(file);
+    const lockOutcomes = loweringOutcomesForLock(file.path, lock, loweringOutcomes);
+    const value: JsonRecord = {
+      ...lock,
+      ...(lockOutcomes.length === 0 ? {} : { loweringOutcomes: lockOutcomes as unknown as JsonValue }),
+    };
+    return {
+      ...file,
+      content: textEncoder.encode(renderValidatedJson(value, file.path)),
+    };
+  });
+}
+
+function parseLockFile(file: RenderedFile): JsonRecord {
+  const parsed = JSON.parse(textDecoder.decode(file.content)) as unknown;
+  if (!isJsonRecord(parsed)) {
+    throw new Error(`skillset: generated lock ${file.path} must be a JSON object`);
+  }
+  return parsed;
+}
+
+function loweringOutcomesForLock(
+  lockPath: string,
+  lock: JsonRecord,
+  loweringOutcomes: readonly SkillsetLoweringOutcome[]
+): readonly SkillsetLoweringOutcome[] {
+  const target = typeof lock.target === "string" ? lock.target : undefined;
+  const outputRoot = outputRootForLockPath(lockPath);
+  const lockOutputs = outputPathsForLock(outputRoot, lock);
+  return loweringOutcomes
+    .filter((outcome) => {
+      if (target !== undefined && (outcome.target ?? "workspace") !== target) return false;
+      const outputPaths = outcome.outputs?.map((output) => output.path) ?? [];
+      if (outputPaths.length === 0) {
+        return outputRoot === "." && outcome.target === undefined;
+      }
+      return outputPaths.some((path) => lockOutputs.has(path));
+    })
+    .sort((left, right) =>
+      compareStrings(
+        `${left.sourceUnit}\0${left.target ?? ""}\0${left.featureId}\0${left.status}\0${left.sourcePath ?? ""}`,
+        `${right.sourceUnit}\0${right.target ?? ""}\0${right.featureId}\0${right.status}\0${right.sourcePath ?? ""}`
+      )
+    );
+}
+
+function outputPathsForLock(outputRoot: string, lock: JsonRecord): ReadonlySet<string> {
+  const items = Array.isArray(lock.items) ? lock.items : [];
+  const paths = new Set<string>();
+  for (const item of items) {
+    if (!isJsonRecord(item)) continue;
+    let files: readonly string[] = [];
+    if (Array.isArray(item.files) && item.files.every((entry) => typeof entry === "string")) {
+      files = item.files;
+    } else if (typeof item.outputPath === "string") {
+      files = [item.outputPath];
+    }
+    for (const file of files) paths.add(join(outputRoot, file).replaceAll("\\", "/"));
+  }
+  return paths;
+}
+
+function outputRootForLockPath(lockPath: string): string {
+  if (lockPath === ".skillset.lock") return ".";
+  return dirname(lockPath).replaceAll("\\", "/");
+}
+
+function isLockFilePath(path: string): boolean {
+  return path === ".skillset.lock" || path.endsWith("/.skillset.lock");
 }
 
 async function diagnoseMissingManagedOutputs(

--- a/plugins-claude/.skillset.lock
+++ b/plugins-claude/.skillset.lock
@@ -33,6 +33,59 @@
       "version": "0.1.1"
     }
   ],
+  "loweringOutcomes": [
+    {
+      "evidence": [
+        {
+          "kind": "docs",
+          "ref": "docs/features/plugins.md"
+        },
+        {
+          "kind": "external-docs",
+          "ref": "https://code.claude.com/docs/en/plugins-reference",
+          "verifiedAt": "2026-06-04"
+        },
+        {
+          "kind": "external-docs",
+          "ref": "https://developers.openai.com/codex/plugins/build",
+          "verifiedAt": "2026-06-04"
+        }
+      ],
+      "featureId": "plugin-manifests",
+      "outputs": [
+        {
+          "kind": "plugin",
+          "path": "plugins-claude/plugins/skillset/.claude-plugin/plugin.json"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/plugins/skillset",
+      "sourceUnit": "plugin.skillset.config:root",
+      "status": "emitted",
+      "target": "claude"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "plugin skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "plugin-skills",
+      "outputs": [
+        {
+          "kind": "plugin-skill",
+          "path": "plugins-claude/plugins/skillset/skills/use-skillset/SKILL.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/plugins/skillset/skills/use-skillset/SKILL.md",
+      "sourceUnit": "plugin.skillset.skill:use-skillset",
+      "status": "emitted",
+      "target": "claude"
+    }
+  ],
   "outputRoot": "plugins-claude",
   "schemaVersion": 1,
   "selectedTargets": [

--- a/plugins-codex/.skillset.lock
+++ b/plugins-codex/.skillset.lock
@@ -33,6 +33,59 @@
       "version": "0.1.1"
     }
   ],
+  "loweringOutcomes": [
+    {
+      "evidence": [
+        {
+          "kind": "docs",
+          "ref": "docs/features/plugins.md"
+        },
+        {
+          "kind": "external-docs",
+          "ref": "https://code.claude.com/docs/en/plugins-reference",
+          "verifiedAt": "2026-06-04"
+        },
+        {
+          "kind": "external-docs",
+          "ref": "https://developers.openai.com/codex/plugins/build",
+          "verifiedAt": "2026-06-04"
+        }
+      ],
+      "featureId": "plugin-manifests",
+      "outputs": [
+        {
+          "kind": "plugin",
+          "path": "plugins-codex/plugins/skillset/.codex-plugin/plugin.json"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/plugins/skillset",
+      "sourceUnit": "plugin.skillset.config:root",
+      "status": "emitted",
+      "target": "codex"
+    },
+    {
+      "evidence": [
+        {
+          "kind": "test",
+          "note": "plugin skill rendering coverage",
+          "ref": "apps/skillset/src/__tests__/skillset.test.ts"
+        }
+      ],
+      "featureId": "plugin-skills",
+      "outputs": [
+        {
+          "kind": "plugin-skill",
+          "path": "plugins-codex/plugins/skillset/skills/use-skillset/SKILL.md"
+        }
+      ],
+      "schema": "skillset-lowering-outcome@1",
+      "sourcePath": ".skillset/plugins/skillset/skills/use-skillset/SKILL.md",
+      "sourceUnit": "plugin.skillset.skill:use-skillset",
+      "status": "emitted",
+      "target": "codex"
+    }
+  ],
   "outputRoot": "plugins-codex",
   "schemaVersion": 1,
   "selectedTargets": [


### PR DESCRIPTION
## Context

Once lowering outcomes are collected, they need to persist into the surfaces users and agents already inspect: build reports and lock/report artifacts. Otherwise adapter fidelity issues remain transient.

## Changes

- Persists structured lowering outcomes in build/report surfaces.
- Carries emitted, pass-through, transformed, unsupported, and scoped outcomes through generated reporting.
- Adds core tests for stable output shapes and representative build cases.

## Verification

- Local pre-push gate passed during `gt submit`: package build, 474 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check`.
- Focused tests cover stable lowering outcome JSON, multiple outputs, scoped outcomes, and build-report persistence.

## Risks

- Report/lock surface changes may affect consumers reading those files directly. The shape is intentionally structured and tested for determinism.
