### PR TITLE
fix(ci): allow generated changelog history in terminology guard

### DIFF
--- a/scripts/__tests__/terminology-guard.test.ts
+++ b/scripts/__tests__/terminology-guard.test.ts
@@ -67,6 +67,7 @@ describe("terminology guard", () => {
     expect(isScannablePath(".claude/skills/x/SKILL.md")).toBe(false);
     expect(isScannablePath(".agents/plans/p/PLAN.md")).toBe(false);
     expect(isScannablePath(".changeset/x.md")).toBe(false);
+    expect(isScannablePath("apps/skillset/CHANGELOG.md")).toBe(false);
     expect(isScannablePath("packages/transforms/src/engine.ts")).toBe(false);
     expect(isScannablePath("packages/core/src/render.ts")).toBe(false);
     expect(isScannablePath("packages/core/src/deterministic-projection.ts")).toBe(false);

--- a/scripts/terminology-guard.ts
+++ b/scripts/terminology-guard.ts
@@ -61,6 +61,9 @@ export const ALLOWLIST_PATHS: readonly string[] = [
   // Changesets and change-provenance notes describe the cutover / prior changes.
   ".changeset/",
   ".skillset/changes/",
+  // Package changelogs are generated release history and may quote old terms from
+  // prior public changes.
+  "apps/skillset/CHANGELOG.md",
   // Deferred follow-up: the transform-dialect `lowering` capability is a distinct
   // concept (see RETRO); renaming it is a separate behavioral change.
   "packages/transforms/",


### PR DESCRIPTION
## Context

The `skillset@0.13.5` release PR generated historical changelog text that included retired terminology from the terminology cutover. Main CI failed because `terminology:guard` scanned `apps/skillset/CHANGELOG.md`.

## What Changed

- Exclude `apps/skillset/CHANGELOG.md` from terminology guard scanning as generated release history.
- Add regression coverage so the generated package changelog stays treated like other historical/generated surfaces.

## Verification

- `bun test scripts/__tests__/terminology-guard.test.ts`
- `bun run terminology:guard`
- `bun run check`
- Graphite pre-push reran `skillset ci` and `check` successfully.
