### PR TITLE
docs(vocab): finalize provider source vocabulary (SET-135)

### DIFF
--- a/docs/target-surfaces.md
+++ b/docs/target-surfaces.md
@@ -1,23 +1,23 @@
-# Target Surface Evidence Matrix
+# Provider Surface Evidence Matrix
 
-This is the cheap-to-refresh map between Skillset source and the Claude/Codex target surfaces it renders to. It exists so target drift is caught deliberately: each surface row has a **status** and, where it depends on live provider docs, a **verified** date and source. Golden manifest tests in `apps/skillset/src/__tests__/contract.test.ts` and `apps/skillset/src/__tests__/skillset.test.ts` pin the generated shapes that these rows claim.
+This is the cheap-to-refresh map between Skillset source and the Claude/Codex provider surfaces it builds. It exists so provider drift is caught deliberately: each surface row has a **status** and, where it depends on live provider docs, a **verified** date and source. Golden manifest tests in `apps/skillset/src/__tests__/contract.test.ts` and `apps/skillset/src/__tests__/skillset.test.ts` pin the generated shapes that these rows claim.
 
 Refreshing is intentionally cheap: re-read the linked provider docs, update the verified date, and adjust a row + its golden test if the surface changed.
 
 ## Support vocabulary
 
 - **Implemented** — Skillset parses, validates, renders, tests, and documents this surface today.
-- **Portable** — authored once as Skillset source because the target outcomes share the same intent.
-- **Target-native** — supported only through one target's native source or adapter path; not portable by default.
+- **Adaptive** — authored once as Skillset source because the provider outcomes share the same intent and can be meaningfully adapted.
+- **Provider-native** — supported only through one provider's native source or adapter path; not adaptive by default.
 - **Metadata-only** — captured in generated metadata or lock provenance, not target-enforced behavior.
 - **Planned** — accepted doctrine or a draft/accepted ADR, but parser/render support has not landed yet.
 - **Reserved** — accepted vocabulary that currently fails with a clear diagnostic until supporting provenance lands.
 - **Deferred** — intentionally not rendered yet; the reason is documented and this is not a gap to fill silently.
-- **Unsupported** — cannot render to an enabled target without explicit target scoping or a visible unsupported destination policy result.
+- **Unsupported** — cannot build to an enabled provider destination without explicit provider scoping or a visible unsupported destination policy result.
 - **Lossy** — a possible render would drop behavior or target meaning; v1 treats lossy render as unsupported unless a future ADR defines visible provenance.
 - **Future** — intentionally outside the v1 contract, tracked so later design does not accidentally masquerade as current support.
 
-Default behavior for unsupported or lossy render is fail-loud. Softer modes must record visible warnings, skipped-source provenance, or force provenance before they can be treated as safe.
+Default behavior for unsupported or lossy build results is fail-loud. Softer modes must record visible warnings, skipped-source provenance, or force provenance before they can be treated as safe.
 
 ## Source contract
 
@@ -28,40 +28,40 @@ Default behavior for unsupported or lossy render is fail-loud. Softer modes must
 | skill top-level `version` (semver) | skill `metadata.version` | Implemented | Skill-local version; release state wins after `skillset release apply`. |
 | `skillset.name` | machine identity | Implemented | Root and plugin explicit identity; directory names remain the default. `skillset.id` is unsupported. |
 | skill top-level `name` | skill identity | Implemented | Skill-local `skillset.name` / `skillset.id` are unsupported. |
-| `compile.targets` | enabled provider renderings | Implemented | Root-only provider selection; defaults to all supported targets. |
+| `compile.targets` | enabled provider outputs | Implemented | Root-only provider selection; defaults to all supported providers. |
 | `compile.build: updated/all` | normalized build mode in lock provenance | Implemented | Parser, CLI overrides, plan-first writes, and lock metadata are implemented. |
 | `compile.skillset.metadata: false` | suppress generated skill `metadata.generated` / `metadata.version` | Implemented | Source metadata remains source-only; locks record `skillsetMetadata`. |
 | `compile.unsupportedDestination: error` | build/diff/check unsupported destination policy | Implemented | Default policy; preserves current fail-loud unsupported behavior. |
 | `compile.unsupportedDestination: warn/skip/force` | doctor/lock provenance | Reserved | Recognized names that fail until non-error unsupported destination policy semantics are implemented and documented. |
-| omitted `compile.targets` | all supported provider renderings | Implemented | Shorthand for the default target plan; equivalent to `compile.targets: [claude, codex]` while both providers are supported. |
-| `claude.projectRoot` / `codex.projectRoot` | target adapter metadata | Implemented | Parsed and inherited with provider blocks; build still does not mutate user-level config. |
-| `claude.userRoot` / `codex.userRoot` | target adapter metadata | Implemented | Parsed and inherited with provider blocks for future setup/explain flows. |
-| `claude.defaults.<surface>` / `codex.defaults.<surface>` | target option defaults for `agents`, `instructions`, `plugins`, `skills` | Implemented | Canonical target-local defaults; file-level target fields win. |
-| `defaults.<target>.<surface>` | same target option defaults | Implemented | Root/plugin shorthand; does not introduce bare top-level `targets:` provider selection. |
-| skill top-level `model` | (source-only warning) | Implemented | Warns unless every enabled target has `claude.model`, `codex.model`, or target defaults. |
-| `profiles.models` / `model_profile` | target-native model and reasoning fields | Future | Deferred alias design for repo-local model intent names; see the [model and reasoning alias profiles ADR](adrs/drafts/20260604-model-and-reasoning-alias-profiles.md). |
+| omitted `compile.targets` | all supported provider outputs | Implemented | Shorthand for the default provider plan; equivalent to `compile.targets: [claude, codex]` while both providers are supported. |
+| `claude.projectRoot` / `codex.projectRoot` | provider adapter metadata | Implemented | Parsed and inherited with provider blocks; build still does not mutate user-level config. |
+| `claude.userRoot` / `codex.userRoot` | provider adapter metadata | Implemented | Parsed and inherited with provider blocks for future setup/explain flows. |
+| `claude.defaults.<surface>` / `codex.defaults.<surface>` | provider option defaults for `agents`, `instructions`, `plugins`, `skills` | Implemented | Canonical provider-local defaults; file-level provider fields win. |
+| `defaults.<provider>.<surface>` | same provider option defaults | Implemented | Root/plugin shorthand; does not introduce bare top-level `targets:` provider selection. |
+| skill top-level `model` | (source-only warning) | Implemented | Warns unless every enabled provider has `claude.model`, `codex.model`, or provider defaults. |
+| `profiles.models` / `model_profile` | provider-native model and reasoning fields | Future | Deferred alias design for repo-local model intent names; see the [model and reasoning alias profiles ADR](adrs/drafts/20260604-model-and-reasoning-alias-profiles.md). |
 | `.skillset/sets/<name>/set.yaml` / `set:<name>` | focused generated-output selection and future marketplace/bundle indexes | Future | Deferred collection design for grouped marketplaces, bundles, and curated loadouts; see the [first-class sets ADR](adrs/drafts/20260604-first-class-sets.md). |
 
-Canonical target selection:
+Canonical provider selection:
 
 ```yaml
 compile:
   targets:
     - claude
     - codex
-  unsupported: error
+  unsupportedDestination: error
 ```
 
-Shorthand target selection with the same internal target plan:
+Shorthand provider selection with the same internal provider plan:
 
 ```yaml
 compile:
   targets: [claude, codex]
 ```
 
-When `compile.targets` is omitted, Skillset also normalizes to the same all-supported-provider target plan. Target-specific `claude` and `codex` blocks configure native output details and lower-level opt-outs; they are not a second provider-selection surface.
+When `compile.targets` is omitted, Skillset also normalizes to the same all-supported-provider plan. Provider-specific `claude` and `codex` blocks configure native output details and nested opt-outs; they are not a second provider-selection surface.
 
-Adapter defaults deliberately use `claude` / `codex` blocks or the `defaults.<target>` shorthand, not a top-level `targets:` map. That preserves the ADR-0001 boundary: `compile.targets` selects provider renderings, while provider blocks carry target-native config and scoped overrides.
+Adapter defaults deliberately use `claude` / `codex` blocks or the `defaults.<provider>` shorthand, not a top-level `targets:` map. That preserves the ADR-0001 boundary: `compile.targets` selects provider outputs, while provider blocks carry provider-native config and scoped overrides.
 
 ## Plugin manifest (Claude `.claude-plugin/plugin.json`)
 
@@ -79,8 +79,8 @@ Live-doc verified against `code.claude.com/docs/en/plugins` and `code.claude.com
 | `output-styles/` | `outputStyles: "./output-styles/"` | Implemented | |
 | `themes/` | `experimental.themes: "./themes/"` | Implemented | |
 | `monitors/monitors.json` | `experimental.monitors: "./monitors/monitors.json"` | Implemented | |
-| `bin/` | executable PATH component | Target-native / Implemented | Documented Claude plugin-root component; conventional `bin/` and `bin.source` copy into Claude plugin output and are locked as plugin features. |
-| `settings.json` | default plugin settings | Target-native / Future | Documented Claude plugin-root component for enabled plugins. Skillset v1 does not mutate live settings; the [reviewed settings suggestion workflow](adrs/drafts/20260604-reviewed-settings-suggestions.md) is future work. |
+| `bin/` | executable PATH component | Provider-native / Implemented | Documented Claude plugin-root component; conventional `bin/` and `bin.source` copy into Claude plugin output and are locked as plugin features. |
+| `settings.json` | default plugin settings | Provider-native / Future | Documented Claude plugin-root component for enabled plugins. Skillset v1 does not mutate live settings; the [reviewed settings suggestion workflow](adrs/drafts/20260604-reviewed-settings-suggestions.md) is future work. |
 
 ## Project agents (Claude)
 
@@ -118,7 +118,7 @@ Live-doc verified against `developers.openai.com/codex/plugins/build` and `devel
 | `.mcp.json` | `.mcp.json` | Implemented | Conventional `.mcp.json` and `mcp.source` copy into Codex plugin output and are locked as plugin features. |
 | `.app.json` | `.app.json` (manifest `apps`) | Implemented | Opaque pass-through. |
 | plugin `agents/` | (none) | Unsupported / Deferred | Codex plugin docs do not document a plugin `agents/` component. Do not copy Claude plugin agents here. |
-| `.skillset/src/agents/*.md` | project `.codex/agents/*.toml` | Portable / Implemented | Codex documents project/user custom agents as standalone TOML files. Skillset renders portable project agents into project custom agents; plugin-agent rendering remains unsupported. |
+| `.skillset/src/agents/*.md` | project `.codex/agents/*.toml` | Adaptive / Implemented | Codex documents project/user custom agents as standalone TOML files. Skillset builds adaptive project agents into project custom agents; plugin-agent output remains unsupported. |
 | user `~/.codex/agents/*.toml` | user custom agents | Future | User/global writes need explicit setup/review flows and must not happen as a side effect of `skillset build`. |
 
 ## Instructions
@@ -127,7 +127,7 @@ Live-doc verified against `developers.openai.com/codex/plugins/build` and `devel
 | --- | --- | --- | --- |
 | `.skillset/instructions/**/*.md` | `.claude/rules/**/*.md` (`paths` kept) | `AGENTS.md` at derived dirs, source-boundary comments | Implemented |
 | `.skillset/rules/**/*.md` | n/a | n/a | Unsupported — use `.skillset/instructions/**/*.md`. |
-| `.skillset/src/codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | Target-native / Implemented — Codex command execution policy, not instruction Markdown. |
+| `.skillset/src/codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | Provider-native / Implemented — Codex command execution policy, not instruction Markdown. |
 
 Codex truncates `AGENTS.md` beyond `project_doc_max_bytes` (32 KiB default); `skillset build`/`check` warns. Verified 2026-06-03 (`developers.openai.com/codex/guides/agents-md`, `openai/codex#7138`).
 

--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -4,7 +4,7 @@
 
 This is the stable doctrinal layer for the Skillset compiler. It describes what Skillset believes, how it decides between competing designs, and what agents should preserve when changing the source contract. When implementation or tactical docs drift from this document, bring the repo back into alignment or make a deliberate decision to change the tenets.
 
-Skillset exists to make reusable agent loadouts easier to author and safer to ship across Claude and Codex. It should make the happy path smaller, not make authors learn every target-specific file shape before they can write a useful skill.
+Skillset exists to make reusable agent loadouts easier to author and safer to ship across Claude and Codex. It should make the happy path smaller, not make authors learn every provider-specific file shape before they can write a useful skill.
 
 ## Documentation Tiers
 
@@ -12,14 +12,14 @@ Skillset docs are organized by how often the information should change:
 
 - **Tenets**: What we believe and why. This document changes only when our model of Skillset changes.
 - **Decisions and packets**: ADRs under `docs/adrs/`, goal packets, review reports, and retros that explain what is true now, what changed, and why.
-- **Guides and references**: How to use the current compiler, source layout, target rendering, versioning, imports, hooks, resources, and checks.
+- **Guides and references**: How to use the current compiler, source layout, provider builds, versioning, imports, hooks, resources, and checks.
 - **Agent guidance**: `AGENTS.md`, generated skills, and repo-local instructions. These are practical operating notes and change with the repo.
 
 Tenets govern the other tiers. A guide can be stale, a packet can be superseded, and an `AGENTS.md` file can be tactical. The tenets are the long-lived test for whether a proposal fits the system we are building.
 
 ## Principles
 
-These are the foundational beliefs of Skillset. Every source-schema decision, renderer, lint rule, import helper, and generated-output contract should be consistent with them.
+These are the foundational beliefs of Skillset. Every source-schema decision, provider adapter, lint rule, import helper, and generated-output contract should be consistent with them.
 
 ### Help the happy path
 
@@ -29,31 +29,31 @@ Power should come from derivation, defaults, validation, and clear escape hatche
 
 ### Source is the product
 
-`.skillset/` is the authored source of truth. Claude and Codex outputs are target-native renderings of that source.
+`.skillset/` is the authored source of truth. Claude and Codex outputs are provider-native build artifacts written to concrete destinations.
 
 Generated plugin repositories, standalone skill roots, lockfiles, and instruction files can be committed and reviewed, but they are not source truth. Edits should flow from source to generated output through `skillset build`, and `skillset check` should make stale output visible.
 
 ### One meaning, one key
 
-When Claude and Codex expose the same semantic feature, Skillset should provide one portable source key for that meaning. Exact matches do not deserve parallel `claude_*` and `codex_*` vocabulary just because the target manifests spell them differently.
+When Claude and Codex expose the same semantic feature, Skillset should provide one adaptive source key for that meaning. Exact matches do not deserve parallel `claude_*` and `codex_*` vocabulary just because provider manifests spell them differently.
 
-Provider-native aliases can be accepted when they are safe and unambiguous. The resolver should normalize aliases into the canonical Skillset concept before rendering target output.
+Provider-native aliases can be accepted when they are safe and unambiguous. The resolver should normalize aliases into the canonical Skillset concept before adapting source to provider output.
 
 ### Render intent, not filenames
 
-Close matches should be designed from the author's intent, not from whichever target file shape appeared first. The question is not "how do we copy a Claude subagent into Codex?" but "what outcome is the author trying to create, and what is the faithful Codex-native way to create a similar outcome?"
+Close matches should be designed from the author's intent, not from whichever provider file shape appeared first. The question is not "how do we copy a Claude subagent into Codex?" but "what outcome is the author trying to create, and what is the faithful Codex-native way to create a similar outcome?"
 
-This applies to agents, subagents, hooks, instructions, resources, app/MCP manifests, and any future runtime surface. If Skillset cannot render an intent faithfully for a target, it should say so through target-specific support, diagnostics, or explicit opt-out rather than pretending the outputs are equivalent.
+This applies to agents, subagents, hooks, instructions, resources, app/MCP manifests, and any future runtime surface. If Skillset cannot adapt an intent faithfully for a provider, it should say so through provider-specific support, diagnostics, or explicit opt-out rather than pretending the outputs are equivalent.
 
-### Target truth beats fake portability
+### Provider truth beats fake portability
 
-Portable source keys are for behavior that is actually portable. Root provider selection is a compile concern, not target-native semantics: a root `compile.targets` list may say which provider renderings to build, while `claude` and `codex` blocks stay reserved for target-specific options, explicit target toggles, and visible target-native escape hatches.
+Adaptive source keys are for behavior Skillset can meaningfully adapt. Root provider selection is a compile concern, not provider-native semantics: a root `compile.targets` list may say which provider outputs to build, while `claude` and `codex` blocks stay reserved for provider-specific options, explicit provider toggles, and visible provider-native escape hatches.
 
-It is better for a feature to be honestly target-specific than falsely unified. Skillset should not introduce a separate `agents` abstraction in v1 when `codex` is the practical Codex skill/plugin/agent-ish target.
+It is better for a feature to be honestly provider-specific than falsely unified. Skillset should not introduce a shared abstraction when the providers do not offer a meaningfully equivalent destination.
 
 ### Derive by default, override when wrong
 
-Authors should write information only they know. Skillset should derive what it already knows: names from directories when appropriate, manifest values from source metadata, target output paths from defaults, generated version fallbacks from the nearest source version, and generated descriptions from the source fields that already exist.
+Authors should write information only they know. Skillset should derive what it already knows: names from directories when appropriate, manifest values from source metadata, destination paths from defaults, generated version fallbacks from the nearest source version, and generated descriptions from the source fields that already exist.
 
 Overrides are healthy when derivation is wrong. They should be scoped, explicit, and visible in resolved output or lock provenance. If authors routinely override everything, the derivation rules are probably wrong.
 
@@ -75,25 +75,25 @@ These are guarantees authors and agents should be able to rely on.
 
 ### Generated output is reproducible
 
-Generated output should be deterministic, disposable, and reviewable. Rebuilding from the same source should produce the same target files and lock provenance.
+Generated output should be deterministic, disposable, and reviewable. Rebuilding from the same source should produce the same provider files and lock provenance.
 
-### Target output stays native
+### Provider output stays native
 
 Claude output should look like Claude. Codex output should look like Codex. Skillset can normalize source authoring without forcing targets into an unnatural shared shape.
 
 ### Lockfiles carry heavy provenance
 
-Generated skill frontmatter should stay lightweight. Product-facing generated fields such as `metadata.version` and `metadata.generated` belong in the skill itself; heavier source hashes, source paths, target state, skipped target information, and drift evidence belong in nearby `.skillset.lock` files.
+Generated skill frontmatter should stay lightweight. Product-facing generated fields such as `metadata.version` and `metadata.generated` belong in the skill itself; heavier source hashes, source paths, provider state, skipped provider information, and drift evidence belong in nearby `.skillset.lock` files.
 
 ### Migration is explicit, ambiguity is not
 
-Import helpers can reduce migration pain, but the source contract should not keep old spellings once Skillset can still cut over cleanly. Unknown portable keys and obsolete aliases should fail unless the author uses a clearly target-native escape hatch.
+Import helpers can reduce migration pain, but the source contract should not keep old spellings once Skillset can still cut over cleanly. Unknown adaptive keys and obsolete aliases should fail unless the author uses a clearly provider-native escape hatch.
 
 ### Drift should become visible early
 
-Stale generated output, unsupported target features, unsafe resource mappings, unmanaged generated-destination collisions, malformed locks, and target-incompatible hooks should become visible before they become quiet runtime surprises. Fail when the compiler cannot proceed safely; when a confirmed build replaces a recoverable unmanaged collision or target-side edit, it should warn and preserve enough backup state to restore the prior file.
+Stale generated output, unsupported provider features, unsafe resource mappings, unmanaged generated-destination collisions, malformed locks, and provider-incompatible hooks should become visible before they become quiet runtime surprises. Fail when the compiler cannot proceed safely; when a confirmed build replaces a recoverable unmanaged collision or destination-side edit, it should warn and preserve enough backup state to restore the prior file.
 
-Unsupported destination policy should be explicit. The default should fail when authored source cannot render faithfully to an enabled target. Softer modes such as warn, skip, or force are escape hatches for migration and provider drift; they must record what happened in warnings, doctor output, or lock provenance rather than making unsupported source look synchronized.
+Unsupported destination policy should be explicit. The default should fail when authored source cannot build faithfully for an enabled provider destination. Softer modes such as warn, skip, or force are escape hatches for migration and provider drift; they must record what happened in warnings, doctor output, or lock provenance rather than making unsupported source look synchronized.
 
 ## Patterns
 
@@ -101,37 +101,37 @@ These are recurring design shapes that operationalize the principles and promise
 
 ### Normalize exact matches
 
-When a Claude and Codex feature is semantically the same, define a portable source key and render it to target-native syntax. `implicit_invocation`, skill version metadata, source descriptions, and target enablement are examples of this pattern.
+When a Claude and Codex feature is semantically the same, define an adaptive source key and adapt it to provider-native syntax. `implicit_invocation`, skill version metadata, source descriptions, and provider enablement are examples of this pattern.
 
 ### Model near matches by intent
 
-When features are similar but not identical, name the intent first and design the render second. Instructions that render to Claude rules and Codex `AGENTS.md` files, agent roles that may render differently per target, and hook definitions that stay definitions rather than activation are examples of this pattern.
+When features are similar but not identical, name the intent first and design the provider adaptation second. Instructions that build to Claude rules and Codex `AGENTS.md` files, agent roles that may write differently per provider, and hook definitions that stay definitions rather than activation are examples of this pattern.
 
 ### Prefer defaults and scoped overrides
 
-The default posture is to compile for both Claude and Codex when source is portable. Root `compile.targets` can narrow that provider set, and lower levels can opt out or back in with `claude` and `codex` toggles where the resolver supports it. Boolean target settings should use defaults; objects should exist for real overrides.
+The default posture is to compile for both Claude and Codex when source is adaptive. Root `compile.targets` can narrow that provider set, and nested source can opt out or back in with `claude` and `codex` toggles where the resolver supports it. Boolean provider settings should use defaults; objects should exist for real overrides.
 
 ### Keep escape hatches visible
 
-Target-native escape hatches should be obvious in source. Underscore-prefixed keys such as `_allow` and `_deny` signal that the author is intentionally leaving the portable layer. Escape hatches should still be validated for file safety, locked for provenance, and rendered only where the target can accept them.
+Provider-native escape hatches should be obvious in source. Underscore-prefixed keys such as `_allow` and `_deny` signal that the author is intentionally leaving the adaptive layer. Escape hatches should still be validated for file safety, locked for provenance, and written only where the provider can accept them.
 
 ### Treat tooling as authoring surface
 
-`skillset lint`, `skillset check`, `skillset import`, and future explain/scaffold tools are not secondary conveniences. They are how Skillset codifies good loadout authoring, keeps target behavior honest, and teaches the next author what to fix.
+`skillset lint`, `skillset check`, `skillset import`, and future explain/scaffold tools are not secondary conveniences. They are how Skillset codifies good loadout authoring, keeps provider behavior honest, and teaches the next author what to fix.
 
 ## Current Doctrine Implications
 
 These are not a replacement for the schema reference. They are examples of how the tenets should guide near-term design.
 
-- Prefer `tool_intent` for portable tool-policy meaning, with target-native `_` escape hatches for provider-specific vocabulary.
+- Prefer `tool_intent` for adaptive tool-policy meaning, with provider-native `_` escape hatches for provider-specific vocabulary.
 - Prefer `instructions` as the source concept for repo guidance, even if Claude output still uses rules and Codex output still uses `AGENTS.md`.
 - Use `skillset.schema` for the version of the source contract or compiler schema, while generated skill product versions stay simple through fields like `metadata.version`.
 - Do not require a source name that is distinct from the real plugin or skill name unless there is a concrete identity problem that derivation cannot solve.
-- Use root `compile.targets` for provider selection. Keep bare top-level `targets:` out of the source contract, default to both targets for portable source, and keep `claude` / `codex` blocks for target-specific options and lower-level opt-outs.
-- Treat root `compile.unsupportedDestination` as visible unsupported destination policy. The default is `error`; `warn` and `skip` must surface skipped source in diagnostics or lock provenance, and `force` must only render through an explicit target-native destination rather than pretending unsupported behavior became portable.
+- Use root `compile.targets` for provider selection. Keep bare top-level `targets:` out of the source contract, default to both providers for adaptive source, and keep `claude` / `codex` blocks for provider-specific options and nested opt-outs.
+- Treat root `compile.unsupportedDestination` as visible unsupported destination policy. The default is `error`; `warn` and `skip` must surface skipped source in diagnostics or lock provenance, and `force` must only render through an explicit provider-native destination rather than pretending unsupported behavior became portable.
 
 ## Posture
 
-Skillset is opinionated about source authoring and conservative about target activation. It should give authors a small, clear, source-first contract while preserving the native expectations of Claude and Codex.
+Skillset is opinionated about source authoring and conservative about provider activation. It should give authors a small, clear, source-first contract while preserving the native expectations of Claude and Codex.
 
-It should grow deliberately. A new portable key is valuable when it removes repetition, prevents drift, and renders faithfully. A new target-specific escape hatch is valuable when it keeps target truth explicit. A new abstraction is justified only when it makes authoring easier without making the system less honest.
+It should grow deliberately. A new adaptive key is valuable when it removes repetition, prevents drift, and builds faithfully. A new provider-specific escape hatch is valuable when it keeps provider truth explicit. A new abstraction is justified only when it makes authoring easier without making the system less honest.

--- a/scripts/terminology-guard.ts
+++ b/scripts/terminology-guard.ts
@@ -4,9 +4,11 @@
  * Blocks retired compiler vocabulary (the `lowering`/`lowering outcome` family,
  * the old `compile.unsupported` config key, and friends) from drifting back into
  * active source, docs, generated Skillset guidance, CLI output, schema names, and
- * tests. The new vocabulary is derive/render/build, target (provider) vs
- * destination (scope), render result(s), compile.unsupportedDestination, and
- * unsupported destination policy.
+ * tests. The active vocabulary uses build/compile/adapt/transform/write,
+ * provider vs destination, render result(s), compile.unsupportedDestination,
+ * and unsupported destination policy. Some internal schema names still use
+ * `target` where the code is modeling the Claude/Codex provider enum; new
+ * adopter-facing language should prefer provider/destination.
  *
  * Allowlists are deliberately small and explicit; see ALLOWLIST_PATHS and
  * ALLOWLIST_LINE below and the "Updating the allowlist" note at the bottom.
@@ -183,7 +185,7 @@ async function main(): Promise<void> {
     console.error(`    ${violation.text}`);
   }
   console.error(
-    "skillset: replace retired terminology with the derive/render/destination vocabulary, " +
+    "skillset: replace retired terminology with the build/provider/destination vocabulary, " +
       "or extend the allowlist in scripts/terminology-guard.ts for deliberate historical/deferred context."
   );
   process.exit(1);
@@ -202,7 +204,7 @@ if (import.meta.main) {
  * The guard runs in `bun run check`. When it fails:
  *
  * 1. Prefer fixing the source: replace the retired term with the
- *    derive/render/destination vocabulary. This is correct ~99% of the time.
+ *    build/provider/destination vocabulary. This is correct ~99% of the time.
  * 2. Only allowlist for DELIBERATE historical or deferred context:
  *    - A whole file/tree that is historical (ADRs), generated (validated from
  *      `.skillset/` source elsewhere), or owns a deferred concept (the


### PR DESCRIPTION
## Context

This settles the public vocabulary we need before the larger layout and hook work. The goal is to make Skillset language easier to reason about for adopters: providers are the tool ecosystems, destinations are where files are written, and adaptive source is the portable source that Skillset can transform for each provider.

## What changed

- Refreshed `docs/tenets.md` and `docs/target-surfaces.md` around provider/destination/adaptive-source language.
- Updated the terminology guard to preserve the new vocabulary and avoid drifting back toward retired adopter-facing terms.
- Kept this branch documentation-focused so the follow-on layout branches have a stable naming base.

## Verification

- `bun run check` passed on the full submitted stack.
- Terminology guard passed as part of `bun run check`.

## Risks / rollout

Low implementation risk: this is documentation and guardrail vocabulary. The main risk is conceptual churn, so the branch intentionally lands before the source-layout changes that depend on this language.