### PR TITLE
fix(changes): report stacked change evidence

### DIFF
--- a/.changeset/stacked-change-evidence.md
+++ b/.changeset/stacked-change-evidence.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Report stacked pending change evidence in `skillset change check` while preserving strict stale-evidence failures.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -2790,6 +2790,126 @@ Grouped documentation-only edits are intentionally ignored for release planning 
   expect(checked.stdout).toContain("change check passed");
 });
 
+test("SET-114: repeated pending entries can share current evidence for stacked changes", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: stacked-change-root
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Body.
+`,
+  });
+  await commitFixture(root);
+
+  await Bun.write(join(root, ".skillset/skills/demo/SKILL.md"), "---\nname: demo\ndescription: Demo.\n---\n\nChanged body for stacked entries.\n");
+  const report = await changeStatus(root, { since: "HEAD" });
+  const demo = report.sourceChanges.find((change) => change.id === "skill:demo");
+  expect(demo?.currentHash).toBeDefined();
+
+  await writePendingChange(root, "first.md", `
+---
+id: 111111abcdef
+bump: patch
+scope: skill:demo
+evidence:
+  - scope: skill:demo
+    currentHash: ${demo?.currentHash}
+  - scope: skill:demo
+    currentHash: ${demo?.currentHash}
+  - scope: skill:demo
+    currentHash: sha256:older-supplemental
+---
+
+First stacked branch reason keeps its own audit trail for the final source state.
+`);
+  await writePendingChange(root, "second.md", `
+---
+id: 222222abcdef
+bump: patch
+scope: skill:demo
+evidence:
+  - scope: skill:demo
+    currentHash: ${demo?.currentHash}
+  - scope: skill:demo
+    currentHash: sha256:older-supplemental
+---
+
+Second stacked branch reason also points at the final source state deliberately.
+`);
+
+  const checked = await runSkillsetCli("change", "check", "--root", root, "--since", "HEAD");
+  expect(checked.exitCode).toBe(0);
+  expect(checked.stdout).toContain("stacked evidence: skill: demo");
+  expect(checked.stdout).toContain("shared by 2 pending entries");
+  expect(checked.stdout).toContain(".skillset/changes/pending/first.md, .skillset/changes/pending/second.md");
+  expect(checked.stdout).not.toContain("shared by 3 pending entries");
+  expect(checked.stdout).not.toContain("sha256:older-supplemental");
+  expect(checked.stdout).toContain("change check passed");
+});
+
+test("SET-114: repeated pending entries still fail when one carries stale evidence", async () => {
+  const root = await contractFixture({
+    ".skillset/config.yaml": `
+skillset:
+  name: stale-stacked-change-root
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Body.
+`,
+  });
+  await commitFixture(root);
+
+  await Bun.write(join(root, ".skillset/skills/demo/SKILL.md"), "---\nname: demo\ndescription: Demo.\n---\n\nChanged body for stale stacked evidence.\n");
+  const report = await changeStatus(root, { since: "HEAD" });
+  const demo = report.sourceChanges.find((change) => change.id === "skill:demo");
+  expect(demo?.currentHash).toBeDefined();
+
+  await writePendingChange(root, "current.md", `
+---
+id: 333333abcdef
+bump: patch
+scope: skill:demo
+evidence:
+  - scope: skill:demo
+    currentHash: ${demo?.currentHash}
+---
+
+Current branch reason covers the final source state for this stacked example.
+`);
+  await writePendingChange(root, "stale.md", `
+---
+id: 444444abcdef
+bump: patch
+scope: skill:demo
+evidence:
+  - scope: skill:demo
+    currentHash: sha256:stale
+---
+
+Older branch reason must be refreshed instead of silently covered by another entry.
+`);
+
+  const checked = await runSkillsetCli("change", "check", "--root", root, "--since", "HEAD");
+  expect(checked.exitCode).toBe(1);
+  expect(checked.stdout).toContain("stale.md: change-evidence-stale");
+  expect(checked.stdout).toContain("change check found 1 error");
+});
+
 test("SET-35: change check rejects invalid pending entry shape, reason, and evidence", async () => {
   const root = await contractFixture({
     ".skillset/config.yaml": `

--- a/apps/skillset/src/change-entries.ts
+++ b/apps/skillset/src/change-entries.ts
@@ -51,7 +51,14 @@ export interface ChangeCheckReport {
   readonly entries: readonly PendingChangeEntry[];
   readonly issues: readonly ChangeCheckIssue[];
   readonly ok: boolean;
+  readonly stackedEvidence: readonly ChangeCheckStackedEvidence[];
   readonly status: ChangeStatusReport;
+}
+
+export interface ChangeCheckStackedEvidence {
+  readonly paths: readonly string[];
+  readonly scope: string;
+  readonly sourceHash: string;
 }
 
 interface ChangeValidationContext {
@@ -137,6 +144,7 @@ async function validateChangeCheck(
     entries,
     issues: issues.sort(compareIssues),
     ok: !issues.some((issue) => issue.severity === "error"),
+    stackedEvidence: stackedEvidenceGroups(validEntries, context),
     status,
   };
 }
@@ -307,6 +315,34 @@ function findDuplicateIds(entries: readonly PendingChangeEntry[]): ReadonlySet<s
     counts.set(entry.id, (counts.get(entry.id) ?? 0) + 1);
   }
   return new Set([...counts].filter(([, count]) => count > 1).map(([id]) => id));
+}
+
+function stackedEvidenceGroups(
+  entries: ReadonlySet<PendingChangeEntry>,
+  context: ChangeValidationContext
+): readonly ChangeCheckStackedEvidence[] {
+  const groups = new Map<string, { readonly paths: Set<string>; readonly scope: string; readonly sourceHash: string }>();
+  for (const entry of entries) {
+    for (const scope of entry.scopes) {
+      const sourceHash = expectedHashForScope(scope, context);
+      if (sourceHash === undefined || !(entry.sourceHashes.get(scope) ?? []).includes(sourceHash)) continue;
+      const key = `${scope}\0${sourceHash}`;
+      const existing = groups.get(key);
+      if (existing === undefined) {
+        groups.set(key, { paths: new Set([entry.path]), scope, sourceHash });
+        continue;
+      }
+      existing.paths.add(entry.path);
+    }
+  }
+  return [...groups.values()]
+    .filter((group) => group.paths.size > 1)
+    .map((group) => ({
+      paths: [...group.paths].sort(compareStrings),
+      scope: group.scope,
+      sourceHash: group.sourceHash,
+    }))
+    .sort((left, right) => compareStrings(`${left.scope}\0${left.sourceHash}`, `${right.scope}\0${right.sourceHash}`));
 }
 
 function hasSeverityBearingRegion(regions: readonly { readonly severityBearing: boolean }[] | undefined): boolean {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -624,6 +624,11 @@ function printChangeCheck(report: ChangeCheckReport): void {
     const path = issue.path === undefined ? "" : `${issue.path}: `;
     console.log(`  ${issue.severity}: ${path}${issue.code}: ${issue.message}`);
   }
+  for (const group of report.stackedEvidence) {
+    console.log(
+      `  stacked evidence: ${sourceUnitDisplay(group.scope)} ${group.sourceHash} shared by ${group.paths.length} pending entries: ${group.paths.join(", ")}`
+    );
+  }
   const errors = report.issues.filter((issue) => issue.severity === "error").length;
   const warnings = report.issues.length - errors;
   if (errors === 0) {

--- a/docs/adrs/drafts/20260609-source-change-release-provenance.md
+++ b/docs/adrs/drafts/20260609-source-change-release-provenance.md
@@ -80,6 +80,8 @@ Release state is optional source-controlled state that maps releasable scopes to
 
 `skillset release plan` reads pending entries and current hashes, suggests or resolves version changes, and previews changelog sections without writing. `skillset release apply` updates release state, generated changelog projections, append-only history/release records, locks, and generated target outputs. It should not rewrite source content merely to bump counters.
 
+Stacked pending entries keep one strict evidence rule: every entry must carry evidence for the current source hash of each declared scope. A Graphite stack can therefore end with multiple pending entries pointing at the same source unit and final hash. That is allowed, and `change check` should make it visible as stacked evidence rather than warning. A stale entry for the same scope still fails even if another entry has the current hash. This preserves the invariant that each branch reason remains attached to the state being released instead of borrowing coverage from a later branch.
+
 Published or marketplace-facing artifacts default to ordinary SemVer. Build metadata is not a public update strategy in v1 because target install/update behavior for build-metadata-only version differences remains unproven.
 
 ## Supports

--- a/docs/features/changes.md
+++ b/docs/features/changes.md
@@ -28,6 +28,8 @@ Compact ids are generated once at scaffold time as 12 lower-case hex characters.
 
 `skillset change check` validates pending entry ids, duplicate ids, scopes, bumps, required reason bodies, source hash evidence, group shape, and coverage for current source changes. Entries can cover multiple scopes, carry `ignored: true`, and use `group` for external issue or change grouping metadata. Child plugin entries cover the derived plugin aggregate for coverage and release planning, but plugin config changes still require their own plugin-level story. `external.*` is rejected in v1 so issue ids do not get duplicated outside `group`. Refs resolve as `@<hex-prefix>` with at least 6 hex characters, and ambiguous prefixes fail with candidate refs.
 
+Stacked branches may produce multiple pending entries for the same source unit. `change check` intentionally stays strict: each entry must carry evidence for the current source hash at the stack tip. If two valid entries point at the same scope and hash, the check prints a `stacked evidence` note so release/history attribution is explicit. If one entry still points at an older hash, it remains a `change-evidence-stale` error even when another entry covers the same scope, because silently borrowing another reason would hide lower-branch work.
+
 `change check` also warns when an entry declares `bump: none` for an added, removed, or severity-bearing source unit. `supports` edits remain source-significant but are not inherently severity-bearing. Source coverage diagnostics stay separate from generated-output drift.
 
 `skillset change add` writes pending entries non-interactively from `--reason`, `--reason-file`, `--reason -`, or piped stdin. `skillset change reason` updates or appends to a pending reason without changing the generated id. `skillset change list` prints copyable refs and supports `--group` filtering. `skillset change show` resolves pending entries before applied history. `skillset change history` reads applied history records and stays distinct from status.
@@ -40,7 +42,7 @@ Change entries participate in source provenance because they explain current sou
 
 ## Tests and Fixtures
 
-Fixtures cover unchanged deterministic status, body edits, source-only support/dependency metadata edits, plugin child edits that affect aggregate plugin identity without a version bump, child plugin coverage of aggregate plugin changes, partial dependency hashing, read-only CLI behavior, generated-output drift separation, pending-entry coverage failures, multi-scope pending entries, invalid pending entry diagnostics, ambiguous ref resolution, reason file/stdin input, append behavior, group filters, show output, and history lookup.
+Fixtures cover unchanged deterministic status, body edits, source-only support/dependency metadata edits, plugin child edits that affect aggregate plugin identity without a version bump, child plugin coverage of aggregate plugin changes, partial dependency hashing, read-only CLI behavior, generated-output drift separation, pending-entry coverage failures, multi-scope pending entries, repeated stacked entries for one current source hash, invalid pending entry diagnostics, ambiguous ref resolution, reason file/stdin input, append behavior, group filters, show output, and history lookup.
 
 ## Evidence
 


### PR DESCRIPTION
## Context

SET-114 clarifies how `skillset change check` should behave when a stacked branch sequence leaves multiple pending entries for the same current source hash. Multiple valid entries are allowed and visible; stale evidence remains an error.

## What Changed

- Added structured `stackedEvidence` to change-check reports.
- Printed advisory stacked-evidence notes with source unit, hash, count, and pending entry paths.
- Added contract coverage for duplicate evidence rows, supplemental older hashes, valid stacked entries, and stale sibling entries.
- Documented the strict evidence rule in the changes docs and source provenance ADR draft.
- Added a patch Changeset for `skillset`.

## Verification

- `bun test apps/skillset/src/__tests__/contract.test.ts --test-name-pattern "SET-114|SET-35"`
- `bun run conformance:fast`
- `bun run changeset:status`
- `bun run check`
- Graphite pre-push hook: `skillset-ci` and `check`

## Risk

Low. The new stacked-evidence output is advisory only; validation remains strict for stale or missing evidence.