### PR TITLE
feat(config): cut compile.unsupported to compile.unsupportedDestination (SET-123)

### DIFF
--- a/.agents/plans/2026-06-17-derive-render-terminology-cutover/RETRO.md
+++ b/.agents/plans/2026-06-17-derive-render-terminology-cutover/RETRO.md
@@ -34,8 +34,8 @@
 
 | Issue | Branch | Status | PR |
 | --- | --- | --- | --- |
-| SET-122 | `set-122-mechanical-rename-to-render-result-vocabulary` | Implemented + verified locally; Linear In Progress | pending (batch at end) |
-| SET-123 | (pending) | not started | — |
+| SET-122 | `set-122-mechanical-rename-to-render-result-vocabulary` | Implemented + reviewed (5/5) + verified | pending (batch at end) |
+| SET-123 | `set-123-cut-config-over-to-compileunsupporteddestination` | Implemented + verified locally; Linear In Progress | pending (batch at end) |
 | SET-124 | (pending) | not started | — |
 | SET-125 | (pending) | not started | — |
 | SET-126 | (pending) | not started | — |
@@ -59,9 +59,19 @@ Residual old-vocab (intentionally deferred, classified):
 - SET-124/transforms (needs-judgment): `packages/transforms` `lowering` field (`bidirectional`/`to-codex`/`none`), `render.ts` "faithful Codex lowering", `setup.ts` import "lowering", `adopt.ts` `match.lowering`.
 - SET-125 (docs/guidance + feature framing): `loweringOwner` field (28 entries) + `feature-registry` `id`/`title`/`summary`/notes, `docs/**` and `.skillset/**`, ADR drafts, "version lowering"/"dependency lowering"/"instruction lowering" evidence notes.
 
+### SET-123 — Cut config to compile.unsupportedDestination
+
+- Config key `compile.unsupported` → `compile.unsupportedDestination`. No legacy alias (parser is strict on unknown `compile` keys, so the old key now fails — clean cutover, no blocker found).
+- `CompileConfig.unsupported` field → `unsupportedDestination`; default config + parser return + `build.ts` readers (3×) updated.
+- Policy type `CompileUnsupportedPolicy` → `UnsupportedDestinationPolicy` (`types.ts`); `COMPILE_UNSUPPORTED_POLICIES` → `UNSUPPORTED_DESTINATION_POLICIES`; `readCompileUnsupportedPolicy` → `readUnsupportedDestinationPolicy` (reads `record.unsupportedDestination`). No `index.ts` export existed.
+- Policy error message: "lowering policy blocked N outcome(s) (compile.unsupported: …)" → "unsupported destination policy blocked N render result(s) (compile.unsupportedDestination: …)".
+- Tests: `skillset.test.ts` config tests (YAML keys, matchObjects, names) + policy-message assertions in `render-result-policy.test.ts`/`render-result-build.test.ts`. No YAML config files set the key (default "error"), so no fixture files needed changing.
+- `skillset:build` wrote 0 files — config policy is not lock-serialized, so no generated drift.
+- Boundary: `SkillsetRenderResultPolicy` annotation values (`unsupported:error`, `scope:excluded`, …) left unchanged (per-result annotations, not the config key). Docs (`docs/layout.md`, `docs/target-surfaces.md`) and `.skillset/**` guidance still mention `compile.unsupported` — owned by SET-125.
+
 ## Execution Log (continued)
 
-- Pending executor updates for SET-123..126.
+- Pending executor updates for SET-124..126.
 
 ## Tracker Mutations
 
@@ -79,9 +89,15 @@ Residual old-vocab (intentionally deferred, classified):
 - `git diff --check` — clean.
 - Note: bare `bun test` (whole-tree) reports ~145 failures from gitignored external clones under `fixtures/external/repos/`; the repo gate is the scoped `bun run test`. Pre-existing `await ... .rejects` (TS 80007) editor hints exist repo-wide; `tsc` gate is clean. `bun run check` (full aggregate) reserved for final handoff.
 
+### SET-123 (all green)
+
+- `bun run typecheck` clean; `bun run test` 483 pass / 0 fail; `bun run skillset:build` wrote 0 files; `bun run skillset:check` no drift; `bun run skillset:lint` clean; `git diff --check` clean. Residual scan: no `compile.unsupported`/`CompileUnsupportedPolicy` in active code (docs/.skillset deferred to SET-125).
+
 ## Local Review Log
 
-- Pending executor updates.
+- SET-122 mechanical-rename reviewer: **5/5**. No P0/P1/P2. One P3 (index.ts re-export `type` block not re-alphabetized after token swap) — fixed and amended into the SET-122 commit. Verified behavior preservation, no missed active renames, boundaries respected, cross-refs resolve.
+- SET-123 config/schema reviewer: **5/5**. No findings. Verified complete cutover (no residual `compile.unsupported`/`CompileUnsupportedPolicy`), old key now genuinely rejected by the strict allowlist (no alias), behavior preserved (default "error", reserved-policy path), tests still hit their named validation paths.
+
 - Required reviewer lanes:
   - mechanical rename reviewer;
   - config/schema reviewer;

--- a/.changeset/set-123-unsupported-destination-config.md
+++ b/.changeset/set-123-unsupported-destination-config.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Cut the unsupported-render compile policy key from `compile.unsupported` to `compile.unsupportedDestination` with no legacy alias. Policy diagnostics now read "unsupported destination policy blocked …" and reference the new key.

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -203,7 +203,7 @@ Defaulted.
     build: "all",
     skillset: { metadata: false },
     targets: ["claude", "codex"],
-    unsupported: "error",
+    unsupportedDestination: "error",
   });
   expect(graph.root.targets.claude.options.projectRoot).toBe(".claude");
   expect(graph.root.targets.claude.options.userRoot).toBe("~/.claude");
@@ -3391,7 +3391,7 @@ skillset:
   );
 });
 
-test("compile.unsupported defaults to error and accepts explicit error", async () => {
+test("compile.unsupportedDestination defaults to error and accepts explicit error", async () => {
   const defaultRoot = await fixture({
     ".skillset/config.yaml": `
 skillset:
@@ -3408,7 +3408,7 @@ skillset:
 skillset:
   name: test-root
 compile:
-  unsupported: error
+  unsupportedDestination: error
 `,
     ".skillset/plugins/alpha/skillset.yaml": `
 skillset:
@@ -3417,14 +3417,14 @@ skillset:
   });
 
   await expect(loadBuildGraph(defaultRoot)).resolves.toMatchObject({
-    root: { compile: { targets: ["claude", "codex"], unsupported: "error" } },
+    root: { compile: { targets: ["claude", "codex"], unsupportedDestination: "error" } },
   });
   await expect(loadBuildGraph(explicitRoot)).resolves.toMatchObject({
-    root: { compile: { targets: ["claude", "codex"], unsupported: "error" } },
+    root: { compile: { targets: ["claude", "codex"], unsupportedDestination: "error" } },
   });
 });
 
-test("compile.unsupported rejects malformed, unknown, and deferred policies", async () => {
+test("compile.unsupportedDestination rejects malformed, unknown, and deferred policies", async () => {
   const basePlugin = {
     ".skillset/plugins/alpha/skillset.yaml": `
 skillset:
@@ -3447,7 +3447,7 @@ compile: true
 skillset:
   name: test-root
 compile:
-  unsupported: maybe
+  unsupportedDestination: maybe
 `,
     ...basePlugin,
   });
@@ -3459,7 +3459,7 @@ compile:
 skillset:
   name: test-root
 compile:
-  unsupported: warn
+  unsupportedDestination: warn
 `,
     ...basePlugin,
   });

--- a/docs/adrs/0000-source-first-loadouts.md
+++ b/docs/adrs/0000-source-first-loadouts.md
@@ -52,5 +52,5 @@ It does not decide how future agent, hook, resource, MCP, app, or install workfl
 
 ## References
 
-- [Tenets](../tenets.md) - governing design principles for source-first loadouts and target-native lowering.
-- [ADR-0001: Root Compile Policy](0001-root-compile-policy.md) - accepted `compile.targets` and `compile.unsupported` direction.
+- [Tenets](../tenets.md) - governing design principles for source-first loadouts and target-native rendering.
+- [ADR-0001: Root Compile Policy](0001-root-compile-policy.md) - accepted `compile.targets` and `compile.unsupportedDestination` direction.

--- a/docs/adrs/0001-root-compile-policy.md
+++ b/docs/adrs/0001-root-compile-policy.md
@@ -15,7 +15,7 @@ depends_on: [0]
 
 Skillset originally let target provider blocks such as `claude` and `codex` sit at the top level of configuration. That worked for target-native options, but it made provider selection awkward. A source repo that wanted to compile both providers had to repeat boolean-ish target settings, and new source surfaces could look like silent failures if they were added without revisiting every target block.
 
-Provider selection is not a Claude or Codex semantic feature. It is a compile concern: which projections should Skillset build from the source graph. Unsupported lowering is also a compile concern: what happens when authored source cannot lower faithfully to an enabled provider.
+Provider selection is not a Claude or Codex semantic feature. It is a compile concern: which outputs should Skillset build from the source graph. Unsupported destination behavior is also a compile concern: what happens when authored source cannot render faithfully to an enabled provider.
 
 ## Decision
 
@@ -28,7 +28,7 @@ compile:
   targets:
     - claude
     - codex
-  unsupported: error
+  unsupportedDestination: error
 ```
 
 This means:
@@ -37,7 +37,7 @@ This means:
 - Omitting `compile.targets` defaults to every supported provider.
 - Bare top-level `targets:` is rejected so provider selection has one canonical home.
 - `claude` and `codex` blocks remain target-specific options, output settings, target-native escape hatches, and lower-level opt-outs.
-- `compile.unsupported` defaults to `error`.
+- `compile.unsupportedDestination` defaults to `error`.
 - `warn`, `skip`, and `force` are reserved until warnings, doctor output, and lock provenance can record exactly what happened.
 
 The test: if a setting decides whether Skillset builds a provider projection, it belongs under `compile`. If it configures the shape of a provider-native output, it belongs under that provider's block or a lower-level target override.
@@ -48,7 +48,7 @@ The test: if a setting decides whether Skillset builds a provider projection, it
 
 The common case gets smaller. Authors can say "compile these providers" once, then let source presence drive skills, plugins, instructions, hooks, and future surfaces.
 
-New source surfaces are less likely to disappear silently. If a provider is enabled and Skillset cannot lower authored source faithfully, the default policy fails before generated output can look synchronized.
+New source surfaces are less likely to disappear silently. If a provider is enabled and Skillset cannot render authored source faithfully, the default policy fails before generated output can look synchronized.
 
 Target-specific configuration stays honest. `claude` and `codex` remain the visible places for target-native differences instead of becoming a mix of provider selection and target semantics.
 
@@ -67,4 +67,4 @@ This ADR does not define a portable source model for agents, hook activation, in
 ## References
 
 - [ADR-0000: Source-First Loadouts](0000-source-first-loadouts.md) - baseline source-first compiler doctrine.
-- [Tenets](../tenets.md) - governing design principles for source-first loadouts and target-native lowering.
+- [Tenets](../tenets.md) - governing design principles for source-first loadouts and target-native rendering.

--- a/docs/adrs/decision-map.json
+++ b/docs/adrs/decision-map.json
@@ -89,7 +89,7 @@
       "depends_on": ["0"],
       "inbound": [
         {
-          "context": "- [ADR-0001: Root Compile Policy](0001-root-compile-policy.md) - accepted `compile.targets` and `compile.unsupported` direction.",
+          "context": "- [ADR-0001: Root Compile Policy](0001-root-compile-policy.md) - accepted `compile.targets` and `compile.unsupportedDestination` direction.",
           "from": "0000",
           "fromPath": "docs/adrs/0000-source-first-loadouts.md"
         },

--- a/packages/core/src/__tests__/render-result-build.test.ts
+++ b/packages/core/src/__tests__/render-result-build.test.ts
@@ -596,8 +596,8 @@ async function expectUnsupportedOutcome(
   root: string,
   expected: Pick<SkillsetRenderResult, "featureId" | "sourceUnit"> & { readonly reason: string }
 ): Promise<void> {
-  await expect(buildSkillsetResult(root)).rejects.toThrow("lowering policy blocked 1 outcome");
-  await expect(checkSkillsetResult(root)).rejects.toThrow("lowering policy blocked 1 outcome");
+  await expect(buildSkillsetResult(root)).rejects.toThrow("unsupported destination policy blocked 1 render result");
+  await expect(checkSkillsetResult(root)).rejects.toThrow("unsupported destination policy blocked 1 render result");
   try {
     await diffSkillsetResult(root);
     throw new Error("expected diffSkillsetResult to reject");
@@ -615,7 +615,7 @@ async function expectUnsupportedOutcome(
       })
     );
     const message = error instanceof Error ? error.message : String(error);
-    expect(message).toContain("lowering policy blocked 1 outcome");
+    expect(message).toContain("unsupported destination policy blocked 1 render result");
     expect(message).toContain(expected.featureId);
     expect(message).toContain("codex");
     expect(message).toContain("unsupported");

--- a/packages/core/src/__tests__/render-result-policy.test.ts
+++ b/packages/core/src/__tests__/render-result-policy.test.ts
@@ -8,7 +8,7 @@ describe("render result policy", () => {
   it("blocks failed, lossy, and unsupported outcomes", () => {
     for (const status of ["failed", "lossy", "unsupported"] satisfies readonly SkillsetRenderResultStatus[]) {
       expect(() => enforceRenderResultPolicy([outcome(status)], "error")).toThrow(
-        "lowering policy blocked 1 outcome"
+        "unsupported destination policy blocked 1 render result"
       );
     }
   });

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -102,7 +102,7 @@ export async function buildSkillsetResult(
     mapOutputPath: outPath,
     scopes: options.scopes,
   });
-  enforceRenderResultPolicy(renderResults, graph.root.compile.unsupported);
+  enforceRenderResultPolicy(renderResults, graph.root.compile.unsupportedDestination);
   const renderedWithoutOutcomeMetadata = mirroredRenderedFiles(scopedRendered, outPath);
   const instructionDiagnostics = diagnoseLargeInstructionFiles(renderedWithoutOutcomeMetadata);
   diagnostics.push(...instructionDiagnostics);
@@ -173,7 +173,7 @@ export async function diffSkillsetResult(
     mapOutputPath: outPath,
     scopes: options.scopes,
   });
-  enforceRenderResultPolicy(renderResults, graph.root.compile.unsupported);
+  enforceRenderResultPolicy(renderResults, graph.root.compile.unsupportedDestination);
   const renderedWithoutOutcomeMetadata = mirroredRenderedFiles(scopedRendered, outPath);
   const instructionDiagnostics = diagnoseLargeInstructionFiles(renderedWithoutOutcomeMetadata);
   diagnostics.push(...instructionDiagnostics);
@@ -262,7 +262,7 @@ export async function checkSkillsetResult(
     mapOutputPath: outPath,
     scopes: options.scopes,
   });
-  enforceRenderResultPolicy(renderResults, graph.root.compile.unsupported);
+  enforceRenderResultPolicy(renderResults, graph.root.compile.unsupportedDestination);
   const renderedWithoutOutcomeMetadata = mirroredRenderedFiles(scopedRendered, outPath);
   const instructionDiagnostics = diagnoseLargeInstructionFiles(renderedWithoutOutcomeMetadata);
   diagnostics.push(...instructionDiagnostics);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,7 +2,7 @@ import type {
   CompileBuildMode,
   CompileConfig,
   CompileSkillsetConfig,
-  CompileUnsupportedPolicy,
+  UnsupportedDestinationPolicy,
   DistributionConfig,
   JsonRecord,
   JsonValue,
@@ -21,7 +21,7 @@ const DEFAULT_SURFACES = new Set<FeatureSurface>(["agents", "instructions", "plu
 const CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "defaults", "dependencies", "skillset", "supports"]);
 const ROOT_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "compile", "distributions", "tests"]);
 const COMPILE_BUILD_MODES = new Set<CompileBuildMode>(["updated", "all"]);
-const COMPILE_UNSUPPORTED_POLICIES = new Set<CompileUnsupportedPolicy>([
+const UNSUPPORTED_DESTINATION_POLICIES = new Set<UnsupportedDestinationPolicy>([
   "error",
   "warn",
   "skip",
@@ -72,20 +72,20 @@ export function readCompileConfig(record: JsonRecord, label: string): CompileCon
       build: "updated",
       skillset: { metadata: true },
       targets: [...TARGET_NAMES],
-      unsupported: "error",
+      unsupportedDestination: "error",
     };
   }
 
   for (const key of Object.keys(compile)) {
-    if (key !== "build" && key !== "skillset" && key !== "targets" && key !== "unsupported") {
+    if (key !== "build" && key !== "skillset" && key !== "targets" && key !== "unsupportedDestination") {
       throw new Error(`skillset: unsupported compile key ${key} in ${label}`);
     }
   }
 
-  const unsupported = readCompileUnsupportedPolicy(compile, `${label}.compile.unsupported`);
-  if (unsupported !== "error") {
+  const unsupportedDestination = readUnsupportedDestinationPolicy(compile, `${label}.compile.unsupportedDestination`);
+  if (unsupportedDestination !== "error") {
     throw new Error(
-      `skillset: ${label}.compile.unsupported ${unsupported} is reserved but not supported yet; ` +
+      `skillset: ${label}.compile.unsupportedDestination ${unsupportedDestination} is reserved but not supported yet; ` +
         "use error until warning, skip, or force provenance is implemented"
     );
   }
@@ -94,7 +94,7 @@ export function readCompileConfig(record: JsonRecord, label: string): CompileCon
     build: readCompileBuildMode(compile, `${label}.compile.build`),
     skillset: readCompileSkillsetConfig(compile, `${label}.compile.skillset`),
     targets: readCompileTargetNames(compile, `${label}.compile.targets`),
-    unsupported,
+    unsupportedDestination,
   };
 }
 
@@ -461,18 +461,18 @@ function readCompileSkillsetConfig(record: JsonRecord, label: string): CompileSk
   return { metadata };
 }
 
-function readCompileUnsupportedPolicy(record: JsonRecord, label: string): CompileUnsupportedPolicy {
-  const value = record.unsupported;
+function readUnsupportedDestinationPolicy(record: JsonRecord, label: string): UnsupportedDestinationPolicy {
+  const value = record.unsupportedDestination;
   if (value === undefined) return "error";
   if (typeof value !== "string") {
     throw new Error(`skillset: expected ${label} to be one of: error, warn, skip, force`);
   }
-  if (!COMPILE_UNSUPPORTED_POLICIES.has(value as CompileUnsupportedPolicy)) {
+  if (!UNSUPPORTED_DESTINATION_POLICIES.has(value as UnsupportedDestinationPolicy)) {
     throw new Error(
       `skillset: unsupported ${label} ${JSON.stringify(value)}; expected one of: error, warn, skip, force`
     );
   }
-  return value as CompileUnsupportedPolicy;
+  return value as UnsupportedDestinationPolicy;
 }
 
 function readDistributionObject(record: JsonRecord, label: string): DistributionConfig {

--- a/packages/core/src/render-result-policy.ts
+++ b/packages/core/src/render-result-policy.ts
@@ -1,9 +1,9 @@
 import { SkillsetRenderResultError, type SkillsetRenderResult } from "./render-result";
-import type { CompileUnsupportedPolicy } from "./types";
+import type { UnsupportedDestinationPolicy } from "./types";
 
 export function enforceRenderResultPolicy(
   renderResults: readonly SkillsetRenderResult[],
-  unsupportedPolicy: CompileUnsupportedPolicy
+  unsupportedPolicy: UnsupportedDestinationPolicy
 ): void {
   const blocked = renderResults.filter(isPolicyBlockingOutcome);
   if (blocked.length === 0) return;
@@ -20,11 +20,11 @@ function isPolicyBlockingOutcome(outcome: SkillsetRenderResult): boolean {
 
 function formatRenderResultPolicyError(
   outcomes: readonly SkillsetRenderResult[],
-  unsupportedPolicy: CompileUnsupportedPolicy
+  unsupportedPolicy: UnsupportedDestinationPolicy
 ): string {
-  const noun = outcomes.length === 1 ? "outcome" : "outcomes";
+  const noun = outcomes.length === 1 ? "render result" : "render results";
   return [
-    `skillset: lowering policy blocked ${outcomes.length} ${noun} (compile.unsupported: ${unsupportedPolicy})`,
+    `skillset: unsupported destination policy blocked ${outcomes.length} ${noun} (compile.unsupportedDestination: ${unsupportedPolicy})`,
     ...outcomes.map(formatBlockedOutcome),
   ].join("\n");
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,7 +36,7 @@ export interface ReleaseState {
   readonly scopes: Readonly<Record<string, ReleaseScopeState>>;
 }
 
-export type CompileUnsupportedPolicy = "error" | "warn" | "skip" | "force";
+export type UnsupportedDestinationPolicy = "error" | "warn" | "skip" | "force";
 export type CompileBuildMode = "updated" | "all";
 export type BuildScope = "repo" | "plugins" | "project" | "user";
 
@@ -48,7 +48,7 @@ export interface CompileConfig {
   readonly build: CompileBuildMode;
   readonly skillset: CompileSkillsetConfig;
   readonly targets: readonly TargetName[];
-  readonly unsupported: CompileUnsupportedPolicy;
+  readonly unsupportedDestination: UnsupportedDestinationPolicy;
 }
 
 export type DistributionDestinationKind = "git" | "local";


### PR DESCRIPTION
Phase 2 of the derive/render/destination terminology cutover.

- Config key compile.unsupported -> compile.unsupportedDestination, no legacy
  alias (parser stays strict on unknown compile keys; old key now rejects)
- CompileConfig.unsupported field -> unsupportedDestination
- Policy type CompileUnsupportedPolicy -> UnsupportedDestinationPolicy;
  COMPILE_UNSUPPORTED_POLICIES -> UNSUPPORTED_DESTINATION_POLICIES;
  readCompileUnsupportedPolicy -> readUnsupportedDestinationPolicy
- Policy diagnostic: 'unsupported destination policy blocked N render result(s)
  (compile.unsupportedDestination: ...)'
- Tests updated; no YAML config files set the key (default error)

Docs and .skillset guidance still mention compile.unsupported -> SET-125.