### PR TITLE
ci(release): harden package release workflow

### DIFF
--- a/.changeset/sharp-falcons-flow.md
+++ b/.changeset/sharp-falcons-flow.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Harden package release automation with immutable workflow action pins and tag-authoritative GitHub release creation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,16 @@ jobs:
     outputs:
       has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
       - run: bun install --frozen-lockfile
       - name: Create or update version PR
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
@@ -49,8 +49,8 @@ jobs:
       tag: ${{ steps.plan.outputs.tag }}
       version: ${{ steps.plan.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
       - run: bun install --frozen-lockfile
@@ -69,17 +69,18 @@ jobs:
       id-token: write
     outputs:
       name: ${{ steps.publish.outputs.name }}
+      published: ${{ steps.publish.outputs.published }}
       registry_complete: ${{ steps.publish.outputs.registry_complete }}
       tag: ${{ steps.publish.outputs.tag }}
       version: ${{ steps.publish.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
       - run: bun install --frozen-lockfile
@@ -97,7 +98,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Create GitHub release
@@ -106,6 +107,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.publish.outputs.version || needs.publish-plan.outputs.version }}
           DIST_TAG: ${{ needs.publish.outputs.tag || needs.publish-plan.outputs.tag }}
+          PUBLISHED: ${{ needs.publish.outputs.published }}
         run: |
           create_args=()
           if [ "$DIST_TAG" != "latest" ]; then
@@ -114,18 +116,34 @@ jobs:
             create_args+=(--latest)
           fi
 
+          tag="v$VERSION"
           notes="Published skillset@$VERSION to npm with dist-tag \`$DIST_TAG\`."
-          version_target="$(git log -n 1 --format=%H -- apps/skillset/package.json)"
+          version_target="$(git log -n 1 --format=%H -S "\"version\": \"$VERSION\"" -- apps/skillset/package.json)"
           if [ -z "$version_target" ]; then
-            echo "Could not resolve package version commit" >&2
+            echo "Could not resolve commit that introduced apps/skillset/package.json version $VERSION" >&2
             exit 1
           fi
 
-          if gh release view "v$VERSION" >/dev/null 2>&1; then
-            echo "GitHub release v$VERSION already exists"
+          git fetch --force --tags origin
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            tag_target="$(git rev-list -n 1 "$tag")"
+            if [ "$tag_target" != "$version_target" ]; then
+              echo "$tag points to $tag_target, expected $version_target" >&2
+              exit 1
+            fi
+          elif [ "$PUBLISHED" = "true" ]; then
+            git tag "$tag" "$version_target"
+            git push origin "refs/tags/$tag"
           else
-            gh release create "v$VERSION" \
-              --target "$version_target" \
+            echo "$tag is missing for already-published skillset@$VERSION; create the tag at $version_target before backfilling the GitHub release" >&2
+            exit 1
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub release $tag already exists"
+          else
+            gh release create "$tag" \
+              --verify-tag \
               --title "skillset v$VERSION" \
               --notes "$notes" \
               "${create_args[@]}"

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -12,7 +12,7 @@ Changesets owns npm package version and package changelog calculation. The Skill
 
 Feature branches that change package-facing behavior should include a `.changeset/*.md` file. When the branch merges to `main`, `.github/workflows/release.yml` runs `changesets/action` to create or update a `chore(release): version packages` pull request.
 
-When the version PR merges to `main`, the same workflow checks the npm registry. If the current `apps/skillset/package.json` version is already published and the intended dist-tag points to it, the workflow exits the publish step without entering the protected publish environment and ensures a missing GitHub release can still be created for the package-version commit. If the version is missing, the workflow enters the `npm` environment, runs the full package preflight, publishes with `npm publish`, waits for the version and dist-tag to appear on the registry, and creates the matching GitHub release if it does not already exist.
+When the version PR merges to `main`, the same workflow checks the npm registry. If the current `apps/skillset/package.json` version is already published and the intended dist-tag points to it, the workflow exits the publish step without entering the protected publish environment and ensures a missing GitHub release can still be created when the matching `v<version>` tag already points at the package-version commit. If the version is missing, the workflow enters the `npm` environment, runs the full package preflight, publishes with `npm publish`, waits for the version and dist-tag to appear on the registry, creates and pushes the matching `v<version>` tag at the package-version commit, and creates the GitHub release with `--verify-tag` if it does not already exist.
 
 The publish wrapper derives the npm dist-tag from the version: stable versions publish to `latest`, and prerelease versions publish to their prerelease label such as `beta`.
 
@@ -40,7 +40,7 @@ bun run publish:packages
 
 ## Trusted Publishing Setup
 
-The workflow is prepared for npm Trusted Publishing by using a publish job with `permissions.id-token: write`, Node 24, the npm CLI for the final publish, and the protected GitHub environment `npm`. Bun remains the package build, test, and preflight runtime; npm owns the OIDC exchange because Trusted Publishing is currently documented for `npm publish`. Configure the trusted publisher for the npm package with:
+The workflow is prepared for npm Trusted Publishing by using a publish job with `permissions.id-token: write`, SHA-pinned workflow actions, Node 24, the npm CLI for the final publish, and the protected GitHub environment `npm`. Bun remains the package build, test, and preflight runtime; npm owns the OIDC exchange because Trusted Publishing is currently documented for `npm publish`. Configure the trusted publisher for the npm package with:
 
 | Field | Value |
 | --- | --- |


### PR DESCRIPTION
## Context

Follow-up hardening for the package release workflow after PR #84. This handles the in-repo parts that can move without touching npmjs.com settings: immutable action pins and tag-authoritative GitHub release creation.

## What Changed

- SHA-pinned every action used by `.github/workflows/release.yml` while keeping comments for the human-readable action version:
  - `actions/checkout` v4
  - `oven-sh/setup-bun` v2
  - `actions/setup-node` v4
  - `changesets/action` v1
- Exposed the publish step's `published` output to the GitHub release job.
- Made GitHub release creation tag-authoritative:
  - resolves the commit that introduced the current `apps/skillset/package.json` version;
  - fetches tags and verifies `v<version>` points at that package-version commit;
  - creates and pushes `v<version>` only after this workflow run actually published the package;
  - fails clearly for already-published backfills when the matching tag is missing;
  - creates the GitHub release with `--verify-tag` so `gh release create` cannot silently auto-create tags.
- Updated package release docs to describe the stricter tag/release behavior.
- Added a patch Changeset for this package-release automation hardening.

## Verification

- `git diff --check`
- `bun run check:workflows`
- `bun run changeset:status`
- `bun run publish:plan`
- `bun run publish:registry-check:published`
- `bun run publish:check`
- Graphite submit dry-run
- Graphite submit, including Lefthook pre-push gates:
  - `skillset ci` passed
  - `bun run check` passed with 500 tests, Ultracite doctor, Skillset lint/check, and `git diff --check`

## Notes / Risk

This does not configure npm Trusted Publishing on npmjs.com. That remains the one manual setup step. The release workflow now fails closed if npm says a version is already published but the matching git tag is missing, which is intentional: backfilling published versions should be explicit rather than letting release automation invent tags after the fact.
