### PR TITLE
ci(release): scope changesets to package payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,30 @@ permissions:
   contents: read
 
 jobs:
+  changeset:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'changeset-release/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+      - run: bun install --frozen-lockfile
+      - name: Read pull request file list
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: >-
+          gh api --paginate
+          "repos/$GH_REPO/pulls/$PR_NUMBER/files?per_page=100"
+          --jq '.[] | "\(.status)\t\(.filename)"'
+          > "$RUNNER_TEMP/changed-files.txt"
+      - run: bun run changeset:check -- --changed-files "$RUNNER_TEMP/changed-files.txt"
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ bun run conformance:fast
 bun run conformance:determinism
 bun run conformance:adapters
 bun run conformance:external
+bun run changeset:check
 bun run changeset:status
 bun run publish:check
 bun run publish:label-release-pr

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -14,6 +14,20 @@ Only the unscoped `skillset` CLI package is public in the current package postur
 
 Feature branches that change package-facing behavior should include a `.changeset/*.md` file on the branch that owns the behavior. In Graphite stacks, keep release intent branch-local: do not hide lower-branch package changes by adding one cleanup Changeset at the stack tip. If the lower branch owns the package-facing code, the lower branch owns the Changeset, and any missing release intent should be fixed on that branch before restacking upward.
 
+Package-facing means a change that can affect the published `skillset` CLI package payload or its runtime behavior. The guardrail intentionally does not treat docs, workflow files, release scripts, generated Skillset source-unit state, fixtures, or repo-only maintenance as package-facing by default. Current package-facing paths are:
+
+| Path | Why it requires a package Changeset |
+| --- | --- |
+| `apps/skillset/src/**` except tests | CLI and `create-skillset` runtime source bundled into the package. |
+| `apps/skillset/package.json` | Published package metadata, bin entries, dependencies, and version-bearing state. |
+| `packages/core/src/**` except tests | Internal compiler/library implementation bundled through the CLI. |
+| `packages/lint/src/**` except tests | Lint implementation consumed by the CLI. |
+| `packages/transforms/src/**` except tests | Transform implementation consumed by the CLI. |
+| `packages/*/package.json` for `core`, `lint`, and `transforms` | Runtime dependency and package metadata for the private workspace packages that feed the CLI. |
+| `bun.lock` / `bun.lockb` | Dependency resolution that can alter the packaged CLI runtime. |
+
+`bun run changeset:check` enforces this boundary. It fails when package-facing paths change without an active `.changeset/*.md`, and it also fails when an active Changeset appears on a branch that only changes repo machinery. Deleted Changesets are ignored so cleanup branches can remove mistaken package-release entries.
+
 When a branch with unreleased Changesets merges to `main`, `.github/workflows/release.yml` runs `changesets/action` to create or update a `chore(release): version packages` pull request. Skillset then applies missing release intent labels to that generated version PR. It preserves any existing human-provided label family and only fills gaps. The labeler uses source PR evidence from the package release range: if every consumed Changeset source PR carries explicit `stack:boundary` evidence and the generated version is stable, it may add `publish:auto`; otherwise it adds `publish:manual` so the release stays behind the protected environment.
 
 When the version PR merges to `main`, the same workflow checks the npm registry and resolves the release intent labels from the merged version PR. If the current `apps/skillset/package.json` version is already published and the intended dist-tag points to it, the workflow exits the publish step without entering a publish environment and ensures a missing GitHub release can still be created when the matching `v<version>` tag already points at the package-version commit. If the version is missing, the workflow runs the publish policy. Low-risk generated releases can publish through `npm-auto`; anything ambiguous routes to the protected manual `npm` environment; `publish:none` skips npm and GitHub release creation; `publish:block` stops the release workflow. Successful publishes wait for the version and dist-tag to appear on the registry, create and push the matching `v<version>` tag at the package-version commit, and create the GitHub release with `--verify-tag` if it does not already exist.
@@ -40,6 +54,7 @@ Source PRs may also use `stack:boundary`. That label is not a release-size inten
 
 ```bash
 bun run changeset
+bun run changeset:check
 bun run changeset:status
 bun run publish:plan
 bun run publish:label-release-pr
@@ -50,6 +65,8 @@ bun run publish:registry-check:published
 ```
 
 `bun run publish:label-release-pr` is a workflow helper that runs after `changesets/action` creates or updates the generated version PR. It labels missing intent families without overriding existing human intent.
+
+`bun run changeset:check` is the branch-local package-release guard. Locally it diffs against the remote trunk; in PR CI it uses the pull request file list so stacked branches are checked against their own review diff.
 
 `bun run publish:policy` is the release-workflow policy gate. It reads the current commit, the associated Changesets release PR, exact-SHA GitHub checks, source PR stack evidence, package/changelog state, and npm registry state, then emits GitHub Actions outputs for `auto`, `manual`, `none`, or `block`.
 
@@ -84,4 +101,4 @@ The repository intentionally does not commit an npm auth token in `.npmrc` and t
 
 ## No Package Release
 
-Package-facing changes should include a `.changeset/*.md` file. Internal-only changes may intentionally omit a Changeset when they do not affect the published package contract; call that out in the PR body so the release workflow's version-PR behavior is easy to audit. Skillset source-unit changes under `.skillset/changes` are separate from npm package changes and do not satisfy package release intent by themselves.
+Package-facing changes should include a `.changeset/*.md` file. Internal-only changes should omit a Changeset when they do not affect the published package contract; call that out in the PR body when the distinction is subtle so the release workflow's version-PR behavior is easy to audit. Skillset source-unit changes under `.skillset/changes` are separate from npm package changes and do not satisfy package release intent by themselves.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,6 +44,10 @@ pre-push:
       env:
         GIT_PAGER: cat
       run: git diff --check "$(scripts/git-trunk.sh)...HEAD"
+    - name: changesets
+      env:
+        GIT_PAGER: cat
+      run: bun run changeset:check
     - name: workflows
       env:
         GIT_PAGER: cat

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check": "bun run build && bun run test && bun run ultracite:doctor && bun run skillset:verify && git diff --check",
     "check:workflows": "if command -v actionlint >/dev/null 2>&1; then actionlint .github/workflows/*.yml; else echo 'skillset: actionlint not installed; skipping workflow lint'; fi",
     "changeset": "changeset",
+    "changeset:check": "bun scripts/changeset-guard.ts",
     "changeset:status": "changeset status --verbose",
     "conformance:adapters": "bun test packages/core/src/__tests__/adapter-conformance.test.ts packages/core/src/__tests__/adapter-conformance-coverage.test.ts",
     "conformance:determinism": "bun test packages/core/src/__tests__/deterministic-projection.test.ts",

--- a/scripts/__tests__/changeset-guard.test.ts
+++ b/scripts/__tests__/changeset-guard.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateChangesetGuard,
+  isActiveChangesetEntry,
+  isPackageAffectingPath,
+  parseChangedFileLine,
+} from "../changeset-guard";
+
+describe("changeset guard", () => {
+  test("requires an active changeset for published package payload changes", () => {
+    const result = evaluateChangesetGuard([
+      { path: "apps/skillset/src/cli.ts", status: "M" },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.packageFiles.map((file) => file.path)).toEqual(["apps/skillset/src/cli.ts"]);
+    expect(result.diagnostics[0]).toContain("Package-facing changes require a .changeset/*.md entry");
+  });
+
+  test("passes package payload changes with an active changeset", () => {
+    const result = evaluateChangesetGuard([
+      { path: "packages/core/src/build.ts", status: "M" },
+      { path: ".changeset/runtime-build.md", status: "A" },
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test("blocks active changesets when only repo machinery changed", () => {
+    const result = evaluateChangesetGuard([
+      { path: ".github/workflows/release.yml", status: "M" },
+      { path: "docs/package-releases.md", status: "M" },
+      { path: "scripts/release-policy.ts", status: "M" },
+      { path: ".changeset/release-policy.md", status: "A" },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.packageFiles).toEqual([]);
+    expect(result.diagnostics[0]).toContain("Changeset entries are only for published package payload changes");
+  });
+
+  test("passes repo-only changes without a changeset", () => {
+    const result = evaluateChangesetGuard([
+      { path: ".github/workflows/release.yml", status: "M" },
+      { path: "docs/package-releases.md", status: "M" },
+      { path: "scripts/release-policy.ts", status: "M" },
+    ]);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("does not treat tests as package payload changes", () => {
+    expect(isPackageAffectingPath("apps/skillset/src/__tests__/skillset.test.ts")).toBe(false);
+    expect(isPackageAffectingPath("packages/core/src/__tests__/build-result.test.ts")).toBe(false);
+    expect(isPackageAffectingPath("packages/lint/src/rules/name-directory.ts")).toBe(true);
+  });
+
+  test("ignores deleted changesets so cleanup branches can remove mistakes", () => {
+    expect(isActiveChangesetEntry({ path: ".changeset/old.md", status: "D" })).toBe(false);
+    expect(isActiveChangesetEntry({ path: ".changeset/new.md", status: "A" })).toBe(true);
+
+    const result = evaluateChangesetGuard([
+      { path: ".changeset/old.md", status: "D" },
+      { path: "docs/package-releases.md", status: "M" },
+    ]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("parses both name-status and path-only changed file lines", () => {
+    expect(parseChangedFileLine("M\tapps/skillset/src/cli.ts")).toEqual({
+      path: "apps/skillset/src/cli.ts",
+      status: "M",
+    });
+    expect(parseChangedFileLine("modified\tpackages/core/src/build.ts")).toEqual({
+      path: "packages/core/src/build.ts",
+      status: "modified",
+    });
+    expect(parseChangedFileLine("R100\tpackages/core/src/old.ts\tpackages/core/src/new.ts")).toEqual({
+      path: "packages/core/src/new.ts",
+      status: "R100",
+    });
+    expect(parseChangedFileLine("docs/package-releases.md")).toEqual({
+      path: "docs/package-releases.md",
+    });
+    expect(parseChangedFileLine("")).toBeUndefined();
+  });
+});

--- a/scripts/__tests__/release-policy.test.ts
+++ b/scripts/__tests__/release-policy.test.ts
@@ -5,6 +5,7 @@ import {
   type ReleasePolicyInput,
   ciStateFromCheckRuns,
   evaluateReleasePolicy,
+  shouldReadExactShaCi,
 } from "../release-policy";
 import { distTagForVersion } from "../publish";
 
@@ -315,5 +316,10 @@ describe("release policy CI state", () => {
         ])
       )
     ).toBe("failed");
+  });
+
+  test("skips exact-SHA CI polling when the registry already has the current version and tag", () => {
+    expect(shouldReadExactShaCi(false)).toBe(true);
+    expect(shouldReadExactShaCi(true)).toBe(false);
   });
 });

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -1,0 +1,192 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type ChangedFile = {
+  path: string;
+  status?: string;
+};
+
+export type ChangesetGuardResult = {
+  changesetFiles: readonly ChangedFile[];
+  diagnostics: readonly string[];
+  ok: boolean;
+  packageFiles: readonly ChangedFile[];
+};
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const changedFilesOption = "--changed-files";
+const baseOption = "--base";
+
+export function evaluateChangesetGuard(changedFiles: readonly ChangedFile[]): ChangesetGuardResult {
+  const packageFiles = changedFiles.filter((file) => isPackageAffectingPath(file.path));
+  const changesetFiles = changedFiles.filter(isActiveChangesetEntry);
+  const diagnostics: string[] = [];
+
+  if (packageFiles.length > 0 && changesetFiles.length === 0) {
+    diagnostics.push(
+      `Package-facing changes require a .changeset/*.md entry. Changed package paths: ${summarizePaths(packageFiles)}`
+    );
+  }
+
+  if (packageFiles.length === 0 && changesetFiles.length > 0) {
+    diagnostics.push(
+      `Changeset entries are only for published package payload changes. Remove ${summarizePaths(changesetFiles)} or include the package-facing change on this branch.`
+    );
+  }
+
+  return {
+    changesetFiles,
+    diagnostics,
+    ok: diagnostics.length === 0,
+    packageFiles,
+  };
+}
+
+export function isActiveChangesetEntry(file: ChangedFile) {
+  return /^\.changeset\/[^/]+\.md$/.test(file.path) && !isDeletedStatus(file.status);
+}
+
+export function isPackageAffectingPath(path: string) {
+  if (path === "apps/skillset/package.json") return true;
+  if (path === "bun.lock" || path === "bun.lockb") return true;
+
+  if (isRuntimeSourcePath(path, "apps/skillset/src")) return true;
+  if (isRuntimeSourcePath(path, "packages/core/src")) return true;
+  if (isRuntimeSourcePath(path, "packages/lint/src")) return true;
+  if (isRuntimeSourcePath(path, "packages/transforms/src")) return true;
+
+  return (
+    path === "packages/core/package.json" ||
+    path === "packages/lint/package.json" ||
+    path === "packages/transforms/package.json"
+  );
+}
+
+export function parseChangedFileLine(line: string): ChangedFile | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+
+  const tabParts = trimmed.split("\t");
+  const [tabStatus] = tabParts;
+  if (tabParts.length > 1 && tabStatus && isStatusToken(tabStatus)) {
+    const path = tabParts.at(-1);
+    if (path) return { path, status: tabStatus };
+  }
+
+  const statusMatch = trimmed.match(/^([A-Za-z][A-Za-z0-9]*)\s+(.+)$/);
+  if (statusMatch) {
+    const [, status, path] = statusMatch;
+    if (status && path && isStatusToken(status)) return { path, status };
+  }
+
+  return { path: trimmed };
+}
+
+function isRuntimeSourcePath(path: string, root: string) {
+  if (!path.startsWith(`${root}/`)) return false;
+  const relative = path.slice(root.length + 1);
+  if (!relative) return false;
+  if (relative.startsWith("__tests__/")) return false;
+  if (relative.endsWith(".test.ts")) return false;
+  if (relative === "AGENTS.md") return false;
+  return true;
+}
+
+function isDeletedStatus(status: string | undefined) {
+  return status === "D" || status === "deleted" || status === "removed";
+}
+
+function isStatusToken(value: string) {
+  return /^[ACDMRTUXB][0-9]*$/.test(value) || githubFileStatuses.has(value);
+}
+
+const githubFileStatuses = new Set([
+  "added",
+  "changed",
+  "copied",
+  "deleted",
+  "modified",
+  "removed",
+  "renamed",
+  "unchanged",
+]);
+
+function summarizePaths(files: readonly ChangedFile[]) {
+  const paths = files.map((file) => file.path);
+  const shown = paths.slice(0, 8);
+  const suffix = paths.length > shown.length ? `, and ${paths.length - shown.length} more` : "";
+  return shown.join(", ") + suffix;
+}
+
+async function readChangedFilesFromPath(path: string) {
+  const raw = await Bun.file(path).text();
+  return raw.split("\n").map(parseChangedFileLine).filter((file): file is ChangedFile => Boolean(file));
+}
+
+async function readChangedFilesFromGit(base: string) {
+  const output = await runText(["git", "diff", "--name-status", `${base}...HEAD`]);
+  if (!output) return [];
+  return output.split("\n").map(parseChangedFileLine).filter((file): file is ChangedFile => Boolean(file));
+}
+
+async function runText(command: readonly string[]) {
+  const subprocess = Bun.spawn([...command], {
+    cwd: rootDir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(`${command.join(" ")} failed: ${stderr.trim()}`);
+  }
+
+  return stdout.trim();
+}
+
+async function defaultBase() {
+  return runText(["scripts/git-trunk.sh"]);
+}
+
+async function main() {
+  const args = Bun.argv.slice(2);
+  const changedFilesPath = valueAfter(args, changedFilesOption);
+  const base = valueAfter(args, baseOption) ?? (await defaultBase());
+  const changedFiles = changedFilesPath
+    ? await readChangedFilesFromPath(changedFilesPath)
+    : await readChangedFilesFromGit(base);
+  const result = evaluateChangesetGuard(changedFiles);
+
+  if (result.packageFiles.length === 0 && result.changesetFiles.length === 0) {
+    console.error("skillset: changeset guard found no package-facing changes");
+  } else {
+    console.error(
+      `skillset: changeset guard found ${result.packageFiles.length} package-facing path(s) and ${result.changesetFiles.length} active changeset(s)`
+    );
+  }
+
+  for (const diagnostic of result.diagnostics) {
+    console.error(`skillset: ${diagnostic}`);
+  }
+
+  if (!result.ok) process.exit(1);
+}
+
+function valueAfter(args: readonly string[], option: string) {
+  const index = args.indexOf(option);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -249,6 +249,10 @@ export function evaluateReleasePolicy(input: ReleasePolicyInput): ReleasePolicyR
   });
 }
 
+export function shouldReadExactShaCi(registryComplete: boolean) {
+  return !registryComplete;
+}
+
 function makeReport(
   input: ReleasePolicyInput,
   options: {
@@ -605,6 +609,7 @@ async function commandLabelReleasePr() {
 async function readPolicyInput(): Promise<ReleasePolicyInput> {
   const packageInfo = await readPackageInfo();
   const registry = await readRegistryState(packageInfo.name, packageInfo.version, packageInfo.tag);
+  const registryComplete = registry.published && registry.taggedVersion === packageInfo.version;
   const repository = process.env.GITHUB_REPOSITORY ?? (await runText(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]));
   const ref = process.env.GITHUB_REF ?? `refs/heads/${await runText(["git", "branch", "--show-current"])}`;
   const sha = process.env.GITHUB_SHA ?? (await runText(["git", "rev-parse", "HEAD"]));
@@ -614,7 +619,7 @@ async function readPolicyInput(): Promise<ReleasePolicyInput> {
     readChangedFiles(),
     readPreviousVersion(),
     readFile(changelogPath, "utf8"),
-    readCiPassed(repository, sha),
+    shouldReadExactShaCi(registryComplete) ? readCiPassed(repository, sha) : Promise.resolve(true),
   ]);
   const sourcePullRequests = previousVersion
     ? await readSourcePullRequests(repository, previousVersion)
@@ -627,7 +632,7 @@ async function readPolicyInput(): Promise<ReleasePolicyInput> {
     packageName: packageInfo.name,
     published: registry.published,
     ref,
-    registryComplete: registry.published && registry.taggedVersion === packageInfo.version,
+    registryComplete,
     repository,
     sha,
     tag: packageInfo.tag,


### PR DESCRIPTION
## Context

This tightens package-release governance after a docs/release-policy-only change accidentally created a Changesets release PR. Changesets should describe published `skillset` CLI package payload changes, not every repo maintenance change.

## Changes

- Add `scripts/changeset-guard.ts` and `bun run changeset:check` to require active `.changeset/*.md` files only when package-facing paths change.
- Wire the guard into pre-push and PR CI, with PR CI reading the GitHub pull request file list so stacked branches are checked branch-locally.
- Skip exact-SHA CI polling inside `publish:policy` when npm already has the current version and dist-tag, so no-op release backfills do not wait five minutes.
- Document the package-facing path boundary in `docs/package-releases.md` and list the command in `AGENTS.md`.

## Verification

- `bun test scripts/__tests__/changeset-guard.test.ts scripts/__tests__/release-policy.test.ts`
- `bun run changeset:check -- --base main`
- `bun run typecheck`
- `bun run check:workflows`
- `bun run ultracite:doctor`
- `bun run check`
- `bun run hooks:pre-push`

## Release note

No npm Changeset is included because this changes repo release governance, hooks, CI, docs, and tests only; it does not alter the published CLI package payload.