### PR TITLE
feat(workbench): add diagnostic primitives

### DIFF
--- a/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
+++ b/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
@@ -24,8 +24,8 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
 | 0 | SET-153 | n/a | n/a | Created | Roadmap parent |
-| 1 | SET-154 | `set-154-cut-cli-semantics-to-skillset-check-and-skillset-verify` | pending | pending | M1 command cutover |
-| 2 | SET-155 | `set-155-introduce-skillsetworkbench-diagnostic-primitives` | pending | pending | M2 diagnostics |
+| 1 | SET-154 | `set-154-cut-cli-semantics-to-skillset-check-and-skillset-verify` | pending | committed | M1 command cutover |
+| 2 | SET-155 | `set-155-introduce-skillsetworkbench-diagnostic-primitives` | pending | in progress | M2 diagnostics |
 | 3 | SET-156 | `set-156-add-workbench-presets-rules-and-existing-lint-bridge` | pending | pending | M2 presets and lint bridge |
 | 4 | SET-157 | `set-157-add-bun-yamltoml-and-markdown-parser-backed-workbench-checks` | pending | pending | M3 parsers |
 | 5 | SET-158 | `set-158-add-schema-backed-workbench-rules-for-source-contracts` | pending | pending | M3 schema |
@@ -94,12 +94,23 @@ Use this as the durable execution ledger. For stacked work, this should normally
 - Blockers: none.
 ```
 
+```text
+2026-06-20 12:05 ET - SET-155 diagnostics primitives
+- Changed: Added the private @skillset/workbench package with diagnostic, location, subject, rule metadata, summary, sorting, and formatting primitives.
+- Changed: Kept the package intentionally foundational; presets, lint bridging, parsers, schemas, and fixture rules remain in their owning branches.
+- Verified: Focused Workbench diagnostic tests, typecheck, changeset guard, and full `bun run check` passed.
+- Review: Two read-only local reviewers scored the branch 5/5 with no P0-P3 findings.
+- Next: Commit SET-155 and create the SET-156 branch for presets plus the lint bridge.
+- Blockers: none.
+```
+
 ## Local Review Log
 
 | Round | Scope / Lanes | Report Paths | P0/P1/P2/P3 Result | Fix Commits / Notes |
 | --- | --- | --- | --- | --- |
 | 1 | SET-154 CLI/runtime and docs/tests/generated guidance | Subagent reports in thread: Carver, Banach | P1 README stale public semantics; P3 runtime hook failure coverage; P3 stale test names | Fixed README `check`/`verify` guidance, added check/verify stop-hook failure assertions, renamed stale generated-output test titles; reran affected tests |
 | 2 | SET-154 re-review | Main-agent read-only re-review after fixes | 5/5; no P0-P3 findings | Fixed final leftover `skillset build`/`check` generated AGENTS-size wording before scoring; full gate passed |
+| 3 | SET-155 diagnostics primitives | Subagent reports in thread: Mill, Huygens | 5/5; no P0-P3 findings | No fixes required after reviewer loop |
 
 ## Verification Log
 
@@ -119,6 +130,10 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | active wording sweep | SET-154 review fixes | pass | No active user-facing stale `skillset check` generated-output semantics remained; remaining matches are internal API assertions or historical ADR text |
 | `bun ./apps/skillset/src/cli.ts check --root . && bun ./apps/skillset/src/cli.ts verify --root . && git diff --check` | SET-154 final README fix | pass | Command smokes and whitespace check passed |
 | `.changeset/workbench-check-verify.md` | SET-154 release intent | pass | Patch Changeset added for public command split |
+| `bun test packages/workbench/src/__tests__/diagnostics.test.ts` | SET-155 focused tests | pass | 4 pass, 0 fail |
+| `bun run typecheck` | SET-155 typecheck | pass | `tsc --noEmit` |
+| `bun run changeset:check` | SET-155 release guard | pass | 7 package-facing paths and 1 active changeset |
+| `bun run check` | full repo gate after SET-155 | pass | 544 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
 
 ## Remote Review / CI Log
 
@@ -136,6 +151,8 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Carson | 4.5/5 | P3 | README Lefthook paragraph still said pre-commit runs the old lint/check pair. | Rewrite to describe `bun run skillset:verify` pre-commit behavior. | README now matches `lefthook.yml`. | Command/text sweep pass |
 | Ampere | 4.5/5 | P3 | README self-hosted command checklist omitted `bun run skillset:verify`. | Add `bun run skillset:verify` to checklist. | README checklist now includes build, lint, check, verify, and aggregate check. | Command/text sweep pass |
 | Volta | 5/5 | none | No remaining P0-P3 findings. | n/a | M1 review loop clean. | Smoke verification matched intended behavior |
+| Mill | 5/5 | none | No remaining P0-P3 findings for the Workbench diagnostic API. | n/a | M2 SET-155 review loop clean. | Reviewer called the package JSON-safe, deterministic, and appropriately small |
+| Huygens | 5/5 | none | No remaining P0-P3 findings for Workbench diagnostic correctness/tests. | n/a | M2 SET-155 review loop clean. | Reviewer verified sorting, summary, formatting, JSON safety, and edge-case posture |
 
 ## Forbidden Actions Audit
 

--- a/.changeset/workbench-diagnostics.md
+++ b/.changeset/workbench-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Introduce the private Workbench diagnostic primitives that back the new `skillset check` authoring-correctness surface.

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "bin": {
         "create-skillset": "dist/create.js",
         "skillset": "dist/cli.js",
@@ -45,6 +45,10 @@
     },
     "packages/transforms": {
       "name": "@skillset/transforms",
+      "version": "0.0.0",
+    },
+    "packages/workbench": {
+      "name": "@skillset/workbench",
       "version": "0.0.0",
     },
   },
@@ -182,6 +186,8 @@
     "@skillset/lint": ["@skillset/lint@workspace:packages/lint"],
 
     "@skillset/transforms": ["@skillset/transforms@workspace:packages/transforms"],
+
+    "@skillset/workbench": ["@skillset/workbench@workspace:packages/workbench"],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@skillset/workbench",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/workbench/src/__tests__/diagnostics.test.ts
+++ b/packages/workbench/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createWorkbenchDiagnostic,
+  formatWorkbenchDiagnostic,
+  sortWorkbenchDiagnostics,
+  summarizeWorkbenchDiagnostics,
+} from "../index";
+import type { WorkbenchDiagnostic } from "../types";
+
+const diagnostic = (
+  overrides: Partial<WorkbenchDiagnostic> = {}
+): WorkbenchDiagnostic => createWorkbenchDiagnostic({
+  location: { column: 3, line: 2, path: ".skillset/src/skills/demo/SKILL.md" },
+  message: "Demo finding",
+  ruleId: "skillset/demo",
+  scope: "source",
+  severity: "warning",
+  subject: { kind: "skill", path: ".skillset/src/skills/demo/SKILL.md" },
+  ...overrides,
+});
+
+describe("workbench diagnostics", () => {
+  test("creates JSON-safe diagnostics with optional help and fix metadata", () => {
+    const fix = { kind: "manual", message: "Update the source file." } as const;
+    const help = ["Keep generated files out of source changes."];
+    const location = { column: 3, line: 2, path: ".skillset/src/skills/demo/SKILL.md" };
+    const subject = { kind: "skill", path: ".skillset/src/skills/demo/SKILL.md" };
+    const found = diagnostic({
+      fix,
+      help,
+      location,
+      subject,
+    });
+
+    help.push("Input mutation should not affect the diagnostic.");
+    location.line = 99;
+    subject.path = "mutated.md";
+
+    expect(JSON.parse(JSON.stringify(found))).toEqual(found);
+    expect(found).toEqual({
+      fix: { kind: "manual", message: "Update the source file." },
+      help: ["Keep generated files out of source changes."],
+      location: { column: 3, line: 2, path: ".skillset/src/skills/demo/SKILL.md" },
+      message: "Demo finding",
+      ruleId: "skillset/demo",
+      scope: "source",
+      severity: "warning",
+      subject: { kind: "skill", path: ".skillset/src/skills/demo/SKILL.md" },
+    });
+  });
+
+  test("sorts by path, line, column, scope, rule, subject, and message", () => {
+    const unsorted = [
+      diagnostic({ location: { line: 9, path: "b.md" }, message: "B" }),
+      diagnostic({ location: { line: 3, path: "a.md" }, message: "C" }),
+      diagnostic({ location: { line: 2, path: "a.md" }, message: "A" }),
+      diagnostic({ location: { column: 1, line: 2, path: "a.md" }, message: "B" }),
+    ];
+
+    expect(sortWorkbenchDiagnostics(unsorted).map((found) => formatWorkbenchDiagnostic(found))).toEqual([
+      "a.md:2:1: warning: skillset/demo: B",
+      "a.md:2: warning: skillset/demo: A",
+      "a.md:3: warning: skillset/demo: C",
+      "b.md:9: warning: skillset/demo: B",
+    ]);
+  });
+
+  test("sorts diagnostics without locations by subject path", () => {
+    const unsorted = [
+      createWorkbenchDiagnostic({
+        message: "Demo finding",
+        ruleId: "skillset/demo",
+        scope: "source",
+        severity: "warning",
+        subject: { kind: "skill", path: "b.md" },
+      }),
+      createWorkbenchDiagnostic({
+        message: "Demo finding",
+        ruleId: "skillset/demo",
+        scope: "source",
+        severity: "warning",
+        subject: { kind: "skill", path: "a.md" },
+      }),
+    ];
+    const [first] = unsorted;
+    if (first === undefined) throw new Error("Expected a diagnostic fixture.");
+
+    expect(sortWorkbenchDiagnostics(unsorted).map((found) => found.subject.path)).toEqual([
+      "a.md",
+      "b.md",
+    ]);
+    expect(formatWorkbenchDiagnostic(first)).toBe("warning: skillset/demo: Demo finding");
+  });
+
+  test("summarizes severity counts and blocks success only on errors", () => {
+    const result = summarizeWorkbenchDiagnostics([
+      diagnostic({ severity: "info" }),
+      diagnostic({ severity: "warning" }),
+      diagnostic({ severity: "error" }),
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCount).toBe(1);
+    expect(result.warningCount).toBe(1);
+    expect(result.infoCount).toBe(1);
+    expect(result.diagnostics).toHaveLength(3);
+
+    expect(summarizeWorkbenchDiagnostics([diagnostic({ severity: "warning" })]).ok).toBe(true);
+  });
+
+  test("formats workspace-level diagnostics without a file location", () => {
+    expect(
+      formatWorkbenchDiagnostic(createWorkbenchDiagnostic({
+        message: "Workspace issue",
+        ruleId: "skillset/demo",
+        scope: "workspace",
+        severity: "warning",
+        subject: { kind: "workspace", id: "root" },
+      }))
+    ).toBe("warning: skillset/demo: Workspace issue");
+  });
+});

--- a/packages/workbench/src/diagnostics.ts
+++ b/packages/workbench/src/diagnostics.ts
@@ -1,0 +1,112 @@
+import type {
+  WorkbenchDiagnostic,
+  WorkbenchLocation,
+  WorkbenchRunResult,
+  WorkbenchScope,
+  WorkbenchSeverity,
+  WorkbenchSubject,
+} from "./types";
+
+export function createWorkbenchDiagnostic(args: {
+  readonly fix?: WorkbenchDiagnostic["fix"];
+  readonly help?: readonly string[];
+  readonly location?: WorkbenchLocation;
+  readonly message: string;
+  readonly ruleId: string;
+  readonly scope: WorkbenchScope;
+  readonly severity: WorkbenchSeverity;
+  readonly subject: WorkbenchSubject;
+}): WorkbenchDiagnostic {
+  return {
+    ...(args.location === undefined ? {} : { location: { ...args.location } }),
+    ...(args.help === undefined ? {} : { help: [...args.help] }),
+    ...(args.fix === undefined ? {} : { fix: { ...args.fix } }),
+    message: args.message,
+    ruleId: args.ruleId,
+    scope: args.scope,
+    severity: args.severity,
+    subject: { ...args.subject },
+  };
+}
+
+export function summarizeWorkbenchDiagnostics(
+  diagnostics: readonly WorkbenchDiagnostic[]
+): WorkbenchRunResult {
+  let errorCount = 0;
+  let infoCount = 0;
+  let warningCount = 0;
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.severity === "error") errorCount += 1;
+    if (diagnostic.severity === "info") infoCount += 1;
+    if (diagnostic.severity === "warning") warningCount += 1;
+  }
+  return {
+    diagnostics: sortWorkbenchDiagnostics(diagnostics),
+    errorCount,
+    infoCount,
+    ok: errorCount === 0,
+    warningCount,
+  };
+}
+
+export function sortWorkbenchDiagnostics(
+  diagnostics: readonly WorkbenchDiagnostic[]
+): readonly WorkbenchDiagnostic[] {
+  return [...diagnostics].sort(compareWorkbenchDiagnostics);
+}
+
+export function compareWorkbenchDiagnostics(
+  left: WorkbenchDiagnostic,
+  right: WorkbenchDiagnostic
+): number {
+  return (
+    compareStrings(locationPath(left), locationPath(right)) ||
+    compareNumbers(locationLine(left), locationLine(right)) ||
+    compareNumbers(locationColumn(left), locationColumn(right)) ||
+    compareStrings(left.scope, right.scope) ||
+    compareStrings(left.ruleId, right.ruleId) ||
+    compareStrings(subjectKey(left.subject), subjectKey(right.subject)) ||
+    compareStrings(left.message, right.message)
+  );
+}
+
+export function formatWorkbenchDiagnostic(diagnostic: WorkbenchDiagnostic): string {
+  const location = formatLocation(diagnostic.location);
+  const prefix = location === "" ? "" : `${location}: `;
+  return `${prefix}${diagnostic.severity}: ${diagnostic.ruleId}: ${diagnostic.message}`;
+}
+
+function formatLocation(location: WorkbenchLocation | undefined): string {
+  if (location === undefined) return "";
+  if (location.line === undefined) return location.path;
+  if (location.column === undefined) return `${location.path}:${location.line}`;
+  return `${location.path}:${location.line}:${location.column}`;
+}
+
+function locationPath(diagnostic: WorkbenchDiagnostic): string {
+  return diagnostic.location?.path ?? diagnostic.subject.path ?? "";
+}
+
+function locationLine(diagnostic: WorkbenchDiagnostic): number {
+  return diagnostic.location?.line ?? Number.POSITIVE_INFINITY;
+}
+
+function locationColumn(diagnostic: WorkbenchDiagnostic): number {
+  return diagnostic.location?.column ?? Number.POSITIVE_INFINITY;
+}
+
+function subjectKey(subject: WorkbenchSubject): string {
+  return `${subject.kind}:${subject.path ?? ""}:${subject.id ?? ""}`;
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareNumbers(left: number, right: number): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  compareWorkbenchDiagnostics,
+  createWorkbenchDiagnostic,
+  formatWorkbenchDiagnostic,
+  sortWorkbenchDiagnostics,
+  summarizeWorkbenchDiagnostics,
+} from "./diagnostics";
+export type {
+  WorkbenchDiagnostic,
+  WorkbenchFix,
+  WorkbenchLocation,
+  WorkbenchRuleMetadata,
+  WorkbenchRunResult,
+  WorkbenchScope,
+  WorkbenchSeverity,
+  WorkbenchSubject,
+} from "./types";

--- a/packages/workbench/src/types.ts
+++ b/packages/workbench/src/types.ts
@@ -1,0 +1,56 @@
+export type WorkbenchSeverity = "error" | "info" | "warning";
+
+export type WorkbenchScope =
+  | "generated"
+  | "provider"
+  | "release"
+  | "resource"
+  | "runtime"
+  | "source"
+  | "workspace";
+
+export interface WorkbenchLocation {
+  readonly column?: number;
+  readonly endColumn?: number;
+  readonly endLine?: number;
+  readonly line?: number;
+  readonly path: string;
+}
+
+export interface WorkbenchSubject {
+  readonly id?: string;
+  readonly kind: string;
+  readonly path?: string;
+}
+
+export interface WorkbenchFix {
+  readonly kind: "manual" | "suggestion";
+  readonly message: string;
+}
+
+export interface WorkbenchRuleMetadata {
+  readonly category?: string;
+  readonly description: string;
+  readonly docs?: readonly string[];
+  readonly id: string;
+  readonly scope: WorkbenchScope;
+}
+
+export interface WorkbenchDiagnostic {
+  readonly fix?: WorkbenchFix;
+  readonly help?: readonly string[];
+  readonly location?: WorkbenchLocation;
+  readonly message: string;
+  readonly ruleId: string;
+  readonly scope: WorkbenchScope;
+  readonly severity: WorkbenchSeverity;
+  readonly subject: WorkbenchSubject;
+}
+
+export interface WorkbenchRunResult {
+  readonly diagnostics: readonly WorkbenchDiagnostic[];
+  readonly errorCount: number;
+  readonly infoCount: number;
+  readonly ok: boolean;
+  readonly warningCount: number;
+}


### PR DESCRIPTION
## Context

This introduces the Workbench package foundation used by the rest of the stack.

## Changes

- Adds `@skillset/workbench` with diagnostic types, severities, locations, and result helpers.
- Adds initial tests for diagnostic construction and summary behavior.
- Adds a branch-local changeset for the new package surface.

## Verification

- Local reviewer loop completed with final 5/5 and no P0-P3 findings.
- `bun run check`
- `bun run hooks:pre-push`
- Hosted CI required before leaving draft.

## Risks

This branch is primitive-only; later stack entries wire it into CLI behavior and real checks.
