### PR TITLE
feat(workbench): add parser-backed checks

### DIFF
--- a/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
+++ b/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
@@ -26,8 +26,8 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 0 | SET-153 | n/a | n/a | Created | Roadmap parent |
 | 1 | SET-154 | `set-154-cut-cli-semantics-to-skillset-check-and-skillset-verify` | pending | committed | M1 command cutover |
 | 2 | SET-155 | `set-155-introduce-skillsetworkbench-diagnostic-primitives` | pending | committed | M2 diagnostics |
-| 3 | SET-156 | `set-156-add-workbench-presets-rules-and-existing-lint-bridge` | pending | in progress | M2 presets and lint bridge |
-| 4 | SET-157 | `set-157-add-bun-yamltoml-and-markdown-parser-backed-workbench-checks` | pending | pending | M3 parsers |
+| 3 | SET-156 | `set-156-add-workbench-presets-rules-and-existing-lint-bridge` | pending | committed | M2 presets and lint bridge |
+| 4 | SET-157 | `set-157-add-bun-yamltoml-and-markdown-parser-backed-workbench-checks` | pending | in progress | M3 parsers |
 | 5 | SET-158 | `set-158-add-schema-backed-workbench-rules-for-source-contracts` | pending | pending | M3 schema |
 | 6 | SET-159 | `set-159-add-graph-and-provider-compatibility-workbench-rules` | pending | pending | M4 graph/provider |
 | 7 | SET-160 | `set-160-add-resource-and-runtime-workbench-rules` | pending | pending | M4 resource/runtime |
@@ -115,6 +115,28 @@ Use this as the durable execution ledger. For stacked work, this should normally
 - Blockers: none.
 ```
 
+```text
+2026-06-20 13:20 ET - SET-157 parser-backed syntax checks
+- Changed: Added Bun-backed JSON/YAML/TOML syntax parsing, Markdown frontmatter/body/heading extraction, and exported parser helpers to @skillset/workbench.
+- Changed: Refactored WorkbenchParseResult into a kind-discriminated union so later schema-backed rules can narrow by parse kind without optional-field ambiguity.
+- Fixed: Reviewer-raised parser issues by rejecting explicit null/scalar/array Markdown frontmatter, preserving literal trailing heading hashes, tracking Markdown fences by marker and length, and reporting multiline structured syntax diagnostics away from hard-coded line 1.
+- Decision: Bun parser error line/column fields can point at the TypeScript call site in this runtime, so parserErrorLocation trusts them only when they map back into the document and otherwise uses a syntax-focused document fallback.
+- Verified: Focused parser/Workbench tests, typecheck, changeset guard, and full `bun run check` passed with the new parser tests staged and included in the tracked-file test harness.
+- Review: Fresh SET-157 local re-review found TOML aggregate location and closing-fence edge cases; fixes are in progress.
+- Blockers: none.
+```
+
+```text
+2026-06-20 13:45 ET - SET-157 parser review fixes
+- Fixed: Read Bun TOML aggregate child error positions before generic parser-error metadata so non-dangling TOML syntax failures point at the document line instead of line 1.
+- Fixed: Required Markdown closing fences to contain only matching marker characters plus trailing spaces or tabs; info-string fence lines no longer close an active fence.
+- Fixed: Rejected CommonMark-invalid backtick opening fences whose info strings contain backticks so they do not suppress following headings.
+- Fixed: Accepted trailing spaces or tabs on frontmatter opening/closing delimiters.
+- Verified: Focused parser/Workbench tests, typecheck, and whitespace check passed after the fixes.
+- Review: Peirce and Avicenna re-reviews reached 5/5 with no remaining P0-P3 findings.
+- Blockers: none.
+```
+
 ## Local Review Log
 
 | Round | Scope / Lanes | Report Paths | P0/P1/P2/P3 Result | Fix Commits / Notes |
@@ -123,6 +145,8 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | 2 | SET-154 re-review | Main-agent read-only re-review after fixes | 5/5; no P0-P3 findings | Fixed final leftover `skillset build`/`check` generated AGENTS-size wording before scoring; full gate passed |
 | 3 | SET-155 diagnostics primitives | Subagent reports in thread: Mill, Huygens | 5/5; no P0-P3 findings | No fixes required after reviewer loop |
 | 4 | SET-156 presets and lint bridge | Subagent reports in thread: Meitner, Pasteur, Dewey | P1 stale selector/typecheck concerns; P3 strict rule-id selection semantics | Standardized on `ruleIds`, added exact strict rule-id selection coverage, made unchecked scope validation typecheck cleanly, and reached 5/5 re-review |
+| 5 | SET-157 parser-backed checks | Subagent reports in thread: Jason, Zeno | P2 parse-result optional bag, hard-coded syntax locations, nullable frontmatter, and heading hash stripping; P3 fence handling | Refactored parse result to a discriminated union, added document-oriented syntax locations, rejected non-object frontmatter, fixed heading hash handling, and tracked Markdown fences by marker/length |
+| 6 | SET-157 re-review | Subagent reports in thread: Avicenna, Peirce | P2 TOML aggregate locations and closing-fence info-string bug; P3 whitespace frontmatter delimiter and invalid backtick opening fence | Added aggregate child-position extraction, strict closing/opening fence detection, delimiter whitespace support, and focused regression tests |
 
 ## Verification Log
 
@@ -150,6 +174,17 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | `bun run typecheck --pretty false` | SET-156 typecheck | pass | `tsc --noEmit --pretty false` |
 | `bun run changeset:check` | SET-156 release guard | pass | 8 package-facing paths and 1 active changeset |
 | `bun run check` | full repo gate after SET-156 | pass | 549 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
+| `bun test packages/workbench/src/__tests__/parser.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-157 focused tests | pass | 20 pass, 0 fail |
+| `bun run typecheck --pretty false` | SET-157 typecheck | pass | `tsc --noEmit --pretty false` |
+| `bun run changeset:check` | SET-157 release guard | pass | 8 package-facing paths and 1 active changeset |
+| `bun run check` | full repo gate after SET-157 | pass | 564 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
+| `bun test packages/workbench/src/__tests__/parser.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-157 review fixes | pass | 21 pass, 0 fail |
+| `bun run typecheck --pretty false` | SET-157 review fixes | pass | `tsc --noEmit --pretty false` |
+| `git diff --check` | SET-157 review fixes | pass | no whitespace errors |
+| `bun test packages/workbench/src/__tests__/parser.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-157 P3 fence fix | pass | 21 pass, 0 fail |
+| `bun run typecheck --pretty false` | SET-157 P3 fence fix | pass | `tsc --noEmit --pretty false` |
+| `git diff --check` | SET-157 P3 fence fix | pass | no whitespace errors |
+| `bun run check` | full repo gate after SET-157 review fixes | pass | 565 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
 
 ## Remote Review / CI Log
 
@@ -172,6 +207,10 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Meitner | 3/5 | P1/P3 | Reported selector API drift and ambiguous strict rule-id selection semantics. | Align selector API and decide exact rule-id behavior. | Live code was already on `ruleIds`; kept `ruleIds` and changed exact rule-id selection to include strict diagnostics without requiring `preset: strict`. | Re-review passed |
 | Pasteur | 3/5 | P1 | Bad-scope runtime validation test used an unsafe readonly-to-mutable cast in an earlier snapshot. | Make frozen-array and unchecked-scope tests typecheck cleanly. | Rewrote unchecked scope test through `WorkbenchScopeSelection` and reran typecheck. | `bun run typecheck --pretty false` pass |
 | Dewey | 5/5 | none | No remaining P0-P3 findings after SET-156 fixes. | n/a | M2 SET-156 review loop clean. | Reviewer verified `ruleIds`, strict selection, typecheck, targeted tests, and no lock/package churn |
+| Jason | 3/5 | P2/P3 | Parse result API was an optional-field bag; headings stripped literal trailing hashes; syntax diagnostics stayed on line 1. | Refactor parser result into a discriminated union, fix heading hash handling, and extract or fallback parser locations. | Implemented discriminated parse-result variants, closing-sequence-only heading stripping, and document-oriented syntax location fallback. | Focused and full gates passed |
+| Zeno | 3/5 | P2/P3 | Invalid JSON/YAML/TOML diagnostics used line 1; null frontmatter was accepted; heading and fence parsing corrupted source facts. | Add multiline syntax location tests, reject non-object frontmatter, preserve literal heading hashes, and track fences by marker/length. | Added regression coverage and parser fixes for all reported cases. | Focused and full gates passed |
+| Avicenna | 5/5 | none | Closing fences with trailing info strings leaked headings; TOML aggregate errors still reported line 1; follow-up re-review found a narrow P3 invalid opening-fence edge. | Require closing fences to be same-marker same/longer and trailing whitespace only; read TOML aggregate child positions; reject backtick opening fences whose info strings contain backticks. | SET-157 Avicenna final re-review clean. | Focused tests, typecheck, staged whitespace, direct probe |
+| Peirce | 5/5 | none | No remaining P0-P3 findings after TOML aggregate and frontmatter delimiter fixes. | n/a | SET-157 Peirce re-review clean. | Focused tests, Workbench tests, typecheck, staged whitespace, direct probes |
 
 ## Forbidden Actions Audit
 

--- a/packages/workbench/src/__tests__/parser.test.ts
+++ b/packages/workbench/src/__tests__/parser.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkWorkbenchSyntax,
+  inferWorkbenchParseKind,
+  parseWorkbenchDocument,
+} from "../index";
+
+describe("workbench parser", () => {
+  test("infers parse kinds from paths", () => {
+    expect(inferWorkbenchParseKind("config.json")).toBe("json");
+    expect(inferWorkbenchParseKind(".skillset.lock")).toBe("json");
+    expect(inferWorkbenchParseKind("SKILL.md")).toBe("markdown");
+    expect(inferWorkbenchParseKind("notes.markdown")).toBe("markdown");
+    expect(inferWorkbenchParseKind("agent.toml")).toBe("toml");
+    expect(inferWorkbenchParseKind("skillset.yaml")).toBe("yaml");
+    expect(inferWorkbenchParseKind("skillset.yml")).toBe("yaml");
+    expect(inferWorkbenchParseKind("README.txt")).toBe("unknown");
+  });
+
+  test("parses valid JSON, YAML, and TOML with Bun-backed syntax checks", () => {
+    expect(checkWorkbenchSyntax({ content: `{"name":"demo"}`, path: "demo.json" })).toEqual([]);
+    expect(checkWorkbenchSyntax({ content: "name: demo\n", path: "demo.yaml" })).toEqual([]);
+    expect(checkWorkbenchSyntax({ content: 'name = "demo"\n', path: "demo.toml" })).toEqual([]);
+
+    const yamlParsed = parseWorkbenchDocument({ content: "name: demo\n", path: "demo.yaml" });
+    expect(yamlParsed.kind).toBe("yaml");
+    if (yamlParsed.kind !== "yaml") throw new Error("expected YAML parse result");
+    expect(yamlParsed.data).toEqual({
+      name: "demo",
+    });
+
+    const tomlParsed = parseWorkbenchDocument({ content: 'name = "demo"\n', path: "demo.toml" });
+    expect(tomlParsed.kind).toBe("toml");
+    if (tomlParsed.kind !== "toml") throw new Error("expected TOML parse result");
+    expect(tomlParsed.data).toEqual({
+      name: "demo",
+    });
+  });
+
+  test("reports structured syntax diagnostics for invalid JSON, YAML, and TOML", () => {
+    expect(
+      checkWorkbenchSyntax({ content: `{\n  "name": "demo",\n  "description":\n}`, path: "demo.json" })
+    ).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ line: 3, path: "demo.json" }),
+        ruleId: "syntax/json",
+        severity: "error",
+      })
+    );
+    expect(checkWorkbenchSyntax({ content: "name: demo\nsummary: [\n", path: "demo.yaml" })).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ line: 2, path: "demo.yaml" }),
+        ruleId: "syntax/yaml",
+        severity: "error",
+      })
+    );
+    expect(checkWorkbenchSyntax({ content: 'name = "demo"\nsummary =\n', path: "demo.toml" })).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ line: 2, path: "demo.toml" }),
+        ruleId: "syntax/toml",
+        severity: "error",
+      })
+    );
+    expect(
+      checkWorkbenchSyntax({ content: 'name = "demo"\n[section\nkey = 1\n', path: "demo.toml" })
+    ).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ line: 3, path: "demo.toml" }),
+        ruleId: "syntax/toml",
+        severity: "error",
+      })
+    );
+  });
+
+  test("parses Markdown frontmatter, body, and headings with source line facts", () => {
+    const parsed = parseWorkbenchDocument({
+      content: `---\nname: demo\ndescription: Demo skill.\n---\n\n# Title\n\nText.\n\n\`\`\`\n# Ignored\n\`\`\`\n\n## Next\n`,
+      path: "SKILL.md",
+    });
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.kind).toBe("markdown");
+    if (parsed.kind !== "markdown") throw new Error("expected markdown parse result");
+    expect(parsed.frontmatter).toEqual({
+      description: "Demo skill.",
+      name: "demo",
+    });
+    expect(parsed.bodyStartLine).toBe(5);
+    expect(parsed.headings).toEqual([
+      { depth: 1, line: 6, text: "Title" },
+      { depth: 2, line: 14, text: "Next" },
+    ]);
+  });
+
+  test("preserves heading text hashes unless they are a Markdown closing sequence", () => {
+    const parsed = parseWorkbenchDocument({
+      content: "# C#\n# Title###\n# Title ###\n",
+      path: "README.md",
+    });
+
+    expect(parsed.kind).toBe("markdown");
+    if (parsed.kind !== "markdown") throw new Error("expected markdown parse result");
+    expect(parsed.headings).toEqual([
+      { depth: 1, line: 1, text: "C#" },
+      { depth: 1, line: 2, text: "Title###" },
+      { depth: 1, line: 3, text: "Title" },
+    ]);
+  });
+
+  test("ignores headings inside matching Markdown fences only", () => {
+    const parsed = parseWorkbenchDocument({
+      content:
+        "````\n# ignored\n```\n# still ignored\n````\n# visible\n~~~\n# tilde ignored\n```\n# still tilde ignored\n~~~\n# also visible\n    ```\n# indented fence marker is visible\n```ts\n# hidden\n``` ts\n# still hidden\n```\n# final visible\n``` ```\n# invalid opening fence keeps this visible\n",
+      path: "README.md",
+    });
+
+    expect(parsed.kind).toBe("markdown");
+    if (parsed.kind !== "markdown") throw new Error("expected markdown parse result");
+    expect(parsed.headings).toEqual([
+      { depth: 1, line: 6, text: "visible" },
+      { depth: 1, line: 12, text: "also visible" },
+      { depth: 1, line: 14, text: "indented fence marker is visible" },
+      { depth: 1, line: 20, text: "final visible" },
+      { depth: 1, line: 22, text: "invalid opening fence keeps this visible" },
+    ]);
+  });
+
+  test("reports Markdown frontmatter syntax diagnostics", () => {
+    expect(checkWorkbenchSyntax({ content: "---\nname: demo\n", path: "SKILL.md" })).toEqual([
+      expect.objectContaining({
+        location: { line: 1, path: "SKILL.md" },
+        ruleId: "syntax/markdown-frontmatter",
+      }),
+    ]);
+
+    expect(checkWorkbenchSyntax({ content: "---\nname: [\n---\nBody\n", path: "SKILL.md" })).toEqual([
+      expect.objectContaining({
+        location: { line: 2, path: "SKILL.md" },
+        ruleId: "syntax/markdown-frontmatter",
+      }),
+    ]);
+
+    for (const frontmatter of ["- nope", "null", "42", "plain scalar"]) {
+      expect(
+        checkWorkbenchSyntax({ content: `---\n${frontmatter}\n---\nBody\n`, path: "SKILL.md" })
+      ).toEqual([
+        expect.objectContaining({
+          location: { line: 2, path: "SKILL.md" },
+          message: "frontmatter must be a YAML object",
+          ruleId: "syntax/markdown-frontmatter",
+        }),
+      ]);
+    }
+  });
+
+  test("accepts frontmatter delimiters with trailing whitespace", () => {
+    const parsed = parseWorkbenchDocument({
+      content: "---   \nname: demo\n---\t\n# Title\n",
+      path: "SKILL.md",
+    });
+
+    expect(parsed.kind).toBe("markdown");
+    if (parsed.kind !== "markdown") throw new Error("expected markdown parse result");
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.frontmatter).toEqual({ name: "demo" });
+    expect(parsed.headings).toEqual([{ depth: 1, line: 4, text: "Title" }]);
+  });
+});

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -17,6 +17,11 @@ export {
   WORKBENCH_SCOPE_IDS,
 } from "./presets";
 export {
+  checkWorkbenchSyntax,
+  inferWorkbenchParseKind,
+  parseWorkbenchDocument,
+} from "./parser";
+export {
   compareWorkbenchDiagnostics,
   createWorkbenchDiagnostic,
   formatWorkbenchDiagnostic,
@@ -27,7 +32,12 @@ export type {
   WorkbenchDiagnostic,
   WorkbenchDiagnosticSelection,
   WorkbenchFix,
+  WorkbenchJsonParseResult,
   WorkbenchLocation,
+  WorkbenchMarkdownHeading,
+  WorkbenchMarkdownParseResult,
+  WorkbenchParseKind,
+  WorkbenchParseResult,
   WorkbenchPreset,
   WorkbenchPresetId,
   WorkbenchRuleMetadata,
@@ -36,4 +46,7 @@ export type {
   WorkbenchScope,
   WorkbenchSeverity,
   WorkbenchSubject,
+  WorkbenchTomlParseResult,
+  WorkbenchUnknownParseResult,
+  WorkbenchYamlParseResult,
 } from "./types";

--- a/packages/workbench/src/parser.ts
+++ b/packages/workbench/src/parser.ts
@@ -1,0 +1,348 @@
+import { createWorkbenchDiagnostic } from "./diagnostics";
+import type {
+  WorkbenchDiagnostic,
+  WorkbenchMarkdownHeading,
+  WorkbenchParseKind,
+  WorkbenchParseResult,
+} from "./types";
+
+interface ParserErrorLocation {
+  readonly column?: number;
+  readonly line: number;
+}
+
+interface MarkdownFence {
+  readonly length: number;
+  readonly marker: "`" | "~";
+}
+
+export function inferWorkbenchParseKind(path: string): WorkbenchParseKind {
+  if (path.endsWith(".json") || path.endsWith(".skillset.lock")) return "json";
+  if (path.endsWith(".md") || path.endsWith(".markdown")) return "markdown";
+  if (path.endsWith(".toml")) return "toml";
+  if (path.endsWith(".yaml") || path.endsWith(".yml")) return "yaml";
+  return "unknown";
+}
+
+export function parseWorkbenchDocument(args: {
+  readonly content: string;
+  readonly kind?: WorkbenchParseKind;
+  readonly path: string;
+}): WorkbenchParseResult {
+  const kind = args.kind ?? inferWorkbenchParseKind(args.path);
+  if (kind === "json") return parseJson(args.path, args.content);
+  if (kind === "markdown") return parseMarkdown(args.path, args.content);
+  if (kind === "toml") return parseToml(args.path, args.content);
+  if (kind === "yaml") return parseYaml(args.path, args.content);
+  return { diagnostics: [], kind, path: args.path };
+}
+
+export function checkWorkbenchSyntax(args: {
+  readonly content: string;
+  readonly kind?: WorkbenchParseKind;
+  readonly path: string;
+}): readonly WorkbenchDiagnostic[] {
+  return parseWorkbenchDocument(args).diagnostics;
+}
+
+function parseJson(path: string, content: string): WorkbenchParseResult {
+  try {
+    return { data: JSON.parse(content) as unknown, diagnostics: [], kind: "json", path };
+  } catch (error) {
+    return {
+      diagnostics: [
+        syntaxDiagnostic(path, "syntax/json", errorMessage(error), parserErrorLocation(error, content)),
+      ],
+      kind: "json",
+      path,
+    };
+  }
+}
+
+function parseToml(path: string, content: string): WorkbenchParseResult {
+  try {
+    return { data: Bun.TOML.parse(content) as unknown, diagnostics: [], kind: "toml", path };
+  } catch (error) {
+    return {
+      diagnostics: [
+        syntaxDiagnostic(path, "syntax/toml", errorMessage(error), parserErrorLocation(error, content)),
+      ],
+      kind: "toml",
+      path,
+    };
+  }
+}
+
+function parseYaml(path: string, content: string): WorkbenchParseResult {
+  try {
+    return { data: Bun.YAML.parse(content) as unknown, diagnostics: [], kind: "yaml", path };
+  } catch (error) {
+    return {
+      diagnostics: [
+        syntaxDiagnostic(path, "syntax/yaml", errorMessage(error), parserErrorLocation(error, content)),
+      ],
+      kind: "yaml",
+      path,
+    };
+  }
+}
+
+function parseMarkdown(path: string, content: string): WorkbenchParseResult {
+  const normalized = content.replaceAll(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  if (!isFrontmatterDelimiter(lines[0] ?? "")) {
+    return {
+      body: normalized,
+      bodyStartLine: 1,
+      diagnostics: [],
+      headings: markdownHeadings(lines, 1),
+      kind: "markdown",
+      path,
+    };
+  }
+
+  const closingIndex = lines.findIndex(
+    (line, index) => index > 0 && isFrontmatterDelimiter(line)
+  );
+  if (closingIndex === -1) {
+    return {
+      diagnostics: [
+        syntaxDiagnostic(
+          path,
+          "syntax/markdown-frontmatter",
+          "frontmatter starts with --- but never closes",
+          { line: 1 }
+        ),
+      ],
+      headings: [],
+      kind: "markdown",
+      path,
+    };
+  }
+
+  const frontmatterText = lines.slice(1, closingIndex).join("\n");
+  const bodyLines = lines.slice(closingIndex + 1);
+  const bodyStartLine = closingIndex + 2;
+  const body = bodyLines.join("\n");
+
+  let parsed: unknown;
+  try {
+    parsed = frontmatterText.trim() === "" ? {} : Bun.YAML.parse(frontmatterText);
+  } catch (error) {
+    const location = parserErrorLocation(error, frontmatterText);
+    return {
+      body,
+      bodyStartLine,
+      diagnostics: [
+        syntaxDiagnostic(path, "syntax/markdown-frontmatter", errorMessage(error), {
+          ...location,
+          line: location.line + 1,
+        }),
+      ],
+      headings: markdownHeadings(bodyLines, bodyStartLine),
+      kind: "markdown",
+      path,
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      body,
+      bodyStartLine,
+      diagnostics: [
+        syntaxDiagnostic(path, "syntax/markdown-frontmatter", "frontmatter must be a YAML object", {
+          line: 2,
+        }),
+      ],
+      headings: markdownHeadings(bodyLines, bodyStartLine),
+      kind: "markdown",
+      path,
+    };
+  }
+
+  return {
+    body,
+    bodyStartLine,
+    diagnostics: [],
+    frontmatter: parsed ?? {},
+    headings: markdownHeadings(bodyLines, bodyStartLine),
+    kind: "markdown",
+    path,
+  };
+}
+
+function markdownHeadings(
+  lines: readonly string[],
+  startLine: number
+): readonly WorkbenchMarkdownHeading[] {
+  const headings: WorkbenchMarkdownHeading[] = [];
+  let fence: MarkdownFence | undefined;
+  for (const [index, line] of lines.entries()) {
+    if (fence !== undefined) {
+      if (closesFence(line, fence)) fence = undefined;
+      continue;
+    }
+
+    const openedFence = readFence(line);
+    if (openedFence !== undefined) {
+      fence = openedFence;
+      continue;
+    }
+
+    const heading = parseMarkdownHeading(line);
+    if (heading === undefined) continue;
+    headings.push({
+      depth: heading.depth,
+      line: startLine + index,
+      text: heading.text,
+    });
+  }
+  return headings;
+}
+
+function parseMarkdownHeading(line: string): Pick<WorkbenchMarkdownHeading, "depth" | "text"> | undefined {
+  const match = /^(#{1,6})(?:[ \t]+|$)(.*)$/u.exec(line);
+  if (match === null) return undefined;
+
+  let text = match[2]!.trimEnd();
+  const closingSequence = /[ \t]+#{1,}[ \t]*$/u.exec(text);
+  if (closingSequence !== null) {
+    text = text.slice(0, closingSequence.index).trimEnd();
+  }
+
+  return { depth: match[1]!.length, text };
+}
+
+function readFence(line: string): MarkdownFence | undefined {
+  const match = /^( {0,3})(`{3,}|~{3,})(.*)$/u.exec(line);
+  if (match === null) return undefined;
+  const sequence = match[2]!;
+  const marker = sequence[0] as "`" | "~";
+  const info = match[3]!;
+  if (marker === "`" && info.includes("`")) return undefined;
+  return { length: sequence.length, marker };
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const candidate = readClosingFence(line);
+  return candidate?.marker === fence.marker && candidate.length >= fence.length;
+}
+
+function readClosingFence(line: string): MarkdownFence | undefined {
+  const match = /^( {0,3})(`{3,}|~{3,})[ \t]*$/u.exec(line);
+  if (match === null) return undefined;
+  const sequence = match[2]!;
+  return { length: sequence.length, marker: sequence[0] as "`" | "~" };
+}
+
+function isFrontmatterDelimiter(line: string): boolean {
+  return /^---[ \t]*$/u.test(line);
+}
+
+function syntaxDiagnostic(
+  path: string,
+  ruleId: string,
+  message: string,
+  location: ParserErrorLocation
+): WorkbenchDiagnostic {
+  return createWorkbenchDiagnostic({
+    location: { ...location, path },
+    message,
+    ruleId,
+    scope: "source",
+    severity: "error",
+    subject: { kind: "file", path },
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parserErrorLocation(error: unknown, content: string): ParserErrorLocation {
+  const lines = content.replaceAll(/\r\n?/g, "\n").split("\n");
+  const fallback = fallbackSyntaxLocation(lines);
+  if (typeof error !== "object" || error === null) return fallback;
+  const aggregateLocation = aggregateErrorLocation(error, lines);
+  if (aggregateLocation !== undefined) return aggregateLocation;
+
+  const record = error as { column?: unknown; line?: unknown; sourceURL?: unknown };
+  if (typeof record.sourceURL === "string") return fallback;
+  const line = typeof record.line === "number" && Number.isFinite(record.line) ? record.line + 1 : 1;
+  const column =
+    typeof record.column === "number" && Number.isFinite(record.column)
+      ? record.column + 1
+      : undefined;
+  const lineText = lines[line - 1];
+  if (lineText === undefined) return fallback;
+  const hasDocumentColumn = column === undefined || column <= lineText.length + 1;
+  if (!hasDocumentColumn) return fallback;
+  return column === undefined ? { line } : { column, line };
+}
+
+function aggregateErrorLocation(error: object, lines: readonly string[]): ParserErrorLocation | undefined {
+  const aggregate = error as { errors?: unknown };
+  if (!Array.isArray(aggregate.errors)) return undefined;
+  for (const child of aggregate.errors) {
+    const location = childErrorLocation(child, lines);
+    if (location !== undefined) return location;
+  }
+  return undefined;
+}
+
+function childErrorLocation(error: unknown, lines: readonly string[]): ParserErrorLocation | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const record = error as { column?: unknown; line?: unknown; position?: unknown };
+  const position = readPositionLocation(record.position, lines);
+  if (position !== undefined) return position;
+
+  const line = typeof record.line === "number" && Number.isFinite(record.line) ? record.line + 1 : 1;
+  const column =
+    typeof record.column === "number" && Number.isFinite(record.column)
+      ? record.column + 1
+      : undefined;
+  return documentLocation(line, column, lines);
+}
+
+function readPositionLocation(position: unknown, lines: readonly string[]): ParserErrorLocation | undefined {
+  if (typeof position !== "object" || position === null) return undefined;
+  const record = position as { column?: unknown; line?: unknown };
+  const line = typeof record.line === "number" && Number.isFinite(record.line) ? record.line : 1;
+  const column =
+    typeof record.column === "number" && Number.isFinite(record.column)
+      ? record.column
+      : undefined;
+  return documentLocation(line, column, lines);
+}
+
+function documentLocation(
+  line: number,
+  column: number | undefined,
+  lines: readonly string[]
+): ParserErrorLocation | undefined {
+  const lineText = lines[line - 1];
+  if (lineText === undefined) return undefined;
+  if (column !== undefined && column > lineText.length + 1) return undefined;
+  return column === undefined ? { line } : { column, line };
+}
+
+function fallbackSyntaxLocation(lines: readonly string[]): ParserErrorLocation {
+  const danglingAssignment = lines.findIndex((line) =>
+    /(?:^|\s)(?:"[^"]+"|[A-Za-z0-9_-]+)\s*[:=]\s*$/u.test(line)
+  );
+  if (danglingAssignment !== -1) return { line: danglingAssignment + 1 };
+
+  const danglingCollection = lines.findIndex((line) =>
+    /(?:^|\s)(?:"[^"]+"|[A-Za-z0-9_-]+)\s*[:=]\s*[[{]\s*$/u.test(line)
+  );
+  if (danglingCollection !== -1) return { line: danglingCollection + 1 };
+
+  const firstNonEmptyLine = lines.findIndex((line) => line.trim() !== "");
+  if (firstNonEmptyLine !== -1) return { line: firstNonEmptyLine + 1 };
+
+  return { line: 1 };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/workbench/src/types.ts
+++ b/packages/workbench/src/types.ts
@@ -4,6 +4,8 @@ export type WorkbenchPresetId = "standard" | "strict";
 
 export type WorkbenchRuleLevel = "standard" | "strict";
 
+export type WorkbenchParseKind = "json" | "markdown" | "toml" | "unknown" | "yaml";
+
 export type WorkbenchScope =
   | "generated"
   | "provider"
@@ -65,6 +67,56 @@ export interface WorkbenchDiagnostic {
   readonly scope: WorkbenchScope;
   readonly severity: WorkbenchSeverity;
   readonly subject: WorkbenchSubject;
+}
+
+export interface WorkbenchMarkdownHeading {
+  readonly depth: number;
+  readonly line: number;
+  readonly text: string;
+}
+
+export type WorkbenchParseResult =
+  | WorkbenchJsonParseResult
+  | WorkbenchMarkdownParseResult
+  | WorkbenchTomlParseResult
+  | WorkbenchUnknownParseResult
+  | WorkbenchYamlParseResult;
+
+export interface WorkbenchJsonParseResult {
+  readonly data?: unknown;
+  readonly diagnostics: readonly WorkbenchDiagnostic[];
+  readonly kind: "json";
+  readonly path: string;
+}
+
+export interface WorkbenchYamlParseResult {
+  readonly data?: unknown;
+  readonly diagnostics: readonly WorkbenchDiagnostic[];
+  readonly kind: "yaml";
+  readonly path: string;
+}
+
+export interface WorkbenchTomlParseResult {
+  readonly data?: unknown;
+  readonly diagnostics: readonly WorkbenchDiagnostic[];
+  readonly kind: "toml";
+  readonly path: string;
+}
+
+export interface WorkbenchMarkdownParseResult {
+  readonly body?: string;
+  readonly bodyStartLine?: number;
+  readonly diagnostics: readonly WorkbenchDiagnostic[];
+  readonly frontmatter?: Record<string, unknown>;
+  readonly headings: readonly WorkbenchMarkdownHeading[];
+  readonly kind: "markdown";
+  readonly path: string;
+}
+
+export interface WorkbenchUnknownParseResult {
+  readonly diagnostics: readonly WorkbenchDiagnostic[];
+  readonly kind: "unknown";
+  readonly path: string;
 }
 
 export interface WorkbenchRunResult {


### PR DESCRIPTION
## Context

This branch gives Workbench real parser-backed checks for source files instead of string-only validation.

## Changes

- Adds Bun-backed YAML, TOML, and JSON parsing checks.
- Adds Markdown/frontmatter parsing checks for source files.
- Normalizes parse failures into Workbench diagnostics.

## Verification

- Local reviewer loop completed with final 5/5 and no P0-P3 findings.
- `bun run check`
- `bun run hooks:pre-push`
- Hosted CI required before leaving draft.

## Risks

Parser behavior is intentionally bounded to correctness diagnostics; formatting/fix behavior remains out of scope.
