### PR TITLE
chore(release): cut 0.1.0-beta.10

### DIFF
--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillset",
-  "version": "0.1.0-beta.9",
+  "version": "0.1.0-beta.10",
   "description": "Source-first compiler for Claude and Codex agent loadouts.",
   "type": "module",
   "files": [

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.1.0-beta.9",
+      "version": "0.1.0-beta.10",
       "bin": {
         "create-skillset": "dist/create.js",
         "skillset": "dist/cli.js",


### PR DESCRIPTION
## Summary
- bump the public `skillset` package from `0.1.0-beta.9` to `0.1.0-beta.10`
- refresh `bun.lock` workspace package metadata to match
- package the merged conformance and inspection stack (#77-#81)

## Verification
- `bun install --lockfile-only`
- `bun run build:npm`
- `bun run check` (499 pass, 0 fail; Ultracite doctor clean; skillset lint/check clean)
- pre-push hook during `gt submit` (skillset-ci and check passed)

## Release Notes
This beta includes feature registry drift checks, host-specific projection leak detection, adapter conformance fixtures tied to registry claims, conformance coverage reporting, and feature capability inspection through `features`, `doctor`, and `explain`.
