### PR TITLE
fix(core): return structured check drift results

### DIFF
--- a/.changeset/fuzzy-owls-rest.md
+++ b/.changeset/fuzzy-owls-rest.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Return structured check drift results from the core API while preserving CLI and helper failure behavior.

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -532,6 +532,11 @@ export async function runCli(
   const result = await checkSkillsetResult(rootPath, options);
   printDiagnostics(result.diagnostics);
   console.log(`skillset: checked ${result.data.checkedFiles} generated files`);
+  if (!result.ok) {
+    console.error(`skillset: generated output is not current`);
+    for (const failure of result.data.failures) console.error(failure);
+    process.exitCode = 1;
+  }
 }
 
 export function reportCliError(error: unknown): void {

--- a/packages/core/src/__tests__/consumer.test.ts
+++ b/packages/core/src/__tests__/consumer.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  checkSkillset,
   buildSkillsetResult,
   checkSkillsetResult,
   diffSkillsetResult,
@@ -25,6 +26,15 @@ description: Demo skill.
 Body.
 `,
 };
+
+const SECOND_SKILL = `
+---
+name: keeper
+description: Keeper skill.
+---
+
+Keep the source graph valid.
+`;
 
 describe("@skillset/core consumer API", () => {
   it("supports a quiet preview-build-check loop through public result APIs", async () => {
@@ -66,6 +76,7 @@ describe("@skillset/core consumer API", () => {
 
       const checked = await checkSkillsetResult(root);
       expect(checked.operation).toBe("check");
+      expect(checked.ok).toBe(true);
       expect(checked.writes).toEqual({
         deletedPaths: [],
         mode: "read",
@@ -73,6 +84,7 @@ describe("@skillset/core consumer API", () => {
         writtenPaths: [],
       });
       expect(checked.data.checkedFiles).toBe(build.data.length);
+      expect(checked.data.failures).toEqual([]);
       expect(checked.diagnostics).toEqual([]);
 
       const clean = await diffSkillsetResult(root);
@@ -85,6 +97,102 @@ describe("@skillset/core consumer API", () => {
       console.warn = originalWarn;
       process.exitCode = previousExitCode;
     }
+  });
+
+  it("returns structured check drift while preserving the throwing convenience helper", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+    const expectedOutput = ".claude/skills/demo/SKILL.md";
+    await buildSkillsetResult(root);
+    await Bun.write(join(root, expectedOutput), "stale\n");
+
+    const result = await checkSkillsetResult(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.operation).toBe("check");
+    expect(result.writes.mode).toBe("read");
+    expect(result.data.checkedFiles).toBeGreaterThan(0);
+    expect(result.data.failures).toHaveLength(1);
+    expect(result.data.failures[0]).toContain(expectedOutput);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "generated-output-changed",
+        outputPath: expectedOutput,
+        severity: "error",
+      })
+    );
+    await expect(checkSkillset(root)).rejects.toThrow("skillset: generated output is not current");
+  });
+
+  it("classifies missing generated output before a first build", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+    const expectedOutput = ".claude/skills/demo/SKILL.md";
+
+    const result = await checkSkillsetResult(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.data.failures).toContain(`missing generated file: ${expectedOutput}`);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "generated-output-missing",
+        outputPath: expectedOutput,
+        severity: "error",
+      })
+    );
+  });
+
+  it("classifies deleted managed generated output", async () => {
+    const root = await fixture(DEMO_FIXTURE);
+    const expectedOutput = ".claude/skills/demo/SKILL.md";
+    await buildSkillsetResult(root);
+    await rm(join(root, expectedOutput));
+
+    const result = await checkSkillsetResult(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.data.failures).toEqual([`missing managed generated file: ${expectedOutput}`]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "generated-output-missing-managed",
+        outputPath: expectedOutput,
+        severity: "error",
+      })
+    );
+  });
+
+  it("classifies stale generated output for removed source units", async () => {
+    const root = await fixture({
+      ...DEMO_FIXTURE,
+      ".skillset/skills/keeper/SKILL.md": SECOND_SKILL,
+    });
+    const expectedOutput = ".claude/skills/demo/SKILL.md";
+    await buildSkillsetResult(root);
+    await rm(join(root, ".skillset/skills/demo"), { recursive: true });
+
+    const result = await checkSkillsetResult(root);
+
+    expect(result.ok).toBe(false);
+    expect(result.data.failures).toContain(`stale generated file: ${expectedOutput}`);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "generated-output-removed",
+        outputPath: expectedOutput,
+        severity: "error",
+      })
+    );
+  });
+
+  it("still rejects invalid source config as an exceptional error", async () => {
+    const root = await fixture({
+      ".skillset/config.yaml": `
+skillset:
+  name: invalid-core-check-root
+compile:
+  targets:
+    - nope
+`,
+    });
+
+    await expect(checkSkillsetResult(root)).rejects.toThrow("unsupported target");
   });
 });
 

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -239,7 +239,11 @@ export async function checkSkillset(
   rootPath: string,
   options: SkillsetOptions = {}
 ): Promise<CheckResult> {
-  return (await checkSkillsetResult(rootPath, options)).data;
+  const result = await checkSkillsetResult(rootPath, options);
+  if (!result.ok) {
+    throw new Error(`skillset: generated output is not current\n${result.data.failures.join("\n")}`);
+  }
+  return result.data;
 }
 
 export type SkillsetCheckResult = SkillsetOperationResult<CheckResult>;
@@ -275,6 +279,7 @@ export async function checkSkillsetResult(
   const actualPaths = await listGeneratedFiles(rootPath, outputRoots, rendered, previousManagedState.paths);
   const actual = new Set(actualPaths);
   const failures: string[] = [];
+  const driftDiagnostics: SkillsetDiagnostic[] = [];
 
   for (const file of rendered) {
     if (!actual.has(file.path)) {
@@ -283,13 +288,19 @@ export async function checkSkillsetResult(
           ? `missing managed generated file: ${file.path}`
           : `missing generated file: ${file.path}`
       );
+      driftDiagnostics.push(generatedDriftDiagnostic(
+        previousManagedState.paths.has(file.path) ? "missing-managed" : "missing",
+        file.path
+      ));
       continue;
     }
 
     const outputPath = resolveInside(rootPath, file.path);
     const current = await readFile(outputPath);
     if (!bytesEqual(current, file.content)) {
-      failures.push(versionDriftMessage(file.path, current, file.content) ?? `stale generated file: ${file.path}`);
+      const message = versionDriftMessage(file.path, current, file.content) ?? `stale generated file: ${file.path}`;
+      failures.push(message);
+      driftDiagnostics.push(generatedDriftDiagnostic("changed", file.path, message));
     }
   }
 
@@ -297,18 +308,15 @@ export async function checkSkillsetResult(
     if (!previousManagedState.paths.has(path)) continue;
     if (!expected.has(path)) {
       failures.push(`stale generated file: ${path}`);
+      driftDiagnostics.push(generatedDriftDiagnostic("removed", path));
     }
   }
 
-  if (failures.length > 0) {
-    throw new Error(`skillset: generated output is not current\n${failures.join("\n")}`);
-  }
-
   return {
-    data: { checkedFiles: rendered.length },
-    diagnostics,
+    data: { checkedFiles: rendered.length, failures },
+    diagnostics: [...diagnostics, ...driftDiagnostics],
     loweringOutcomes: loweringOutcomesWithDiagnostics,
-    ok: true,
+    ok: failures.length === 0,
     operation: "check",
     writes: {
       deletedPaths: [],
@@ -317,6 +325,29 @@ export async function checkSkillsetResult(
       writtenPaths: [],
     },
   };
+}
+
+function generatedDriftDiagnostic(
+  kind: "changed" | "missing" | "missing-managed" | "removed",
+  path: string,
+  message = generatedDriftMessage(kind, path)
+): SkillsetDiagnostic {
+  return {
+    code: `generated-output-${kind}`,
+    message,
+    outputPath: path,
+    severity: "error",
+  };
+}
+
+function generatedDriftMessage(
+  kind: "changed" | "missing" | "missing-managed" | "removed",
+  path: string
+): string {
+  if (kind === "changed") return `stale generated file: ${path}`;
+  if (kind === "missing") return `missing generated file: ${path}`;
+  if (kind === "missing-managed") return `missing managed generated file: ${path}`;
+  return `stale generated file: ${path}`;
 }
 
 function buildResult(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,9 @@ export {
   type FeatureSupportCapability,
 } from "./authoring";
 export {
+  buildSkillset,
   buildSkillsetResult,
+  checkSkillset,
   checkSkillsetResult,
   diffSkillset,
   diffSkillsetResult,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -252,6 +252,7 @@ export interface SkillsetOptions {
 
 export interface CheckResult {
   readonly checkedFiles: number;
+  readonly failures: readonly string[];
 }
 
 export interface LintIssue {


### PR DESCRIPTION
## Context

Linear: SET-106

`checkSkillsetResult` is a core result API. Ordinary generated-output drift should be returned as structured check data instead of escaping as an exception, while the older convenience helper and CLI should continue to fail loudly.

## Changes

- Return `ok: false` plus `data.failures` from `checkSkillsetResult` for ordinary generated-output drift.
- Add generated-output drift diagnostics with stable codes for changed, missing, missing-managed, and removed output.
- Preserve `checkSkillset()` throwing behavior for callers that want the old convenience API.
- Preserve CLI nonzero behavior for `skillset check` drift.
- Export `buildSkillset` and `checkSkillset` from the root core API.
- Add consumer API tests for clean checks, changed output, missing first-build output, deleted managed output, removed source output, and exceptional invalid config.

## Verification

- `bun test packages/core/src/__tests__/consumer.test.ts`
- `bun run typecheck`
- `bun run check`
- Pre-push `lefthook` gate from `gt submit`
- Local review pass: 4/5 initially; P3 drift-classification coverage was fixed before submit

## Notes

Diagnostics are the structured machine-readable drift signal; `data.failures` preserves human-readable compatibility text for CLI and helper errors.
