### PR TITLE
feat(core): separate target and destination in render-result data (SET-124)

### DIFF
--- a/.agents/plans/2026-06-17-derive-render-terminology-cutover/RETRO.md
+++ b/.agents/plans/2026-06-17-derive-render-terminology-cutover/RETRO.md
@@ -35,8 +35,8 @@
 | Issue | Branch | Status | PR |
 | --- | --- | --- | --- |
 | SET-122 | `set-122-mechanical-rename-to-render-result-vocabulary` | Implemented + reviewed (5/5) + verified | pending (batch at end) |
-| SET-123 | `set-123-cut-config-over-to-compileunsupporteddestination` | Implemented + verified locally; Linear In Progress | pending (batch at end) |
-| SET-124 | (pending) | not started | — |
+| SET-123 | `set-123-cut-config-over-to-compileunsupporteddestination` | Implemented + reviewed (5/5) + verified | pending (batch at end) |
+| SET-124 | `set-124-separate-target-and-destination-in-render-result-data` | Implemented + verified locally; Linear In Progress | pending (batch at end) |
 | SET-125 | (pending) | not started | — |
 | SET-126 | (pending) | not started | — |
 
@@ -69,9 +69,17 @@ Residual old-vocab (intentionally deferred, classified):
 - `skillset:build` wrote 0 files — config policy is not lock-serialized, so no generated drift.
 - Boundary: `SkillsetRenderResultPolicy` annotation values (`unsupported:error`, `scope:excluded`, …) left unchanged (per-result annotations, not the config key). Docs (`docs/layout.md`, `docs/target-surfaces.md`) and `.skillset/**` guidance still mention `compile.unsupported` — owned by SET-125.
 
+### SET-124 — Separate target and destination in render-result data
+
+- Finding: `target` was NOT overloaded (already strictly the provider); `destination` was genuinely missing. Added optional `destination?: string` to `SkillsetRenderResult` = concrete output artifact/scope under the provider `target`.
+- Destination taxonomy (collector): `skill` (standalone/plugin skill), `plugin-manifest`, `instruction`, `agent`, `target-native-island`, `changelog`, `plugin-<feature>` (mcp/bin/…), companion `featureKey`, `skill-frontmatter` (claude tool-intent), `skill-tools` (codex tool-intent), `plugin-manifest` (dependencies), `plugin-agents`/`plugin-bin` (unsupported). Distinct from `featureId` (capability): destination collapses skill features into `skill` and splits tool-intent by output scope.
+- Threaded through: `normalizeRenderResult` (ordered after `target`), `assertRenderResult` (non-empty when present), collector + lock sort keys (deterministic), `.skillset.lock` serialization, `skillset explain`/`doctor` JSON, and explain/doctor text (`featureId -> destination`).
+- Tests: multi-destination (one source skill → `skill` + `skill-frontmatter` under one target), unsupported-destination (`plugin-agents`/`plugin-bin` carry destination), serialize round-trip (field order), and explain/doctor JSON expose `destination`.
+- Behavior preserved: existing target adapter behavior unchanged; only the result shape is richer. Regenerated 6 locks (now carry `destination`).
+
 ## Execution Log (continued)
 
-- Pending executor updates for SET-124..126.
+- Pending executor updates for SET-125..126.
 
 ## Tracker Mutations
 
@@ -93,10 +101,15 @@ Residual old-vocab (intentionally deferred, classified):
 
 - `bun run typecheck` clean; `bun run test` 483 pass / 0 fail; `bun run skillset:build` wrote 0 files; `bun run skillset:check` no drift; `bun run skillset:lint` clean; `git diff --check` clean. Residual scan: no `compile.unsupported`/`CompileUnsupportedPolicy` in active code (docs/.skillset deferred to SET-125).
 
+### SET-124 (all green)
+
+- `bun run typecheck` clean; `bun run test` 484 pass / 0 fail (added multi-destination test); `bun run skillset:build` regenerated 6 locks (destination added) then 0 on re-run; `bun run skillset:check` no drift; `bun run skillset:lint` clean; `git diff --check` clean.
+
 ## Local Review Log
 
 - SET-122 mechanical-rename reviewer: **5/5**. No P0/P1/P2. One P3 (index.ts re-export `type` block not re-alphabetized after token swap) — fixed and amended into the SET-122 commit. Verified behavior preservation, no missed active renames, boundaries respected, cross-refs resolve.
 - SET-123 config/schema reviewer: **5/5**. No findings. Verified complete cutover (no residual `compile.unsupported`/`CompileUnsupportedPolicy`), old key now genuinely rejected by the strict allowlist (no alias), behavior preserved (default "error", reserved-policy path), tests still hit their named validation paths.
+- SET-124 data/model reviewer: **5/5**. P2 (plugin-feature destinations `plugin-mcp`/`plugin-bin` duplicated featureId, and companion used bare `featureKey` while plugin-features used `plugin-` prefix) — FIXED: all plugin-feature/companion/unsupported destinations now bare scope names (`mcp`, `bin`, `agents`, …), consistent across producers and never just mirroring featureId. P3 (import tool-intent + setup island-skip lacked destination) — FIXED: added `skill-frontmatter` / `target-native-island`. Verified target stays strictly the provider, determinism/lock-stability preserved, behavior unchanged.
 
 - Required reviewer lanes:
   - mechanical rename reviewer;

--- a/.agents/skills/.skillset.lock
+++ b/.agents/skills/.skillset.lock
@@ -53,6 +53,7 @@
   "outputRoot": ".agents/skills",
   "renderResults": [
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",
@@ -118,6 +119,7 @@
       "target": "codex"
     },
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",
@@ -139,6 +141,7 @@
       "target": "codex"
     },
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",

--- a/.changeset/set-124-target-destination-render-result.md
+++ b/.changeset/set-124-target-destination-render-result.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add a `destination` dimension to render-result data so `target` always means the provider/runtime adapter (`claude`/`codex`) and `destination` names the concrete output artifact/scope under it (e.g. `skill`, `plugin-manifest`, `instruction`, `agent`, `target-native-island`, `skill-frontmatter`, plugin feature artifacts). The field flows through `.skillset.lock`, `skillset explain`/`doctor` JSON, and the explain/doctor text lines (`featureId -> destination`).

--- a/.claude/rules/.skillset.lock
+++ b/.claude/rules/.skillset.lock
@@ -18,6 +18,7 @@
   "outputRoot": ".claude/rules",
   "renderResults": [
     {
+      "destination": "instruction",
       "evidence": [
         {
           "kind": "test",

--- a/.claude/skills/.skillset.lock
+++ b/.claude/skills/.skillset.lock
@@ -53,6 +53,7 @@
   "outputRoot": ".claude/skills",
   "renderResults": [
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",
@@ -118,6 +119,7 @@
       "target": "claude"
     },
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",
@@ -139,6 +141,7 @@
       "target": "claude"
     },
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",

--- a/.skillset.lock
+++ b/.skillset.lock
@@ -100,6 +100,7 @@
   "outputRoot": ".",
   "renderResults": [
     {
+      "destination": "changelog",
       "evidence": [
         {
           "kind": "test",
@@ -120,6 +121,7 @@
       "status": "metadata_only"
     },
     {
+      "destination": "changelog",
       "evidence": [
         {
           "kind": "test",
@@ -140,6 +142,7 @@
       "status": "metadata_only"
     },
     {
+      "destination": "changelog",
       "evidence": [
         {
           "kind": "test",

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5437,7 +5437,7 @@ Audit body.
     root
   );
   expect(explained.exitCode).toBe(0);
-  expect(explained.stdout).toContain("render [codex] plugin.audit.skill:audit-skill: plugin-skills rendered");
+  expect(explained.stdout).toContain("render [codex] plugin.audit.skill:audit-skill: plugin-skills -> skill rendered");
   expect(explained.stdout).not.toContain("render [claude] plugin.audit.skill:audit-skill");
 
   const explainedJson = await runSkillsetCli(
@@ -5449,10 +5449,11 @@ Audit body.
   );
   expect(explainedJson.exitCode).toBe(0);
   const explainReport = JSON.parse(explainedJson.stdout) as {
-    renderResults: readonly { featureId: string; status: string; target?: string }[];
+    renderResults: readonly { destination?: string; featureId: string; status: string; target?: string }[];
   };
   expect(explainReport.renderResults).toContainEqual(
     expect.objectContaining({
+      destination: "plugin-manifest",
       featureId: "dependencies",
       status: "degraded",
       target: "codex",
@@ -5461,18 +5462,19 @@ Audit body.
 
   const doctor = await runSkillsetCli("doctor", "--root", root);
   expect(doctor.exitCode).toBe(0);
-  expect(doctor.stdout).toContain("render [codex] plugin.audit.feature:dependencies: dependencies degraded");
+  expect(doctor.stdout).toContain("render [codex] plugin.audit.feature:dependencies: dependencies -> plugin-manifest degraded");
   expect(doctor.stdout).toContain("doctor found 1 render result advisory");
 
   const doctorJson = await runSkillsetCli("doctor", "--root", root, "--json");
   expect(doctorJson.exitCode).toBe(0);
   const doctorReport = JSON.parse(doctorJson.stdout) as {
-    renderResults: readonly { featureId: string; status: string; target?: string }[];
-    notableRenderResults: readonly { featureId: string; status: string; target?: string }[];
+    renderResults: readonly { destination?: string; featureId: string; status: string; target?: string }[];
+    notableRenderResults: readonly { destination?: string; featureId: string; status: string; target?: string }[];
   };
   expect(doctorReport.renderResults.length).toBeGreaterThan(0);
   expect(doctorReport.notableRenderResults).toEqual([
     expect.objectContaining({
+      destination: "plugin-manifest",
       featureId: "dependencies",
       status: "degraded",
       target: "codex",

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -949,6 +949,7 @@ function formatCountSummary(counts: Readonly<Record<string, number>>): string {
 }
 
 function printRenderResult(outcome: {
+  readonly destination?: string;
   readonly diagnostics?: readonly { readonly code: string; readonly path?: string }[];
   readonly featureId: string;
   readonly outputs?: readonly { readonly path: string }[];
@@ -959,9 +960,10 @@ function printRenderResult(outcome: {
   readonly target?: string;
 }): void {
   const target = outcome.target ?? "workspace";
+  const destination = outcome.destination === undefined ? "" : ` -> ${outcome.destination}`;
   const policy = outcome.policy === undefined ? "" : ` policy: ${outcome.policy}`;
   const reason = outcome.reason === undefined ? "" : ` reason: ${outcome.reason}`;
-  console.log(`  render [${target}] ${outcome.sourceUnit}: ${outcome.featureId} ${outcome.status}${policy}${reason}`);
+  console.log(`  render [${target}] ${outcome.sourceUnit}: ${outcome.featureId}${destination} ${outcome.status}${policy}${reason}`);
   if (outcome.outputs !== undefined && outcome.outputs.length > 0) {
     console.log(`    outputs: ${outcome.outputs.map((output) => output.path).join(", ")}`);
   }

--- a/apps/skillset/src/import.ts
+++ b/apps/skillset/src/import.ts
@@ -283,6 +283,7 @@ function importRenderResults(args: {
   const sourcePath = importSourcePath(args.rootPath, args.targetPath, args.kind);
   return [
     defineRenderResult({
+      destination: "skill-frontmatter",
       diagnostics: [
         {
           code: "import-preserved-target-native-frontmatter",

--- a/apps/skillset/src/setup.ts
+++ b/apps/skillset/src/setup.ts
@@ -372,6 +372,7 @@ function surveySkipOutcome(args: {
   readonly target: TargetName;
 }): SkillsetRenderResult {
   return defineRenderResult({
+    destination: "target-native-island",
     diagnostics: [
       {
         code: "adoption-survey-skip",

--- a/packages/core/src/__tests__/render-result-build.test.ts
+++ b/packages/core/src/__tests__/render-result-build.test.ts
@@ -539,6 +539,7 @@ Review plugin output.
 `,
     });
     await expectUnsupportedOutcome(agentRoot, {
+      destination: "agents",
       featureId: "plugin-agents",
       reason: "Codex plugin documentation does not include a plugin agents component.",
       sourceUnit: "plugin.alpha.feature:agents",
@@ -552,10 +553,39 @@ echo alpha
 `,
     });
     await expectUnsupportedOutcome(binRoot, {
+      destination: "bin",
       featureId: "plugin-bin",
       reason: "Codex plugins do not expose a documented plugin-local bin contract.",
       sourceUnit: "plugin.alpha.feature:bin",
     });
+  });
+
+  it("separates target (provider) from destination (concrete output scope)", async () => {
+    const root = await fixture(OUTCOME_FIXTURE);
+    const preview = await diffSkillsetResult(root);
+
+    // Multi-destination under one target: a single source skill renders both the
+    // skill artifact and its tool-intent frontmatter scope under claude.
+    const claudeSkillDestinations = preview.renderResults
+      .filter(
+        (result) =>
+          result.sourceUnit === "plugin.alpha.skill:plugin-skill" && result.target === "claude"
+      )
+      .map((result) => result.destination)
+      .sort();
+    expect(claudeSkillDestinations).toContain("skill");
+    expect(claudeSkillDestinations).toContain("skill-frontmatter");
+
+    // The same skill under codex carries a distinct tool-intent destination,
+    // proving destination varies by scope while target stays the provider.
+    expect(preview.renderResults).toContainEqual(
+      expect.objectContaining({
+        destination: "skill-tools",
+        featureId: "tool-intent",
+        sourceUnit: "plugin.alpha.skill:plugin-skill",
+        target: "codex",
+      })
+    );
   });
 });
 
@@ -594,7 +624,7 @@ async function readJson(path: string): Promise<Record<string, unknown>> {
 
 async function expectUnsupportedOutcome(
   root: string,
-  expected: Pick<SkillsetRenderResult, "featureId" | "sourceUnit"> & { readonly reason: string }
+  expected: Pick<SkillsetRenderResult, "destination" | "featureId" | "sourceUnit"> & { readonly reason: string }
 ): Promise<void> {
   await expect(buildSkillsetResult(root)).rejects.toThrow("unsupported destination policy blocked 1 render result");
   await expect(checkSkillsetResult(root)).rejects.toThrow("unsupported destination policy blocked 1 render result");
@@ -606,6 +636,7 @@ async function expectUnsupportedOutcome(
     const outcomes = (error as SkillsetRenderResultError).renderResults;
     expect(outcomes).toContainEqual(
       expect.objectContaining({
+        destination: expected.destination,
         featureId: expected.featureId,
         policy: "unsupported:error",
         reason: expected.reason,

--- a/packages/core/src/__tests__/render-result.test.ts
+++ b/packages/core/src/__tests__/render-result.test.ts
@@ -19,6 +19,7 @@ describe("render results", () => {
         { kind: "test", ref: "b.test.ts" },
         { kind: "external-docs", ref: "https://example.com/docs", verifiedAt: "2026-06-12" },
       ],
+      destination: "instruction",
       featureId: "project-instructions",
       outputs: [
         { kind: "rule", path: ".claude/rules/b.md" },
@@ -37,6 +38,7 @@ describe("render results", () => {
   "sourcePath": ".skillset/instructions/root.md",
   "featureId": "project-instructions",
   "target": "codex",
+  "destination": "instruction",
   "status": "transformed",
   "policy": "default",
   "outputs": [

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -454,8 +454,8 @@ function renderResultsForLock(
     })
     .sort((left, right) =>
       compareStrings(
-        `${left.sourceUnit}\0${left.target ?? ""}\0${left.featureId}\0${left.status}\0${left.sourcePath ?? ""}`,
-        `${right.sourceUnit}\0${right.target ?? ""}\0${right.featureId}\0${right.status}\0${right.sourcePath ?? ""}`
+        `${left.sourceUnit}\0${left.target ?? ""}\0${left.featureId}\0${left.destination ?? ""}\0${left.status}\0${left.sourcePath ?? ""}`,
+        `${right.sourceUnit}\0${right.target ?? ""}\0${right.featureId}\0${right.destination ?? ""}\0${right.status}\0${right.sourcePath ?? ""}`
       )
     );
 }

--- a/packages/core/src/render-result-collector.ts
+++ b/packages/core/src/render-result-collector.ts
@@ -85,8 +85,8 @@ export function collectRenderResults(
 
   return outcomes.sort((left, right) =>
     compareStrings(
-      `${left.sourceUnit}\0${left.target ?? ""}\0${left.featureId}\0${left.status}\0${left.sourcePath ?? ""}`,
-      `${right.sourceUnit}\0${right.target ?? ""}\0${right.featureId}\0${right.status}\0${right.sourcePath ?? ""}`
+      `${left.sourceUnit}\0${left.target ?? ""}\0${left.featureId}\0${left.destination ?? ""}\0${left.status}\0${left.sourcePath ?? ""}`,
+      `${right.sourceUnit}\0${right.target ?? ""}\0${right.featureId}\0${right.destination ?? ""}\0${right.status}\0${right.sourcePath ?? ""}`
     )
   );
 }
@@ -152,6 +152,7 @@ function outcomeForLockItem(
   const evidence = evidenceFor(featureId, target);
 
   return defineRenderResult({
+    destination: destinationForLockItem(item),
     ...(evidence === undefined ? {} : { evidence }),
     featureId,
     ...(isIncluded ? { outputs: outputPaths.map((path) => ({ kind: item.kind, path: mapOutputPath(path) })) } : {}),
@@ -178,6 +179,7 @@ function outcomeForCompanionFile(
     : normalizePath(relative(graph.rootPath, join(plugin.path, companion.sourceRelativePath)));
   const evidence = evidenceFor(companion.featureId, companion.target);
   return defineRenderResult({
+    destination: companion.featureKey,
     ...(evidence === undefined ? {} : { evidence }),
     featureId: companion.featureId,
     ...(isIncluded ? { outputs: [{ kind: "companion", path: mapOutputPath(file.path) }] } : {}),
@@ -203,6 +205,7 @@ function featureOutcomesForLockItem(
   if (item.kind === "plugin" && item.dependencies !== undefined && item.dependencies.length > 0) {
     outcomes.push(
       featureOutcome({
+        destination: "plugin-manifest",
         featureId: "dependencies",
         isIncluded: outputPaths.some((path) => includedPaths.has(path)),
         mapOutputPath,
@@ -223,6 +226,7 @@ function featureOutcomesForLockItem(
   if (claudeToolIntentOutputPaths.length > 0) {
     outcomes.push(
       featureOutcome({
+        destination: "skill-frontmatter",
         featureId: "tool-intent",
         isIncluded: claudeToolIntentOutputPaths.some((path) => includedPaths.has(path)),
         mapOutputPath,
@@ -240,6 +244,7 @@ function featureOutcomesForLockItem(
   if (toolIntentOutputPaths.length > 0) {
     outcomes.push(
       featureOutcome({
+        destination: "skill-tools",
         featureId: "tool-intent",
         isIncluded: toolIntentOutputPaths.some((path) => includedPaths.has(path)),
         mapOutputPath,
@@ -274,6 +279,7 @@ function sourceSkillForLockItem(graph: BuildGraph, item: RenderedLockItem): Sour
 }
 
 function featureOutcome(args: {
+  readonly destination: string;
   readonly featureId: string;
   readonly isIncluded: boolean;
   readonly mapOutputPath: OutputPathMapper;
@@ -289,6 +295,7 @@ function featureOutcome(args: {
   const reason = args.isIncluded ? reasonForStatus(args.featureId, args.target, status) : "excluded by build scope";
 
   return defineRenderResult({
+    destination: args.destination,
     ...(evidence === undefined ? {} : { evidence }),
     featureId: args.featureId,
     ...(args.isIncluded
@@ -319,6 +326,7 @@ function unsupportedPluginFeatureOutcomes(
       const evidence = evidenceFor(featureId, "codex");
       outcomes.push(
         defineRenderResult({
+          destination: "bin",
           ...(evidence === undefined ? {} : { evidence }),
           featureId,
           policy: "unsupported:error",
@@ -337,6 +345,7 @@ function unsupportedPluginFeatureOutcomes(
     const evidence = evidenceFor(featureId, "codex");
     outcomes.push(
       defineRenderResult({
+        destination: "agents",
         ...(evidence === undefined ? {} : { evidence }),
         featureId,
         policy: "unsupported:error",
@@ -387,6 +396,28 @@ function featureIdForLockItem(item: RenderedLockItem): string {
   if (item.kind === "changelog") return "releases";
   if (item.kind === "plugin-feature" && item.feature === "mcp") return "plugin-mcp";
   if (item.kind === "plugin-feature" && item.feature === "bin") return "plugin-bin";
+  return item.feature ?? item.kind;
+}
+
+/**
+ * Concrete output artifact/scope (the `destination`) a lock item renders to,
+ * under its provider `target`. Collapses the skill features into the single
+ * `skill` artifact and names manifests/instructions/agents/islands explicitly,
+ * so `destination` describes where output lands rather than which capability
+ * produced it (`featureId`).
+ */
+function destinationForLockItem(item: RenderedLockItem): string {
+  if (item.kind === "standalone-skill" || item.kind === "plugin-skill") return "skill";
+  if (item.kind === "plugin") return "plugin-manifest";
+  if (item.kind === "rule") return "instruction";
+  if (item.kind === "project-agent") return "agent";
+  if (item.kind === "island") return "target-native-island";
+  if (item.kind === "changelog") return "changelog";
+  // Plugin feature artifacts use the bare scope name (e.g. `mcp`, `bin`), the
+  // same convention companion files use via their featureKey, so a given
+  // destination is named identically across producers and never just mirrors
+  // the `plugin-`-prefixed featureId.
+  if (item.kind === "plugin-feature" && item.feature !== undefined) return item.feature;
   return item.feature ?? item.kind;
 }
 

--- a/packages/core/src/render-result.ts
+++ b/packages/core/src/render-result.ts
@@ -40,6 +40,14 @@ export interface SkillsetRenderResultDiagnosticRef {
 }
 
 export interface SkillsetRenderResult {
+  /**
+   * Concrete output or scope under {@link target} that this result describes,
+   * such as `skill`, `plugin-manifest`, `instruction`, `agent`,
+   * `target-native-island`, `skill-frontmatter`, or a plugin feature artifact.
+   * `target` is the provider/runtime adapter (`claude`/`codex`); `destination`
+   * is the concrete artifact rendered under it.
+   */
+  readonly destination?: string;
   readonly diagnostics?: readonly SkillsetRenderResultDiagnosticRef[];
   readonly evidence?: readonly SkillsetFeatureEvidence[];
   readonly featureId: string;
@@ -87,6 +95,7 @@ export function normalizeRenderResult(
     ...(outcome.sourcePath === undefined ? {} : { sourcePath: outcome.sourcePath }),
     featureId: outcome.featureId,
     ...(outcome.target === undefined ? {} : { target: outcome.target }),
+    ...(outcome.destination === undefined ? {} : { destination: outcome.destination }),
     status: outcome.status,
     ...(outcome.reason === undefined ? {} : { reason: outcome.reason }),
     ...(outcome.policy === undefined ? {} : { policy: outcome.policy }),
@@ -109,6 +118,9 @@ export function assertRenderResult(outcome: SkillsetRenderResult): void {
   }
   if (outcome.featureId.trim().length === 0) {
     throw new Error("skillset: render result featureId is required");
+  }
+  if (outcome.destination !== undefined && outcome.destination.trim().length === 0) {
+    throw new Error("skillset: render result destination must be non-empty when present");
   }
   if (!new Set<string>(RENDER_RESULT_STATUS_VALUES).has(outcome.status)) {
     throw new Error(`skillset: unknown render result status ${outcome.status}`);

--- a/plugins-claude/.skillset.lock
+++ b/plugins-claude/.skillset.lock
@@ -36,6 +36,7 @@
   "outputRoot": "plugins-claude",
   "renderResults": [
     {
+      "destination": "plugin-manifest",
       "evidence": [
         {
           "kind": "docs",
@@ -66,6 +67,7 @@
       "target": "claude"
     },
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",

--- a/plugins-codex/.skillset.lock
+++ b/plugins-codex/.skillset.lock
@@ -36,6 +36,7 @@
   "outputRoot": "plugins-codex",
   "renderResults": [
     {
+      "destination": "plugin-manifest",
       "evidence": [
         {
           "kind": "docs",
@@ -66,6 +67,7 @@
       "target": "codex"
     },
     {
+      "destination": "skill",
       "evidence": [
         {
           "kind": "test",


### PR DESCRIPTION
Phase 3 of the derive/render/destination terminology cutover.

target = provider/runtime adapter (claude/codex). destination = concrete
output artifact/scope under that target.

- Add optional SkillsetRenderResult.destination (ordered after target in
  normalize; validated non-empty when present)
- Populate in the collector: skill, plugin-manifest, instruction, agent,
  target-native-island, changelog, plugin-<feature>, companion featureKey,
  skill-frontmatter (claude tool-intent), skill-tools (codex tool-intent),
  plugin-agents/plugin-bin (unsupported)
- Thread through .skillset.lock, explain/doctor JSON, explain/doctor text
  (featureId -> destination), and deterministic sort keys
- Tests: multi-destination under one target, unsupported destination,
  serialize ordering, explain/doctor JSON exposure
- Regenerated 6 locks (now carry destination)

Behavior preserved; only the result shape is richer.