### PR TITLE
ci(release): gate automatic npm publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,75 @@ jobs:
         id: plan
         run: bun run publish:plan
 
-  publish:
-    name: Publish to npm
+  publish-policy:
+    name: Publish Policy
     needs: publish-plan
-    if: github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main' && needs.publish-plan.outputs.should_publish == 'true'
+    if: github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main' && needs.publish-plan.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+    outputs:
+      channel: ${{ steps.policy.outputs.channel }}
+      create_github_release: ${{ steps.policy.outputs.create_github_release }}
+      decision: ${{ steps.policy.outputs.decision }}
+      publish: ${{ steps.policy.outputs.publish }}
+      release: ${{ steps.policy.outputs.release }}
+      should_publish: ${{ steps.policy.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: .bun-version
+      - run: bun install --frozen-lockfile
+      - name: Resolve publish policy
+        id: policy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SKILLSET_RELEASE_POLICY_CI_ATTEMPTS: "30"
+          SKILLSET_RELEASE_POLICY_CI_WAIT_MS: "10000"
+        run: bun run publish:policy
+
+  publish-auto:
+    name: Publish to npm automatically
+    needs: [publish-plan, publish-policy]
+    if: github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main' && needs.publish-plan.outputs.should_publish == 'true' && needs.publish-policy.outputs.decision == 'auto' && needs.publish-policy.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-auto
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      name: ${{ steps.publish.outputs.name }}
+      published: ${{ steps.publish.outputs.published }}
+      registry_complete: ${{ steps.publish.outputs.registry_complete }}
+      tag: ${{ steps.publish.outputs.tag }}
+      version: ${{ steps.publish.outputs.version }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: .bun-version
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: bun install --frozen-lockfile
+      - name: Validate package before publish
+        run: bun run publish:check
+      - name: Publish package
+        id: publish
+        run: bun run publish:packages
+
+  publish:
+    name: Publish to npm manually
+    needs: [publish-plan, publish-policy]
+    if: github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main' && needs.publish-plan.outputs.should_publish == 'true' && needs.publish-policy.outputs.decision == 'manual' && needs.publish-policy.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -93,8 +158,8 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [publish-plan, publish]
-    if: always() && github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main' && needs.publish-plan.result == 'success' && (needs.publish-plan.outputs.registry_complete == 'true' || needs.publish.outputs.registry_complete == 'true')
+    needs: [publish-plan, publish-policy, publish-auto, publish]
+    if: always() && github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main' && needs.publish-plan.result == 'success' && needs.publish-policy.result == 'success' && needs.publish-policy.outputs.create_github_release == 'true' && (needs.publish-plan.outputs.registry_complete == 'true' || needs.publish-auto.outputs.registry_complete == 'true' || needs.publish.outputs.registry_complete == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -106,9 +171,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          VERSION: ${{ needs.publish.outputs.version || needs.publish-plan.outputs.version }}
-          DIST_TAG: ${{ needs.publish.outputs.tag || needs.publish-plan.outputs.tag }}
-          PUBLISHED: ${{ needs.publish.outputs.published }}
+          VERSION: ${{ needs.publish-auto.outputs.version || needs.publish.outputs.version || needs.publish-plan.outputs.version }}
+          DIST_TAG: ${{ needs.publish-auto.outputs.tag || needs.publish.outputs.tag || needs.publish-plan.outputs.tag }}
+          PUBLISHED: ${{ needs.publish-auto.outputs.published || needs.publish.outputs.published }}
         run: |
           create_args=()
           if [ "$DIST_TAG" != "latest" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ bun run conformance:adapters
 bun run conformance:external
 bun run changeset:status
 bun run publish:check
+bun run publish:policy
 bun run hooks:install
 bun run hooks:pre-push
 bun run ultracite:doctor

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -14,9 +14,23 @@ Only the unscoped `skillset` CLI package is public in the current package postur
 
 Feature branches that change package-facing behavior should include a `.changeset/*.md` file. When the branch merges to `main`, `.github/workflows/release.yml` runs `changesets/action` to create or update a `chore(release): version packages` pull request.
 
-When the version PR merges to `main`, the same workflow checks the npm registry. If the current `apps/skillset/package.json` version is already published and the intended dist-tag points to it, the workflow exits the publish step without entering the protected publish environment and ensures a missing GitHub release can still be created when the matching `v<version>` tag already points at the package-version commit. If the version is missing, the workflow enters the `npm` environment, runs the full package preflight, publishes with `npm publish`, waits for the version and dist-tag to appear on the registry, creates and pushes the matching `v<version>` tag at the package-version commit, and creates the GitHub release with `--verify-tag` if it does not already exist.
+When the version PR merges to `main`, the same workflow checks the npm registry and resolves the release intent labels from the merged version PR. If the current `apps/skillset/package.json` version is already published and the intended dist-tag points to it, the workflow exits the publish step without entering a publish environment and ensures a missing GitHub release can still be created when the matching `v<version>` tag already points at the package-version commit. If the version is missing, the workflow runs the publish policy. Low-risk generated releases can publish through `npm-auto`; anything ambiguous routes to the protected manual `npm` environment; `publish:none` skips npm and GitHub release creation; `publish:block` stops the release workflow. Successful publishes wait for the version and dist-tag to appear on the registry, create and push the matching `v<version>` tag at the package-version commit, and create the GitHub release with `--verify-tag` if it does not already exist.
 
 The publish wrapper derives the npm dist-tag from the version: stable versions publish to `latest`, and prerelease versions publish to their prerelease label such as `beta`.
+
+## Release Intent Labels
+
+Release labels express human intent, not trust. The policy script still verifies the branch, commit, generated Changesets PR shape, changed files, exact-SHA CI, changelog heading, version delta, and registry state before an automatic publish can run.
+
+The release PR supports these mutually exclusive label families:
+
+| Family | Labels | Behavior |
+| --- | --- | --- |
+| Publish | `publish:auto`, `publish:manual`, `publish:none`, `publish:block` | Chooses automatic publish, protected manual publish, intentional no-publish state, or hard block. Missing `publish:*` defaults to manual. |
+| Channel | `channel:stable`, `channel:preview`, `channel:canary` | Declares the intended release channel. V1 only allows `publish:auto` with `channel:stable`, which maps to npm `latest`. |
+| Release | `release:patch`, `release:minor`, `release:major` | Declares release-size intent. When present, the policy compares it against the actual package version delta. |
+
+Conflicting labels within a family, unknown labels under these prefixes, registry drift, or `publish:block` block the workflow with diagnostics. `publish:none` requires an audit reason in the release PR body or comments because it intentionally leaves package-version state unpublished. Any generated release PR that touches workflow files, release scripts, package publish metadata, lockfiles, source files, or other unexpected paths falls back to the manual environment rather than the automatic environment.
 
 ## Commands
 
@@ -24,10 +38,13 @@ The publish wrapper derives the npm dist-tag from the version: stable versions p
 bun run changeset
 bun run changeset:status
 bun run publish:plan
+bun run publish:policy
 bun run publish:check
 bun run publish:registry-check
 bun run publish:registry-check:published
 ```
+
+`bun run publish:policy` is the release-workflow policy gate. It reads the current commit, the associated Changesets release PR, exact-SHA GitHub checks, package/changelog state, and npm registry state, then emits GitHub Actions outputs for `auto`, `manual`, `none`, or `block`.
 
 `bun run publish:check` is the local preflight: it runs the full repo check, rebuilds the npm package output, and performs `bun pm pack --dry-run` from `apps/skillset` so package contents are verified without registry authentication.
 
@@ -42,7 +59,7 @@ bun run publish:packages
 
 ## Trusted Publishing Setup
 
-The workflow is prepared for npm Trusted Publishing by using a publish job with `permissions.id-token: write`, SHA-pinned workflow actions, Node 24, the npm CLI for the final publish, and the protected GitHub environment `npm`. Bun remains the package build, test, and preflight runtime; npm owns the OIDC exchange because Trusted Publishing is currently documented for `npm publish`. Configure the trusted publisher for the npm package with:
+The workflow is prepared for npm Trusted Publishing by using publish jobs with `permissions.id-token: write`, SHA-pinned workflow actions, Node 24, the npm CLI for the final publish, and GitHub environments for publish paths. Bun remains the package build, test, and preflight runtime; npm owns the OIDC exchange because Trusted Publishing is currently documented for `npm publish`. Configure the trusted publisher for the npm package with:
 
 | Field | Value |
 | --- | --- |
@@ -51,8 +68,10 @@ The workflow is prepared for npm Trusted Publishing by using a publish job with 
 | Organization or user | `outfitter-dev` |
 | Repository | `skillset` |
 | Workflow filename | `release.yml` |
-| Environment | `npm` |
+| Environment | Leave blank |
 | Allowed action | `npm publish` |
+
+npm allows one trusted publisher connection per package, so do not create separate npm trusted publisher entries for `npm` and `npm-auto`. Leaving the npm Environment field blank binds publishing to this repository and workflow without pinning one GitHub environment. The workflow still uses GitHub environments for routing: `npm` remains the protected manual approval path, while `npm-auto` should not require manual reviewers because the release policy is the gate that makes that path reachable.
 
 The repository intentionally does not commit an npm auth token in `.npmrc` and the release workflow does not pass `NPM_TOKEN`.
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "publish:check": "bun run check && bun scripts/publish.ts check",
     "publish:packages": "bun scripts/publish.ts publish",
     "publish:plan": "bun scripts/publish.ts plan",
+    "publish:policy": "bun scripts/release-policy.ts policy",
     "publish:registry-check": "bun scripts/publish.ts registry-check",
     "publish:registry-check:published": "bun scripts/publish.ts registry-check --require-published",
     "skillset:build": "bun ./apps/skillset/src/cli.ts build --root . --yes",

--- a/scripts/__tests__/release-policy.test.ts
+++ b/scripts/__tests__/release-policy.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type GitHubCheckRunsResponse,
+  type ReleasePolicyInput,
+  ciStateFromCheckRuns,
+  evaluateReleasePolicy,
+} from "../release-policy";
+import { distTagForVersion } from "../publish";
+
+const baseInput = (
+  labels: readonly string[],
+  overrides: Partial<ReleasePolicyInput> = {}
+): ReleasePolicyInput => ({
+  changelogText: "# Changelog\n\n## 0.13.4\n\n### Patch Changes\n",
+  changedFiles: [
+    { path: ".changeset/example.md", status: "D" },
+    { path: "apps/skillset/CHANGELOG.md", status: "M" },
+    { path: "apps/skillset/package.json", status: "M" },
+  ],
+  ciPassed: true,
+  commit: {
+    authorEmail: "41898282+github-actions[bot]@users.noreply.github.com",
+    authorName: "github-actions[bot]",
+    committerEmail: "noreply@github.com",
+    committerName: "GitHub",
+    subject: "chore(release): version packages (#96)",
+  },
+  packageName: "skillset",
+  previousVersion: "0.13.3",
+  published: false,
+  ref: "refs/heads/main",
+  registryComplete: false,
+  releasePullRequest: {
+    baseRefName: "main",
+    body: "",
+    comments: [],
+    headRefName: "changeset-release/main",
+    labels,
+    number: 96,
+    title: "chore(release): version packages",
+    userLogin: "github-actions[bot]",
+  },
+  repository: "outfitter-dev/skillset",
+  sha: "b25a221f4ddc98a7ab5def2c88e67f63e456e40e",
+  tag: "latest",
+  taggedVersion: "0.13.3",
+  version: "0.13.4",
+  ...overrides,
+});
+
+describe("release policy", () => {
+  test("routes a generated stable release to auto when publish:auto is set", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable", "release:patch"])
+    );
+
+    expect(report.decision).toBe("auto");
+    expect(report.autoEligible).toBe(true);
+    expect(report.shouldPublish).toBe(true);
+    expect(report.createGitHubRelease).toBe(true);
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test("defaults to manual when no publish intent is set", () => {
+    const report = evaluateReleasePolicy(baseInput(["channel:stable"]));
+
+    expect(report.decision).toBe("manual");
+    expect(report.shouldPublish).toBe(true);
+    expect(report.reasons).toContain("No publish:* label is set; routing to manual approval");
+  });
+
+  test("blocks explicit publish:block", () => {
+    const report = evaluateReleasePolicy(baseInput(["publish:block", "channel:stable"]));
+
+    expect(report.decision).toBe("block");
+    expect(report.shouldPublish).toBe(false);
+    expect(report.blockers).toContain("publish:block is set");
+  });
+
+  test("blocks conflicting label families", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "publish:manual", "channel:stable"])
+    );
+
+    expect(report.decision).toBe("block");
+    expect(report.blockers).toEqual([
+      "Conflicting publish: labels: publish:auto, publish:manual",
+    ]);
+  });
+
+  test("blocks unknown labels within policy families", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable", "release:tiny"])
+    );
+
+    expect(report.decision).toBe("block");
+    expect(report.blockers).toEqual(["Unknown release: label: release:tiny"]);
+  });
+
+  test("allows publish:none only with an audit reason", () => {
+    const missingReason = evaluateReleasePolicy(baseInput(["publish:none"]));
+    expect(missingReason.decision).toBe("block");
+    expect(missingReason.blockers).toContain(
+      "publish:none requires an audit reason in the release PR body or comments"
+    );
+
+    const withReason = evaluateReleasePolicy(
+      baseInput(["publish:none"], {
+        releasePullRequest: {
+          ...baseInput(["publish:none"]).releasePullRequest!,
+          body: "publish:none because this version records intentionally skipped package state.",
+        },
+      })
+    );
+    expect(withReason.decision).toBe("none");
+    expect(withReason.shouldPublish).toBe(false);
+    expect(withReason.createGitHubRelease).toBe(false);
+  });
+
+  test("routes publish:auto to manual when channel is not stable", () => {
+    const report = evaluateReleasePolicy(baseInput(["publish:auto", "channel:canary"]));
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain("publish:auto requires channel:stable in v1");
+  });
+
+  test("routes publish:auto to manual when release shape touches workflow files", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable"], {
+        changedFiles: [
+          { path: ".changeset/example.md", status: "D" },
+          { path: ".github/workflows/release.yml", status: "M" },
+          { path: "apps/skillset/CHANGELOG.md", status: "M" },
+          { path: "apps/skillset/package.json", status: "M" },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain(
+      "Unexpected release diff entry: M .github/workflows/release.yml"
+    );
+  });
+
+  test("routes publish:auto to manual when release intent mismatches the version delta", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable", "release:minor"])
+    );
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain(
+      "release:minor is set, but 0.13.3 -> 0.13.4 looks like release:patch"
+    );
+  });
+
+  test("routes publish:auto to manual when the version delta is missing or non-positive", () => {
+    const inputWithMissingPrevious = baseInput(["publish:auto", "channel:stable"]);
+    delete inputWithMissingPrevious.previousVersion;
+    const missingPrevious = evaluateReleasePolicy(
+      inputWithMissingPrevious
+    );
+    expect(missingPrevious.decision).toBe("manual");
+    expect(missingPrevious.diagnostics).toContain(
+      "Could not read previous apps/skillset/package.json version"
+    );
+
+    const sameVersion = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable"], {
+        previousVersion: "0.13.4",
+      })
+    );
+    expect(sameVersion.decision).toBe("manual");
+    expect(sameVersion.diagnostics).toContain(
+      "Expected 0.13.4 to be newer than previous version 0.13.4"
+    );
+  });
+
+  test("routes publish:auto to manual until exact-SHA CI has passed", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable"], { ciPassed: false })
+    );
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain("Exact-SHA CI checks have not passed");
+  });
+});
+
+describe("npm dist-tag derivation", () => {
+  test("uses latest for stable versions and prerelease prefix for prereleases", () => {
+    expect(distTagForVersion("0.13.4")).toBe("latest");
+    expect(distTagForVersion("0.14.0-beta.1")).toBe("beta");
+    expect(distTagForVersion("0.14.0-canary.20260615")).toBe("canary");
+  });
+});
+
+describe("release policy CI state", () => {
+  const checkRuns = (
+    runs: GitHubCheckRunsResponse["check_runs"]
+  ): GitHubCheckRunsResponse => ({ check_runs: runs });
+  const successRun = (name: string): GitHubCheckRunsResponse["check_runs"][number] => ({
+    check_suite: {
+      app: {
+        slug: "github-actions",
+      },
+    },
+    conclusion: "success",
+    name,
+    status: "completed",
+  });
+
+  test("requires the named CI jobs to complete successfully", () => {
+    expect(ciStateFromCheckRuns(checkRuns([successRun("check"), successRun("skillset-ci")]))).toBe(
+      "passed"
+    );
+    expect(ciStateFromCheckRuns(checkRuns([successRun("check")]))).toBe("pending");
+    expect(
+      ciStateFromCheckRuns(
+        checkRuns([
+          successRun("check"),
+          {
+            ...successRun("skillset-ci"),
+            conclusion: "skipped",
+          },
+        ])
+      )
+    ).toBe("failed");
+  });
+});

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -35,7 +35,7 @@ async function readPackageInfo() {
   };
 }
 
-function distTagForVersion(version: string) {
+export function distTagForVersion(version: string) {
   const prerelease = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z.-]+)$/)?.[1];
   if (!prerelease) return "latest";
 
@@ -76,7 +76,7 @@ function registryComplete(state: Awaited<ReturnType<typeof getRegistryState>>) {
   return state.published && state.taggedVersion === state.version;
 }
 
-async function writeGitHubOutput(values: Record<string, string | boolean>) {
+export async function writeGitHubOutput(values: Record<string, string | boolean>) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) return;
 
@@ -233,7 +233,9 @@ async function main() {
   }
 }
 
-await main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (import.meta.main) {
+  await main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -1,0 +1,741 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { distTagForVersion, writeGitHubOutput } from "./publish";
+
+type DistTags = Record<string, string | undefined>;
+
+type RegistryDocument = {
+  "dist-tags"?: DistTags;
+  versions?: Record<string, unknown>;
+};
+
+type PackageJson = {
+  name?: string;
+  version?: string;
+};
+
+export type PublishIntent =
+  | "publish:auto"
+  | "publish:block"
+  | "publish:manual"
+  | "publish:none";
+export type ChannelIntent = "channel:canary" | "channel:preview" | "channel:stable";
+export type ReleaseIntent = "release:major" | "release:minor" | "release:patch";
+export type ReleasePolicyDecision = "auto" | "block" | "manual" | "none";
+
+export type ChangedFile = {
+  path: string;
+  status: string;
+};
+
+export type ReleasePullRequest = {
+  baseRefName: string;
+  body: string;
+  comments: readonly string[];
+  headRefName: string;
+  labels: readonly string[];
+  number: number;
+  title: string;
+  userLogin: string;
+};
+
+export type CommitInfo = {
+  authorEmail: string;
+  authorName: string;
+  committerEmail: string;
+  committerName: string;
+  subject: string;
+};
+
+export type ReleasePolicyInput = {
+  changelogText: string;
+  changedFiles: readonly ChangedFile[];
+  ciPassed: boolean;
+  commit: CommitInfo;
+  packageName: string;
+  published: boolean;
+  ref: string;
+  registryComplete: boolean;
+  repository: string;
+  releasePullRequest?: ReleasePullRequest;
+  sha: string;
+  tag: string;
+  taggedVersion?: string;
+  version: string;
+  previousVersion?: string;
+};
+
+export type ReleasePolicyReport = {
+  autoEligible: boolean;
+  blockers: readonly string[];
+  channel: ChannelIntent | undefined;
+  createGitHubRelease: boolean;
+  decision: ReleasePolicyDecision;
+  diagnostics: readonly string[];
+  publish: PublishIntent | undefined;
+  reasons: readonly string[];
+  release: ReleaseIntent | undefined;
+  shouldPublish: boolean;
+};
+
+type FamilyResult<T extends string> = {
+  conflicts: readonly string[];
+  unknown: readonly string[];
+  value?: T;
+};
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageDir = join(rootDir, "apps", "skillset");
+const packageJsonPath = join(packageDir, "package.json");
+const changelogPath = join(packageDir, "CHANGELOG.md");
+const registryUrl = "https://registry.npmjs.org";
+
+const publishIntents = new Set<PublishIntent>([
+  "publish:auto",
+  "publish:block",
+  "publish:manual",
+  "publish:none",
+]);
+const channelIntents = new Set<ChannelIntent>([
+  "channel:canary",
+  "channel:preview",
+  "channel:stable",
+]);
+const releaseIntents = new Set<ReleaseIntent>([
+  "release:major",
+  "release:minor",
+  "release:patch",
+]);
+
+export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyReport {
+  const labels = input.releasePullRequest?.labels ?? [];
+  const publish = readLabelFamily(labels, "publish:", publishIntents);
+  const channel = readLabelFamily(labels, "channel:", channelIntents);
+  const release = readLabelFamily(labels, "release:", releaseIntents);
+  const blockers = [
+    ...publish.conflicts,
+    ...channel.conflicts,
+    ...release.conflicts,
+    ...publish.unknown,
+    ...channel.unknown,
+    ...release.unknown,
+  ];
+  const diagnostics: string[] = [];
+  const reasons: string[] = [];
+
+  if (input.published && !input.registryComplete) {
+    blockers.push(
+      `${input.packageName}@${input.version} exists, but ${input.tag} points to ${input.taggedVersion ?? "nothing"}`
+    );
+  }
+
+  if (publish.value === "publish:block") {
+    blockers.push("publish:block is set");
+  }
+
+  if (blockers.length > 0) {
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: "block",
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+    });
+  }
+
+  if (publish.value === "publish:none") {
+    if (!hasPublishNoneReason(input.releasePullRequest)) {
+      blockers.push("publish:none requires an audit reason in the release PR body or comments");
+      return makeReport(input, {
+        blockers,
+        channel: channel.value,
+        decision: "block",
+        diagnostics,
+        publish: publish.value,
+        reasons,
+        release: release.value,
+      });
+    }
+
+    reasons.push("publish:none is set, so npm publish and GitHub release creation are skipped");
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: "none",
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+    });
+  }
+
+  if (!publish.value) {
+    reasons.push("No publish:* label is set; routing to manual approval");
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: "manual",
+      diagnostics,
+      reasons,
+      release: release.value,
+    });
+  }
+
+  if (publish.value === "publish:manual") {
+    reasons.push("publish:manual is set");
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: "manual",
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+    });
+  }
+
+  const autoChecks = evaluateAutoChecks(input, channel.value, release.value);
+  diagnostics.push(...autoChecks.diagnostics);
+
+  if (!autoChecks.ok) {
+    reasons.push("publish:auto requested, but one or more low-risk checks failed; routing to manual approval");
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: "manual",
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+    });
+  }
+
+  reasons.push("publish:auto and channel:stable are set, and low-risk generated release checks passed");
+  return makeReport(input, {
+    autoEligible: true,
+    blockers,
+    channel: channel.value,
+    decision: "auto",
+    diagnostics,
+    publish: publish.value,
+    reasons,
+    release: release.value,
+  });
+}
+
+function makeReport(
+  input: ReleasePolicyInput,
+  options: {
+    autoEligible?: boolean;
+    blockers: readonly string[];
+    channel: ChannelIntent | undefined;
+    decision: ReleasePolicyDecision;
+    diagnostics: readonly string[];
+    publish?: PublishIntent | undefined;
+    reasons: readonly string[];
+    release: ReleaseIntent | undefined;
+  }
+): ReleasePolicyReport {
+  const canPublish = options.decision === "auto" || options.decision === "manual";
+  return {
+    autoEligible: options.autoEligible ?? false,
+    blockers: options.blockers,
+    channel: options.channel,
+    createGitHubRelease: canPublish,
+    decision: options.decision,
+    diagnostics: options.diagnostics,
+    publish: options.publish,
+    reasons: options.reasons,
+    release: options.release,
+    shouldPublish: canPublish && !input.published,
+  };
+}
+
+function readLabelFamily<T extends string>(
+  labels: readonly string[],
+  prefix: string,
+  allowed: ReadonlySet<T>
+): FamilyResult<T> {
+  const values = labels.filter((label) => label.startsWith(prefix));
+  const known = values.filter((label): label is T => allowed.has(label as T));
+  const unknown = values.filter((label) => !allowed.has(label as T));
+  const result: { conflicts: string[]; unknown: string[]; value?: T } = {
+    conflicts: [],
+    unknown: unknown.map((label) => `Unknown ${prefix} label: ${label}`),
+  };
+
+  if (known.length > 1) {
+    result.conflicts.push(`Conflicting ${prefix} labels: ${known.join(", ")}`);
+    return result;
+  }
+
+  const [value] = known;
+  if (value) result.value = value;
+  return result;
+}
+
+function evaluateAutoChecks(
+  input: ReleasePolicyInput,
+  channel: ChannelIntent | undefined,
+  release: ReleaseIntent | undefined
+) {
+  const diagnostics: string[] = [];
+  const generatedDiff = evaluateGeneratedReleaseDiff(input.changedFiles);
+  diagnostics.push(...generatedDiff.diagnostics);
+
+  if (input.repository !== "outfitter-dev/skillset") {
+    diagnostics.push(`Expected repository outfitter-dev/skillset, found ${input.repository}`);
+  }
+
+  if (input.ref !== "refs/heads/main") {
+    diagnostics.push(`Expected refs/heads/main, found ${input.ref}`);
+  }
+
+  if (channel !== "channel:stable") {
+    diagnostics.push("publish:auto requires channel:stable in v1");
+  }
+
+  if (input.tag !== "latest") {
+    diagnostics.push(`channel:stable must publish with npm dist-tag latest, found ${input.tag}`);
+  }
+
+  if (!input.releasePullRequest) {
+    diagnostics.push("Could not resolve the release pull request for the current commit");
+  } else {
+    if (input.releasePullRequest.headRefName !== "changeset-release/main") {
+      diagnostics.push(`Expected release PR head changeset-release/main, found ${input.releasePullRequest.headRefName}`);
+    }
+    if (input.releasePullRequest.baseRefName !== "main") {
+      diagnostics.push(`Expected release PR base main, found ${input.releasePullRequest.baseRefName}`);
+    }
+    if (input.releasePullRequest.title !== "chore(release): version packages") {
+      diagnostics.push(`Expected release PR title "chore(release): version packages", found "${input.releasePullRequest.title}"`);
+    }
+    if (input.releasePullRequest.userLogin !== "github-actions[bot]") {
+      diagnostics.push(`Expected release PR author github-actions[bot], found ${input.releasePullRequest.userLogin}`);
+    }
+  }
+
+  if (!/^chore\(release\): version packages \(#\d+\)$/.test(input.commit.subject)) {
+    diagnostics.push(`Expected squash commit subject chore(release): version packages (#<pr>), found "${input.commit.subject}"`);
+  }
+
+  if (!isGitHubActionsIdentity(input.commit.authorName, input.commit.authorEmail)) {
+    diagnostics.push(`Expected GitHub Actions bot author, found ${input.commit.authorName} <${input.commit.authorEmail}>`);
+  }
+
+  if (!isGitHubCommitter(input.commit.committerName, input.commit.committerEmail)) {
+    diagnostics.push(`Expected GitHub committer, found ${input.commit.committerName} <${input.commit.committerEmail}>`);
+  }
+
+  if (!hasChangelogHeading(input.changelogText, input.version)) {
+    diagnostics.push(`apps/skillset/CHANGELOG.md does not contain a ${input.version} release heading`);
+  }
+
+  const expectedRelease = input.previousVersion
+    ? releaseIntentForVersionDelta(input.previousVersion, input.version)
+    : undefined;
+  if (!input.previousVersion) {
+    diagnostics.push("Could not read previous apps/skillset/package.json version");
+  } else if (!expectedRelease) {
+    diagnostics.push(`Expected ${input.version} to be newer than previous version ${input.previousVersion}`);
+  } else if (release && expectedRelease !== release) {
+    diagnostics.push(`${release} is set, but ${input.previousVersion} -> ${input.version} looks like ${expectedRelease}`);
+  }
+
+  if (input.taggedVersion && compareSemver(input.version, input.taggedVersion) <= 0 && !input.registryComplete) {
+    diagnostics.push(
+      `${input.packageName}@${input.version} is not newer than current ${input.tag} dist-tag ${input.taggedVersion}`
+    );
+  }
+
+  if (!input.ciPassed) {
+    diagnostics.push("Exact-SHA CI checks have not passed");
+  }
+
+  return { diagnostics, ok: diagnostics.length === 0 };
+}
+
+function evaluateGeneratedReleaseDiff(changedFiles: readonly ChangedFile[]) {
+  const diagnostics: string[] = [];
+  let hasPackageJson = false;
+  let hasChangelog = false;
+  let hasChangesetDeletion = false;
+
+  for (const file of changedFiles) {
+    if (file.path === "apps/skillset/package.json" && file.status === "M") {
+      hasPackageJson = true;
+      continue;
+    }
+
+    if (file.path === "apps/skillset/CHANGELOG.md" && file.status === "M") {
+      hasChangelog = true;
+      continue;
+    }
+
+    if (/^\.changeset\/[^/]+\.md$/.test(file.path) && file.status === "D") {
+      hasChangesetDeletion = true;
+      continue;
+    }
+
+    diagnostics.push(`Unexpected release diff entry: ${file.status} ${file.path}`);
+  }
+
+  if (!hasPackageJson) diagnostics.push("Generated release diff did not modify apps/skillset/package.json");
+  if (!hasChangelog) diagnostics.push("Generated release diff did not modify apps/skillset/CHANGELOG.md");
+  if (!hasChangesetDeletion) diagnostics.push("Generated release diff did not delete a consumed .changeset/*.md file");
+
+  return { diagnostics, ok: diagnostics.length === 0 };
+}
+
+function hasPublishNoneReason(pr: ReleasePullRequest | undefined) {
+  if (!pr) return false;
+  const texts = [pr.body, ...pr.comments].map((text) => text.toLowerCase());
+  return texts.some((text) => text.includes("publish:none") && /(because|intentional|reason|skip|no publish)/.test(text));
+}
+
+function isGitHubActionsIdentity(name: string, email: string) {
+  return name === "github-actions[bot]" && email === "41898282+github-actions[bot]@users.noreply.github.com";
+}
+
+function isGitHubCommitter(name: string, email: string) {
+  return name === "GitHub" && email === "noreply@github.com";
+}
+
+function hasChangelogHeading(changelog: string, version: string) {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^##\\s+${escaped}(?:\\s|$)`, "m").test(changelog);
+}
+
+function releaseIntentForVersionDelta(previousVersion: string, nextVersion: string): ReleaseIntent | undefined {
+  const previous = parseSemver(previousVersion);
+  const next = parseSemver(nextVersion);
+  if (!previous || !next) return undefined;
+  if (compareSemver(nextVersion, previousVersion) <= 0) return undefined;
+  if (next.major !== previous.major) return "release:major";
+  if (next.minor !== previous.minor) return "release:minor";
+  if (next.patch !== previous.patch || next.prerelease !== previous.prerelease) return "release:patch";
+  return undefined;
+}
+
+function compareSemver(leftVersion: string, rightVersion: string) {
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+  if (!left || !right) return leftVersion.localeCompare(rightVersion);
+
+  for (const key of ["major", "minor", "patch"] as const) {
+    const delta = left[key] - right[key];
+    if (delta !== 0) return delta;
+  }
+
+  if (left.prerelease === right.prerelease) return 0;
+  if (!left.prerelease) return 1;
+  if (!right.prerelease) return -1;
+  return left.prerelease.localeCompare(right.prerelease);
+}
+
+function parseSemver(version: string) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) return undefined;
+  const [, major, minor, patch, prerelease] = match;
+  if (!major || !minor || !patch) return undefined;
+  return {
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: Number.parseInt(patch, 10),
+    prerelease,
+  };
+}
+
+async function commandPolicy() {
+  const input = await readPolicyInput();
+  const report = evaluateReleasePolicy(input);
+
+  printReport(report);
+  await writeGitHubOutput({
+    channel: report.channel ?? "",
+    create_github_release: report.createGitHubRelease,
+    decision: report.decision,
+    name: input.packageName,
+    publish: report.publish ?? "",
+    registry_complete: input.registryComplete,
+    release: report.release ?? "",
+    should_publish: report.shouldPublish,
+    tag: input.tag,
+    version: input.version,
+  });
+
+  if (report.decision === "block") {
+    throw new Error(`Release policy blocked publish: ${report.blockers.join("; ")}`);
+  }
+}
+
+async function readPolicyInput(): Promise<ReleasePolicyInput> {
+  const packageInfo = await readPackageInfo();
+  const registry = await readRegistryState(packageInfo.name, packageInfo.version, packageInfo.tag);
+  const repository = process.env.GITHUB_REPOSITORY ?? (await runText(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]));
+  const ref = process.env.GITHUB_REF ?? `refs/heads/${await runText(["git", "branch", "--show-current"])}`;
+  const sha = process.env.GITHUB_SHA ?? (await runText(["git", "rev-parse", "HEAD"]));
+  const [releasePullRequest, commit, changedFiles, previousVersion, changelogText, ciPassed] = await Promise.all([
+    readReleasePullRequest(repository, sha),
+    readCommitInfo(),
+    readChangedFiles(),
+    readPreviousVersion(),
+    readFile(changelogPath, "utf8"),
+    readCiPassed(repository, sha),
+  ]);
+  const input: ReleasePolicyInput = {
+    changelogText,
+    changedFiles,
+    ciPassed,
+    commit,
+    packageName: packageInfo.name,
+    published: registry.published,
+    ref,
+    registryComplete: registry.published && registry.taggedVersion === packageInfo.version,
+    repository,
+    sha,
+    tag: packageInfo.tag,
+    version: packageInfo.version,
+  };
+
+  if (releasePullRequest) input.releasePullRequest = releasePullRequest;
+  if (registry.taggedVersion) input.taggedVersion = registry.taggedVersion;
+  if (previousVersion) input.previousVersion = previousVersion;
+  return input;
+}
+
+async function readPackageInfo() {
+  const raw = await readFile(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(raw) as PackageJson;
+
+  if (!packageJson.name || !packageJson.version) {
+    throw new Error(`Missing name or version in ${packageJsonPath}`);
+  }
+
+  return {
+    name: packageJson.name,
+    tag: distTagForVersion(packageJson.version),
+    version: packageJson.version,
+  };
+}
+
+async function readRegistryState(name: string, version: string, tag: string) {
+  const response = await fetch(`${registryUrl}/${encodeURIComponent(name)}`, {
+    headers: { accept: "application/json" },
+  });
+
+  if (response.status === 404) {
+    return { published: false, taggedVersion: undefined };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Registry lookup failed for ${name}: ${response.status} ${response.statusText}`);
+  }
+
+  const document = (await response.json()) as RegistryDocument;
+  return {
+    published: Boolean(document.versions?.[version]),
+    taggedVersion: document["dist-tags"]?.[tag],
+  };
+}
+
+async function readReleasePullRequest(repository: string, sha: string): Promise<ReleasePullRequest | undefined> {
+  const pulls = await githubJson<GitHubPullRequest[]>(repository, `/commits/${sha}/pulls`);
+  const [pull] = pulls.filter((candidate) => candidate.base.ref === "main");
+  if (!pull) return undefined;
+
+  const comments = await githubJson<GitHubComment[]>(repository, `/issues/${pull.number}/comments`);
+  return {
+    baseRefName: pull.base.ref,
+    body: pull.body ?? "",
+    comments: comments.map((comment) => comment.body ?? ""),
+    headRefName: pull.head.ref,
+    labels: pull.labels.map((label) => label.name),
+    number: pull.number,
+    title: pull.title,
+    userLogin: pull.user.login,
+  };
+}
+
+async function readCommitInfo(): Promise<CommitInfo> {
+  const output = await runText(["git", "log", "-1", "--format=%an%n%ae%n%cn%n%ce%n%s"]);
+  const [authorName, authorEmail, committerName, committerEmail, ...subjectParts] = output.split("\n");
+  if (!authorName || !authorEmail || !committerName || !committerEmail) {
+    throw new Error("Could not read current commit identity");
+  }
+
+  return {
+    authorEmail,
+    authorName,
+    committerEmail,
+    committerName,
+    subject: subjectParts.join("\n"),
+  };
+}
+
+async function readChangedFiles(): Promise<ChangedFile[]> {
+  const parentExists = await runText(["git", "rev-parse", "--verify", "HEAD^"], { allowFailure: true });
+  if (!parentExists) return [];
+
+  const output = await runText(["git", "diff", "--name-status", "HEAD^", "HEAD"]);
+  if (!output) return [];
+
+  return output.split("\n").map((line) => {
+    const [status, path] = line.split(/\s+/, 2);
+    if (!status || !path) throw new Error(`Could not parse git diff entry: ${line}`);
+    return { path, status };
+  });
+}
+
+async function readPreviousVersion() {
+  const raw = await runText(["git", "show", "HEAD^:apps/skillset/package.json"], {
+    allowFailure: true,
+  });
+  if (!raw) return undefined;
+
+  const packageJson = JSON.parse(raw) as PackageJson;
+  return packageJson.version;
+}
+
+async function readCiPassed(repository: string, sha: string) {
+  if (process.env.SKILLSET_RELEASE_POLICY_ASSUME_CI_PASSED === "1") return true;
+
+  const maxAttempts = Number.parseInt(process.env.SKILLSET_RELEASE_POLICY_CI_ATTEMPTS ?? "1", 10);
+  const waitMs = Number.parseInt(process.env.SKILLSET_RELEASE_POLICY_CI_WAIT_MS ?? "0", 10);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const state = await readCiState(repository, sha);
+    if (state === "passed") return true;
+    if (state === "failed") return false;
+    if (attempt < maxAttempts && waitMs > 0) {
+      console.error(`skillset: waiting for exact-SHA CI checks (${attempt}/${maxAttempts})`);
+      await Bun.sleep(waitMs);
+    }
+  }
+
+  return false;
+}
+
+export function ciStateFromCheckRuns(response: GitHubCheckRunsResponse) {
+  const requiredRuns = new Map(
+    response.check_runs
+      .filter((run) => run.check_suite?.app?.slug === "github-actions")
+      .filter((run) => run.name === "check" || run.name === "skillset-ci")
+      .map((run) => [run.name, run])
+  );
+  const relevantRuns = ["check", "skillset-ci"].map((name) => requiredRuns.get(name));
+
+  if (relevantRuns.some((run) => !run || run.status !== "completed")) return "pending";
+  if (relevantRuns.some((run) => run?.conclusion !== "success")) return "failed";
+
+  return "passed";
+}
+
+async function readCiState(repository: string, sha: string) {
+  const response = await githubJson<GitHubCheckRunsResponse>(repository, `/commits/${sha}/check-runs?per_page=100`);
+  return ciStateFromCheckRuns(response);
+}
+
+async function githubJson<T>(repository: string, path: string): Promise<T> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "x-github-api-version": "2022-11-28",
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  const response = await fetch(`https://api.github.com/repos/${repository}${path}`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed for ${path}: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function runText(command: readonly string[], options: { allowFailure?: boolean } = {}) {
+  const subprocess = Bun.spawn([...command], {
+    cwd: rootDir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ]);
+
+  if (exitCode !== 0) {
+    if (options.allowFailure) return "";
+    throw new Error(`${command.join(" ")} failed: ${stderr.trim()}`);
+  }
+
+  return stdout.trim();
+}
+
+function printReport(report: ReleasePolicyReport) {
+  console.error(`skillset: release policy decision is ${report.decision}`);
+
+  for (const reason of report.reasons) {
+    console.error(`skillset: ${reason}`);
+  }
+
+  for (const diagnostic of report.diagnostics) {
+    console.error(`skillset: policy diagnostic: ${diagnostic}`);
+  }
+
+  for (const blocker of report.blockers) {
+    console.error(`skillset: policy blocker: ${blocker}`);
+  }
+}
+
+type GitHubPullRequest = {
+  base: { ref: string };
+  body?: string | null;
+  head: { ref: string };
+  labels: { name: string }[];
+  number: number;
+  title: string;
+  user: { login: string };
+};
+
+type GitHubComment = {
+  body?: string | null;
+};
+
+export type GitHubCheckRunsResponse = {
+  check_runs: {
+    check_suite?: {
+      app?: {
+        slug?: string;
+      };
+    };
+    conclusion?: string | null;
+    name: string;
+    status: string;
+  }[];
+};
+
+if (import.meta.main) {
+  const [command = "policy"] = Bun.argv.slice(2);
+
+  try {
+    switch (command) {
+      case "policy":
+        await commandPolicy();
+        break;
+      default:
+        throw new Error(`Unknown release-policy command: ${command}`);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "packages/**/*.ts",
     "scripts/build-package.ts",
     "scripts/publish.ts",
+    "scripts/release-policy.ts",
     "scripts/bootstrap/**/*.ts",
     "scripts/__tests__/**/*.ts"
   ]


### PR DESCRIPTION
## Summary

- add a deterministic release policy gate for publish intent labels (`publish:auto`, `publish:manual`, `publish:none`, `publish:block`)
- route the Release workflow through policy-controlled automatic/manual publish jobs and skip GitHub releases for `publish:none`
- document release label semantics and the single npm Trusted Publishing setup with a blank npm Environment field
- cover label conflicts, unknown labels, `publish:none` audit reasons, exact named CI checks, generated diff restrictions, and positive version deltas

## Verification

- `bun test scripts/__tests__/release-policy.test.ts`
- `bun run typecheck`
- `bun run check:workflows`
- `bun run check` (471 pass / 0 fail)
- `gt submit --draft --no-edit --no-interactive --no-stack` pre-push gate (Skillset CI + full check)
- local staged review subagent: 5/5, no P0-P3 findings

## Release notes

This changes release automation only; it does not publish a package by itself. Before using the auto lane, npm Trusted Publishing should be configured as one trusted publisher for `release.yml` with the npm Environment field left blank, and GitHub should keep `npm` protected while `npm-auto` remains policy-gated.
