### PR TITLE
ci(release): require stack boundary for auto publish

### DIFF
--- a/.changeset/stack-boundary-release-policy.md
+++ b/.changeset/stack-boundary-release-policy.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Make automatic package publishing require stack-boundary evidence from the source PR range, and label generated Changesets release PRs with conservative release intent defaults.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     outputs:
       has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
@@ -34,6 +35,11 @@ jobs:
           version: bun run version:packages
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Label version PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun run publish:label-release-pr
 
   publish-plan:
     name: Publish Plan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ bun run conformance:adapters
 bun run conformance:external
 bun run changeset:status
 bun run publish:check
+bun run publish:label-release-pr
 bun run publish:policy
 bun run hooks:install
 bun run hooks:pre-push

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -12,7 +12,9 @@ Only the unscoped `skillset` CLI package is public in the current package postur
 
 ## Flow
 
-Feature branches that change package-facing behavior should include a `.changeset/*.md` file. When the branch merges to `main`, `.github/workflows/release.yml` runs `changesets/action` to create or update a `chore(release): version packages` pull request.
+Feature branches that change package-facing behavior should include a `.changeset/*.md` file on the branch that owns the behavior. In Graphite stacks, keep release intent branch-local: do not hide lower-branch package changes by adding one cleanup Changeset at the stack tip. If the lower branch owns the package-facing code, the lower branch owns the Changeset, and any missing release intent should be fixed on that branch before restacking upward.
+
+When a branch with unreleased Changesets merges to `main`, `.github/workflows/release.yml` runs `changesets/action` to create or update a `chore(release): version packages` pull request. Skillset then applies missing release intent labels to that generated version PR. It preserves any existing human-provided label family and only fills gaps. The labeler uses source PR evidence from the package release range: if every consumed Changeset source PR carries explicit `stack:boundary` evidence and the generated version is stable, it may add `publish:auto`; otherwise it adds `publish:manual` so the release stays behind the protected environment.
 
 When the version PR merges to `main`, the same workflow checks the npm registry and resolves the release intent labels from the merged version PR. If the current `apps/skillset/package.json` version is already published and the intended dist-tag points to it, the workflow exits the publish step without entering a publish environment and ensures a missing GitHub release can still be created when the matching `v<version>` tag already points at the package-version commit. If the version is missing, the workflow runs the publish policy. Low-risk generated releases can publish through `npm-auto`; anything ambiguous routes to the protected manual `npm` environment; `publish:none` skips npm and GitHub release creation; `publish:block` stops the release workflow. Successful publishes wait for the version and dist-tag to appear on the registry, create and push the matching `v<version>` tag at the package-version commit, and create the GitHub release with `--verify-tag` if it does not already exist.
 
@@ -32,19 +34,24 @@ The release PR supports these mutually exclusive label families:
 
 Conflicting labels within a family, unknown labels under these prefixes, registry drift, or `publish:block` block the workflow with diagnostics. `publish:none` requires an audit reason in the release PR body or comments because it intentionally leaves package-version state unpublished. Any generated release PR that touches workflow files, release scripts, package publish metadata, lockfiles, source files, or other unexpected paths falls back to the manual environment rather than the automatic environment.
 
+Source PRs may also use `stack:boundary`. That label is not a release-size intent and it does not replace a Changeset. It marks a source PR as complete enough to be considered for automatic package publication. The publish policy reads the source PRs between the previous package-version commit and the generated version commit; `publish:auto` requires every consumed Changeset source PR to carry `stack:boundary`. Missing boundary evidence falls back to manual approval. Unknown `stack:*` labels block the workflow because label drift should be corrected explicitly.
+
 ## Commands
 
 ```bash
 bun run changeset
 bun run changeset:status
 bun run publish:plan
+bun run publish:label-release-pr
 bun run publish:policy
 bun run publish:check
 bun run publish:registry-check
 bun run publish:registry-check:published
 ```
 
-`bun run publish:policy` is the release-workflow policy gate. It reads the current commit, the associated Changesets release PR, exact-SHA GitHub checks, package/changelog state, and npm registry state, then emits GitHub Actions outputs for `auto`, `manual`, `none`, or `block`.
+`bun run publish:label-release-pr` is a workflow helper that runs after `changesets/action` creates or updates the generated version PR. It labels missing intent families without overriding existing human intent.
+
+`bun run publish:policy` is the release-workflow policy gate. It reads the current commit, the associated Changesets release PR, exact-SHA GitHub checks, source PR stack evidence, package/changelog state, and npm registry state, then emits GitHub Actions outputs for `auto`, `manual`, `none`, or `block`.
 
 `bun run publish:check` is the local preflight: it runs the full repo check, rebuilds the npm package output, and performs `bun pm pack --dry-run` from `apps/skillset` so package contents are verified without registry authentication.
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hooks:pre-push": "lefthook run pre-push --force",
     "prepack": "tsc --noEmit && bun scripts/build-package.ts",
     "publish:check": "bun run check && bun scripts/publish.ts check",
+    "publish:label-release-pr": "bun scripts/release-policy.ts label-release-pr",
     "publish:packages": "bun scripts/publish.ts publish",
     "publish:plan": "bun scripts/publish.ts plan",
     "publish:policy": "bun scripts/release-policy.ts policy",

--- a/scripts/__tests__/release-policy.test.ts
+++ b/scripts/__tests__/release-policy.test.ts
@@ -43,6 +43,15 @@ const baseInput = (
   },
   repository: "outfitter-dev/skillset",
   sha: "b25a221f4ddc98a7ab5def2c88e67f63e456e40e",
+  sourcePullRequests: [
+    {
+      commitShas: ["26b2c3a"],
+      hasChangeset: true,
+      labels: ["stack:boundary"],
+      number: 95,
+      title: "fix(changes): report stacked change evidence",
+    },
+  ],
   tag: "latest",
   taggedVersion: "0.13.3",
   version: "0.13.4",
@@ -60,6 +69,7 @@ describe("release policy", () => {
     expect(report.shouldPublish).toBe(true);
     expect(report.createGitHubRelease).toBe(true);
     expect(report.diagnostics).toEqual([]);
+    expect(report.stack).toBe("stack:boundary");
   });
 
   test("defaults to manual when no publish intent is set", () => {
@@ -123,6 +133,86 @@ describe("release policy", () => {
 
     expect(report.decision).toBe("manual");
     expect(report.diagnostics).toContain("publish:auto requires channel:stable in v1");
+  });
+
+  test("routes publish:auto to manual when source stack evidence is missing", () => {
+    const input = baseInput(["publish:auto", "channel:stable", "release:patch"]);
+    delete input.sourcePullRequests;
+
+    const report = evaluateReleasePolicy(input);
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain(
+      "Could not resolve source PR stack evidence for the generated release"
+    );
+  });
+
+  test("routes publish:auto to manual when changeset source PRs lack stack boundary evidence", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable", "release:patch"], {
+        sourcePullRequests: [
+          {
+            commitShas: ["26b2c3a"],
+            hasChangeset: true,
+            labels: [],
+            number: 95,
+            title: "fix(changes): report stacked change evidence",
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain(
+      "publish:auto requires stack:boundary on every changeset source PR in the release range; missing: #95"
+    );
+  });
+
+  test("routes publish:auto to manual when an unrelated source PR has the boundary", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable", "release:patch"], {
+        sourcePullRequests: [
+          {
+            commitShas: ["26b2c3a"],
+            hasChangeset: true,
+            labels: [],
+            number: 95,
+            title: "fix(changes): report stacked change evidence",
+          },
+          {
+            commitShas: ["9c38db3"],
+            hasChangeset: false,
+            labels: ["stack:boundary"],
+            number: 97,
+            title: "ci(release): gate automatic npm publishes",
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe("manual");
+    expect(report.diagnostics).toContain(
+      "publish:auto requires stack:boundary on every changeset source PR in the release range; missing: #95"
+    );
+  });
+
+  test("blocks unknown stack labels on source PRs", () => {
+    const report = evaluateReleasePolicy(
+      baseInput(["publish:auto", "channel:stable", "release:patch"], {
+        sourcePullRequests: [
+          {
+            commitShas: ["26b2c3a"],
+            hasChangeset: true,
+            labels: ["stack:top"],
+            number: 95,
+            title: "fix(changes): report stacked change evidence",
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe("block");
+    expect(report.blockers).toEqual(["Unknown stack: label: stack:top on #95"]);
   });
 
   test("routes publish:auto to manual when release shape touches workflow files", () => {

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -24,6 +24,7 @@ export type PublishIntent =
 export type ChannelIntent = "channel:canary" | "channel:preview" | "channel:stable";
 export type ReleaseIntent = "release:major" | "release:minor" | "release:patch";
 export type ReleasePolicyDecision = "auto" | "block" | "manual" | "none";
+export type StackIntent = "stack:boundary";
 
 export type ChangedFile = {
   path: string;
@@ -49,6 +50,14 @@ export type CommitInfo = {
   subject: string;
 };
 
+export type SourcePullRequest = {
+  commitShas: readonly string[];
+  hasChangeset: boolean;
+  labels: readonly string[];
+  number: number;
+  title: string;
+};
+
 export type ReleasePolicyInput = {
   changelogText: string;
   changedFiles: readonly ChangedFile[];
@@ -61,6 +70,7 @@ export type ReleasePolicyInput = {
   repository: string;
   releasePullRequest?: ReleasePullRequest;
   sha: string;
+  sourcePullRequests?: readonly SourcePullRequest[];
   tag: string;
   taggedVersion?: string;
   version: string;
@@ -78,6 +88,7 @@ export type ReleasePolicyReport = {
   reasons: readonly string[];
   release: ReleaseIntent | undefined;
   shouldPublish: boolean;
+  stack: StackIntent | undefined;
 };
 
 type FamilyResult<T extends string> = {
@@ -108,19 +119,23 @@ const releaseIntents = new Set<ReleaseIntent>([
   "release:minor",
   "release:patch",
 ]);
+const stackIntents = new Set<StackIntent>(["stack:boundary"]);
 
 export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyReport {
   const labels = input.releasePullRequest?.labels ?? [];
   const publish = readLabelFamily(labels, "publish:", publishIntents);
   const channel = readLabelFamily(labels, "channel:", channelIntents);
   const release = readLabelFamily(labels, "release:", releaseIntents);
+  const stack = readSourceStackLabels(input.sourcePullRequests);
   const blockers = [
     ...publish.conflicts,
     ...channel.conflicts,
     ...release.conflicts,
+    ...stack.conflicts,
     ...publish.unknown,
     ...channel.unknown,
     ...release.unknown,
+    ...stack.unknown,
   ];
   const diagnostics: string[] = [];
   const reasons: string[] = [];
@@ -144,6 +159,7 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
       publish: publish.value,
       reasons,
       release: release.value,
+      stack: stack.value,
     });
   }
 
@@ -158,6 +174,7 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
         publish: publish.value,
         reasons,
         release: release.value,
+        stack: stack.value,
       });
     }
 
@@ -170,6 +187,7 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
       publish: publish.value,
       reasons,
       release: release.value,
+      stack: stack.value,
     });
   }
 
@@ -182,6 +200,7 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
       diagnostics,
       reasons,
       release: release.value,
+      stack: stack.value,
     });
   }
 
@@ -195,10 +214,11 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
       publish: publish.value,
       reasons,
       release: release.value,
+      stack: stack.value,
     });
   }
 
-  const autoChecks = evaluateAutoChecks(input, channel.value, release.value);
+  const autoChecks = evaluateAutoChecks(input, channel.value, release.value, stack.value);
   diagnostics.push(...autoChecks.diagnostics);
 
   if (!autoChecks.ok) {
@@ -211,10 +231,11 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
       publish: publish.value,
       reasons,
       release: release.value,
+      stack: stack.value,
     });
   }
 
-  reasons.push("publish:auto and channel:stable are set, and low-risk generated release checks passed");
+  reasons.push("publish:auto, channel:stable, and stack:boundary are set, and low-risk release checks passed");
   return makeReport(input, {
     autoEligible: true,
     blockers,
@@ -224,6 +245,7 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
     publish: publish.value,
     reasons,
     release: release.value,
+    stack: stack.value,
   });
 }
 
@@ -238,6 +260,7 @@ function makeReport(
     publish?: PublishIntent | undefined;
     reasons: readonly string[];
     release: ReleaseIntent | undefined;
+    stack: StackIntent | undefined;
   }
 ): ReleasePolicyReport {
   const canPublish = options.decision === "auto" || options.decision === "manual";
@@ -252,6 +275,7 @@ function makeReport(
     reasons: options.reasons,
     release: options.release,
     shouldPublish: canPublish && !input.published,
+    stack: options.stack,
   };
 }
 
@@ -281,11 +305,13 @@ function readLabelFamily<T extends string>(
 function evaluateAutoChecks(
   input: ReleasePolicyInput,
   channel: ChannelIntent | undefined,
-  release: ReleaseIntent | undefined
+  release: ReleaseIntent | undefined,
+  stack: StackIntent | undefined
 ) {
   const diagnostics: string[] = [];
   const generatedDiff = evaluateGeneratedReleaseDiff(input.changedFiles);
   diagnostics.push(...generatedDiff.diagnostics);
+  diagnostics.push(...evaluateSourceStackEvidence(input.sourcePullRequests, stack));
 
   if (input.repository !== "outfitter-dev/skillset") {
     diagnostics.push(`Expected repository outfitter-dev/skillset, found ${input.repository}`);
@@ -358,6 +384,58 @@ function evaluateAutoChecks(
   }
 
   return { diagnostics, ok: diagnostics.length === 0 };
+}
+
+function readSourceStackLabels(sourcePullRequests: readonly SourcePullRequest[] | undefined) {
+  if (!sourcePullRequests) return { conflicts: [], unknown: [] };
+
+  const labels = sourcePullRequests.flatMap((pull) =>
+    pull.labels
+      .filter((label) => label.startsWith("stack:"))
+      .map((label) => `${label} on #${pull.number}`)
+  );
+  const normalizedLabels = [...new Set(labels.map((label) => label.split(" on #", 1)[0] ?? label))];
+  const result = readLabelFamily(normalizedLabels, "stack:", stackIntents);
+
+  return {
+    conflicts: result.conflicts.map((conflict) => `${conflict} across source PRs`),
+    unknown: result.unknown.map((unknown) => {
+      const label = unknown.replace("Unknown stack: label: ", "");
+      const source = labels.find((candidate) => candidate.startsWith(label));
+      return source ? `Unknown stack: label: ${source}` : unknown;
+    }),
+    value: result.value,
+  };
+}
+
+function evaluateSourceStackEvidence(
+  sourcePullRequests: readonly SourcePullRequest[] | undefined,
+  stack: StackIntent | undefined
+) {
+  const diagnostics: string[] = [];
+
+  if (!sourcePullRequests) {
+    diagnostics.push("Could not resolve source PR stack evidence for the generated release");
+    return diagnostics;
+  }
+
+  const changesetPulls = sourcePullRequests.filter((pull) => pull.hasChangeset);
+  if (changesetPulls.length === 0) {
+    diagnostics.push("Could not find a source PR that introduced a consumed .changeset/*.md file");
+    return diagnostics;
+  }
+
+  const changesetPullsMissingBoundary = changesetPulls.filter((pull) => !pull.labels.includes("stack:boundary"));
+
+  if (stack !== "stack:boundary" || changesetPullsMissingBoundary.length > 0) {
+    diagnostics.push(
+      `publish:auto requires stack:boundary on every changeset source PR in the release range; missing: ${changesetPullsMissingBoundary
+        .map((pull) => `#${pull.number}`)
+        .join(", ")}`
+    );
+  }
+
+  return diagnostics;
 }
 
 function evaluateGeneratedReleaseDiff(changedFiles: readonly ChangedFile[]) {
@@ -474,6 +552,56 @@ async function commandPolicy() {
   }
 }
 
+async function commandLabelReleasePr() {
+  const packageInfo = await readPackageInfo();
+  const repository = process.env.GITHUB_REPOSITORY ?? (await runText(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]));
+  const releasePullRequest = await readOpenReleasePullRequest(repository);
+
+  if (!releasePullRequest) {
+    console.error("skillset: no open changeset-release/main pull request found");
+    return;
+  }
+
+  const nextPackageInfo = await readPackageInfoFromRef(repository, releasePullRequest.headRefName);
+  const nextTag = distTagForVersion(nextPackageInfo.version);
+  const sourcePullRequests = await readSourcePullRequests(repository, packageInfo.version, "HEAD");
+  const stack = readSourceStackLabels(sourcePullRequests);
+  const stackDiagnostics = [
+    ...stack.conflicts,
+    ...stack.unknown,
+    ...evaluateSourceStackEvidence(sourcePullRequests, stack.value),
+  ];
+  const expectedRelease = releaseIntentForVersionDelta(packageInfo.version, nextPackageInfo.version);
+  const labels = new Set(releasePullRequest.labels);
+  const labelsToAdd: string[] = [];
+
+  if (!hasLabelFamily(labels, "publish:")) {
+    labelsToAdd.push(stackDiagnostics.length === 0 && nextTag === "latest" ? "publish:auto" : "publish:manual");
+  }
+
+  if (!hasLabelFamily(labels, "channel:") && nextTag === "latest") {
+    labelsToAdd.push("channel:stable");
+  }
+
+  if (expectedRelease && !hasLabelFamily(labels, "release:")) {
+    labelsToAdd.push(expectedRelease);
+  }
+
+  if (labelsToAdd.length === 0) {
+    console.error(`skillset: release PR #${releasePullRequest.number} already has release intent labels`);
+    return;
+  }
+
+  for (const label of labelsToAdd) {
+    await runText(["gh", "issue", "edit", String(releasePullRequest.number), "--add-label", label]);
+  }
+
+  console.error(`skillset: added ${labelsToAdd.join(", ")} to release PR #${releasePullRequest.number}`);
+  for (const diagnostic of stackDiagnostics) {
+    console.error(`skillset: stack diagnostic: ${diagnostic}`);
+  }
+}
+
 async function readPolicyInput(): Promise<ReleasePolicyInput> {
   const packageInfo = await readPackageInfo();
   const registry = await readRegistryState(packageInfo.name, packageInfo.version, packageInfo.tag);
@@ -488,6 +616,9 @@ async function readPolicyInput(): Promise<ReleasePolicyInput> {
     readFile(changelogPath, "utf8"),
     readCiPassed(repository, sha),
   ]);
+  const sourcePullRequests = previousVersion
+    ? await readSourcePullRequests(repository, previousVersion)
+    : undefined;
   const input: ReleasePolicyInput = {
     changelogText,
     changedFiles,
@@ -504,6 +635,7 @@ async function readPolicyInput(): Promise<ReleasePolicyInput> {
   };
 
   if (releasePullRequest) input.releasePullRequest = releasePullRequest;
+  if (sourcePullRequests) input.sourcePullRequests = sourcePullRequests;
   if (registry.taggedVersion) input.taggedVersion = registry.taggedVersion;
   if (previousVersion) input.previousVersion = previousVersion;
   return input;
@@ -600,6 +732,122 @@ async function readPreviousVersion() {
 
   const packageJson = JSON.parse(raw) as PackageJson;
   return packageJson.version;
+}
+
+async function readSourcePullRequests(
+  repository: string,
+  previousVersion: string,
+  endRef = "HEAD^"
+): Promise<SourcePullRequest[] | undefined> {
+  const previousVersionCommit = await runText([
+    "git",
+    "log",
+    "-n",
+    "1",
+    "--format=%H",
+    "-S",
+    `"version": "${previousVersion}"`,
+    endRef,
+    "--",
+    "apps/skillset/package.json",
+  ]);
+  if (!previousVersionCommit) return undefined;
+
+  const output = await runText(["git", "rev-list", "--reverse", `${previousVersionCommit}..${endRef}`]);
+  if (!output) return [];
+
+  const byNumber = new Map<number, SourcePullRequest>();
+  for (const commitSha of output.split("\n")) {
+    const changedFiles = await readCommitChangedFiles(commitSha);
+    const hasChangeset = changedFiles.some(
+      (file) => /^\.changeset\/[^/]+\.md$/.test(file.path) && file.status !== "D"
+    );
+    const pulls = await githubJson<GitHubPullRequest[]>(repository, `/commits/${commitSha}/pulls`);
+    const [pull] = pulls;
+
+    if (!pull) {
+      byNumber.set(-byNumber.size - 1, {
+        commitShas: [commitSha],
+        hasChangeset,
+        labels: [],
+        number: 0,
+        title: `Unresolved source commit ${commitSha.slice(0, 7)}`,
+      });
+      continue;
+    }
+
+    const existing = byNumber.get(pull.number);
+    if (existing) {
+      byNumber.set(pull.number, {
+        ...existing,
+        commitShas: [...existing.commitShas, commitSha],
+        hasChangeset: existing.hasChangeset || hasChangeset,
+      });
+      continue;
+    }
+
+    byNumber.set(pull.number, {
+      commitShas: [commitSha],
+      hasChangeset,
+      labels: pull.labels.map((label) => label.name),
+      number: pull.number,
+      title: pull.title,
+    });
+  }
+
+  return [...byNumber.values()];
+}
+
+async function readOpenReleasePullRequest(repository: string): Promise<ReleasePullRequest | undefined> {
+  const pulls = await githubJson<GitHubPullRequest[]>(repository, "/pulls?state=open&base=main&per_page=100");
+  const pull = pulls.find((candidate) => candidate.head.ref === "changeset-release/main");
+  if (!pull) return undefined;
+
+  return {
+    baseRefName: pull.base.ref,
+    body: pull.body ?? "",
+    comments: [],
+    headRefName: pull.head.ref,
+    labels: pull.labels.map((label) => label.name),
+    number: pull.number,
+    title: pull.title,
+    userLogin: pull.user.login,
+  };
+}
+
+async function readPackageInfoFromRef(repository: string, ref: string) {
+  const file = await githubJson<GitHubContentFile>(
+    repository,
+    `/contents/apps/skillset/package.json?ref=${encodeURIComponent(ref)}`
+  );
+  const packageJson = JSON.parse(Buffer.from(file.content, "base64").toString("utf8")) as PackageJson;
+
+  if (!packageJson.name || !packageJson.version) {
+    throw new Error(`Missing name or version in apps/skillset/package.json at ${ref}`);
+  }
+
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+  };
+}
+
+function hasLabelFamily(labels: ReadonlySet<string>, prefix: string) {
+  for (const label of labels) {
+    if (label.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+async function readCommitChangedFiles(commitSha: string) {
+  const output = await runText(["git", "diff-tree", "--no-commit-id", "--name-status", "-r", commitSha]);
+  if (!output) return [];
+
+  return output.split("\n").map((line) => {
+    const [status, path] = line.split(/\s+/, 2);
+    if (!status || !path) throw new Error(`Could not parse git diff entry: ${line}`);
+    return { path, status };
+  });
 }
 
 async function readCiPassed(repository: string, sha: string) {
@@ -710,6 +958,10 @@ type GitHubComment = {
   body?: string | null;
 };
 
+type GitHubContentFile = {
+  content: string;
+};
+
 export type GitHubCheckRunsResponse = {
   check_runs: {
     check_suite?: {
@@ -730,6 +982,9 @@ if (import.meta.main) {
     switch (command) {
       case "policy":
         await commandPolicy();
+        break;
+      case "label-release-pr":
+        await commandLabelReleasePr();
         break;
       default:
         throw new Error(`Unknown release-policy command: ${command}`);


### PR DESCRIPTION
## Summary

- add `stack:boundary` as source-PR evidence for automatic package publishing
- label generated Changesets release PRs with conservative missing intent labels after `changesets/action` runs
- require every consumed Changeset source PR to carry `stack:boundary` before `publish:auto` can pass
- document branch-local Changesets in Graphite stacks and the stack-boundary/manual-fallback behavior

## Verification

- `bun test scripts/__tests__/release-policy.test.ts`
- `bun run typecheck`
- `bun run check:workflows` (local `actionlint` unavailable, command skips as designed)
- `bun run publish:label-release-pr` (no open `changeset-release/main` PR, exits without mutation)
- `bun run check` (475 pass / 0 fail)
- Graphite pre-push gate via `gt submit --draft --no-edit --no-interactive --no-stack` (Skillset CI + full check)
- local review subagent: first pass 3/5 with P1/P2/P3; fixed all findings; second pass 5/5 with no P0-P3 findings

## Release Notes

This is release automation hardening only. It adds a patch Changeset because the public package workflow behavior changes.
