### PR TITLE
docs(release): record private scoped package posture

### DIFF
--- a/.changeset/curly-dodos-wink.md
+++ b/.changeset/curly-dodos-wink.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Document the private scoped-package publish posture for the core, lint, and transforms workspaces.

--- a/docs/adrs/drafts/20260612-core-library-boundary.md
+++ b/docs/adrs/drafts/20260612-core-library-boundary.md
@@ -3,7 +3,7 @@ slug: core-library-boundary
 title: Core Library and CLI Boundary
 status: draft
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-15
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [0, 1, feature-reference-and-schema-registry, fixtures-tests-dogfooding-and-evals, one-action-repo-adoption, source-change-release-provenance]
 ---
@@ -46,7 +46,9 @@ Core operations must be explicit about side effects. A core operation receives a
 
 ## Package and Publish Posture
 
-The package starts private while the API is being shaped. Public publish posture, semver guarantees, and package visibility are deferred to the dedicated publish-posture issue. The published `skillset` beta CLI remains the user-facing compatibility contract until a later issue explicitly promotes `@skillset/core` as a public package. The first implementation slice should be deliberately narrow: create the package shell, expose one read-oriented operation through core, adapt the CLI to consume it, and add API-level tests that prove a non-CLI caller can use it without relying on terminal output or process exits.
+The scoped packages remain private while the API is being shaped. `@skillset/core` is the internal library boundary for compiler facts, structured results, diagnostics, and plans, but it is not yet a public npm contract. `@skillset/lint` and `@skillset/transforms` are implementation-support packages consumed by core and should not be published independently in v1. The published unscoped `skillset` package remains the user-facing compatibility contract.
+
+This means package releases continue to version and publish only the `skillset` CLI package. The scoped workspaces may change exports, internal module layout, and pre-release API names without semver guarantees until a future issue explicitly promotes one of them to a public package. Any `./internal/*` export on a private workspace package is private-only compatibility plumbing for this repo, not a public subpath promise. If `@skillset/core` becomes public later, that issue must define the exported root API, remove or explicitly fence internal subpaths, define dist-tag strategy, prove npm scope ownership, and explain how Trails-facing integration stays optional. `@skillset/lint` and `@skillset/transforms` should remain private unless there is a concrete external consumer that cannot be served through `@skillset/core`.
 
 ## Future Trails Migration Posture
 

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -1,12 +1,14 @@
 # Package Releases
 
-This page covers the npm package release path for the `skillset` package. It is separate from Skillset source-unit releases under `.skillset/changes`, which describe authored plugin, skill, and generated-output provenance.
+This page covers the npm package release path for the unscoped `skillset` package. It is separate from Skillset source-unit releases under `.skillset/changes`, which describe authored plugin, skill, and generated-output provenance.
 
 ## Ownership
 
 GitHub Actions is the package release operator. Local commands are diagnostics and dry-run aids; package publication should happen from the `Release` workflow on `main`.
 
 Changesets owns npm package version and package changelog calculation. The Skillset change/release commands continue to own source-unit reasons, release state, generated entity changelogs, and target output drift. Do not collapse these two release systems unless a future explicit bridge is designed.
+
+Only the unscoped `skillset` CLI package is public in the current package posture. The workspace packages `@skillset/core`, `@skillset/lint`, and `@skillset/transforms` remain private implementation packages: core is the internal library boundary that the CLI and tests consume, while lint and transforms are support packages behind that boundary. Do not include them in npm publish automation or treat their exports as semver-stable until a future package-posture issue explicitly promotes them.
 
 ## Flow
 


### PR DESCRIPTION
## Context

Linear: SET-103

Before continuing to move code into scoped workspaces, we need the publish posture to be explicit so private internal APIs do not accidentally become public npm contracts.

## Changes

- Document that only the unscoped `skillset` CLI package is public today.
- Keep `@skillset/core`, `@skillset/lint`, and `@skillset/transforms` private implementation workspaces.
- Clarify that `@skillset/core` is an internal library boundary, not yet a semver-stable public package.
- Clarify that private `./internal/*` exports are repo-local compatibility plumbing and must be removed or fenced before a future public core publish.
- Add a patch changeset for the public CLI package docs.

## Verification

- `bun run changeset:status` reports a patch bump for `skillset` only.
- `bun run check`
- Pre-push `lefthook` gate from `gt submit`
- Local review pass: 4/5 initially; P3 internal-subpath wording was fixed before submit

## Notes

No release scripts or package visibility were changed because the decision is to keep scoped packages private for now.
