### PR TITLE
feat(core): report adapter conformance coverage

### DIFF
--- a/packages/core/src/__tests__/adapter-conformance-coverage.test.ts
+++ b/packages/core/src/__tests__/adapter-conformance-coverage.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createAdapterConformanceCoverageReport,
+  defineFeatureRegistry,
+  formatAdapterConformanceCoverageReport,
+  type AdapterConformanceCase,
+  type SkillsetFeatureEntry,
+  type SkillsetFeatureRegistry,
+} from "@skillset/core";
+
+describe("adapter conformance coverage", () => {
+  it("reports stable JSON rows and gap rows from registry plus fixture refs", () => {
+    const report = createAdapterConformanceCoverageReport([
+      {
+        featureId: "covered-feature",
+        fixtureRef: "packages/core/src/__tests__/adapter-conformance.test.ts",
+        sourceUnit: "skill:demo",
+        target: "claude",
+      },
+      {
+        featureId: "unsupported-feature",
+        fixtureRef: "packages/core/src/__tests__/adapter-conformance.test.ts",
+        sourceUnit: "plugin.demo.feature:bin",
+        target: "claude",
+      },
+      {
+        featureId: "deleted-feature",
+        fixtureRef: "packages/core/src/__tests__/deleted-conformance.test.ts",
+        sourceUnit: "deleted:demo",
+        target: "claude",
+      },
+      {
+        featureId: "future-feature",
+        fixtureRef: "packages/core/src/__tests__/adapter-conformance.test.ts",
+        sourceUnit: "future:demo",
+        target: "codex",
+      },
+    ], registry());
+
+    expect(report.ok).toBe(false);
+    expect(JSON.stringify(report, null, 2)).toBe(`{
+  "entries": [
+    {
+      "coverage": "covered",
+      "featureId": "covered-feature",
+      "featureStatus": "implemented",
+      "fixtureRefs": [
+        "packages/core/src/__tests__/adapter-conformance.test.ts"
+      ],
+      "supportStatus": "native",
+      "target": "claude",
+      "title": "Covered Feature"
+    },
+    {
+      "coverage": "missing_fixture",
+      "featureId": "covered-feature",
+      "featureStatus": "implemented",
+      "fixtureRefs": [],
+      "supportStatus": "transformed",
+      "target": "codex",
+      "title": "Covered Feature"
+    },
+    {
+      "coverage": "stale_fixture",
+      "featureId": "deleted-feature",
+      "fixtureRefs": [
+        "packages/core/src/__tests__/deleted-conformance.test.ts"
+      ],
+      "reason": "feature id is not present in registry",
+      "target": "claude"
+    },
+    {
+      "coverage": "future",
+      "featureId": "future-feature",
+      "featureStatus": "future",
+      "fixtureRefs": [],
+      "supportStatus": "future",
+      "target": "claude",
+      "title": "Future Feature"
+    },
+    {
+      "coverage": "invalid_fixture",
+      "featureId": "future-feature",
+      "featureStatus": "future",
+      "fixtureRefs": [
+        "packages/core/src/__tests__/adapter-conformance.test.ts"
+      ],
+      "supportStatus": "not_applicable",
+      "target": "codex",
+      "title": "Future Feature"
+    },
+    {
+      "coverage": "covered",
+      "featureId": "unsupported-feature",
+      "featureStatus": "implemented",
+      "fixtureRefs": [
+        "packages/core/src/__tests__/adapter-conformance.test.ts"
+      ],
+      "reason": "Claude does not support this demo feature.",
+      "supportStatus": "unsupported",
+      "target": "claude",
+      "title": "Unsupported Feature"
+    },
+    {
+      "coverage": "unsupported_without_fixture",
+      "featureId": "unsupported-feature",
+      "featureStatus": "implemented",
+      "fixtureRefs": [],
+      "reason": "Codex does not support this demo feature.",
+      "supportStatus": "unsupported",
+      "target": "codex",
+      "title": "Unsupported Feature"
+    }
+  ],
+  "gaps": [
+    {
+      "coverage": "missing_fixture",
+      "featureId": "covered-feature",
+      "featureStatus": "implemented",
+      "fixtureRefs": [],
+      "supportStatus": "transformed",
+      "target": "codex",
+      "title": "Covered Feature"
+    },
+    {
+      "coverage": "stale_fixture",
+      "featureId": "deleted-feature",
+      "fixtureRefs": [
+        "packages/core/src/__tests__/deleted-conformance.test.ts"
+      ],
+      "reason": "feature id is not present in registry",
+      "target": "claude"
+    },
+    {
+      "coverage": "invalid_fixture",
+      "featureId": "future-feature",
+      "featureStatus": "future",
+      "fixtureRefs": [
+        "packages/core/src/__tests__/adapter-conformance.test.ts"
+      ],
+      "supportStatus": "not_applicable",
+      "target": "codex",
+      "title": "Future Feature"
+    },
+    {
+      "coverage": "unsupported_without_fixture",
+      "featureId": "unsupported-feature",
+      "featureStatus": "implemented",
+      "fixtureRefs": [],
+      "reason": "Codex does not support this demo feature.",
+      "supportStatus": "unsupported",
+      "target": "codex",
+      "title": "Unsupported Feature"
+    }
+  ],
+  "ok": false
+}`);
+  });
+
+  it("formats the gap list without coverage percentages", () => {
+    const report = createAdapterConformanceCoverageReport([], registry());
+
+    expect(formatAdapterConformanceCoverageReport(report)).toContain(
+      "adapter conformance coverage found 4 gaps"
+    );
+    expect(formatAdapterConformanceCoverageReport(report)).not.toContain("%");
+  });
+
+  it("can summarize representative current-registry conformance fixture refs", () => {
+    const cases = [
+      { featureId: "standalone-skills", fixtureRef: "packages/core/src/__tests__/adapter-conformance.test.ts", target: "claude" },
+      { featureId: "plugin-skills", fixtureRef: "packages/core/src/__tests__/adapter-conformance.test.ts", target: "codex" },
+      { featureId: "plugin-bin", fixtureRef: "packages/core/src/__tests__/adapter-conformance.test.ts", target: "codex" },
+    ] satisfies readonly AdapterConformanceCase[];
+
+    const report = createAdapterConformanceCoverageReport(cases);
+    const covered = report.entries.filter((entry) => entry.coverage === "covered");
+
+    expect(covered.map((entry) => `${entry.featureId}:${entry.target}`)).toContain("plugin-bin:codex");
+    expect(report.gaps.some((entry) => entry.coverage === "unsupported_without_fixture")).toBe(true);
+  });
+});
+
+function registry(): SkillsetFeatureRegistry {
+  return defineFeatureRegistry([
+    feature({
+      id: "covered-feature",
+      status: "implemented",
+      title: "Covered Feature",
+      targetSupport: {
+        claude: { status: "native" },
+        codex: { status: "transformed" },
+      },
+    }),
+    feature({
+      id: "future-feature",
+      status: "future",
+      title: "Future Feature",
+      targetSupport: {
+        claude: { status: "future" },
+        codex: { status: "not_applicable" },
+      },
+    }),
+    feature({
+      id: "unsupported-feature",
+      status: "implemented",
+      title: "Unsupported Feature",
+      targetSupport: {
+        claude: { reason: "Claude does not support this demo feature.", status: "unsupported" },
+        codex: { reason: "Codex does not support this demo feature.", status: "unsupported" },
+      },
+    }),
+  ]);
+}
+
+function feature(
+  overrides: Pick<SkillsetFeatureEntry, "id" | "status" | "targetSupport" | "title">
+): SkillsetFeatureEntry {
+  const evidence = [{ kind: "test" as const, ref: "packages/core/src/__tests__/adapter-conformance-coverage.test.ts" }];
+  return {
+    docs: ["docs/features/feature-registry.md"],
+    evidence,
+    kind: "source",
+    loweringOwner: "packages/core/src/__tests__/adapter-conformance-coverage.test.ts",
+    sourceShape: "test fixture",
+    summary: `${overrides.title} summary.`,
+    targetSupport: {
+      claude: { evidence, ...overrides.targetSupport.claude },
+      codex: { evidence, ...overrides.targetSupport.codex },
+    },
+    validationOwner: "packages/core/src/__tests__/adapter-conformance-coverage.test.ts",
+    id: overrides.id,
+    status: overrides.status,
+    title: overrides.title,
+  };
+}

--- a/packages/core/src/adapter-conformance-coverage.ts
+++ b/packages/core/src/adapter-conformance-coverage.ts
@@ -1,0 +1,167 @@
+import type { AdapterConformanceCase } from "./adapter-conformance";
+import {
+  skillsetFeatureRegistry,
+  type SkillsetFeatureEntry,
+  type SkillsetFeatureRegistry,
+  type SkillsetFeatureStatus,
+  type SkillsetTargetSupportStatus,
+} from "./feature-registry";
+import { compareStrings } from "./path";
+import type { TargetName } from "./types";
+
+export type AdapterConformanceCoverageStatus =
+  | "covered"
+  | "deferred"
+  | "future"
+  | "invalid_fixture"
+  | "missing_fixture"
+  | "not_applicable"
+  | "planned"
+  | "stale_fixture"
+  | "unsupported_without_fixture";
+
+export interface AdapterConformanceCoverageEntry {
+  readonly coverage: AdapterConformanceCoverageStatus;
+  readonly featureId: string;
+  readonly featureStatus?: SkillsetFeatureStatus;
+  readonly fixtureRefs: readonly string[];
+  readonly reason?: string;
+  readonly supportStatus?: SkillsetTargetSupportStatus;
+  readonly target: TargetName;
+  readonly title?: string;
+}
+
+export interface AdapterConformanceCoverageReport {
+  readonly entries: readonly AdapterConformanceCoverageEntry[];
+  readonly gaps: readonly AdapterConformanceCoverageEntry[];
+  readonly ok: boolean;
+}
+
+export function createAdapterConformanceCoverageReport(
+  cases: readonly AdapterConformanceCase[],
+  registry: SkillsetFeatureRegistry = skillsetFeatureRegistry
+): AdapterConformanceCoverageReport {
+  const entries = [
+    ...registry.flatMap((feature) =>
+      (["claude", "codex"] as const satisfies readonly TargetName[]).map((target) =>
+        coverageEntry(feature, target, fixtureRefsFor(cases, feature.id, target))
+      )
+    ),
+    ...staleFixtureEntries(cases, registry),
+  ].sort(compareEntries);
+  const gaps = entries.filter((entry) => isGap(entry.coverage));
+  return {
+    entries,
+    gaps,
+    ok: gaps.length === 0,
+  };
+}
+
+export function formatAdapterConformanceCoverageReport(
+  report: AdapterConformanceCoverageReport
+): string {
+  if (report.gaps.length === 0) {
+    return `skillset: adapter conformance coverage has no gaps across ${report.entries.length} target claims`;
+  }
+  return [
+    `skillset: adapter conformance coverage found ${report.gaps.length} ${report.gaps.length === 1 ? "gap" : "gaps"}`,
+    ...report.gaps.map((entry) => {
+      const reason = entry.reason === undefined ? "" : ` (${entry.reason})`;
+      const support = entry.supportStatus ?? "unknown support";
+      return `- ${entry.featureId} ${entry.target}: ${entry.coverage} for ${support}${reason}`;
+    }),
+  ].join("\n");
+}
+
+function coverageEntry(
+  feature: SkillsetFeatureEntry,
+  target: TargetName,
+  fixtureRefs: readonly string[]
+): AdapterConformanceCoverageEntry {
+  const support = feature.targetSupport[target];
+  const coverage = coverageStatus(feature.status, support.status, fixtureRefs.length > 0);
+  return {
+    coverage,
+    featureId: feature.id,
+    featureStatus: feature.status,
+    fixtureRefs,
+    ...(support.reason === undefined ? {} : { reason: support.reason }),
+    supportStatus: support.status,
+    target,
+    title: feature.title,
+  };
+}
+
+function coverageStatus(
+  featureStatus: SkillsetFeatureStatus,
+  supportStatus: SkillsetTargetSupportStatus,
+  hasFixture: boolean
+): AdapterConformanceCoverageStatus {
+  if (hasFixture && !supportCanHaveFixture(featureStatus, supportStatus)) return "invalid_fixture";
+  if (hasFixture) return "covered";
+  if (supportStatus === "not_applicable") return "not_applicable";
+  if (featureStatus === "deferred") return "deferred";
+  if (featureStatus === "future" || supportStatus === "future") return "future";
+  if (featureStatus === "planned" || supportStatus === "planned") return "planned";
+  if (supportStatus === "unsupported") return "unsupported_without_fixture";
+  return "missing_fixture";
+}
+
+function supportCanHaveFixture(
+  featureStatus: SkillsetFeatureStatus,
+  supportStatus: SkillsetTargetSupportStatus
+): boolean {
+  if (featureStatus === "deferred" || featureStatus === "future" || featureStatus === "planned") return false;
+  return supportStatus !== "future" && supportStatus !== "not_applicable" && supportStatus !== "planned";
+}
+
+function fixtureRefsFor(
+  cases: readonly AdapterConformanceCase[],
+  featureId: string,
+  target: TargetName
+): readonly string[] {
+  return [...new Set(
+    cases
+      .filter((item) => item.featureId === featureId && item.target === target)
+      .map((item) => item.fixtureRef ?? item.sourceUnit ?? `${item.featureId}:${item.target}`)
+  )].sort(compareStrings);
+}
+
+function staleFixtureEntries(
+  cases: readonly AdapterConformanceCase[],
+  registry: SkillsetFeatureRegistry
+): readonly AdapterConformanceCoverageEntry[] {
+  const registryIds = new Set(registry.map((feature) => feature.id));
+  const grouped = new Map<string, AdapterConformanceCase[]>();
+  for (const item of cases) {
+    if (registryIds.has(item.featureId)) continue;
+    const key = `${item.featureId}\0${item.target}`;
+    grouped.set(key, [...(grouped.get(key) ?? []), item]);
+  }
+  return [...grouped.values()].map((items) => {
+    const [first] = items;
+    if (first === undefined) throw new Error("skillset: internal stale fixture group is empty");
+    return {
+      coverage: "stale_fixture",
+      featureId: first.featureId,
+      fixtureRefs: sortedUnique(items.map((item) => item.fixtureRef ?? item.sourceUnit ?? `${item.featureId}:${item.target}`)),
+      reason: "feature id is not present in registry",
+      target: first.target,
+    };
+  });
+}
+
+function isGap(status: AdapterConformanceCoverageStatus): boolean {
+  return status === "invalid_fixture" || status === "missing_fixture" || status === "stale_fixture" || status === "unsupported_without_fixture";
+}
+
+function compareEntries(
+  left: AdapterConformanceCoverageEntry,
+  right: AdapterConformanceCoverageEntry
+): number {
+  return compareStrings(`${left.featureId}\0${left.target}`, `${right.featureId}\0${right.target}`);
+}
+
+function sortedUnique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort(compareStrings);
+}

--- a/packages/core/src/adapter-conformance.ts
+++ b/packages/core/src/adapter-conformance.ts
@@ -20,6 +20,7 @@ export type AdapterConformanceIssueCode =
 
 export interface AdapterConformanceCase {
   readonly featureId: string;
+  readonly fixtureRef?: string;
   readonly sourceUnit?: string;
   readonly target: TargetName;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,13 @@ export {
   type AdapterConformanceReport,
 } from "./adapter-conformance";
 export {
+  createAdapterConformanceCoverageReport,
+  formatAdapterConformanceCoverageReport,
+  type AdapterConformanceCoverageEntry,
+  type AdapterConformanceCoverageReport,
+  type AdapterConformanceCoverageStatus,
+} from "./adapter-conformance-coverage";
+export {
   assertDeterministicProjection,
   formatDeterministicProjectionReport,
   runDeterministicProjection,


### PR DESCRIPTION
## Context

Adds a registry-wide conformance coverage report so missing or invalid adapter fixture coverage is visible instead of inferred manually.

## What Changed

- Added `createAdapterConformanceCoverageReport` and formatter in `@skillset/core`.
- Reports one row per registry feature/target claim with fixture refs and gap status.
- Flags missing fixtures, invalid fixtures on future/planned/not-applicable claims, unsupported claims without fixtures, and stale fixture cases for deleted/renamed feature ids.
- Pins a stable JSON report shape in tests.

## Verification

- `bun test packages/core/src/__tests__/adapter-conformance-coverage.test.ts packages/core/src/__tests__/adapter-conformance.test.ts`
- `bun run typecheck`
- Full stack pre-push gate: `bun run check`, `bun run skillset:ci`, `git diff --check main..HEAD`

## Review Notes

A P3 review finding showed stale fixture cases could disappear because the report only walked the registry. This PR now emits `stale_fixture` gap rows for case ids not present in the registry.
