### PR TITLE
fix(release): detect github actions check run app slug

### DIFF
--- a/scripts/__tests__/release-policy.test.ts
+++ b/scripts/__tests__/release-policy.test.ts
@@ -299,6 +299,16 @@ describe("release policy CI state", () => {
     name,
     status: "completed",
   });
+  const successRunWithTopLevelApp = (
+    name: string
+  ): GitHubCheckRunsResponse["check_runs"][number] => ({
+    app: {
+      slug: "github-actions",
+    },
+    conclusion: "success",
+    name,
+    status: "completed",
+  });
 
   test("requires the named CI jobs to complete successfully", () => {
     expect(ciStateFromCheckRuns(checkRuns([successRun("check"), successRun("skillset-ci")]))).toBe(
@@ -316,6 +326,14 @@ describe("release policy CI state", () => {
         ])
       )
     ).toBe("failed");
+  });
+
+  test("accepts the live check-runs API shape with the app slug on the run", () => {
+    expect(
+      ciStateFromCheckRuns(
+        checkRuns([successRunWithTopLevelApp("check"), successRunWithTopLevelApp("skillset-ci")])
+      )
+    ).toBe("passed");
   });
 
   test("skips exact-SHA CI polling when the registry already has the current version and tag", () => {

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -877,7 +877,7 @@ async function readCiPassed(repository: string, sha: string) {
 export function ciStateFromCheckRuns(response: GitHubCheckRunsResponse) {
   const requiredRuns = new Map(
     response.check_runs
-      .filter((run) => run.check_suite?.app?.slug === "github-actions")
+      .filter((run) => (run.app?.slug ?? run.check_suite?.app?.slug) === "github-actions")
       .filter((run) => run.name === "check" || run.name === "skillset-ci")
       .map((run) => [run.name, run])
   );
@@ -969,6 +969,9 @@ type GitHubContentFile = {
 
 export type GitHubCheckRunsResponse = {
   check_runs: {
+    app?: {
+      slug?: string;
+    } | null;
     check_suite?: {
       app?: {
         slug?: string;


### PR DESCRIPTION
## Context

The release workflow for `skillset@0.13.5` reached `Publish Policy` after the release PR merged, but the policy step kept waiting even though the required GitHub Actions checks were green.

The check-runs API payload we observed puts the app slug on the check run itself (`check_run.app.slug`) while the policy script only looked at `check_run.check_suite.app.slug`. That made the policy ignore the required `check` and `skillset-ci` runs and keep treating CI as pending.

## What changed

- Accept both GitHub check-run app slug shapes when filtering required Actions checks.
- Add a regression test for the live API shape.

## Verification

- `bun test scripts/__tests__/release-policy.test.ts`
- `bun run publish:policy`
- `bun run check`
- Graphite pre-push gate during `gt submit`

## Risk

Low. The change only broadens release-policy CI detection to support both observed API shapes; the required check names and pass/fail semantics are unchanged.
