### PR TITLE
chore(release): cut 0.1.0-beta.9

### DIFF
--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillset",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "description": "Source-first compiler for Claude and Codex agent loadouts.",
   "type": "module",
   "files": [

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.1.0-beta.8",
+      "version": "0.1.0-beta.9",
       "bin": {
         "create-skillset": "dist/create.js",
         "skillset": "dist/cli.js",


### PR DESCRIPTION
## Summary

- bump the public `skillset` package from `0.1.0-beta.8` to `0.1.0-beta.9`
- refresh `bun.lock` so the workspace package metadata matches

## Verification

- `bun install --lockfile-only`
- `bun run build:npm`
- `bun run check` (476 pass, 0 fail; Ultracite doctor clean; skillset lint/check clean)
- pre-push hook during `gt submit` (skillset-ci and check passed)

## Release Notes

This beta includes the merged SET-19/SET-70/SET-69 stack: unmanaged output protection, lowering outcomes/loss ledger reporting and policy gates, feature-linked diagnostics, runtime hook guardrails, and richer create scaffolding.