### PR TITLE
feat(core): tag diagnostics with feature ids

### DIFF
--- a/apps/skillset/src/__tests__/audit-hardening.test.ts
+++ b/apps/skillset/src/__tests__/audit-hardening.test.ts
@@ -5,8 +5,9 @@ import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 
 import { buildSkillset, checkSkillset } from "../build";
-import { lintSkillset } from "../lint";
+import { inspectSkillset, lintSkillset } from "../lint";
 import { compareStrings } from "../path";
+import { loadBuildGraph } from "../resolver";
 
 const FIXTURE_SKILLSET = join(import.meta.dir, "..", "..", "..", "..", "fixtures", "kitchen-sink", ".skillset");
 
@@ -211,6 +212,11 @@ Alpha body.
   });
 
   await expect(buildSkillset(root)).rejects.toThrow("Notification");
+  const lintReport = await inspectSkillset(await loadBuildGraph(root));
+  expect(lintReport.issues).toContainEqual(expect.objectContaining({
+    code: "hook-target-incompatible",
+    featureId: "plugin-hooks",
+  }));
   await expect(lintSkillset(root)).rejects.toThrow("Codex does not support");
 });
 

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -9,7 +9,7 @@ import { buildSkillset, buildSkillsetResult, checkSkillset, checkSkillsetResult,
 import { changeStatus, collectSourceInventory } from "../change-status";
 import { doctorSkillset, explainPath } from "../authoring";
 import { importSource, importSources } from "../import";
-import { lintSkillset } from "../lint";
+import { inspectSkillset, lintSkillset } from "../lint";
 import { readReleaseState } from "../release-state";
 import { loadBuildGraph } from "../resolver";
 import { createSkillset, initSkillset } from "../setup";
@@ -343,7 +343,12 @@ Body.
 `,
   });
 
-  await expect(loadBuildGraph(root)).rejects.toThrow("does not match skillset.name");
+  await expectFeatureDiagnosticError(loadBuildGraph(root), {
+    code: "plugin-manifest-invalid",
+    featureId: "plugin-manifests",
+    message: expect.stringContaining("does not match skillset.name"),
+    path: ".skillset/plugins/real-dir/skillset.yaml",
+  });
 });
 
 // SET-5: canonical source instructions live in .skillset/instructions/. Claude
@@ -640,12 +645,72 @@ Body.
 `,
     });
 
-    await expect(loadBuildGraph(root)).rejects.toThrow("uses unsupported root hooks.json");
+    await expectFeatureDiagnosticError(loadBuildGraph(root), {
+      code: "plugin-root-hooks-unsupported",
+      featureId: "plugin-hooks",
+      message: expect.stringContaining("uses unsupported root hooks.json"),
+      path: ".skillset/plugins/alpha/hooks.json",
+    });
   }
+});
+
+test("plugin manifest validation errors carry feature diagnostic metadata", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: manifest-errors
+claude: true
+codex: false
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+commands: {}
+`,
+    ".skillset/plugins/alpha/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Body.
+`,
+  });
+
+  await expectFeatureDiagnosticError(loadBuildGraph(root), {
+    code: "plugin-manifest-invalid",
+    featureId: "plugin-manifests",
+    message: expect.stringContaining("unsupported top-level key commands"),
+    path: ".skillset/plugins/alpha/skillset.yaml",
+  });
+
+  const doctorJson = await runSkillsetCli("doctor", "--root", root, "--json");
+  expect(doctorJson.exitCode).toBe(1);
+  const doctorReport = JSON.parse(doctorJson.stdout) as {
+    buildDiagnostics: readonly { code: string; featureId: string; path?: string }[];
+  };
+  expect(doctorReport.buildDiagnostics).toContainEqual(expect.objectContaining({
+    code: "plugin-manifest-invalid",
+    featureId: "plugin-manifests",
+    path: ".skillset/plugins/alpha/skillset.yaml",
+  }));
 });
 
 async function fileExists(path: string): Promise<boolean> {
   return Bun.file(path).exists();
+}
+
+async function expectFeatureDiagnosticError(
+  promise: Promise<unknown>,
+  expected: Record<string, unknown>
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toEqual(expect.objectContaining(expected));
+    return;
+  }
+  throw new Error("expected feature diagnostic error");
 }
 
 // SET-14: golden manifest tests pin the target-surface shapes the evidence
@@ -2365,7 +2430,12 @@ Audit body.
 `,
   });
 
-  await expect(loadBuildGraph(root)).rejects.toThrow("must not depend on itself");
+  await expectFeatureDiagnosticError(loadBuildGraph(root), {
+    code: "plugin-dependencies-invalid",
+    featureId: "dependencies",
+    message: expect.stringContaining("must not depend on itself"),
+    path: ".skillset/plugins",
+  });
 });
 
 test("SET-40: plugin dependencies reject unsupported dependency groups", async () => {
@@ -4418,7 +4488,12 @@ description: Demo.
 Body.
 `,
   });
-  await expect(buildSkillset(missingRoot)).rejects.toThrow("points to missing path repo:missing/mcp.json");
+  await expectFeatureDiagnosticError(buildSkillset(missingRoot), {
+    code: "plugin-mcp-invalid",
+    featureId: "plugin-mcp",
+    message: expect.stringContaining("points to missing path repo:missing/mcp.json"),
+    path: ".skillset/plugins/alpha/skillset.yaml",
+  });
 });
 
 test("SET-26: plugin feature source type mismatches fail loudly", async () => {
@@ -4445,7 +4520,12 @@ description: Demo.
 Body.
 `,
   });
-  await expect(buildSkillset(mcpDirectoryRoot)).rejects.toThrow("feature mcp source must be a file");
+  await expectFeatureDiagnosticError(buildSkillset(mcpDirectoryRoot), {
+    code: "plugin-mcp-invalid",
+    featureId: "plugin-mcp",
+    message: expect.stringContaining("feature mcp source must be a file"),
+    path: ".skillset/plugins/alpha/skillset.yaml",
+  });
 
   const binFileRoot = await contractFixture({
     ".skillset/config.yaml": `
@@ -4470,7 +4550,12 @@ description: Demo.
 Body.
 `,
   });
-  await expect(buildSkillset(binFileRoot)).rejects.toThrow("feature bin source must be a directory");
+  await expectFeatureDiagnosticError(buildSkillset(binFileRoot), {
+    code: "plugin-bin-invalid",
+    featureId: "plugin-bin",
+    message: expect.stringContaining("feature bin source must be a directory"),
+    path: ".skillset/plugins/alpha/skillset.yaml",
+  });
 });
 
 test("SET-26: mcp feature sources are validated as JSON", async () => {
@@ -5418,6 +5503,11 @@ See the [guide](shared:references/guide.md).
 `,
   });
 
+  const lintReport = await inspectSkillset(await loadBuildGraph(root));
+  expect(lintReport.issues).toContainEqual(expect.objectContaining({
+    code: "resource-undeclared-link",
+    featureId: "resources",
+  }));
   await expect(lintSkillset(root)).rejects.toThrow("links to undeclared resource shared:references/guide.md");
   await expect(lintSkillset(root)).rejects.toThrow("resources: { references: [shared:references/guide.md] }");
 });

--- a/apps/skillset/src/__tests__/lint-rules.test.ts
+++ b/apps/skillset/src/__tests__/lint-rules.test.ts
@@ -3,12 +3,14 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { getSkillsetFeature } from "@skillset/core";
 import { lintRules, registerLintRule } from "@skillset/lint";
 
 import { buildSkillset } from "../build";
 import { ciSkillset, renderCiReportMarkdown } from "../ci";
 import { gitSafeEnv } from "../git-env";
-import { lintSkillset } from "../lint";
+import { inspectSkillset, lintSkillset } from "../lint";
+import { loadBuildGraph } from "../resolver";
 
 const WARN_RULE_NAME = "test-warn-marker";
 
@@ -65,6 +67,36 @@ test("lintSkillset throws on a shell-safety pre-resolution violation", async () 
   );
 });
 
+test("lint diagnostics carry feature ids for standalone and plugin skills", async () => {
+  const root = await fixture({
+    "custom-source/config.yaml":
+      "skillset:\n  name: lint-root\nclaude: true\ncodex: false\n",
+    "custom-source/plugins/demo/skillset.yaml": "skillset:\n  name: demo\n",
+    "custom-source/plugins/demo/skills/plugin-skill/SKILL.md":
+      "---\nname: other-plugin\ndescription: Demo.\n---\n\nBody.\n",
+    "custom-source/skills/solo/SKILL.md":
+      "---\nname: other-solo\ndescription: Demo.\n---\n\nBody.\n",
+  });
+
+  const result = await inspectSkillset(await loadBuildGraph(root, { sourceDir: "custom-source" }));
+
+  expect(result.issues).toContainEqual(expect.objectContaining({
+    code: "skill-name-directory-mismatch",
+    featureId: "plugin-skills",
+    path: "custom-source/plugins/demo/skills/plugin-skill/SKILL.md",
+  }));
+  expect(result.issues).toContainEqual(expect.objectContaining({
+    code: "skill-name-directory-mismatch",
+    featureId: "standalone-skills",
+    path: "custom-source/skills/solo/SKILL.md",
+  }));
+  for (const issue of result.issues) {
+    if (issue.featureId !== undefined) {
+      expect(getSkillsetFeature(issue.featureId)?.id).toBe(issue.featureId);
+    }
+  }
+});
+
 test("ci reports env-var fallback warnings without failing", async () => {
   const root = await fixture({
     ".skillset/config.yaml":
@@ -81,7 +113,9 @@ test("ci reports env-var fallback warnings without failing", async () => {
   expect(
     report.lintIssues.some(
       (issue) =>
-        issue.code === "skill-env-var-no-fallback" && issue.severity === "warn"
+        issue.code === "skill-env-var-no-fallback" &&
+        issue.featureId === "standalone-skills" &&
+        issue.severity === "warn"
     )
   ).toBe(true);
   const markdown = renderCiReportMarkdown(report);
@@ -103,6 +137,7 @@ test("lintSkillset returns warn-only issues without throwing", async () => {
   expect(result.issues).toEqual([
     {
       code: WARN_RULE_NAME,
+      featureId: "standalone-skills",
       message: "body contains WARN-MARKER",
       path: ".skillset/skills/demo/SKILL.md",
       severity: "warn",
@@ -126,6 +161,7 @@ test("ci reports lint warnings without failing", async () => {
   expect(report.lintIssues).toEqual([
     {
       code: WARN_RULE_NAME,
+      featureId: "standalone-skills",
       message: "body contains WARN-MARKER",
       path: ".skillset/skills/demo/SKILL.md",
       severity: "warn",

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from "bun:test";
 import { explainPath, listGeneratedEntries } from "../authoring";
 import { buildSkillset, buildSkillsetResult, checkSkillset, diffSkillset } from "../build";
 import { importSource } from "../import";
-import { lintSkillset } from "../lint";
+import { inspectSkillset, lintSkillset } from "../lint";
 import { loadBuildGraph } from "../resolver";
 import { renderValidatedToml } from "../structured-output";
 
@@ -1770,9 +1770,12 @@ deny all
 `,
   });
 
-  await expect(buildSkillset(pluginRulesRoot)).rejects.toThrow(
-    "Codex plugin .rules"
-  );
+  await expectFeatureDiagnosticError(buildSkillset(pluginRulesRoot), {
+    code: "target-native-island-unsupported",
+    featureId: "target-native-islands",
+    message: expect.stringContaining("Codex plugin .rules"),
+    path: ".skillset/src/plugins/alpha/codex/rules/plugin.rules",
+  });
 });
 
 test("Codex project rules islands are only accepted under rules/", async () => {
@@ -1792,7 +1795,12 @@ skillset:
 `,
   });
 
-  await expect(buildSkillset(root)).rejects.toThrow("Codex .rules outside .skillset/src/codex/rules/");
+  await expectFeatureDiagnosticError(buildSkillset(root), {
+    code: "target-native-island-unsupported",
+    featureId: "target-native-islands",
+    message: expect.stringContaining("Codex .rules outside .skillset/src/codex/rules/"),
+    path: ".skillset/src/codex/agents/bad.rules",
+  });
 });
 
 test("target-native island locks include partial provenance and explain/list visibility", async () => {
@@ -2718,6 +2726,11 @@ Tools body.
 `,
   });
 
+  const lintReport = await inspectSkillset(await loadBuildGraph(root));
+  expect(lintReport.issues).toContainEqual(expect.objectContaining({
+    code: "codex-allowed-tools-unsupported",
+    featureId: "tool-intent",
+  }));
   await expect(lintSkillset(root)).rejects.toThrow("codex-allowed-tools-unsupported");
   await expect(buildSkillset(root)).rejects.toThrow("allowed_tools has no Codex skill-local lowering");
 });
@@ -3803,6 +3816,19 @@ async function fixture(files: Record<string, string>): Promise<string> {
 
 async function exists(path: string): Promise<boolean> {
   return Bun.file(path).exists();
+}
+
+async function expectFeatureDiagnosticError(
+  promise: Promise<unknown>,
+  expected: Record<string, unknown>
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toEqual(expect.objectContaining(expected));
+    return;
+  }
+  throw new Error("expected feature diagnostic error");
 }
 
 function normalizeFixture(content: string): string {

--- a/apps/skillset/src/authoring.ts
+++ b/apps/skillset/src/authoring.ts
@@ -1,6 +1,11 @@
 import { resolve, relative } from "node:path";
 
-import { SkillsetLoweringError, type SkillsetLoweringOutcome } from "@skillset/core";
+import {
+  SkillsetFeatureDiagnosticError,
+  SkillsetLoweringError,
+  type SkillsetDiagnostic,
+  type SkillsetLoweringOutcome,
+} from "@skillset/core";
 import { collectLoweringOutcomes } from "@skillset/core/internal/lowering-outcome-collector";
 
 import { diffSkillsetResult, scopedRenderedFiles, type SkillsetDiff } from "./build";
@@ -123,6 +128,7 @@ export async function listGeneratedEntries(
 }
 
 export interface DoctorReport {
+  readonly buildDiagnostics: readonly SkillsetDiagnostic[];
   readonly buildError?: string;
   readonly drift: SkillsetDiff;
   readonly lintIssues: readonly LintIssue[];
@@ -149,9 +155,11 @@ export async function doctorSkillset(
   try {
     graph = await loadBuildGraph(rootPath, options);
   } catch (error) {
+    const buildDiagnostics = diagnosticsFromError(error);
     const loweringOutcomes = loweringOutcomesFromError(error);
     return {
       buildError: errorMessage(error),
+      buildDiagnostics,
       drift: { added: [], changed: [], missing: [], removed: [] },
       lintIssues: [],
       loweringOutcomes,
@@ -163,6 +171,7 @@ export async function doctorSkillset(
   const lint = await inspectSkillset(graph);
 
   let drift: SkillsetDiff = { added: [], changed: [], missing: [], removed: [] };
+  let buildDiagnostics: readonly SkillsetDiagnostic[] = [];
   let buildError: string | undefined;
   let loweringOutcomes: readonly SkillsetLoweringOutcome[] = [];
   try {
@@ -170,6 +179,7 @@ export async function doctorSkillset(
     drift = diff.data;
     loweringOutcomes = diff.loweringOutcomes;
   } catch (error) {
+    buildDiagnostics = diagnosticsFromError(error);
     buildError = errorMessage(error);
     loweringOutcomes = loweringOutcomesFromError(error);
   }
@@ -180,6 +190,7 @@ export async function doctorSkillset(
 
   return {
     ...(buildError === undefined ? {} : { buildError }),
+    buildDiagnostics,
     drift,
     lintIssues: lint.issues,
     loweringOutcomes,
@@ -258,6 +269,19 @@ function notableLoweringOutcomes(
 
 function loweringOutcomesFromError(error: unknown): readonly SkillsetLoweringOutcome[] {
   return error instanceof SkillsetLoweringError ? error.loweringOutcomes : [];
+}
+
+function diagnosticsFromError(error: unknown): readonly SkillsetDiagnostic[] {
+  if (!(error instanceof SkillsetFeatureDiagnosticError)) return [];
+  return [
+    {
+      code: error.code,
+      featureId: error.featureId,
+      message: error.message,
+      ...(error.path === undefined ? {} : { path: error.path }),
+      severity: "error",
+    },
+  ];
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/skillset/src/lint.ts
+++ b/apps/skillset/src/lint.ts
@@ -27,6 +27,8 @@ import type {
   TargetName,
 } from "./types";
 
+type SkillFeatureId = "plugin-skills" | "standalone-skills";
+
 interface DynamicPattern {
   readonly code: string;
   readonly label: string;
@@ -99,30 +101,42 @@ async function inspectBuildGraph(graph: BuildGraph): Promise<LintResult> {
  * (plugin-bound and standalone) and map their diagnostics into LintIssues.
  */
 async function lintSkillRules(graph: BuildGraph): Promise<readonly LintIssue[]> {
-  const skills = [
-    ...graph.plugins.flatMap((plugin) => plugin.skills),
-    ...graph.standaloneSkills,
-  ];
-
-  const subjects: LintSubject[] = [];
-  for (const skill of skills) {
+  const subjects: Array<{ readonly featureId: SkillFeatureId; readonly subject: LintSubject }> = [];
+  for (const skill of graph.plugins.flatMap((plugin) => plugin.skills)) {
     subjects.push({
-      body: skill.body,
-      directoryName: basename(dirname(skill.sourcePath)),
-      files: [basename(skill.sourcePath)],
-      frontmatter: skill.frontmatter,
-      kind: "skill",
-      path: relative(graph.rootPath, skill.sourcePath),
-      raw: await readFile(skill.sourcePath, "utf8"),
+      featureId: "plugin-skills",
+      subject: await lintSubjectForSkill(graph, skill),
+    });
+  }
+  for (const skill of graph.standaloneSkills) {
+    subjects.push({
+      featureId: "standalone-skills",
+      subject: await lintSubjectForSkill(graph, skill),
     });
   }
 
-  return runLintRules(subjects).map(lintIssueFromDiagnostic);
+  return subjects.flatMap(({ featureId, subject }) =>
+    runLintRules([subject]).map((diagnostic) => lintIssueFromDiagnostic(diagnostic, featureId))
+  );
 }
 
-function lintIssueFromDiagnostic(diagnostic: LintDiagnostic): LintIssue {
+async function lintSubjectForSkill(graph: BuildGraph, skill: SourceSkill): Promise<LintSubject> {
+  return {
+    body: skill.body,
+    directoryName: basename(dirname(skill.sourcePath)),
+    files: [basename(skill.sourcePath)],
+    frontmatter: skill.frontmatter,
+    kind: "skill",
+    path: relative(graph.rootPath, skill.sourcePath),
+    raw: await readFile(skill.sourcePath, "utf8"),
+  };
+}
+
+function lintIssueFromDiagnostic(diagnostic: LintDiagnostic, sourceFeatureId?: SkillFeatureId): LintIssue {
+  const featureId = diagnostic.featureId ?? sourceFeatureId;
   return {
     code: diagnostic.code === undefined ? diagnostic.rule : `${diagnostic.rule}:${diagnostic.code}`,
+    ...(featureId === undefined ? {} : { featureId }),
     message: diagnostic.message,
     path: diagnostic.path,
     severity: diagnostic.severity,
@@ -174,6 +188,7 @@ async function lintHookFile(
     return [
       {
         code: "hook-invalid-json",
+        featureId: "plugin-hooks",
         severity: "error",
         path,
         message: `${targetLabel} hook file ${path} is not valid JSON: ${message}`,
@@ -185,7 +200,7 @@ async function lintHookFile(
     validateHookDefinition(parsed, { sourcePath: path, target });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return [{ code: "hook-target-incompatible", message, path, severity: "error" }];
+    return [{ code: "hook-target-incompatible", featureId: "plugin-hooks", message, path, severity: "error" }];
   }
 
   return [];
@@ -210,6 +225,7 @@ async function lintResourceUsage(graph: BuildGraph): Promise<readonly LintIssue[
     for (const undeclared of findUndeclaredResourceLinks(skill.body, skill.resources)) {
       issues.push({
         code: "resource-undeclared-link",
+        featureId: "resources",
         severity: "error",
         path,
         message:
@@ -221,6 +237,7 @@ async function lintResourceUsage(graph: BuildGraph): Promise<readonly LintIssue[
     for (const offender of findPluginRootScriptLinks(skill.body)) {
       issues.push({
         code: "skill-plugin-root-script",
+        featureId: "resources",
         severity: "error",
         path,
         message:
@@ -234,6 +251,7 @@ async function lintResourceUsage(graph: BuildGraph): Promise<readonly LintIssue[
       if (await sourceIsExecutable(resource.sourcePath)) continue;
       issues.push({
         code: "resource-script-not-executable",
+        featureId: "resources",
         severity: "error",
         path,
         message:
@@ -275,19 +293,23 @@ export function lintBuildGraph(graph: BuildGraph): LintResult {
   for (const plugin of graph.plugins) {
     for (const skill of plugin.skills) {
       checkedSkills += 1;
-      issues.push(...lintSkill(graph, skill));
+      issues.push(...lintSkill(graph, skill, "plugin-skills"));
     }
   }
 
   for (const skill of graph.standaloneSkills) {
     checkedSkills += 1;
-    issues.push(...lintSkill(graph, skill));
+    issues.push(...lintSkill(graph, skill, "standalone-skills"));
   }
 
   return { checkedSkills, issues };
 }
 
-function lintSkill(graph: BuildGraph, skill: SourceSkill): readonly LintIssue[] {
+function lintSkill(
+  graph: BuildGraph,
+  skill: SourceSkill,
+  featureId: SkillFeatureId
+): readonly LintIssue[] {
   const issues: LintIssue[] = [];
   issues.push(...lintToolEscapes(graph, skill));
 
@@ -303,6 +325,7 @@ function lintSkill(graph: BuildGraph, skill: SourceSkill): readonly LintIssue[] 
   const labels = matches.map((match) => match.label).join(", ");
   issues.push({
     code: "codex-claude-dynamic-context",
+    featureId,
     severity: "error",
     path,
     message:
@@ -343,6 +366,7 @@ function lintToolEscapes(graph: BuildGraph, skill: SourceSkill): readonly LintIs
     return [
       {
         code: "skill-tools-invalid",
+        featureId: "tool-intent",
         severity: "error",
         path,
         message,
@@ -361,7 +385,8 @@ function lintCodexAllowedTools(graph: BuildGraph, skill: SourceSkill): readonly 
   return [
     {
       code: "codex-allowed-tools-unsupported",
-        severity: "error",
+      featureId: "tool-intent",
+      severity: "error",
       path,
       message:
         `${path} sets allowed_tools for Codex, but Codex skills do not currently have a skill-local allowed-tools equivalent. ` +

--- a/docs/features/feature-registry.md
+++ b/docs/features/feature-registry.md
@@ -70,7 +70,9 @@ External docs prove that a target surface exists. They do not prove Skillset's l
 
 ## Diagnostics
 
-Diagnostics should eventually carry stable feature ids where useful, but user-facing messages must remain readable. A message like `skillset: Codex plugins do not support plugin-local bin/ helpers` is better than a bare `plugin-bin unsupported`; the feature id belongs in structured output, lock/report evidence, or a suffix where it helps agents inspect the issue.
+Diagnostics carry stable feature ids where useful, but user-facing messages remain readable. A message like `skillset: Codex plugins do not support plugin-local bin/ helpers` is better than a bare `plugin-bin unsupported`; the feature id belongs in structured output, lock/report evidence, or a suffix where it helps agents inspect the issue.
+
+The current diagnostic ownership slice covers core build/write diagnostics, selected resolver errors for plugin manifests, root hook placement, and target-native island support, plus lint diagnostics for skill source, plugin hooks, resource declarations, and tool intent. Broader source invalidity that still throws before an operation result exists may remain message-only until the surrounding operation is converted to structured diagnostics.
 
 ## Provenance
 
@@ -78,7 +80,6 @@ Feature ids can appear in lowering outcomes, `.skillset.lock`, reports, doctor/e
 
 ## Future Work
 
-- SET-76 connects diagnostics to feature ids without making messages machine-only.
 - SET-77 adds drift checks for docs, tests, fixtures, and evidence refs.
 - SET-78 exposes capability inspection through authoring CLI surfaces.
 - SET-82 through SET-86 persist outcomes, render them through diagnostics, gate policies, add matrix fixtures, and migrate warnings onto outcome codes.

--- a/packages/core/src/__tests__/build-result.test.ts
+++ b/packages/core/src/__tests__/build-result.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { buildSkillsetResult, diffSkillsetResult, restoreOutputBackup } from "@skillset/core";
+import { buildSkillsetResult, diffSkillsetResult, getSkillsetFeature, restoreOutputBackup } from "@skillset/core";
 
 const DEMO_FIXTURE: Record<string, string> = {
   ".skillset/config.yaml": `
@@ -83,9 +83,11 @@ codex: true
     expect(backupRunId).toBeString();
     expect(result.diagnostics).toContainEqual(expect.objectContaining({
       code: "unmanaged-output-collision",
+      featureId: "output-safety",
       outputPath: "AGENTS.md",
       severity: "warning",
     }));
+    expectKnownDiagnosticFeatureIds(result.diagnostics);
     expect(result.writes.backupManifestPath).toBe(`.skillset/build/backups/${backupRunId}/manifest.json`);
     expect(result.writes.backupRecords).toContainEqual(expect.objectContaining({
       action: "overwrite",
@@ -123,10 +125,12 @@ codex: true
 
     expect(preview.diagnostics).toContainEqual(expect.objectContaining({
       code: "unmanaged-output-collision",
+      featureId: "output-safety",
       message: expect.stringContaining("will be backed up"),
       outputPath: "AGENTS.md",
       severity: "warning",
     }));
+    expectKnownDiagnosticFeatureIds(preview.diagnostics);
     expect(await Bun.file(join(root, ".skillset/build/backups")).exists()).toBe(false);
     expect(await readFile(join(root, "AGENTS.md"), "utf8")).toContain("# Hand Authored Instructions");
   });
@@ -144,6 +148,7 @@ codex: true
     expect(backupRunId).toBeString();
     expect(result.diagnostics).toContainEqual(expect.objectContaining({
       code: "managed-output-edited",
+      featureId: "output-safety",
       outputPath,
       severity: "warning",
     }));
@@ -233,4 +238,14 @@ async function fixture(files: Record<string, string>): Promise<string> {
     await Bun.write(join(root, path), `${content.trim()}\n`);
   }
   return root;
+}
+
+function expectKnownDiagnosticFeatureIds(
+  diagnostics: readonly { readonly featureId?: string }[]
+): void {
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.featureId !== undefined) {
+      expect(getSkillsetFeature(diagnostic.featureId)?.id).toBe(diagnostic.featureId);
+    }
+  }
 }

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 import {
   FEATURE_STATUS_VALUES,
@@ -54,6 +56,17 @@ const SEEDED_FEATURE_IDS = [
   "workflows",
 ];
 
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const REPRESENTATIVE_DIAGNOSTIC_FEATURE_IDS = [
+  "output-safety",
+  "plugin-hooks",
+  "plugin-skills",
+  "project-instructions",
+  "resources",
+  "standalone-skills",
+  "tool-intent",
+] as const;
+
 describe("feature registry", () => {
   it("ships the current feature seed in deterministic order with docs and evidence", () => {
     const features = listSkillsetFeatures();
@@ -104,6 +117,21 @@ describe("feature registry", () => {
       "runtime-adapters",
     ]);
     expect(listSkillsetFeaturesByRuntime("gemini-cli").map((entry) => entry.id)).toEqual(["runtime-adapters"]);
+  });
+
+  it("keeps representative diagnostic feature ids tied to registry entries and owners", () => {
+    for (const id of REPRESENTATIVE_DIAGNOSTIC_FEATURE_IDS) {
+      expect(getSkillsetFeature(id)?.id).toBe(id);
+    }
+
+    for (const feature of listSkillsetFeatures()) {
+      if (feature.loweringOwner !== "future") {
+        expect(existsSync(join(REPO_ROOT, feature.loweringOwner))).toBe(true);
+      }
+      if (feature.validationOwner !== "future") {
+        expect(existsSync(join(REPO_ROOT, feature.validationOwner))).toBe(true);
+      }
+    }
   });
 
   it("sorts entries, looks up by id, and filters target-applicable features", () => {

--- a/packages/core/src/__tests__/lowering-outcome-build.test.ts
+++ b/packages/core/src/__tests__/lowering-outcome-build.test.ts
@@ -513,6 +513,22 @@ echo alpha
     ]);
   });
 
+  it("ignores placeholder-only plugin agent directories for unsupported Codex outcomes", async () => {
+    const root = await fixture({
+      ...OUTCOME_FIXTURE,
+      ".skillset/plugins/alpha/agents/.gitkeep": "",
+    });
+
+    const result = await buildSkillsetResult(root);
+
+    expect(result.loweringOutcomes).not.toContainEqual(expect.objectContaining({
+      featureId: "plugin-agents",
+      sourceUnit: "plugin.alpha.feature:agents",
+      status: "unsupported",
+      target: "codex",
+    }));
+  });
+
   it("enforces unsupported outcome policy with actionable lowering errors", async () => {
     const agentRoot = await fixture({
       ...OUTCOME_FIXTURE,

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -465,6 +465,7 @@ async function diagnoseMissingManagedOutputs(
     if (await exists(resolveInside(rootPath, file.path))) continue;
     diagnostics.push({
       code: "managed-output-missing",
+      featureId: "output-safety",
       message: `managed output is missing and will be regenerated: ${file.path}`,
       outputPath: file.path,
       severity: "warning",

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -176,6 +176,8 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       docs("docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"),
       source("packages/core/src/feature-registry.ts"),
       test("packages/core/src/__tests__/feature-registry.test.ts", "registry ids, vocabulary, evidence, and guard coverage"),
+      test("apps/skillset/src/__tests__/lint-rules.test.ts", "SET-76 lint diagnostics carry feature ids"),
+      test("packages/core/src/__tests__/build-result.test.ts", "SET-76 output-safety diagnostics carry feature ids"),
     ],
     id: "feature-registry",
     kind: "workflow",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,9 @@ export {
   type NormalizedTreeDifference,
   type NormalizedTreeDifferenceKind,
 } from "./normalized-output-tree";
+export {
+  SkillsetFeatureDiagnosticError,
+} from "./operation-result";
 export type {
   SkillsetDiagnostic,
   SkillsetDiagnosticSeverity,

--- a/packages/core/src/lowering-outcome-collector.ts
+++ b/packages/core/src/lowering-outcome-collector.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { readString, isOutputSelected } from "./config";
@@ -332,7 +332,7 @@ function unsupportedPluginFeatureOutcomes(
     }
 
     const agentsPath = join(plugin.path, "agents");
-    if (!existsSync(agentsPath)) continue;
+    if (!hasMeaningfulFiles(agentsPath)) continue;
     const featureId = "plugin-agents";
     const evidence = evidenceFor(featureId, "codex");
     outcomes.push(
@@ -349,6 +349,23 @@ function unsupportedPluginFeatureOutcomes(
     );
   }
   return outcomes;
+}
+
+function hasMeaningfulFiles(path: string): boolean {
+  if (!existsSync(path)) return false;
+  const stats = statSync(path);
+  if (stats.isFile()) return !isPlaceholderFile(path);
+  if (!stats.isDirectory()) return false;
+  for (const entry of readdirSync(path)) {
+    if (isPlaceholderFile(entry)) continue;
+    if (hasMeaningfulFiles(join(path, entry))) return true;
+  }
+  return false;
+}
+
+function isPlaceholderFile(path: string): boolean {
+  const name = path.split("/").pop();
+  return name === ".gitkeep" || name === ".keep" || name === ".DS_Store";
 }
 
 function outputPathsForLockItem(outputRoot: string, item: RenderedLockItem): readonly string[] {

--- a/packages/core/src/operation-result.ts
+++ b/packages/core/src/operation-result.ts
@@ -30,6 +30,25 @@ export interface SkillsetDiagnostic {
   readonly target?: string;
 }
 
+export class SkillsetFeatureDiagnosticError extends Error {
+  readonly code: string;
+  readonly featureId: string;
+  readonly path?: string;
+
+  constructor(args: {
+    readonly code: string;
+    readonly featureId: string;
+    readonly message: string;
+    readonly path?: string;
+  }) {
+    super(args.message);
+    this.name = "SkillsetFeatureDiagnosticError";
+    this.code = args.code;
+    this.featureId = args.featureId;
+    if (args.path !== undefined) this.path = args.path;
+  }
+}
+
 export type SkillsetWriteMode = "dry-run" | "read" | "write";
 
 export interface SkillsetWriteSummary {

--- a/packages/core/src/output-safety.ts
+++ b/packages/core/src/output-safety.ts
@@ -376,6 +376,7 @@ function preflightBackupDiagnostic(record: OutputBackupPlanRecord): SkillsetDiag
     : "existing file is not owned by Skillset";
   return {
     code: record.reason === "managed-target-edit" ? "managed-output-edited" : "unmanaged-output-collision",
+    featureId: "output-safety",
     message: `${reason}; ${record.targetPath} will be backed up before ${record.action}`,
     outputPath: record.targetPath,
     severity: "warning",
@@ -388,6 +389,7 @@ function backupDiagnostic(record: OutputBackupRecord, runId: string, manifestPat
     : "existing file is not owned by Skillset";
   return {
     code: record.reason === "managed-target-edit" ? "managed-output-edited" : "unmanaged-output-collision",
+    featureId: "output-safety",
     message: `${reason}; backed up ${record.targetPath} before ${record.action} (${runId}, ${manifestPath})`,
     outputPath: record.targetPath,
     severity: "warning",

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -17,6 +17,7 @@ import {
   validateConfigDocument,
 } from "./config";
 import { readPluginDependencies, validatePluginDependencyGraph } from "./dependencies";
+import { SkillsetFeatureDiagnosticError } from "./operation-result";
 import { compareStrings, resolveInside, validateSlug } from "./path";
 import { readReleaseState } from "./release-state";
 import { readSkillResources } from "./resources";
@@ -96,7 +97,15 @@ export async function loadBuildGraph(
   await validateSupports(rootConfig.supports, { label: rootConfigPath, rootPath, warnings });
   const releaseState = await readReleaseState(rootPath, options);
   const plugins = await loadPlugins(rootPath, sourceDir, filteredTargets, warnings, outputs);
-  validatePluginDependencyGraph(plugins);
+  try {
+    validatePluginDependencyGraph(plugins);
+  } catch (error) {
+    throw featureDiagnosticError(error, {
+      code: "plugin-dependencies-invalid",
+      featureId: "dependencies",
+      path: join(sourceDir, PLUGINS_DIR),
+    });
+  }
   const standaloneSkills = await loadStandaloneSkills(rootPath, sourceDir, filteredTargets, warnings);
   const { rules, instructionsDir } = await loadInstructions(rootPath, sourceDir, filteredTargets, warnings);
   const projectAgents = await loadProjectAgents(rootPath, sourceDir, filteredTargets, warnings);
@@ -145,6 +154,23 @@ function applyTargetFilter(
   };
 }
 
+function featureDiagnosticError(
+  error: unknown,
+  args: {
+    readonly code: string;
+    readonly featureId: string;
+    readonly path?: string;
+  }
+): SkillsetFeatureDiagnosticError {
+  if (error instanceof SkillsetFeatureDiagnosticError) return error;
+  return new SkillsetFeatureDiagnosticError({
+    code: args.code,
+    featureId: args.featureId,
+    message: error instanceof Error ? error.message : String(error),
+    ...(args.path === undefined ? {} : { path: args.path }),
+  });
+}
+
 async function loadProjectIslands(
   rootPath: string,
   sourceDir: string,
@@ -169,14 +195,26 @@ async function loadProjectIslands(
 
   for (const island of islands) {
     if (island.target === "codex" && island.relativePath.endsWith(".rules") && island.plugin !== undefined) {
-      throw new Error(
-        `skillset: ${relative(rootPath, island.sourcePath)} targets Codex plugin .rules, which are not supported; Codex .rules are project-only command policy`
-      );
+      const path = relative(rootPath, island.sourcePath);
+      throw new SkillsetFeatureDiagnosticError({
+        code: "target-native-island-unsupported",
+        featureId: "target-native-islands",
+        message:
+          `skillset: ${path} targets Codex plugin .rules, which are not supported; ` +
+          "Codex .rules are project-only command policy",
+        path,
+      });
     }
     if (island.target === "codex" && island.relativePath.endsWith(".rules") && !island.relativePath.startsWith("rules/")) {
-      throw new Error(
-        `skillset: ${relative(rootPath, island.sourcePath)} targets Codex .rules outside .skillset/src/codex/rules/; Codex .rules are project-only command policy`
-      );
+      const path = relative(rootPath, island.sourcePath);
+      throw new SkillsetFeatureDiagnosticError({
+        code: "target-native-island-unsupported",
+        featureId: "target-native-islands",
+        message:
+          `skillset: ${path} targets Codex .rules outside .skillset/src/codex/rules/; ` +
+          "Codex .rules are project-only command policy",
+        path,
+      });
     }
   }
 
@@ -436,26 +474,40 @@ async function loadPlugin(
 ): Promise<SourcePlugin> {
   const pluginPath = resolveInside(rootPath, join(sourceDir, PLUGINS_DIR, id));
   const configPath = await resolvePluginConfigPath(pluginPath);
+  const configRelativePath = relative(rootPath, configPath);
   const config = parseYamlRecord(await readFile(configPath, "utf8"), configPath);
-  validateConfigDocument(config, configPath, { featureKeys: PLUGIN_FEATURE_KEYS });
-  await validateSupports(config.supports, { label: relative(rootPath, configPath), rootPath, warnings });
-  const dependencies = readPluginDependencies(config.dependencies, relative(rootPath, configPath));
-  const metadata = readSkillsetMetadata(config, configPath);
-  validateSchemaField(metadata, `${configPath}.skillset.schema`);
-  validateVersionField(metadata, `${configPath}.skillset.version`);
-  const sourceOrigin = readSourceOrigin(metadata, configPath);
-  const configuredId = readSkillsetName(metadata, id, configPath);
-  validateSlug(configuredId, `skillset.name in ${configPath}`);
-  if (configuredId !== id) {
-    throw new Error(
-      `skillset: plugin directory ${id} does not match skillset.name ${configuredId}`
-    );
+  let dependencies: SourcePlugin["dependencies"];
+  let metadata: SourcePlugin["metadata"];
+  let sourceOrigin: SourceOrigin | undefined;
+  let configuredId: string;
+  let inheritedTargets: BuildGraph["root"]["targets"];
+  let targets: SourcePlugin["targets"];
+  try {
+    validateConfigDocument(config, configPath, { featureKeys: PLUGIN_FEATURE_KEYS });
+    await validateSupports(config.supports, { label: configRelativePath, rootPath, warnings });
+    dependencies = readPluginDependencies(config.dependencies, configRelativePath);
+    metadata = readSkillsetMetadata(config, configPath);
+    validateSchemaField(metadata, `${configPath}.skillset.schema`);
+    validateVersionField(metadata, `${configPath}.skillset.version`);
+    sourceOrigin = readSourceOrigin(metadata, configPath);
+    configuredId = readSkillsetName(metadata, id, configPath);
+    validateSlug(configuredId, `skillset.name in ${configPath}`);
+    if (configuredId !== id) {
+      throw new Error(
+        `skillset: plugin directory ${id} does not match skillset.name ${configuredId}`
+      );
+    }
+    inheritedTargets = resolveTargets(parentTargets, config, configPath, {
+      allowDefaults: true,
+    });
+    targets = applyFeatureTargetDefaults(inheritedTargets, "plugins");
+  } catch (error) {
+    throw featureDiagnosticError(error, {
+      code: "plugin-manifest-invalid",
+      featureId: "plugin-manifests",
+      path: configRelativePath,
+    });
   }
-
-  const inheritedTargets = resolveTargets(parentTargets, config, configPath, {
-    allowDefaults: true,
-  });
-  const targets = applyFeatureTargetDefaults(inheritedTargets, "plugins");
   const features = await loadPluginFeatures(
     rootPath,
     pluginPath,
@@ -468,9 +520,13 @@ async function loadPlugin(
   const skills = await loadSkills(rootPath, sourceDir, pluginPath, inheritedTargets, warnings);
 
   if (await exists(join(pluginPath, "hooks.json"))) {
-    throw new Error(
-      `skillset: plugin ${id} uses unsupported root hooks.json; move it to hooks/hooks.json`
-    );
+    const path = relative(rootPath, join(pluginPath, "hooks.json"));
+    throw new SkillsetFeatureDiagnosticError({
+      code: "plugin-root-hooks-unsupported",
+      featureId: "plugin-hooks",
+      message: `skillset: plugin ${id} uses unsupported root hooks.json; move it to hooks/hooks.json`,
+      path,
+    });
   }
   return {
     configPath,
@@ -496,16 +552,25 @@ async function loadPluginFeatures(
 ): Promise<readonly SourcePluginFeature[]> {
   const features: SourcePluginFeature[] = [];
   for (const key of PLUGIN_FEATURE_KEYS) {
-    const feature = await loadPluginFeature(
-      rootPath,
-      pluginPath,
-      config,
-      configPath,
-      targets,
-      pluginId,
-      outputRoots,
-      key
-    );
+    let feature: SourcePluginFeature | undefined;
+    try {
+      feature = await loadPluginFeature(
+        rootPath,
+        pluginPath,
+        config,
+        configPath,
+        targets,
+        pluginId,
+        outputRoots,
+        key
+      );
+    } catch (error) {
+      throw featureDiagnosticError(error, {
+        code: `plugin-${key}-invalid`,
+        featureId: key === "mcp" ? "plugin-mcp" : "plugin-bin",
+        path: relative(rootPath, configPath),
+      });
+    }
     if (feature !== undefined) features.push(feature);
   }
   return features.sort((left, right) => compareStrings(left.key, right.key));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -256,6 +256,7 @@ export interface CheckResult {
 
 export interface LintIssue {
   readonly code: string;
+  readonly featureId?: string;
   readonly message: string;
   readonly path: string;
   /** Errors fail lint/ci; warnings flow through reporting without failing. */

--- a/packages/lint/src/types.ts
+++ b/packages/lint/src/types.ts
@@ -9,6 +9,7 @@ export interface LintGuidance {
 export interface LintDiagnostic {
   readonly rule: string;
   readonly code?: string;
+  readonly featureId?: string;
   readonly severity: LintSeverity;
   readonly message: string;
   readonly path: string;


### PR DESCRIPTION
## Context

Registry entries are most useful when diagnostics carry stable feature ids back to the source/target surface that produced the issue. This branch wires that through the current validation and diagnostic paths.

## Changes

- Tags representative diagnostics with feature ids from the feature registry.
- Adds registry tests that keep diagnostic feature ids tied to known entries and owners.
- Keeps target support claims conservative while making diagnostics easier to reason about.
- Tightens Codex plugin-agent unsupported detection so empty or placeholder-only `agents/` directories do not fail as unsupported features.

## Verification

- Local full gate after review fixes: `bun run check` -> 476 tests / 0 fail; Ultracite doctor, Skillset lint/check, generated drift, and whitespace clean.
- Pre-push gate during `gt submit` passed the same aggregate checks.
- Local review rework fixed the P3 around placeholder-only plugin agent directories; focused coverage now includes that case.

## Risks

- Low behavior risk; this mainly adds structured metadata to diagnostics. The placeholder filter intentionally ignores `.gitkeep`, `.keep`, and `.DS_Store` only.
