### PR TITLE
chore(release): remove nonpackage changeset

### DIFF
--- a/.changeset/stack-boundary-release-policy.md
+++ b/.changeset/stack-boundary-release-policy.md
@@ -1,5 +1,0 @@
----
-"skillset": patch
----
-
-Make automatic package publishing require stack-boundary evidence from the source PR range, and label generated Changesets release PRs with conservative release intent defaults.


### PR DESCRIPTION
## Summary

- remove the stray Changeset from PR #98 because the change touched repo release automation/docs/root scripts, not the published `skillset` CLI payload
- keep `skillset@0.13.4` as the current package release
- prevent the closed generated release PR #99 from being recreated

## Verification

- pre-commit hook passed repo sanity and whitespace
- Graphite pre-push hook skipped package gates because only `.changeset/stack-boundary-release-policy.md` was deleted

## Notes

Closed PR #99 with an audit comment explaining why `skillset@0.13.5` should not be published for PR #98.
