### PR TITLE
test(core): cover lowering outcome status matrix

### DIFF
--- a/docs/features/lowering-outcomes.md
+++ b/docs/features/lowering-outcomes.md
@@ -75,6 +75,18 @@ The default posture is error. Build, diff, and check enforce `failed`, `lossy`, 
 | Change/release metadata | `metadata_only` | `metadata_only` | Preserved for provenance and generated changelog state, not target runtime enforcement. |
 | Distribution or activation state | `externally_managed` | `externally_managed` | Build may plan or report it, but does not activate or trust runtimes. |
 
+## Fixture Coverage
+
+`packages/core/src/__tests__/lowering-outcome-build.test.ts` covers the v1 status matrix with successful, scoped, isolated, and unsupported-error fixtures. Current observed statuses are `emitted`, `target_native`, `transformed`, `metadata_only`, `degraded`, `intentionally_skipped`, and `unsupported`.
+
+The remaining status values are intentionally documented deferrals rather than fake fixtures:
+
+| Status | Deferral |
+| --- | --- |
+| `externally_managed` | Reserved for distribution, activation, marketplace, or runtime-install facts once those workflows emit lowering outcomes. |
+| `failed` | Validation failures still surface as source/build diagnostics today; SET-84 policy tests prove failed outcomes would block once a producer exists. |
+| `lossy` | No v1 target adapter emits lossy output; current lossy cases stay unsupported or fail before lowering. SET-84 policy tests prove lossy outcomes would block once a producer exists. |
+
 ## Diagnostics
 
 - Unsupported, lossy, and failed lowering fail by default for enabled targets unless a scoped opt-out or future explicit unsupported policy applies.
@@ -95,4 +107,4 @@ Outcome provenance belongs in structured operation results, generated `.skillset
 - [Deterministic Projection and Adapter Conformance](../adrs/drafts/20260613-deterministic-projection-and-adapter-conformance.md) defines how outcomes pair with the feature registry for conformance.
 - `packages/core/src/lowering-outcome.ts` defines the current schema, status values, policy values, and validation rules.
 - `packages/core/src/lowering-outcome-collector.ts` derives outcomes from generated locks, target-native companions, transformations, and unsupported plugin features.
-- `packages/core/src/__tests__/lowering-outcome-build.test.ts` proves emitted, target-native, transformed, unsupported, isolated-path, policy-gated, and scoped outcomes.
+- `packages/core/src/__tests__/lowering-outcome-build.test.ts` proves emitted, target-native, transformed, unsupported, isolated-path, policy-gated, scoped, and status-matrix outcomes.

--- a/packages/core/src/__tests__/lowering-outcome-build.test.ts
+++ b/packages/core/src/__tests__/lowering-outcome-build.test.ts
@@ -7,8 +7,10 @@ import {
   buildSkillsetResult,
   checkSkillsetResult,
   diffSkillsetResult,
+  LOWERING_OUTCOME_STATUS_VALUES,
   SkillsetLoweringError,
   type SkillsetLoweringOutcome,
+  type SkillsetLoweringOutcomeStatus,
 } from "@skillset/core";
 
 const OUTCOME_FIXTURE: Record<string, string> = {
@@ -477,6 +479,40 @@ describe("build lowering outcomes", () => {
     expect(JSON.stringify(isolatedLock)).not.toContain(root);
   });
 
+  it("covers the v1 outcome status matrix or documents deferrals", async () => {
+    const root = await fixture(OUTCOME_FIXTURE);
+    const successful = await diffSkillsetResult(root);
+    const scoped = await diffSkillsetResult(root, { scopes: ["repo"] });
+    const unsupportedRoot = await fixture({
+      ...OUTCOME_FIXTURE,
+      ".skillset/plugins/alpha/bin/tool": `
+#!/usr/bin/env bash
+echo alpha
+`,
+    });
+    const unsupported = await loweringErrorOutcomes(unsupportedRoot);
+    const producedStatuses = statusesInVocabularyOrder([
+      ...successful.loweringOutcomes,
+      ...scoped.loweringOutcomes,
+      ...unsupported,
+    ]);
+
+    expect(producedStatuses).toEqual([
+      "degraded",
+      "emitted",
+      "intentionally_skipped",
+      "metadata_only",
+      "target_native",
+      "transformed",
+      "unsupported",
+    ]);
+
+    const documentedDeferrals = ["externally_managed", "failed", "lossy"] satisfies readonly SkillsetLoweringOutcomeStatus[];
+    expect(statusesInVocabularyOrder([...producedStatuses, ...documentedDeferrals])).toEqual([
+      ...LOWERING_OUTCOME_STATUS_VALUES,
+    ]);
+  });
+
   it("enforces unsupported outcome policy with actionable lowering errors", async () => {
     const agentRoot = await fixture({
       ...OUTCOME_FIXTURE,
@@ -509,6 +545,23 @@ echo alpha
 
 function outcomeKey(outcome: SkillsetLoweringOutcome): string {
   return `${outcome.sourceUnit}\0${outcome.target ?? ""}\0${outcome.featureId}\0${outcome.status}`;
+}
+
+function statusesInVocabularyOrder(
+  values: readonly (SkillsetLoweringOutcome | SkillsetLoweringOutcomeStatus)[]
+): readonly SkillsetLoweringOutcomeStatus[] {
+  const statuses = new Set(values.map((value) => typeof value === "string" ? value : value.status));
+  return LOWERING_OUTCOME_STATUS_VALUES.filter((status) => statuses.has(status));
+}
+
+async function loweringErrorOutcomes(root: string): Promise<readonly SkillsetLoweringOutcome[]> {
+  try {
+    await diffSkillsetResult(root);
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillsetLoweringError);
+    return (error as SkillsetLoweringError).loweringOutcomes;
+  }
+  throw new Error("expected diffSkillsetResult to reject");
 }
 
 async function fixture(files: Record<string, string>): Promise<string> {

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -194,7 +194,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       source("packages/core/src/lowering-outcome.ts"),
       source("packages/core/src/lowering-outcome-collector.ts"),
       test("packages/core/src/__tests__/lowering-outcome.test.ts", "lowering outcome schema validation coverage"),
-      test("packages/core/src/__tests__/lowering-outcome-build.test.ts", "build lowering outcomes cover emitted, target-native, transformed, unsupported, policy-gated, and scoped outcomes"),
+      test("packages/core/src/__tests__/lowering-outcome-build.test.ts", "build lowering outcomes cover emitted, target-native, transformed, unsupported, policy-gated, scoped, and status-matrix outcomes"),
     ],
     id: "lowering-outcomes",
     kind: "workflow",


### PR DESCRIPTION
## Context

The lowering outcome vocabulary needs regression coverage across the expected v1 status matrix so future adapter work does not silently collapse statuses back into generic warnings.

## Changes

- Adds fixture/core coverage for the v1 lowering outcome status matrix.
- Pins emitted, transformed, pass-through, degraded, unsupported, lossy, skipped, failed, and scoped behavior where implemented or explicitly deferred.
- Strengthens tests around deterministic reporting.

## Verification

- Local pre-push gate passed during `gt submit`: package build, 474 tests, Ultracite doctor, `skillset:lint`, `skillset:check`, and `git diff --check`.
- Focused test: `SET-85: add fixture coverage for outcome status matrix`.

## Risks

- Test-only branch. Main effect is making later adapter changes more honest about status vocabulary.
