### PR TITLE
feat(core): prove adapter conformance against registry claims

### DIFF
--- a/packages/core/src/__tests__/adapter-conformance.test.ts
+++ b/packages/core/src/__tests__/adapter-conformance.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  checkAdapterConformance,
+  diffSkillsetResult,
+  SkillsetLoweringError,
+  type AdapterConformanceCase,
+  type SkillsetLoweringOutcome,
+} from "@skillset/core";
+
+const CONFORMANCE_FIXTURE: Record<string, string> = {
+  ".skillset/config.yaml": `
+skillset:
+  name: conformance-root
+  marketplace:
+    name: conformance-market
+claude: true
+codex: true
+`,
+  ".skillset/skills/repo-skill/SKILL.md": `
+---
+name: repo-skill
+description: Repo skill.
+---
+
+Use the repo skill.
+`,
+  ".skillset/instructions/root.md": `
+---
+description: Root instructions.
+---
+
+Keep generated output deterministic.
+`,
+  ".skillset/src/agents/reviewer.md": `
+---
+name: reviewer
+description: Reviews code.
+skills:
+  - repo-skill
+---
+
+Review diffs carefully.
+`,
+  ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+  description: Alpha plugin.
+dependencies:
+  plugins:
+    - name: external-tools
+      range: ^2.1.0
+      marketplace: acme
+mcp: true
+`,
+  ".skillset/plugins/alpha/.mcp.json": `
+{
+  "mcpServers": {
+    "alpha": { "command": "node" }
+  }
+}
+`,
+  ".skillset/plugins/alpha/skills/plugin-skill/SKILL.md": `
+---
+name: plugin-skill
+description: Plugin skill.
+tool_intent:
+  allow:
+    read:
+      - docs/**
+---
+
+Use the plugin skill.
+`,
+};
+
+describe("adapter conformance", () => {
+  it("ties representative registry support claims to emitted lowering outcomes", async () => {
+    const root = await fixture(CONFORMANCE_FIXTURE);
+
+    const result = await diffSkillsetResult(root);
+    const report = checkAdapterConformance(result.loweringOutcomes, [
+      { featureId: "standalone-skills", sourceUnit: "skill:repo-skill", target: "claude" },
+      { featureId: "plugin-skills", sourceUnit: "plugin.alpha.skill:plugin-skill", target: "codex" },
+      { featureId: "project-instructions", sourceUnit: "instruction:AGENTS.md", target: "codex" },
+      { featureId: "project-agents", sourceUnit: "agent:reviewer", target: "codex" },
+      { featureId: "plugin-mcp", sourceUnit: "plugin.alpha.feature:mcp", target: "claude" },
+      { featureId: "dependencies", sourceUnit: "plugin.alpha.feature:dependencies", target: "claude" },
+      { featureId: "dependencies", sourceUnit: "plugin.alpha.feature:dependencies", target: "codex" },
+      { featureId: "tool-intent", sourceUnit: "plugin.alpha.skill:plugin-skill", target: "claude" },
+      { featureId: "tool-intent", sourceUnit: "plugin.alpha.skill:plugin-skill", target: "codex" },
+    ]);
+
+    expect(report).toEqual({ issues: [], ok: true });
+  });
+
+  it("proves unsupported feature claims through structured lowering outcomes", async () => {
+    const root = await fixture({
+      ...CONFORMANCE_FIXTURE,
+      ".skillset/plugins/alpha/bin/tool": `
+#!/usr/bin/env bash
+echo alpha
+`,
+    });
+
+    const report = checkAdapterConformance(await loweringErrorOutcomes(root), [
+      { featureId: "plugin-bin", sourceUnit: "plugin.alpha.feature:bin", target: "codex" },
+    ]);
+
+    expect(report).toEqual({ issues: [], ok: true });
+  });
+
+  it("reports missing, mismatched, and reason-drifted outcomes deterministically", () => {
+    const cases: readonly AdapterConformanceCase[] = [
+      { featureId: "dependencies", sourceUnit: "plugin.alpha.feature:dependencies", target: "codex" },
+      { featureId: "plugin-skills", sourceUnit: "plugin.alpha.skill:plugin-skill", target: "codex" },
+      { featureId: "standalone-skills", sourceUnit: "skill:repo-skill", target: "claude" },
+    ];
+    const outcomes: readonly SkillsetLoweringOutcome[] = [
+      outcome({ featureId: "dependencies", reason: "custom stale reason", status: "degraded", target: "codex" }),
+      outcome({ featureId: "plugin-skills", status: "transformed", target: "codex" }),
+      outcome({ featureId: "standalone-skills", status: "emitted", target: "claude" }),
+      outcome({ featureId: "standalone-skills", reason: "contradictory", status: "unsupported", target: "claude" }),
+    ];
+
+    const report = checkAdapterConformance(outcomes, cases);
+
+    expect(report.issues.map((issue) => issue.code)).toEqual([
+      "reason-mismatch",
+      "status-mismatch",
+      "status-mismatch",
+    ]);
+    expect(report.issues[0]?.message).toContain("reason does not match");
+    expect(report.issues[2]?.observed).toEqual(["emitted", "unsupported"]);
+  });
+});
+
+async function loweringErrorOutcomes(root: string): Promise<readonly SkillsetLoweringOutcome[]> {
+  try {
+    await diffSkillsetResult(root);
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillsetLoweringError);
+    return (error as SkillsetLoweringError).loweringOutcomes;
+  }
+  throw new Error("expected diffSkillsetResult to reject");
+}
+
+function outcome(
+  overrides: {
+    readonly featureId: string;
+    readonly reason?: string;
+    readonly status: SkillsetLoweringOutcome["status"];
+    readonly target: NonNullable<SkillsetLoweringOutcome["target"]>;
+  }
+): SkillsetLoweringOutcome {
+  const sourceUnitByFeature: Record<string, string> = {
+    dependencies: "plugin.alpha.feature:dependencies",
+    "plugin-skills": "plugin.alpha.skill:plugin-skill",
+    "standalone-skills": "skill:repo-skill",
+  };
+  return {
+    evidence: [{ kind: "test", ref: "packages/core/src/__tests__/adapter-conformance.test.ts" }],
+    featureId: overrides.featureId,
+    ...(overrides.reason === undefined ? {} : { reason: overrides.reason }),
+    schema: "skillset-lowering-outcome@1",
+    sourceUnit: sourceUnitByFeature[overrides.featureId] ?? "unknown",
+    status: overrides.status,
+    target: overrides.target,
+  };
+}
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-adapter-conformance-"));
+  for (const [path, content] of Object.entries(files)) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}

--- a/packages/core/src/adapter-conformance.ts
+++ b/packages/core/src/adapter-conformance.ts
@@ -1,0 +1,203 @@
+import {
+  getSkillsetFeature,
+  skillsetFeatureRegistry,
+  type SkillsetFeatureRegistry,
+  type SkillsetTargetSupportStatus,
+} from "./feature-registry";
+import type { SkillsetLoweringOutcome, SkillsetLoweringOutcomeStatus } from "./lowering-outcome";
+import { compareStrings } from "./path";
+import type { TargetName } from "./types";
+
+export type AdapterConformanceIssueCode =
+  | "feature-not-found"
+  | "missing-outcome"
+  | "missing-outcome-evidence"
+  | "missing-outcome-reason"
+  | "reason-mismatch"
+  | "status-mismatch"
+  | "support-not-applicable"
+  | "support-reason-missing";
+
+export interface AdapterConformanceCase {
+  readonly featureId: string;
+  readonly sourceUnit?: string;
+  readonly target: TargetName;
+}
+
+export interface AdapterConformanceIssue {
+  readonly code: AdapterConformanceIssueCode;
+  readonly expected?: readonly string[];
+  readonly featureId: string;
+  readonly message: string;
+  readonly observed?: readonly string[];
+  readonly sourceUnit?: string;
+  readonly target: TargetName;
+}
+
+export interface AdapterConformanceReport {
+  readonly issues: readonly AdapterConformanceIssue[];
+  readonly ok: boolean;
+}
+
+export function checkAdapterConformance(
+  outcomes: readonly SkillsetLoweringOutcome[],
+  cases: readonly AdapterConformanceCase[],
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): AdapterConformanceReport {
+  const issues = cases.flatMap((item) => checkConformanceCase(outcomes, item, registry));
+  return {
+    issues: issues.sort(compareIssues),
+    ok: issues.length === 0,
+  };
+}
+
+export function assertAdapterConformance(
+  outcomes: readonly SkillsetLoweringOutcome[],
+  cases: readonly AdapterConformanceCase[],
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): void {
+  const report = checkAdapterConformance(outcomes, cases, registry);
+  if (report.ok) return;
+  throw new Error(formatAdapterConformanceReport(report));
+}
+
+export function formatAdapterConformanceReport(report: AdapterConformanceReport): string {
+  return [
+    `skillset: adapter conformance failed with ${report.issues.length} ${report.issues.length === 1 ? "issue" : "issues"}`,
+    ...report.issues.map((issue) => `- ${issue.featureId} ${issue.target}: ${issue.message}`),
+  ].join("\n");
+}
+
+function checkConformanceCase(
+  outcomes: readonly SkillsetLoweringOutcome[],
+  item: AdapterConformanceCase,
+  registry: SkillsetFeatureRegistry
+): readonly AdapterConformanceIssue[] {
+  const feature = getSkillsetFeature(item.featureId, registry);
+  if (feature === undefined) {
+    return [issue(item, "feature-not-found", `feature registry id ${item.featureId} does not exist`)];
+  }
+  const support = feature.targetSupport[item.target];
+  const expectedStatuses = expectedOutcomeStatuses(support.status);
+  if (expectedStatuses.length === 0) {
+    return [
+      issue(
+        item,
+        "support-not-applicable",
+        `${item.target} support status ${support.status} does not lower into adapter outcomes`
+      ),
+    ];
+  }
+
+  const matching = outcomes.filter((outcome) =>
+    outcome.featureId === item.featureId &&
+    outcome.target === item.target &&
+    (item.sourceUnit === undefined || outcome.sourceUnit === item.sourceUnit)
+  );
+  if (matching.length === 0) {
+    return [
+      issue(item, "missing-outcome", `${item.target} ${support.status} support has no matching lowering outcome`, {
+        expected: expectedStatuses,
+      }),
+    ];
+  }
+
+  const observedStatuses = sortedUnique(matching.map((outcome) => outcome.status));
+  const conforming = matching.filter((outcome) =>
+    expectedStatuses.includes(outcome.status)
+  );
+  const unexpectedStatuses = observedStatuses.filter((status) => !expectedStatuses.includes(status as SkillsetLoweringOutcomeStatus));
+  if (conforming.length === 0 || unexpectedStatuses.length > 0) {
+    return [
+      issue(
+        item,
+        "status-mismatch",
+        `${item.target} ${support.status} support lowered with ${observedStatuses.join(", ")}`,
+        { expected: expectedStatuses, observed: observedStatuses }
+      ),
+    ];
+  }
+
+  const issues: AdapterConformanceIssue[] = [];
+  for (const outcome of conforming) {
+    if ((outcome.evidence?.length ?? 0) === 0) {
+      issues.push(issue(item, "missing-outcome-evidence", `${outcome.sourceUnit} has no lowering evidence`));
+    }
+    if (reasonRequired(support.status)) {
+      if (support.reason === undefined) {
+        issues.push(issue(item, "support-reason-missing", `${support.status} support has no registry reason`));
+      }
+      if (outcome.reason === undefined) {
+        issues.push(issue(item, "missing-outcome-reason", `${outcome.sourceUnit} has no lowering reason`));
+      }
+      if (support.reason !== undefined && outcome.reason !== undefined && support.reason !== outcome.reason) {
+        issues.push(issue(item, "reason-mismatch", `${outcome.sourceUnit} reason does not match registry support reason`));
+      }
+    }
+  }
+  return issues;
+}
+
+function expectedOutcomeStatuses(
+  status: SkillsetTargetSupportStatus
+): readonly SkillsetLoweringOutcomeStatus[] {
+  switch (status) {
+    case "degraded":
+      return ["degraded"];
+    case "externally_managed":
+      return ["externally_managed"];
+    case "lossy":
+      return ["lossy"];
+    case "metadata_only":
+      return ["metadata_only"];
+    case "native":
+      return ["emitted", "target_native"];
+    case "pass_through":
+      return ["target_native"];
+    case "shimmed":
+      return ["degraded", "transformed"];
+    case "transformed":
+      return ["transformed"];
+    case "unsupported":
+      return ["unsupported"];
+    case "future":
+    case "not_applicable":
+    case "planned":
+      return [];
+  }
+}
+
+function reasonRequired(status: SkillsetTargetSupportStatus): boolean {
+  return status === "degraded" || status === "lossy" || status === "unsupported";
+}
+
+function issue(
+  item: AdapterConformanceCase,
+  code: AdapterConformanceIssueCode,
+  message: string,
+  options: {
+    readonly expected?: readonly string[];
+    readonly observed?: readonly string[];
+  } = {}
+): AdapterConformanceIssue {
+  return {
+    code,
+    ...(options.expected === undefined ? {} : { expected: options.expected }),
+    featureId: item.featureId,
+    message,
+    ...(options.observed === undefined ? {} : { observed: options.observed }),
+    ...(item.sourceUnit === undefined ? {} : { sourceUnit: item.sourceUnit }),
+    target: item.target,
+  };
+}
+
+function sortedUnique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort(compareStrings);
+}
+
+function compareIssues(left: AdapterConformanceIssue, right: AdapterConformanceIssue): number {
+  return compareStrings(
+    `${left.featureId}\0${left.target}\0${left.sourceUnit ?? ""}\0${left.code}`,
+    `${right.featureId}\0${right.target}\0${right.sourceUnit ?? ""}\0${right.code}`
+  );
+}

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -636,7 +636,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     status: "implemented",
     summary: "Normalizes tool policy intent into Claude allowed-tools fields and Codex metadata sidecars.",
     targetSupport: {
-      claude: { status: "native" },
+      claude: { status: "transformed" },
       codex: { status: "metadata_only" },
     },
     title: "Tool Intent",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,15 @@ export {
   type SkillsetDiffResult,
 } from "./build";
 export {
+  assertAdapterConformance,
+  checkAdapterConformance,
+  formatAdapterConformanceReport,
+  type AdapterConformanceCase,
+  type AdapterConformanceIssue,
+  type AdapterConformanceIssueCode,
+  type AdapterConformanceReport,
+} from "./adapter-conformance";
+export {
   assertDeterministicProjection,
   formatDeterministicProjectionReport,
   runDeterministicProjection,


### PR DESCRIPTION
## Context

Connects adapter conformance fixtures to the feature registry so target support claims have executable lowering evidence.

## What Changed

- Added `checkAdapterConformance`, `assertAdapterConformance`, and report formatting in `@skillset/core`.
- Validates expected lowering statuses for representative registry claims.
- Verifies lowering evidence and reason alignment for degraded/lossy/unsupported claims.
- Rejects contradictory mixed outcomes when unexpected statuses appear beside conforming statuses.
- Corrected the `tool-intent` Claude support claim to match the observed transformed lowering behavior.

## Verification

- `bun test packages/core/src/__tests__/adapter-conformance.test.ts packages/core/src/__tests__/lowering-outcome-build.test.ts packages/core/src/__tests__/feature-registry.test.ts`
- `bun run typecheck`
- Full stack pre-push gate: `bun run check`, `bun run skillset:ci`, `git diff --check main..HEAD`

## Review Notes

A P2 review finding showed one conforming outcome could hide a contradictory unsupported/lossy sibling. This PR now reports that as `status-mismatch`.
