### PR TITLE
feat(core): check feature registry drift

### DIFF
--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -82,4 +82,4 @@ Runtime support records are registry evidence, not generated target files. Futur
 - [Feature registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) - schema-backed support and evidence direction.
 - [Agents](agents.md) - project-agent support and Codex skill-preface shim.
 - [Tests and Evals](tests-and-evals.md) - activation/eval boundary.
-- `fixtures/external/repos/superpowers` - external multi-runtime fixture evidence.
+- `fixtures/external/repos.yaml` - pinned external multi-runtime fixture manifest, including Superpowers.

--- a/packages/core/src/__tests__/feature-registry-check.test.ts
+++ b/packages/core/src/__tests__/feature-registry-check.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  checkFeatureRegistryDrift,
+  listSkillsetFeatures,
+  type SkillsetFeatureEntry,
+  type SkillsetFeatureEvidence,
+} from "@skillset/core";
+
+describe("feature registry drift checks", () => {
+  it("keeps the shipped registry docs, owners, and evidence refs resolvable", async () => {
+    const report = await checkFeatureRegistryDrift(process.cwd());
+
+    expect(report.issues).toEqual([]);
+    expect(report.checkedFeatures).toBe(listSkillsetFeatures().length);
+    expect(report.ok).toBe(true);
+  });
+
+  it("reports implemented features with no entry evidence", async () => {
+    const root = await fixture({
+      "docs/features/demo.md": "# Demo\n",
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: ["docs/features/demo.md"],
+        evidence: [],
+        id: "demo",
+        loweringOwner: "src/demo.ts",
+        validationOwner: "src/demo.ts",
+      }),
+    ]);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues).toContainEqual({
+      code: "missing-evidence",
+      featureId: "demo",
+      field: "evidence",
+      message: "implemented feature demo requires at least one evidence ref",
+    });
+  });
+
+  it("reports missing docs with the entry and field", async () => {
+    const root = await fixture({
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: ["docs/features/missing.md"],
+        id: "demo",
+        loweringOwner: "src/demo.ts",
+        validationOwner: "src/demo.ts",
+      }),
+    ]);
+
+    expect(report.issues).toContainEqual({
+      code: "missing-doc-ref",
+      featureId: "demo",
+      field: "docs[0]",
+      message: "demo docs[0] points to missing doc ref docs/features/missing.md",
+      ref: "docs/features/missing.md",
+    });
+  });
+
+  it("reports refs that only differ by path casing", async () => {
+    const root = await fixture({
+      "docs/features/Demo.md": "# Demo\n",
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: ["docs/features/demo.md"],
+        id: "demo",
+        loweringOwner: "src/demo.ts",
+        validationOwner: "src/demo.ts",
+      }),
+    ]);
+
+    expect(report.issues).toContainEqual({
+      code: "missing-doc-ref",
+      featureId: "demo",
+      field: "docs[0]",
+      message: "demo docs[0] points to missing doc ref docs/features/demo.md",
+      ref: "docs/features/demo.md",
+    });
+  });
+
+  it("reports missing markdown fragments and accepts existing heading fragments", async () => {
+    const root = await fixture({
+      "docs/features/demo.md": "# Demo\n\n## Existing Heading!\n\n## Existing Heading!\n",
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: [
+          "docs/features/demo.md#existing-heading",
+          "docs/features/demo.md#existing-heading-1",
+          "docs/features/demo.md#missing-heading",
+        ],
+        id: "demo",
+        loweringOwner: "src/demo.ts",
+        validationOwner: "src/demo.ts",
+      }),
+    ]);
+
+    expect(report.issues).toContainEqual({
+      code: "missing-ref-fragment",
+      featureId: "demo",
+      field: "docs[2]",
+      message: "demo docs[2] points to missing doc ref fragment docs/features/demo.md#missing-heading",
+      ref: "docs/features/demo.md#missing-heading",
+    });
+    expect(report.issues.filter((issue) => issue.code === "missing-ref-fragment")).toHaveLength(1);
+  });
+
+  it("reports local refs that escape the checked root", async () => {
+    const root = await fixture({
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+    await Bun.write(join(root, "../outside-registry-ref.txt"), "outside\n");
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: ["../outside-registry-ref.txt"],
+        id: "demo",
+        loweringOwner: "src/demo.ts",
+        validationOwner: "src/demo.ts",
+      }),
+    ]);
+
+    expect(report.issues).toContainEqual({
+      code: "outside-root-ref",
+      featureId: "demo",
+      field: "docs[0]",
+      message: "demo docs[0] points outside root with doc ref ../outside-registry-ref.txt",
+      ref: "../outside-registry-ref.txt",
+    });
+  });
+
+  it("reports missing fixture and test evidence refs", async () => {
+    const root = await fixture({
+      "docs/features/demo.md": "# Demo\n",
+      "src/demo.ts": "export {};\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: ["docs/features/demo.md"],
+        evidence: [
+          { kind: "fixture", ref: "fixtures/missing" },
+          { kind: "test", ref: "tests/missing.test.ts" },
+        ],
+        id: "demo",
+        loweringOwner: "src/demo.ts",
+        validationOwner: "src/demo.ts",
+      }),
+    ]);
+
+    expect(report.issues.map((issue) => `${issue.field}:${issue.ref}`)).toEqual([
+      "evidence[0]:fixtures/missing",
+      "evidence[1]:tests/missing.test.ts",
+      "targetSupport.claude.evidence[0]:fixtures/missing",
+      "targetSupport.claude.evidence[1]:tests/missing.test.ts",
+      "targetSupport.codex.evidence[0]:fixtures/missing",
+      "targetSupport.codex.evidence[1]:tests/missing.test.ts",
+    ]);
+  });
+
+  it("ignores future owner sentinels and external evidence refs", async () => {
+    const root = await fixture({
+      "docs/features/demo.md": "# Demo\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, [
+      feature({
+        docs: ["docs/features/demo.md"],
+        evidence: [
+          { kind: "external-docs", ref: "https://example.com/docs", verifiedAt: "2026-06-14" },
+        ],
+        id: "demo",
+        loweringOwner: "future",
+        status: "planned",
+        validationOwner: "future",
+      }),
+    ]);
+
+    expect(report).toEqual({
+      checkedFeatures: 1,
+      issues: [],
+      ok: true,
+    });
+  });
+});
+
+function feature(
+  overrides: Partial<SkillsetFeatureEntry> & { readonly id: string }
+): SkillsetFeatureEntry {
+  const defaultEvidence: readonly SkillsetFeatureEvidence[] = [
+    { kind: "test", ref: "tests/demo.test.ts" },
+  ];
+  const evidence = overrides.evidence ?? defaultEvidence;
+  return {
+    docs: overrides.docs ?? ["docs/features/demo.md"],
+    evidence,
+    id: overrides.id,
+    kind: overrides.kind ?? "source",
+    loweringOwner: overrides.loweringOwner ?? "src/demo.ts",
+    sourceShape: overrides.sourceShape ?? ".skillset/demo",
+    status: overrides.status ?? "implemented",
+    summary: overrides.summary ?? "Demo feature.",
+    targetSupport: overrides.targetSupport ?? {
+      claude: { evidence, status: "native" },
+      codex: { evidence, status: "native" },
+    },
+    title: overrides.title ?? "Demo",
+    validationOwner: overrides.validationOwner ?? "src/demo.ts",
+  };
+}
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-feature-registry-check-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), content);
+  }
+  return root;
+}

--- a/packages/core/src/feature-registry-check.ts
+++ b/packages/core/src/feature-registry-check.ts
@@ -1,0 +1,367 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
+
+import { compareStrings } from "./path";
+import {
+  skillsetFeatureRegistry,
+  type SkillsetFeatureEntry,
+  type SkillsetFeatureEvidence,
+  type SkillsetFeatureRegistry,
+  type SkillsetRuntimeId,
+  type SkillsetRuntimeSupport,
+  type SkillsetTargetSupport,
+} from "./feature-registry";
+
+export type FeatureRegistryDriftCode =
+  | "missing-doc-ref"
+  | "missing-evidence"
+  | "missing-evidence-ref"
+  | "missing-owner-ref"
+  | "missing-ref-fragment"
+  | "outside-root-ref";
+
+export interface FeatureRegistryDriftIssue {
+  readonly code: FeatureRegistryDriftCode;
+  readonly featureId: string;
+  readonly field: string;
+  readonly message: string;
+  readonly ref?: string;
+}
+
+export interface FeatureRegistryDriftReport {
+  readonly checkedFeatures: number;
+  readonly issues: readonly FeatureRegistryDriftIssue[];
+  readonly ok: boolean;
+}
+
+export async function checkFeatureRegistryDrift(
+  rootPath: string,
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): Promise<FeatureRegistryDriftReport> {
+  const resolvedRootPath = resolve(rootPath);
+  const issues: FeatureRegistryDriftIssue[] = [];
+
+  for (const feature of registry) {
+    checkEvidencePresence(issues, feature);
+    await checkDocs(issues, resolvedRootPath, feature);
+    await checkOwners(issues, resolvedRootPath, feature);
+    await checkEvidenceRefs(issues, resolvedRootPath, feature);
+  }
+
+  return {
+    checkedFeatures: registry.length,
+    issues: issues.sort(compareDriftIssues),
+    ok: issues.length === 0,
+  };
+}
+
+function checkEvidencePresence(
+  issues: FeatureRegistryDriftIssue[],
+  feature: SkillsetFeatureEntry
+): void {
+  if (feature.status === "implemented" && feature.evidence.length === 0) {
+    issues.push({
+      code: "missing-evidence",
+      featureId: feature.id,
+      field: "evidence",
+      message: `implemented feature ${feature.id} requires at least one evidence ref`,
+    });
+  }
+
+  for (const target of ["claude", "codex"] as const) {
+    const support = feature.targetSupport[target];
+    if (supportRequiresEvidence(support) && (support.evidence?.length ?? 0) === 0) {
+      issues.push({
+        code: "missing-evidence",
+        featureId: feature.id,
+        field: `targetSupport.${target}.evidence`,
+        message: `${feature.id} ${target} support requires evidence`,
+      });
+    }
+  }
+
+  for (const [runtime, support] of Object.entries(feature.runtimeSupport ?? {}) as ReadonlyArray<
+    readonly [SkillsetRuntimeId, SkillsetRuntimeSupport]
+  >) {
+    if (supportRequiresEvidence(support) && (support.evidence?.length ?? 0) === 0) {
+      issues.push({
+        code: "missing-evidence",
+        featureId: feature.id,
+        field: `runtimeSupport.${runtime}.evidence`,
+        message: `${feature.id} ${runtime} runtime support requires evidence`,
+      });
+    }
+  }
+}
+
+async function checkDocs(
+  issues: FeatureRegistryDriftIssue[],
+  rootPath: string,
+  feature: SkillsetFeatureEntry
+): Promise<void> {
+  if (feature.docs.length === 0) {
+    issues.push({
+      code: "missing-doc-ref",
+      featureId: feature.id,
+      field: "docs",
+      message: `${feature.id} requires at least one docs ref`,
+    });
+    return;
+  }
+
+  for (const [index, ref] of feature.docs.entries()) {
+    await pushMissingLocalRef(issues, rootPath, {
+      code: "missing-doc-ref",
+      featureId: feature.id,
+      field: `docs[${index}]`,
+      kind: "doc",
+      ref,
+    });
+  }
+}
+
+async function checkOwners(
+  issues: FeatureRegistryDriftIssue[],
+  rootPath: string,
+  feature: SkillsetFeatureEntry
+): Promise<void> {
+  await pushMissingLocalRef(issues, rootPath, {
+    code: "missing-owner-ref",
+    featureId: feature.id,
+    field: "loweringOwner",
+    kind: "owner",
+    ref: feature.loweringOwner,
+  });
+  await pushMissingLocalRef(issues, rootPath, {
+    code: "missing-owner-ref",
+    featureId: feature.id,
+    field: "validationOwner",
+    kind: "owner",
+    ref: feature.validationOwner,
+  });
+}
+
+async function checkEvidenceRefs(
+  issues: FeatureRegistryDriftIssue[],
+  rootPath: string,
+  feature: SkillsetFeatureEntry
+): Promise<void> {
+  await checkEvidenceList(issues, rootPath, feature.id, "evidence", feature.evidence);
+
+  for (const target of ["claude", "codex"] as const) {
+    await checkEvidenceList(
+      issues,
+      rootPath,
+      feature.id,
+      `targetSupport.${target}.evidence`,
+      feature.targetSupport[target].evidence ?? []
+    );
+  }
+
+  for (const [runtime, support] of Object.entries(feature.runtimeSupport ?? {}) as ReadonlyArray<
+    readonly [SkillsetRuntimeId, SkillsetRuntimeSupport]
+  >) {
+    await checkEvidenceList(
+      issues,
+      rootPath,
+      feature.id,
+      `runtimeSupport.${runtime}.evidence`,
+      support.evidence ?? []
+    );
+  }
+}
+
+async function checkEvidenceList(
+  issues: FeatureRegistryDriftIssue[],
+  rootPath: string,
+  featureId: string,
+  field: string,
+  evidence: readonly SkillsetFeatureEvidence[]
+): Promise<void> {
+  for (const [index, item] of evidence.entries()) {
+    if (!isLocalEvidenceKind(item.kind)) continue;
+    await pushMissingLocalRef(issues, rootPath, {
+      code: "missing-evidence-ref",
+      featureId,
+      field: `${field}[${index}]`,
+      kind: item.kind,
+      ref: item.ref,
+    });
+  }
+}
+
+async function pushMissingLocalRef(
+  issues: FeatureRegistryDriftIssue[],
+  rootPath: string,
+  args: {
+    readonly code: FeatureRegistryDriftCode;
+    readonly featureId: string;
+    readonly field: string;
+    readonly kind: string;
+    readonly ref: string;
+  }
+): Promise<void> {
+  const { fragment, path: ref } = parseRef(args.ref);
+  if (ref === "future" || ref.length === 0 || isExternalRef(ref)) return;
+  if (!isInsideRoot(rootPath, ref)) {
+    issues.push({
+      code: "outside-root-ref",
+      featureId: args.featureId,
+      field: args.field,
+      message: `${args.featureId} ${args.field} points outside root with ${args.kind} ref ${args.ref}`,
+      ref: args.ref,
+    });
+    return;
+  }
+  const resolvedRef = resolve(rootPath, ref);
+  if (await existsExactLocalRef(rootPath, ref)) {
+    if (fragment !== undefined) {
+      await pushMissingMarkdownFragment(issues, resolvedRef, { ...args, fragment });
+    }
+    return;
+  }
+  issues.push({
+    code: args.code,
+    featureId: args.featureId,
+    field: args.field,
+    message: `${args.featureId} ${args.field} points to missing ${args.kind} ref ${args.ref}`,
+    ref: args.ref,
+  });
+}
+
+async function pushMissingMarkdownFragment(
+  issues: FeatureRegistryDriftIssue[],
+  path: string,
+  args: {
+    readonly featureId: string;
+    readonly field: string;
+    readonly fragment: string;
+    readonly kind: string;
+    readonly ref: string;
+  }
+): Promise<void> {
+  if (!path.endsWith(".md") || args.fragment.length === 0) return;
+  const expected = normalizeFragment(args.fragment);
+  if (expected.length === 0) return;
+  const fragments = markdownHeadingFragments(await readFile(path, "utf8"));
+  if (fragments.has(expected)) return;
+  issues.push({
+    code: "missing-ref-fragment",
+    featureId: args.featureId,
+    field: args.field,
+    message: `${args.featureId} ${args.field} points to missing ${args.kind} ref fragment ${args.ref}`,
+    ref: args.ref,
+  });
+}
+
+function isInsideRoot(rootPath: string, ref: string): boolean {
+  const relativePath = relative(rootPath, resolve(rootPath, ref));
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function supportRequiresEvidence(
+  support: Pick<SkillsetRuntimeSupport | SkillsetTargetSupport, "status">
+): boolean {
+  return support.status !== "future" && support.status !== "planned";
+}
+
+function isLocalEvidenceKind(kind: SkillsetFeatureEvidence["kind"]): boolean {
+  return kind === "docs" || kind === "fixture" || kind === "source" || kind === "test";
+}
+
+function parseRef(ref: string): { readonly fragment?: string; readonly path: string } {
+  const [path, fragment] = ref.split("#", 2);
+  return {
+    ...(fragment === undefined ? {} : { fragment }),
+    path: path ?? "",
+  };
+}
+
+function markdownHeadingFragments(markdown: string): ReadonlySet<string> {
+  const fragments = new Set<string>();
+  const seen = new Map<string, number>();
+  for (const line of markdown.split(/\r?\n/u)) {
+    const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/u.exec(line);
+    const heading = match?.[2];
+    if (heading === undefined) continue;
+    const base = markdownHeadingSlug(heading);
+    if (base.length === 0) continue;
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    fragments.add(count === 0 ? base : `${base}-${count}`);
+  }
+  return fragments;
+}
+
+function markdownHeadingSlug(heading: string): string {
+  return heading
+    .replace(/`([^`]+)`/gu, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/gu, "$1")
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
+    .trim()
+    .replace(/\s+/gu, "-");
+}
+
+function normalizeFragment(fragment: string): string {
+  try {
+    return decodeURIComponent(fragment).toLowerCase();
+  } catch {
+    return fragment.toLowerCase();
+  }
+}
+
+function isExternalRef(ref: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/iu.test(ref);
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function existsExactLocalRef(rootPath: string, ref: string): Promise<boolean> {
+  const resolvedRef = resolve(rootPath, ref);
+  const relativePath = relative(rootPath, resolvedRef);
+  if (relativePath === "") return true;
+
+  const parts = relativePath.split(/[\\/]+/u).filter(Boolean);
+  let currentPath = rootPath;
+  for (const part of parts) {
+    let entries: string[];
+    try {
+      entries = await readdir(currentPath);
+    } catch (error) {
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error.code === "ENOENT" || error.code === "ENOTDIR")
+      ) {
+        return false;
+      }
+      throw error;
+    }
+    if (!entries.includes(part)) return false;
+    currentPath = resolve(currentPath, part);
+  }
+  return exists(currentPath);
+}
+
+function compareDriftIssues(
+  left: FeatureRegistryDriftIssue,
+  right: FeatureRegistryDriftIssue
+): number {
+  return compareStrings(
+    `${left.featureId}\0${left.field}\0${left.code}\0${left.ref ?? ""}`,
+    `${right.featureId}\0${right.field}\0${right.code}\0${right.ref ?? ""}`
+  );
+}

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -529,12 +529,12 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         status: "externally_managed",
       },
       cursor: {
-        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos/superpowers")],
+        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos.yaml")],
         reason: "Cursor support needs target documentation and adapter evidence before Skillset can lower or distribute it.",
         status: "planned",
       },
       "gemini-cli": {
-        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos/superpowers")],
+        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos.yaml")],
         reason: "Gemini support needs target documentation and adapter evidence before Skillset can lower or distribute it.",
         status: "planned",
       },
@@ -549,7 +549,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         status: "future",
       },
       opencode: {
-        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos/superpowers")],
+        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos.yaml")],
         reason: "OpenCode support needs target documentation and adapter evidence before Skillset can lower or distribute it.",
         status: "planned",
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,12 @@ export {
   type SkillsetTargetSupportStatus,
 } from "./feature-registry";
 export {
+  checkFeatureRegistryDrift,
+  type FeatureRegistryDriftCode,
+  type FeatureRegistryDriftIssue,
+  type FeatureRegistryDriftReport,
+} from "./feature-registry-check";
+export {
   LOWERING_OUTCOME_SCHEMA,
   LOWERING_OUTCOME_STATUS_VALUES,
   SkillsetLoweringError,


### PR DESCRIPTION
## Context

Adds a first-party feature-registry drift check so the registry can prove its own docs, owner, and evidence references still resolve.

## What Changed

- Added `checkFeatureRegistryDrift` and report/issue types in `@skillset/core`.
- Verifies implemented features have evidence and target/runtime support claims have evidence where required.
- Checks docs, owner, source, fixture, and test refs for containment and existence.
- Validates Markdown heading fragments for local `.md#heading` refs so renamed headings do not silently pass.

## Verification

- `bun test packages/core/src/__tests__/feature-registry-check.test.ts packages/core/src/__tests__/feature-registry.test.ts`
- `bun run typecheck`
- Full stack pre-push gate: `bun run check`, `bun run skillset:ci`, `git diff --check main..HEAD`

## Review Notes

Follow-up review called out fragment drift as a P3; this PR now catches Markdown heading-fragment drift. Evidence `note` text is intentionally not parsed as a test-name contract in this slice.
