### PR TITLE
feat(workbench): add resource and runtime diagnostics

### DIFF
--- a/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
+++ b/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
@@ -210,6 +210,13 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | `bun run typecheck --pretty false` | SET-159 typecheck | pass | `tsc --noEmit --pretty false` |
 | `bun run changeset:check` | SET-159 release guard | pass | 8 package-facing paths and 1 active changeset |
 | `bun run check` | full repo gate after SET-159 | pass | 577 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
+| `bun test packages/workbench/src/__tests__/*.test.ts` | SET-160 focused tests | pass | 37 pass, 0 fail |
+| `bun run typecheck` | SET-160 typecheck | pass | `tsc --noEmit` |
+| `bun run changeset:check` | SET-160 release guard | pass | 8 package-facing paths and 1 active changeset |
+| `git diff --check` | SET-160 whitespace guard | pass | no whitespace errors |
+| `bun run check` | full repo gate after SET-160 staged files | pass | 581 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
+| `bun test packages/workbench/src/__tests__/resource-runtime.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-160 P3 test-title fix | pass | 37 pass, 0 fail |
+| `bun run typecheck && git diff --check --cached` | SET-160 P3 test-title fix | pass | typecheck and staged whitespace clean |
 
 ## Remote Review / CI Log
 
@@ -244,6 +251,10 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Mencius | 5/5 | none | No remaining P0-P3 findings after the workspace allowlist correction. | n/a | SET-158 final Mencius re-review clean. | Focused Workbench tests, typecheck, staged whitespace, direct workspace-config probe |
 | Darwin | 5/5 | none | No remaining P0-P3 findings for the Workbench compatibility bridge. | n/a | SET-159 Darwin review clean. | Focused Workbench tests, typecheck, staged whitespace, changeset guard |
 | Noether | 5/5 | none | No remaining P0-P3 findings for the Workbench compatibility bridge API and tests. | n/a | SET-159 Noether review clean. | Focused compatibility tests, all Workbench tests, typecheck, staged whitespace |
+| Bernoulli | 5/5 | none | No P0-P3 findings for the Workbench resource/runtime bridge. | n/a | SET-160 Bernoulli review clean. | Focused resource-runtime test and typecheck pass |
+| Pauli | 5/5 | none | No P0-P3 findings for API shape, diagnostic semantics, and no-overreach boundary. | n/a | SET-160 Pauli review clean. | Focused resource-runtime tests, all Workbench tests, and typecheck pass |
+| Epicurus | 4.8/5 | P3 | Runtime-filter test title said strict selection while asserting standard selection. | Rename the title to match the standard selection assertion. | Test now says standard selection. | Focused Workbench tests and typecheck pass |
+| Parfit | 5/5 | none | No P0-P3 findings after reviewing the untracked implementation and test files directly. | n/a | SET-160 Parfit review clean. | Focused resource-runtime test pass |
 
 ## Forbidden Actions Audit
 

--- a/packages/workbench/src/__tests__/resource-runtime.test.ts
+++ b/packages/workbench/src/__tests__/resource-runtime.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  LintIssue,
+  SkillsetFeatureEntry,
+} from "@skillset/core";
+
+import {
+  formatWorkbenchDiagnostic,
+  selectWorkbenchDiagnostics,
+  workbenchDiagnosticsFromResourceLintIssues,
+  workbenchDiagnosticsFromRuntimeSupport,
+} from "../index";
+
+describe("resource and runtime diagnostics", () => {
+  test("maps only resource lint issues into resource diagnostics", () => {
+    const issues = [
+      {
+        code: "hook-target-incompatible",
+        featureId: "plugin-hooks",
+        message: "Hook cannot render for codex.",
+        path: ".skillset/src/plugins/demo/hooks/hooks.json",
+        severity: "error",
+      },
+      {
+        code: "resource-undeclared-link",
+        featureId: "resources",
+        message: ".skillset/src/skills/demo/SKILL.md links to undeclared resource ./scripts/run.sh",
+        path: ".skillset/src/skills/demo/SKILL.md",
+        severity: "error",
+      },
+      {
+        code: "resource-script-not-executable",
+        featureId: "resources",
+        message: "Script resource is not executable.",
+        path: ".skillset/src/skills/demo/SKILL.md",
+        severity: "warn",
+      },
+    ] satisfies readonly LintIssue[];
+
+    const diagnostics = workbenchDiagnosticsFromResourceLintIssues(issues);
+
+    expect(diagnostics.map(formatWorkbenchDiagnostic)).toEqual([
+      ".skillset/src/skills/demo/SKILL.md: warning: resource/resource-script-not-executable: Script resource is not executable.",
+      ".skillset/src/skills/demo/SKILL.md: error: resource/resource-undeclared-link: .skillset/src/skills/demo/SKILL.md links to undeclared resource ./scripts/run.sh",
+    ]);
+    expect(diagnostics.every((diagnostic) => diagnostic.scope === "resource")).toBeTrue();
+    expect(diagnostics.every((diagnostic) => diagnostic.subject.kind === "resource")).toBeTrue();
+  });
+
+  test("accepts resource diagnostics identified by legacy resource codes", () => {
+    const diagnostics = workbenchDiagnosticsFromResourceLintIssues([
+      {
+        code: "skill-plugin-root-script",
+        message: "Skill links to plugin-root script path.",
+        path: ".skillset/src/plugins/demo/skills/tool/SKILL.md",
+        severity: "error",
+      },
+    ]);
+
+    expect(formatWorkbenchDiagnostic(diagnostics[0]!)).toBe(
+      ".skillset/src/plugins/demo/skills/tool/SKILL.md: error: resource/skill-plugin-root-script: Skill links to plugin-root script path."
+    );
+  });
+
+  test("maps explicit runtime diagnostics and keeps caveats as help", () => {
+    const diagnostics = workbenchDiagnosticsFromRuntimeSupport(
+      [
+        feature({
+          id: "project-agents",
+          runtimeSupport: {
+            "codex-cli": {
+              caveats: ["Skill loading is instruction-guided rather than runtime-enforced."],
+              diagnostics: ["Skill-loading intent is not enforced by Codex metadata."],
+              evidence: [{ kind: "docs", ref: "docs/features/agents.md" }],
+              mechanism: "Render a deterministic instruction preface.",
+              status: "shimmed",
+            },
+            "claude-code": {
+              mechanism: "Claude reads project agents natively.",
+              status: "native",
+            },
+          },
+        }),
+      ],
+      { locationPath: "docs/features/runtime-adapters.md" }
+    );
+
+    expect(diagnostics.map(formatWorkbenchDiagnostic)).toEqual([
+      "docs/features/runtime-adapters.md: warning: runtime/shimmed: codex-cli project-agents: Skill-loading intent is not enforced by Codex metadata.",
+    ]);
+    expect(diagnostics[0]).toMatchObject({
+      featureId: "project-agents",
+      help: [
+        "Mechanism: Render a deterministic instruction preface.",
+        "Caveat: Skill loading is instruction-guided rather than runtime-enforced.",
+        "Evidence: docs docs/features/agents.md",
+      ],
+      scope: "runtime",
+      subject: {
+        id: "project-agents:codex-cli",
+        kind: "runtime-support",
+      },
+    });
+  });
+
+  test("filters runtime diagnostics by runtime and participates in standard selection", () => {
+    const diagnostics = workbenchDiagnosticsFromRuntimeSupport(
+      [
+        feature({
+          id: "runtime-adapters",
+          runtimeSupport: {
+            "codex-cli": {
+              diagnostics: ["Codex diagnostic."],
+              status: "native",
+            },
+            "gemini-cli": {
+              diagnostics: ["Gemini diagnostic."],
+              reason: "Gemini adapter is planned.",
+              setup: ["Install Gemini CLI separately."],
+              status: "planned",
+            },
+          },
+        }),
+      ],
+      { runtimes: ["gemini-cli"] }
+    );
+
+    expect(diagnostics.map(formatWorkbenchDiagnostic)).toEqual([
+      "warning: runtime/planned: gemini-cli runtime-adapters: Gemini diagnostic.",
+    ]);
+    expect(diagnostics[0]?.help).toEqual([
+      "Reason: Gemini adapter is planned.",
+      "Setup: Install Gemini CLI separately.",
+    ]);
+    expect(selectWorkbenchDiagnostics(diagnostics, { preset: "standard" })).toEqual(diagnostics);
+  });
+});
+
+function feature(
+  overrides: Pick<SkillsetFeatureEntry, "id"> &
+    Partial<Omit<SkillsetFeatureEntry, "id">>
+): SkillsetFeatureEntry {
+  const { id, ...rest } = overrides;
+  return {
+    docs: ["docs/features/test.md"],
+    evidence: [],
+    id,
+    kind: "workflow",
+    renderOwner: "packages/core/src/test.ts",
+    sourceShape: ".skillset/src/test",
+    status: "implemented",
+    summary: "Test feature.",
+    targetSupport: {
+      claude: { status: "native" },
+      codex: { status: "native" },
+    },
+    title: "Test Feature",
+    validationOwner: "packages/core/src/test.ts",
+    ...rest,
+  };
+}

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -12,6 +12,12 @@ export {
   type WorkbenchCompatibilityDiagnosticOptions,
 } from "./compatibility";
 export {
+  workbenchDiagnosticsFromResourceLintIssues,
+  workbenchDiagnosticsFromRuntimeSupport,
+  type WorkbenchResourceDiagnosticOptions,
+  type WorkbenchRuntimeSupportDiagnosticOptions,
+} from "./resource-runtime";
+export {
   getWorkbenchPreset,
   isWorkbenchPresetId,
   isWorkbenchScope,

--- a/packages/workbench/src/resource-runtime.ts
+++ b/packages/workbench/src/resource-runtime.ts
@@ -1,0 +1,133 @@
+import type {
+  LintIssue,
+  SkillsetFeatureEntry,
+  SkillsetRuntimeId,
+  SkillsetRuntimeSupport,
+} from "@skillset/core";
+
+import { createWorkbenchDiagnostic, sortWorkbenchDiagnostics } from "./diagnostics";
+import type {
+  WorkbenchDiagnostic,
+  WorkbenchLocation,
+  WorkbenchSeverity,
+} from "./types";
+
+const RESOURCE_LINT_CODES = new Set([
+  "resource-script-not-executable",
+  "resource-undeclared-link",
+  "skill-plugin-root-script",
+]);
+
+export interface WorkbenchResourceDiagnosticOptions {
+  readonly rulePrefix?: string;
+}
+
+export interface WorkbenchRuntimeSupportDiagnosticOptions {
+  readonly locationPath?: string;
+  readonly runtimes?: readonly SkillsetRuntimeId[];
+}
+
+export function workbenchDiagnosticsFromResourceLintIssues(
+  issues: readonly LintIssue[],
+  options: WorkbenchResourceDiagnosticOptions = {}
+): readonly WorkbenchDiagnostic[] {
+  const rulePrefix = options.rulePrefix ?? "resource";
+  const diagnostics = issues
+    .filter(isResourceLintIssue)
+    .map((issue) => resourceLintDiagnostic(issue, rulePrefix));
+  return sortWorkbenchDiagnostics(diagnostics);
+}
+
+export function workbenchDiagnosticsFromRuntimeSupport(
+  features: readonly SkillsetFeatureEntry[],
+  options: WorkbenchRuntimeSupportDiagnosticOptions = {}
+): readonly WorkbenchDiagnostic[] {
+  const runtimeFilter = options.runtimes === undefined ? undefined : new Set(options.runtimes);
+  const diagnostics: WorkbenchDiagnostic[] = [];
+
+  for (const feature of features) {
+    const supportEntries = Object.entries(feature.runtimeSupport ?? {}) as readonly [
+      SkillsetRuntimeId,
+      SkillsetRuntimeSupport,
+    ][];
+
+    for (const [runtime, support] of supportEntries) {
+      if (runtimeFilter !== undefined && !runtimeFilter.has(runtime)) continue;
+      diagnostics.push(...runtimeSupportDiagnostics(feature, runtime, support, options));
+    }
+  }
+
+  return sortWorkbenchDiagnostics(diagnostics);
+}
+
+function isResourceLintIssue(issue: LintIssue): boolean {
+  return issue.featureId === "resources" || RESOURCE_LINT_CODES.has(issue.code);
+}
+
+function resourceLintDiagnostic(
+  issue: LintIssue,
+  rulePrefix: string
+): WorkbenchDiagnostic {
+  return createWorkbenchDiagnostic({
+    ...(issue.featureId === undefined ? {} : { featureId: issue.featureId }),
+    location: { path: issue.path },
+    message: issue.message,
+    ruleId: `${rulePrefix}/${issue.code}`,
+    scope: "resource",
+    severity: lintSeverity(issue.severity),
+    subject: { kind: "resource", path: issue.path },
+  });
+}
+
+function runtimeSupportDiagnostics(
+  feature: SkillsetFeatureEntry,
+  runtime: SkillsetRuntimeId,
+  support: SkillsetRuntimeSupport,
+  options: WorkbenchRuntimeSupportDiagnosticOptions
+): readonly WorkbenchDiagnostic[] {
+  const diagnostics: WorkbenchDiagnostic[] = [];
+  const diagnosticLocation = location(options);
+  const help = runtimeHelp(support);
+
+  for (const diagnostic of support.diagnostics ?? []) {
+    diagnostics.push(createWorkbenchDiagnostic({
+      featureId: feature.id,
+      ...(help === undefined ? {} : { help }),
+      ...(diagnosticLocation === undefined ? {} : { location: diagnosticLocation }),
+      message: `${runtime} ${feature.id}: ${diagnostic}`,
+      ruleId: `runtime/${support.status}`,
+      scope: "runtime",
+      severity: "warning",
+      subject: {
+        id: `${feature.id}:${runtime}`,
+        kind: "runtime-support",
+      },
+    }));
+  }
+
+  return diagnostics;
+}
+
+function runtimeHelp(support: SkillsetRuntimeSupport): readonly string[] | undefined {
+  const help = [
+    support.mechanism === undefined ? undefined : `Mechanism: ${support.mechanism}`,
+    support.reason === undefined ? undefined : `Reason: ${support.reason}`,
+    ...(support.setup ?? []).map((step) => `Setup: ${step}`),
+    ...(support.caveats ?? []).map((caveat) => `Caveat: ${caveat}`),
+    ...(support.evidence ?? []).map((evidence) => {
+      const suffix = evidence.note === undefined ? "" : ` (${evidence.note})`;
+      return `Evidence: ${evidence.kind} ${evidence.ref}${suffix}`;
+    }),
+  ].filter((value): value is string => value !== undefined);
+
+  return help.length === 0 ? undefined : help;
+}
+
+function lintSeverity(severity: LintIssue["severity"]): WorkbenchSeverity {
+  return severity === "warn" ? "warning" : "error";
+}
+
+function location(options: WorkbenchRuntimeSupportDiagnosticOptions): WorkbenchLocation | undefined {
+  if (options.locationPath === undefined) return undefined;
+  return { path: options.locationPath };
+}


### PR DESCRIPTION
## Context

This branch extends Workbench into resource and runtime-adjacent checks that are common sources of broken skillsets.

## Changes

- Adds resource diagnostics for referenced files and related source assets.
- Adds runtime-oriented diagnostics for source shapes that compile but would be brittle or incomplete.
- Extends tests for bad and good resource/runtime inputs.

## Verification

- Local reviewer loop completed with final 5/5 and no P0-P3 findings.
- `bun run check`
- `bun run hooks:pre-push`
- Hosted CI required before leaving draft.

## Risks

Diagnostics are conservative by design; provider-specific behavior should stay precise rather than speculative.
