### PR TITLE
feat(core): detect host-specific projection leaks

### DIFF
--- a/packages/core/src/__tests__/deterministic-projection.test.ts
+++ b/packages/core/src/__tests__/deterministic-projection.test.ts
@@ -88,7 +88,7 @@ describe("deterministic projection runner", () => {
       afterProjection: async (run) => {
         await Bun.write(join(run.outputRoot, "leak.txt"), `workspace=${run.workspacePath}\n`);
       },
-    })).rejects.toThrow("contains forbidden value");
+    })).rejects.toThrow("contains forbidden-substring leak");
   });
 
   it("fails when generated output leaks the shared temp runner root", async () => {
@@ -98,7 +98,42 @@ describe("deterministic projection runner", () => {
       afterProjection: async (run) => {
         await Bun.write(join(run.outputRoot, "leak.txt"), `tempRoot=${dirname(dirname(run.workspacePath))}\n`);
       },
-    })).rejects.toThrow("contains forbidden value");
+    })).rejects.toThrow("contains forbidden-substring leak");
+  });
+
+  it("honors host leak opt-out while keeping caller forbidden substrings", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+
+    const allowed = await runDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        await Bun.write(join(run.outputRoot, "example.txt"), "/tmp/example\n");
+      },
+      comparisonOptions: {
+        hostLeakOptions: false,
+      },
+    });
+    expect(allowed.ok).toBe(true);
+
+    await expect(runDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        await Bun.write(join(run.outputRoot, "example.txt"), "literal-token\n");
+      },
+      comparisonOptions: {
+        forbiddenSubstrings: ["literal-token"],
+        hostLeakOptions: false,
+      },
+    })).rejects.toThrow("contains forbidden value literal-token");
+
+    await expect(runDeterministicProjection(root, {
+      afterProjection: (run) => {
+        const writes = run.build.writes as unknown as { writtenPaths: string[] };
+        writes.writtenPaths = [...writes.writtenPaths, "literal-token"];
+      },
+      comparisonOptions: {
+        forbiddenSubstrings: ["literal-token"],
+        hostLeakOptions: false,
+      },
+    })).rejects.toThrow("operation-result.left.json contains forbidden-substring leak");
   });
 
   it("rejects source symlinks instead of copying external state", async () => {
@@ -111,6 +146,31 @@ describe("deterministic projection runner", () => {
     await expect(runDeterministicProjection(root)).rejects.toThrow(
       "deterministic projection source does not support symlinks: .skillset/config.yaml"
     );
+  });
+
+  it("excludes configured generated output roots from copied source workspaces", async () => {
+    const root = await fixture({
+      ".skillset/config.yaml": `
+skillset:
+  name: output-root-exclusion
+claude:
+  skills:
+    path: generated/skills
+codex: false
+`,
+      ".skillset/skills/demo/SKILL.md": DEMO_SKILL,
+      "generated/skills/stale/SKILL.md": "stale generated output\n",
+    });
+
+    const report = await assertDeterministicProjection(root, {
+      afterProjection: async (run) => {
+        if (await exists(join(run.workspacePath, "generated/skills/stale/SKILL.md"))) {
+          throw new Error("copied configured output root into deterministic workspace");
+        }
+      },
+    });
+
+    expect(report.ok).toBe(true);
   });
 
   it("rejects empty source selections before running a projection", async () => {

--- a/packages/core/src/__tests__/host-leak.test.ts
+++ b/packages/core/src/__tests__/host-leak.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+
+import { assertNoHostLeaks, detectHostLeaks } from "@skillset/core";
+
+describe("host leak detection", () => {
+  it("detects POSIX host paths without dumping the full path", () => {
+    const issues = detectHostLeaks("report.json", [
+      "path=/Users/matt/project/.skillset/config.yaml",
+      "temp=/private/var/folders/zz/abc/T/project/file.txt",
+    ].join("\n"));
+
+    expect(issues).toEqual([
+      {
+        kind: "posix-host-path",
+        path: "report.json",
+        redacted: "/Users/.../config.yaml",
+      },
+      {
+        kind: "posix-host-path",
+        path: "report.json",
+        redacted: "/private/.../file.txt",
+      },
+    ]);
+  });
+
+  it("detects Windows host paths", () => {
+    const issues = detectHostLeaks("report.json", "path=C:\\Users\\matt\\project\\file.txt\n");
+
+    expect(issues).toEqual([
+      {
+        kind: "windows-host-path",
+        path: "report.json",
+        redacted: "C:/.../file.txt",
+      },
+    ]);
+  });
+
+  it("detects configured repo, temp, home, and workspace paths as categories", () => {
+    const issues = detectHostLeaks("operation-result.json", [
+      "repo=/repo/skillset",
+      "temp=/tmp/skillset-projection-abc",
+      "home=/Users/matt",
+      "workspace=/tmp/skillset-projection-abc/left/workspace",
+    ].join("\n"), {
+      homePath: "/Users/matt",
+      repoRootPath: "/repo/skillset",
+      tempRootPath: "/tmp/skillset-projection-abc",
+      workspacePaths: ["/tmp/skillset-projection-abc/left/workspace"],
+    });
+
+    expect(issues.map((issue) => issue.kind)).toContain("repo-path");
+    expect(issues.map((issue) => issue.kind)).toContain("temp-path");
+    expect(issues.map((issue) => issue.kind)).toContain("home-path");
+    expect(issues.map((issue) => issue.kind)).toContain("workspace-path");
+    expect(issues.filter((issue) => issue.kind === "posix-host-path")).toHaveLength(3);
+  });
+
+  it("redacts non-path forbidden substrings without echoing the value", () => {
+    const issues = detectHostLeaks("report.json", "token=secret-token\n", {
+      forbiddenSubstrings: ["secret-token"],
+    });
+
+    expect(issues).toEqual([
+      {
+        kind: "forbidden-substring",
+        path: "report.json",
+        redacted: "[redacted]",
+      },
+    ]);
+    expect(JSON.stringify(issues)).not.toContain("secret-token");
+  });
+
+  it("keeps ordinary docs paths and URLs out of the leak set", () => {
+    const issues = detectHostLeaks("docs.md", [
+      "See https://example.com/docs/path",
+      "Use docs/features/skills.md",
+      "Generated output is under .skillset/build/out",
+      "A POSIX-looking option like /docs/reference is not host-specific.",
+    ].join("\n"));
+
+    expect(issues).toEqual([]);
+  });
+
+  it("throws a concise error for assertion callers", () => {
+    const bytes = new TextEncoder().encode("workspace=/tmp/skillset-projection-abc/left/workspace\n");
+
+    expect(() => assertNoHostLeaks("report.json", bytes)).toThrow(
+      "skillset: report.json contains posix-host-path leak (/tmp/.../workspace)"
+    );
+  });
+});

--- a/packages/core/src/deterministic-projection.ts
+++ b/packages/core/src/deterministic-projection.ts
@@ -7,6 +7,7 @@ import {
   ISOLATED_OUT_ROOT,
   type SkillsetBuildResult,
 } from "./build";
+import { assertNoHostLeaks, type HostLeakDetectionOptions } from "./host-leak";
 import { compareStrings, resolveInside } from "./path";
 import {
   compareNormalizedOutputTreeEntries,
@@ -16,6 +17,7 @@ import {
   type NormalizedTreeComparison,
   type NormalizedOutputTreeOptions,
 } from "./normalized-output-tree";
+import { loadBuildGraph } from "./resolver";
 import type { JsonRecord, JsonValue, SkillsetOptions } from "./types";
 import { stringifyJson } from "./yaml";
 
@@ -52,6 +54,8 @@ export interface DeterministicProjectionOptions {
   readonly buildOptions?: SkillsetOptions;
   /** Extra output-tree comparison options. */
   readonly comparisonOptions?: NormalizedOutputTreeOptions;
+  /** Additional source-copy exclusions, relative to the source root. */
+  readonly copyExcludePaths?: readonly string[];
   /** Test/conformance hook that may inspect or perturb a temp projection. */
   readonly afterProjection?: (run: DeterministicProjectionRunContext) => Promise<void> | void;
   /** Keep the temp runner root on disk for local debugging. */
@@ -85,23 +89,35 @@ export async function runDeterministicProjection(
   const resolvedRootPath = resolve(rootPath);
   const tempRootPath = await createTempRoot(options.tempParentPath);
   try {
-    const left = await runProjection(resolvedRootPath, tempRootPath, "left", options);
-    const right = await runProjection(resolvedRootPath, tempRootPath, "right", options);
-    const forbiddenSubstrings = [
+    const copyExcludedPaths = await projectionCopyExcludedPaths(resolvedRootPath, options);
+    const left = await runProjection(resolvedRootPath, tempRootPath, "left", options, copyExcludedPaths);
+    const right = await runProjection(resolvedRootPath, tempRootPath, "right", options, copyExcludedPaths);
+    const configuredForbiddenSubstrings = options.comparisonOptions?.forbiddenSubstrings ?? [];
+    const projectionForbiddenSubstrings = [
       tempRootPath,
       left.workspacePath,
       right.workspacePath,
-      ...(options.comparisonOptions?.forbiddenSubstrings ?? []),
+      ...configuredForbiddenSubstrings,
     ];
+    const hostLeakOptions: false | HostLeakDetectionOptions = options.comparisonOptions?.hostLeakOptions === false
+      ? false
+      : {
+          ...(options.comparisonOptions?.hostLeakOptions ?? {}),
+          forbiddenSubstrings: projectionForbiddenSubstrings,
+          repoRootPath: resolvedRootPath,
+          tempRootPath,
+          workspacePaths: [left.workspacePath, right.workspacePath],
+        };
     const outputComparison = await compareNormalizedOutputTrees(
       left.outputRoot,
       right.outputRoot,
       {
         ...options.comparisonOptions,
-        forbiddenSubstrings,
+        forbiddenSubstrings: hostLeakOptions === false ? configuredForbiddenSubstrings : projectionForbiddenSubstrings,
+        hostLeakOptions,
       }
     );
-    const resultComparison = compareProjectionResults(left, right, forbiddenSubstrings);
+    const resultComparison = compareProjectionResults(left, right, hostLeakOptions, configuredForbiddenSubstrings);
     return {
       ok: outputComparison.equal && resultComparison.equal,
       outputComparison,
@@ -148,10 +164,11 @@ async function runProjection(
   rootPath: string,
   tempRootPath: string,
   name: DeterministicProjectionRunName,
-  options: DeterministicProjectionOptions
+  options: DeterministicProjectionOptions,
+  copyExcludedPaths: readonly string[]
 ): Promise<DeterministicProjectionRunContext> {
   const workspacePath = join(tempRootPath, name, "workspace");
-  await copySourceSelection(rootPath, workspacePath, options.sourcePaths ?? DEFAULT_SOURCE_PATHS);
+  await copySourceSelection(rootPath, workspacePath, options.sourcePaths ?? DEFAULT_SOURCE_PATHS, copyExcludedPaths);
   const build = await buildSkillsetResult(workspacePath, {
     ...options.buildOptions,
     buildMode: "all",
@@ -170,7 +187,8 @@ async function runProjection(
 async function copySourceSelection(
   rootPath: string,
   workspacePath: string,
-  sourcePaths: readonly string[]
+  sourcePaths: readonly string[],
+  copyExcludedPaths: readonly string[]
 ): Promise<void> {
   await mkdir(workspacePath, { recursive: true });
   const normalizedSourcePaths = sourcePaths.map(normalizeRelativePath).sort(compareStrings);
@@ -182,21 +200,33 @@ async function copySourceSelection(
     const target = sourcePath === "." ? workspacePath : join(workspacePath, sourcePath);
     await mkdir(dirname(target), { recursive: true });
     await cp(source, target, {
-      filter: (path) => shouldCopyPath(rootPath, path),
+      filter: (path) => shouldCopyPath(rootPath, path, copyExcludedPaths),
       recursive: true,
     });
   }
 }
 
-async function shouldCopyPath(rootPath: string, path: string): Promise<boolean> {
+async function shouldCopyPath(rootPath: string, path: string, copyExcludedPaths: readonly string[]): Promise<boolean> {
   const relativePath = normalizePath(relative(rootPath, path));
   if (relativePath === "") return true;
   if ((await lstat(path)).isSymbolicLink()) {
     throw new Error(`skillset: deterministic projection source does not support symlinks: ${relativePath}`);
   }
-  return !DEFAULT_COPY_EXCLUDED_PATHS.some(
+  return !copyExcludedPaths.some(
     (excluded) => relativePath === excluded || relativePath.startsWith(`${excluded}/`)
   );
+}
+
+async function projectionCopyExcludedPaths(
+  rootPath: string,
+  options: DeterministicProjectionOptions
+): Promise<readonly string[]> {
+  const graph = await loadBuildGraph(rootPath, options.buildOptions ?? {});
+  return sortedUnique([
+    ...DEFAULT_COPY_EXCLUDED_PATHS,
+    ...graph.outputRoots,
+    ...(options.copyExcludePaths ?? []),
+  ].map(normalizeRelativePath).filter((path) => path !== "."));
 }
 
 async function createTempRoot(tempParentPath: string | undefined): Promise<string> {
@@ -208,23 +238,25 @@ async function createTempRoot(tempParentPath: string | undefined): Promise<strin
 function compareProjectionResults(
   left: DeterministicProjectionRunContext,
   right: DeterministicProjectionRunContext,
+  hostLeakOptions: false | HostLeakDetectionOptions,
   forbiddenSubstrings: readonly string[]
 ): NormalizedTreeComparison {
   return compareNormalizedOutputTreeEntries(
-    [projectionResultEntry(left, forbiddenSubstrings)],
-    [projectionResultEntry(right, forbiddenSubstrings)]
+    [projectionResultEntry(left, hostLeakOptions, forbiddenSubstrings)],
+    [projectionResultEntry(right, hostLeakOptions, forbiddenSubstrings)]
   );
 }
 
 function projectionResultEntry(
   run: DeterministicProjectionRunContext,
+  hostLeakOptions: false | HostLeakDetectionOptions,
   forbiddenSubstrings: readonly string[]
 ): NormalizedOutputTreeEntry {
   const content = stringifyJson(buildResultSummary(run.build));
-  for (const forbidden of forbiddenSubstrings) {
-    if (content.includes(forbidden)) {
-      throw new Error(`skillset: deterministic projection result for ${run.name} contains forbidden value ${forbidden}`);
-    }
+  if (hostLeakOptions !== false) {
+    assertNoHostLeaks(`operation-result.${run.name}.json`, textEncoder.encode(content), hostLeakOptions);
+  } else if (forbiddenSubstrings.length > 0) {
+    assertNoHostLeaks(`operation-result.${run.name}.json`, textEncoder.encode(content), { forbiddenSubstrings });
   }
   return {
     bytes: textEncoder.encode(content),
@@ -263,4 +295,8 @@ function normalizeRelativePath(path: string): string {
 
 function normalizePath(path: string): string {
   return path.replaceAll("\\", "/");
+}
+
+function sortedUnique(paths: readonly string[]): readonly string[] {
+  return [...new Set(paths)].sort(compareStrings);
 }

--- a/packages/core/src/host-leak.ts
+++ b/packages/core/src/host-leak.ts
@@ -1,0 +1,146 @@
+const textDecoder = new TextDecoder();
+
+export type HostLeakKind =
+  | "forbidden-substring"
+  | "home-path"
+  | "posix-host-path"
+  | "repo-path"
+  | "temp-path"
+  | "windows-host-path"
+  | "workspace-path";
+
+export interface HostLeakDetectionOptions {
+  readonly forbiddenSubstrings?: readonly string[];
+  readonly homePath?: string;
+  readonly repoRootPath?: string;
+  readonly tempRootPath?: string;
+  readonly workspacePaths?: readonly string[];
+}
+
+export interface HostLeakMatch {
+  readonly kind: HostLeakKind;
+  readonly redacted: string;
+}
+
+export interface HostLeakIssue {
+  readonly kind: HostLeakKind;
+  readonly path: string;
+  readonly redacted: string;
+}
+
+export function detectHostLeaksInBytes(
+  path: string,
+  bytes: Uint8Array,
+  options: HostLeakDetectionOptions = {}
+): readonly HostLeakIssue[] {
+  return detectHostLeaks(path, textDecoder.decode(bytes), options);
+}
+
+export function detectHostLeaks(
+  path: string,
+  text: string,
+  options: HostLeakDetectionOptions = {}
+): readonly HostLeakIssue[] {
+  const matches: HostLeakMatch[] = [
+    ...explicitPathMatches(text, options),
+    ...patternMatches(text),
+  ];
+  return dedupeMatches(matches).map((match) => ({
+    kind: match.kind,
+    path,
+    redacted: match.redacted,
+  }));
+}
+
+export function assertNoHostLeaks(
+  path: string,
+  bytes: Uint8Array,
+  options: HostLeakDetectionOptions = {}
+): void {
+  const [first] = detectHostLeaksInBytes(path, bytes, options);
+  if (first === undefined) return;
+  throw new Error(
+    `skillset: ${path} contains ${first.kind} leak (${first.redacted})`
+  );
+}
+
+function explicitPathMatches(
+  text: string,
+  options: HostLeakDetectionOptions
+): readonly HostLeakMatch[] {
+  const matches: HostLeakMatch[] = [];
+  for (const value of options.forbiddenSubstrings ?? []) {
+    pushExplicitMatch(matches, text, value, "forbidden-substring");
+  }
+  pushExplicitMatch(matches, text, options.repoRootPath, "repo-path");
+  pushExplicitMatch(matches, text, options.tempRootPath, "temp-path");
+  pushExplicitMatch(matches, text, options.homePath, "home-path");
+  for (const workspacePath of options.workspacePaths ?? []) {
+    pushExplicitMatch(matches, text, workspacePath, "workspace-path");
+  }
+  return matches;
+}
+
+function pushExplicitMatch(
+  matches: HostLeakMatch[],
+  text: string,
+  value: string | undefined,
+  kind: HostLeakKind
+): void {
+  if (value === undefined || value.length === 0 || !text.includes(value)) return;
+  matches.push({ kind, redacted: kind === "forbidden-substring" ? redactForbiddenSubstring(value) : redactHostPath(value) });
+}
+
+function patternMatches(text: string): readonly HostLeakMatch[] {
+  const matches: HostLeakMatch[] = [];
+  for (const match of text.matchAll(POSIX_HOST_PATH_PATTERN)) {
+    const value = match[1];
+    if (value === undefined) continue;
+    matches.push({ kind: "posix-host-path", redacted: redactHostPath(value) });
+  }
+  for (const match of text.matchAll(WINDOWS_HOST_PATH_PATTERN)) {
+    const value = match[1];
+    if (value === undefined) continue;
+    matches.push({ kind: "windows-host-path", redacted: redactHostPath(value) });
+  }
+  return matches;
+}
+
+const POSIX_HOST_PATH_PATTERN = /(?:^|[\s"'=:(])((?:\/(?:Users|home|tmp|private\/tmp|private\/var\/folders|var\/folders)\/)[^\s"'<>)`]+)/gu;
+const WINDOWS_HOST_PATH_PATTERN = /(?:^|[\s"'=:(])([A-Za-z]:[\\/](?:Users|Temp|tmp)[^\s"'<>)`]+)/gu;
+
+function dedupeMatches(matches: readonly HostLeakMatch[]): readonly HostLeakMatch[] {
+  const seen = new Set<string>();
+  const unique: HostLeakMatch[] = [];
+  for (const match of matches) {
+    const key = `${match.kind}\0${match.redacted}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(match);
+  }
+  return unique;
+}
+
+function redactHostPath(path: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  const parts = normalized.split("/").filter(Boolean);
+  if (/^[A-Za-z]:/u.test(parts[0] ?? "")) {
+    const drive = parts[0];
+    const tail = parts.at(-1);
+    return tail === undefined ? `${drive}/...` : `${drive}/.../${tail}`;
+  }
+  const root = normalized.startsWith("/") ? "/" : "";
+  const first = parts[0];
+  const tail = parts.at(-1);
+  if (first === undefined) return path;
+  if (tail === undefined || tail === first) return `${root}${first}/...`;
+  return `${root}${first}/.../${tail}`;
+}
+
+function redactForbiddenSubstring(value: string): string {
+  return isPathShaped(value) ? redactHostPath(value) : "[redacted]";
+}
+
+function isPathShaped(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:[\\/]/u.test(value) || value.includes("/") || value.includes("\\");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,15 @@ export {
   type FeatureRegistryDriftReport,
 } from "./feature-registry-check";
 export {
+  assertNoHostLeaks,
+  detectHostLeaks,
+  detectHostLeaksInBytes,
+  type HostLeakDetectionOptions,
+  type HostLeakIssue,
+  type HostLeakKind,
+  type HostLeakMatch,
+} from "./host-leak";
+export {
   LOWERING_OUTCOME_SCHEMA,
   LOWERING_OUTCOME_STATUS_VALUES,
   SkillsetLoweringError,

--- a/packages/core/src/normalized-output-tree.ts
+++ b/packages/core/src/normalized-output-tree.ts
@@ -3,6 +3,7 @@ import { lstat, readdir, readFile, readlink, stat } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 
 import { compareStrings } from "./path";
+import { assertNoHostLeaks, type HostLeakDetectionOptions } from "./host-leak";
 import type { JsonValue } from "./types";
 import { isJsonRecord, parseYamlRecord, stringifyYaml, stripUndefinedValue } from "./yaml";
 
@@ -13,6 +14,7 @@ export interface NormalizedOutputTreeOptions {
   readonly excludePathPrefixes?: readonly string[];
   readonly excludePaths?: readonly string[];
   readonly forbiddenSubstrings?: readonly string[];
+  readonly hostLeakOptions?: false | HostLeakDetectionOptions;
   readonly structuredJsonPaths?: readonly string[];
   readonly structuredYamlPaths?: readonly string[];
 }
@@ -209,6 +211,15 @@ function assertNoForbiddenSubstrings(
   bytes: Uint8Array,
   options: NormalizedOutputTreeOptions
 ): void {
+  if (options.hostLeakOptions !== undefined && options.hostLeakOptions !== false) {
+    assertNoHostLeaks(path, bytes, {
+      ...(options.hostLeakOptions ?? {}),
+      forbiddenSubstrings: [
+        ...(options.hostLeakOptions?.forbiddenSubstrings ?? []),
+        ...(options.forbiddenSubstrings ?? []),
+      ],
+    });
+  }
   const forbidden = options.forbiddenSubstrings ?? [];
   if (forbidden.length === 0) return;
   for (const value of forbidden) {


### PR DESCRIPTION
## Context

Hardens deterministic projection comparisons against host-specific output leaks before conformance fixtures depend on them.

## What Changed

- Added host leak detection for repo paths, temp roots, workspace paths, home-style paths, POSIX/Windows host paths, and caller forbidden substrings.
- Wires deterministic projection output comparison through host leak detection.
- Excludes configured output roots when copying source into temp projection workspaces.
- Preserves caller `forbiddenSubstrings` checks even when broad host leak detection is opted out.

## Verification

- `bun test packages/core/src/__tests__/deterministic-projection.test.ts packages/core/src/__tests__/host-leak.test.ts packages/core/src/__tests__/normalized-output-tree.test.ts`
- `bun run typecheck`
- Full stack pre-push gate: `bun run check`, `bun run skillset:ci`, `git diff --check main..HEAD`

## Review Notes

A P2 review finding found operation-result summaries could bypass caller forbidden substrings when `hostLeakOptions: false`; this PR now tests and blocks that path.
