### PR TITLE
chore(release): cut 0.13.0 stable

### DIFF
--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -1,14 +1,13 @@
 {
   "name": "skillset",
-  "version": "0.1.0-beta.10",
+  "version": "0.13.0",
   "description": "Source-first compiler for Claude and Codex agent loadouts.",
   "type": "module",
   "files": [
     "dist/*.js"
   ],
   "publishConfig": {
-    "access": "public",
-    "tag": "beta"
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.1.0-beta.10",
+      "version": "0.13.0",
       "bin": {
         "create-skillset": "dist/create.js",
         "skillset": "dist/cli.js",


### PR DESCRIPTION
## Summary
- promote the public package from `0.1.0-beta.10` to stable `0.13.0`
- remove `publishConfig.tag: beta` so future package publishes use npm's default `latest` tag
- refresh `bun.lock` workspace package metadata to match

## Version Rationale
I reviewed the merged PR history and treated the major capability waves as pre-1.0 minor milestones rather than continuing to stuff all work into `0.1.0-beta.*`:

1. public/source-contract foundation and target facts (#1-#14)
2. fixture, dogfood, and eval boundary (#15-#17)
3. change selectors and pre-public contract cleanup (#18-#20)
4. deterministic test runner, init/adoption, CI, and repo tooling (#21-#29)
5. import/adopt/external fixture maturity (#30, #34-#43)
6. lint and workspace split foundation (#31-#33)
7. `@skillset/core` boundary and consumer API (#44-#49)
8. feature registry and adapter capability records (#50-#52)
9. lowering outcome schema and build collection (#53-#54)
10. distribution/runtime adapter/version audit/probe work (#58-#64)
11. output safety and unmanaged backup behavior (#65)
12. outcome ledger policy/reporting and setup/hooks finish-out (#66-#75)
13. registry drift, host leak detection, conformance coverage, and capability inspection (#77-#81)

That makes `0.13.0` a better honest pre-1.0 stable version than `0.1.0-beta.11`, without implying the project is ready for `1.0`.

## Verification
- `npm view skillset@0.13.0 version --json` returns 404 before publish, so the version is available
- `bun install --lockfile-only`
- `bun run build:npm`
- `bun run check` (499 pass, 0 fail; Ultracite doctor clean; skillset lint/check clean)
- `npm pack --dry-run` from `apps/skillset` (tarball contains `dist/cli.js`, `dist/create.js`, and `package.json`)
- pre-push hook during `gt submit` (`skillset-ci` and `check` passed)

## Publish Plan
After this PR merges, publish `skillset@0.13.0` to npm with the default `latest` tag and push `v0.13.0`.
