### PR TITLE
ci(actions): use Node 24-compatible workflow actions

### DIFF
--- a/.changeset/smooth-plums-compare.md
+++ b/.changeset/smooth-plums-compare.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Update GitHub workflow actions to Node 24-compatible major versions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
@@ -34,18 +34,18 @@ jobs:
     steps:
       - name: Checkout same-repo pull request
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Checkout fork pull request
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Checkout push
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -49,7 +49,7 @@ jobs:
       tag: ${{ steps.plan.outputs.tag }}
       version: ${{ steps.plan.outputs.version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
@@ -74,15 +74,16 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
       version: ${{ steps.publish.outputs.version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
+          package-manager-cache: false
       - run: bun install --frozen-lockfile
       - name: Validate package before publish
         run: bun run publish:check
@@ -98,7 +99,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - name: Create GitHub release


### PR DESCRIPTION
## Context

GitHub Actions now warns on Node 20 JavaScript actions, and the release workflow hit that warning during the `0.13.1` publish. Upstream `actions/checkout@v5` and `actions/setup-node@v5` both declare `runs.using: node24`.

## Changes

- Updates CI checkout steps from `actions/checkout@v4` to `actions/checkout@v5`.
- Updates SHA-pinned release workflow checkout usages from `actions/checkout` v4 to the v5 tag commit.
- Updates the release publish job from SHA-pinned `actions/setup-node` v4 to v5.
- Disables `setup-node` v5 automatic package-manager caching in the privileged publish job.
- Adds a patch changeset for the release-infra update.

## Verification

- `bun run check:workflows`
- `bun run changeset:status`
- `git diff --check`
- `bun run check`
- Graphite pre-push gate: `skillset-ci` and `check`

## Notes

`oven-sh/setup-bun@v2` and `changesets/action@v1` remain on their current SHA-pinned versions; this PR only changes the GitHub-owned actions that were producing Node 20 warnings.
