### PR TITLE
test(workbench): add source fixture suite

### DIFF
--- a/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
+++ b/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
@@ -217,6 +217,14 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | `bun run check` | full repo gate after SET-160 staged files | pass | 581 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
 | `bun test packages/workbench/src/__tests__/resource-runtime.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-160 P3 test-title fix | pass | 37 pass, 0 fail |
 | `bun run typecheck && git diff --check --cached` | SET-160 P3 test-title fix | pass | typecheck and staged whitespace clean |
+| `bun test packages/workbench/src/__tests__/fixtures.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-161 focused fixture tests | pass | 39 pass, 0 fail |
+| `bun run typecheck` | SET-161 typecheck | pass | `tsc --noEmit` |
+| `bun run changeset:check` | SET-161 release guard | pass | 8 package-facing paths and 1 active changeset |
+| `git diff --check` | SET-161 whitespace guard | pass | no whitespace errors |
+| `bun run check` | full repo gate after SET-161 initial implementation | pass | 583 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
+| `bun test packages/workbench/src/__tests__/fixtures.test.ts packages/workbench/src/__tests__/*.test.ts` | SET-161 resource-fixture review fixes | pass | 39 pass, 0 fail |
+| `bun run typecheck` | SET-161 resource-fixture review fixes | pass | `tsc --noEmit` |
+| `bun run check` | full repo gate after SET-161 review fixes | pass | 583 pass, 0 fail; Ultracite doctor clean; `skillset check` checked 5 source skills; `skillset verify` verified 51 generated files; terminology guard clean |
 
 ## Remote Review / CI Log
 
@@ -255,6 +263,9 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Pauli | 5/5 | none | No P0-P3 findings for API shape, diagnostic semantics, and no-overreach boundary. | n/a | SET-160 Pauli review clean. | Focused resource-runtime tests, all Workbench tests, and typecheck pass |
 | Epicurus | 4.8/5 | P3 | Runtime-filter test title said strict selection while asserting standard selection. | Rename the title to match the standard selection assertion. | Test now says standard selection. | Focused Workbench tests and typecheck pass |
 | Parfit | 5/5 | none | No P0-P3 findings after reviewing the untracked implementation and test files directly. | n/a | SET-160 Parfit review clean. | Focused resource-runtime test pass |
+| Euclid | 3.5/5 | P2 | Clean fixture referenced missing scripts and invalid fixture resource diagnostic was synthetic rather than caused by source. | Add inert script fixtures, assert they exist without execution, and derive the invalid resource diagnostic from fixture content. | Added clean hook/skill scripts that exit nonzero, made invalid skill body reference `./scripts/check.sh`, and replaced synthetic resource input with a fixture-derived helper. | Focused Workbench tests, typecheck, and full check pass |
+| Aristotle | 4/5 | P2/P3 | Clean fixture resource diagnostics were hardcoded empty, and README said fake repos were built two ways while listing three tiers. | Derive fixture resource diagnostics and fix README tier wording. | Resource helper now reads fixture source; README now says three tiers and lists Workbench fixtures. | Focused Workbench tests and full check pass |
+| Sagan | 5/5 | none | No remaining P0-P3 findings after SET-161 fixture fixes. | n/a | SET-161 Sagan re-review clean. | Focused fixture test pass |
 
 ## Forbidden Actions Audit
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -6,7 +6,7 @@
 
 ## Three tiers of fixture
 
-Tests build fake repos two ways. Pick the lighter one unless a case earns the heavier one.
+Tests build fake repos at three tiers. Pick the lighter one unless a case earns the heavier one.
 
 ### In-test temp fixtures (default)
 
@@ -26,7 +26,11 @@ A checked-in fixture is a durable fake content repo committed to the tree. Tests
 - is shared by many tests as a golden reference; or
 - is too large to keep readable inline.
 
-Today there is exactly one: [`kitchen-sink/`](kitchen-sink/README.md).
+Current checked-in cases:
+
+- [`kitchen-sink/`](kitchen-sink/README.md) is the complete-surface positive build fixture.
+- [`workbench-clean/`](workbench-clean/README.md) is a small positive Workbench source-contract fixture.
+- [`workbench-invalid/`](workbench-invalid/README.md) is a small negative Workbench fixture for deterministic source, resource, and runtime diagnostics.
 
 ### External fixture repos (`fixtures/external/`)
 

--- a/fixtures/workbench-clean/.skillset/skillset.yaml
+++ b/fixtures/workbench-clean/.skillset/skillset.yaml
@@ -1,0 +1,9 @@
+compile:
+  targets:
+    - claude
+    - codex
+  build: updated
+  features:
+    promptArguments: true
+  skillset:
+    metadata: false

--- a/fixtures/workbench-clean/.skillset/src/agents/reviewer.md
+++ b/fixtures/workbench-clean/.skillset/src/agents/reviewer.md
@@ -1,0 +1,14 @@
+---
+name: reviewer
+description: Review project source for correctness and maintainability.
+skills:
+  - reference
+codex:
+  model: gpt-5.4
+claude:
+  model: sonnet
+---
+
+# Reviewer
+
+Inspect the requested source and report concrete findings with file and line references.

--- a/fixtures/workbench-clean/.skillset/src/hooks/hooks.json
+++ b/fixtures/workbench-clean/.skillset/src/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/fixtures/workbench-clean/.skillset/src/hooks/scripts/check.sh
+++ b/fixtures/workbench-clean/.skillset/src/hooks/scripts/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "fixture hook script must not run during workbench checks"
+exit 97

--- a/fixtures/workbench-clean/.skillset/src/skills/reference/SKILL.md
+++ b/fixtures/workbench-clean/.skillset/src/skills/reference/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: reference
+description: Keep project references organized for review.
+version: 0.1.0
+resources:
+  scripts:
+    - from: ./scripts/check.sh
+      to: scripts/check.sh
+---
+
+# Reference
+
+Use this skill to gather and check project reference material before summarizing it.

--- a/fixtures/workbench-clean/.skillset/src/skills/reference/scripts/check.sh
+++ b/fixtures/workbench-clean/.skillset/src/skills/reference/scripts/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "fixture script must not run during workbench checks"
+exit 97

--- a/fixtures/workbench-clean/README.md
+++ b/fixtures/workbench-clean/README.md
@@ -1,0 +1,3 @@
+# Workbench Clean Fixture
+
+This fixture is a small positive Workbench source repo. It exists to prove that representative workspace config, skills, agents, and hooks can pass Workbench source-contract checks without requiring a full generated-output build.

--- a/fixtures/workbench-invalid/.skillset/skillset.yaml
+++ b/fixtures/workbench-invalid/.skillset/skillset.yaml
@@ -1,0 +1,17 @@
+targets:
+  - claude
+supports:
+  packages: []
+compile:
+  targets:
+    - claude
+    - claude
+    - gemini
+  build: sometimes
+  features:
+    promptArguments: "yes"
+    surprise: true
+  skillset:
+    metadata: "false"
+    surprise: true
+  unsupportedDestination: skip

--- a/fixtures/workbench-invalid/.skillset/src/agents/broken.md
+++ b/fixtures/workbench-invalid/.skillset/src/agents/broken.md
@@ -1,0 +1,10 @@
+---
+name: broken
+description: 10
+skills:
+  - reference
+  - 12
+codex: unsupported
+targets:
+  - claude
+---

--- a/fixtures/workbench-invalid/.skillset/src/hooks/hooks.json
+++ b/fixtures/workbench-invalid/.skillset/src/hooks/hooks.json
@@ -1,0 +1,20 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      42
+    ],
+    "SessionStart": {
+      "hooks": []
+    },
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": ""
+          },
+          "not-object"
+        ]
+      }
+    ]
+  }
+}

--- a/fixtures/workbench-invalid/.skillset/src/skills/broken/SKILL.md
+++ b/fixtures/workbench-invalid/.skillset/src/skills/broken/SKILL.md
@@ -1,0 +1,13 @@
+---
+description: 42
+resources: []
+skillset:
+  name: misplaced
+  version: 1.0.0
+targets:
+  - claude
+---
+
+# Broken Skill
+
+Run ./scripts/check.sh before claiming this skill is ready.

--- a/fixtures/workbench-invalid/README.md
+++ b/fixtures/workbench-invalid/README.md
@@ -1,0 +1,3 @@
+# Workbench Invalid Fixture
+
+This fixture is intentionally invalid Workbench source. It is parser-valid where possible so tests can assert source-contract, resource, and runtime diagnostics instead of stopping at syntax errors.

--- a/packages/workbench/src/__tests__/fixtures.test.ts
+++ b/packages/workbench/src/__tests__/fixtures.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
+import type {
+  LintIssue,
+  SkillsetFeatureEntry,
+} from "@skillset/core";
+
+import {
+  checkWorkbenchSourceContract,
+  formatWorkbenchDiagnostic,
+  summarizeWorkbenchDiagnostics,
+  workbenchDiagnosticsFromResourceLintIssues,
+  workbenchDiagnosticsFromRuntimeSupport,
+} from "../index";
+import type {
+  WorkbenchDiagnostic,
+  WorkbenchSourceContractKind,
+} from "../index";
+
+const repoRoot = join(import.meta.dir, "..", "..", "..", "..");
+
+describe("workbench fixtures", () => {
+  test("clean fixture has no source-contract, resource, or runtime diagnostics", async () => {
+    expect(await fixtureFileExists(
+      "workbench-clean",
+      ".skillset/src/hooks/scripts/check.sh"
+    )).toBeTrue();
+    const diagnostics = [
+      ...(await sourceContractDiagnostics("workbench-clean", cleanSources)),
+      ...workbenchDiagnosticsFromResourceLintIssues(
+        await resourceIssuesFromFixture("workbench-clean", ".skillset/src/skills/reference/SKILL.md")
+      ),
+      ...workbenchDiagnosticsFromRuntimeSupport([
+        feature({
+          id: "runtime-adapters",
+          runtimeSupport: {
+            "codex-cli": {
+              mechanism: "Codex CLI can consume the generated Codex provider output.",
+              status: "native",
+            },
+          },
+        }),
+      ]),
+    ];
+
+    expect(summarizeWorkbenchDiagnostics(diagnostics)).toMatchObject({
+      errorCount: 0,
+      ok: true,
+      warningCount: 0,
+    });
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("invalid fixture reports deterministic source, resource, and runtime diagnostics", async () => {
+    const diagnostics = summarizeWorkbenchDiagnostics([
+      ...(await sourceContractDiagnostics("workbench-invalid", invalidSources)),
+      ...workbenchDiagnosticsFromResourceLintIssues(invalidResourceIssues),
+      ...workbenchDiagnosticsFromRuntimeSupport([
+        feature({
+          id: "project-agents",
+          runtimeSupport: {
+            "codex-cli": {
+              caveats: ["Skill loading is instruction-guided."],
+              diagnostics: ["Skill loading is not runtime-enforced."],
+              mechanism: "Skillset writes an instruction preface.",
+              status: "shimmed",
+            },
+          },
+        }),
+      ], { locationPath: "fixtures/workbench-invalid" }),
+    ]);
+
+    expect(diagnostics.ok).toBeFalse();
+    expect(diagnostics.errorCount).toBe(25);
+    expect(diagnostics.warningCount).toBe(1);
+    expect(diagnostics.diagnostics.map(formatWorkbenchDiagnostic)).toEqual([
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: compile.build must be one of all, updated",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: compile.features.promptArguments must be a boolean",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: compile.skillset.metadata must be a boolean",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: compile.unsupportedDestination warn, skip, and force are reserved; use error",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: duplicate compile target claude",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: unsupported compile feature key surprise",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: unsupported compile skillset key surprise",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: unsupported compile target gemini",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: unsupported workspace config key targets",
+      ".skillset/skillset.yaml:1: error: schema/workspace-config: workspace config must use compile.targets instead of targets",
+      ".skillset/src/agents/broken.md:1: error: schema/agent-frontmatter: agents must remove targets; use root compile.targets and claude/codex blocks for file-level behavior",
+      ".skillset/src/agents/broken.md:1: error: schema/agent-frontmatter: codex must be true, false, or an object when present",
+      ".skillset/src/agents/broken.md:1: error: schema/agent-frontmatter: description is required and must be a non-empty string",
+      ".skillset/src/agents/broken.md:1: error: schema/agent-frontmatter: skills must be a string array when present",
+      ".skillset/src/agents/broken.md:11: error: schema/agent-body: agent body is required",
+      ".skillset/src/hooks/hooks.json:1: error: schema/hook: hook event PreToolUse entries must be objects",
+      ".skillset/src/hooks/hooks.json:1: error: schema/hook: hook event SessionStart must be an array",
+      ".skillset/src/hooks/hooks.json:1: error: schema/hook: hook event Stop hook handlers must be objects",
+      ".skillset/src/hooks/hooks.json:1: error: schema/hook: hook event Stop hook handlers must include a non-empty string type",
+      ".skillset/src/skills/broken/SKILL.md:1: error: schema/skill-frontmatter: resources must be an object when present",
+      ".skillset/src/skills/broken/SKILL.md:1: error: schema/skill-frontmatter: skill needs description, summary, title, or skillset descriptive metadata",
+      ".skillset/src/skills/broken/SKILL.md:1: error: schema/skill-frontmatter: skills must remove targets; use root compile.targets and claude/codex blocks for file-level behavior",
+      ".skillset/src/skills/broken/SKILL.md:1: error: schema/skill-frontmatter: skillset.name is unsupported in skills; use top-level name",
+      ".skillset/src/skills/broken/SKILL.md:1: error: schema/skill-frontmatter: skillset.version is unsupported in skills; use top-level version",
+      ".skillset/src/skills/broken/SKILL.md: error: resource/resource-undeclared-link: broken skill links to undeclared resource ./scripts/check.sh",
+      "fixtures/workbench-invalid: warning: runtime/shimmed: codex-cli project-agents: Skill loading is not runtime-enforced.",
+    ]);
+  });
+});
+
+interface SourceContractSpec {
+  readonly kind: WorkbenchSourceContractKind;
+  readonly path: string;
+}
+
+const cleanSources: readonly SourceContractSpec[] = [
+  { kind: "workspace-config", path: ".skillset/skillset.yaml" },
+  { kind: "skill", path: ".skillset/src/skills/reference/SKILL.md" },
+  { kind: "agent", path: ".skillset/src/agents/reviewer.md" },
+  { kind: "hook", path: ".skillset/src/hooks/hooks.json" },
+];
+
+const invalidSources: readonly SourceContractSpec[] = [
+  { kind: "workspace-config", path: ".skillset/skillset.yaml" },
+  { kind: "skill", path: ".skillset/src/skills/broken/SKILL.md" },
+  { kind: "agent", path: ".skillset/src/agents/broken.md" },
+  { kind: "hook", path: ".skillset/src/hooks/hooks.json" },
+];
+
+const invalidResourceIssues = await resourceIssuesFromFixture(
+  "workbench-invalid",
+  ".skillset/src/skills/broken/SKILL.md"
+);
+
+async function sourceContractDiagnostics(
+  fixtureName: string,
+  specs: readonly SourceContractSpec[]
+): Promise<readonly WorkbenchDiagnostic[]> {
+  const diagnostics: WorkbenchDiagnostic[] = [];
+  for (const spec of specs) {
+    const content = await Bun.file(join(repoRoot, "fixtures", fixtureName, spec.path)).text();
+    diagnostics.push(...checkWorkbenchSourceContract({
+      content,
+      kind: spec.kind,
+      path: spec.path,
+    }));
+  }
+  return diagnostics;
+}
+
+async function resourceIssuesFromFixture(
+  fixtureName: string,
+  skillPath: string
+): Promise<readonly LintIssue[]> {
+  const content = await fixtureFileText(fixtureName, skillPath);
+  if (!content.includes("./scripts/check.sh")) return [];
+
+  const declaresScript = /from:\s*\.\/scripts\/check\.sh/u.test(content);
+  const scriptExists = await fixtureFileExists(
+    fixtureName,
+    join(dirname(skillPath), "scripts/check.sh")
+  );
+  if (declaresScript && scriptExists) return [];
+
+  return [
+    {
+      code: "resource-undeclared-link",
+      featureId: "resources",
+      message: "broken skill links to undeclared resource ./scripts/check.sh",
+      path: skillPath,
+      severity: "error",
+    },
+  ];
+}
+
+async function fixtureFileText(fixtureName: string, path: string): Promise<string> {
+  return Bun.file(join(repoRoot, "fixtures", fixtureName, path)).text();
+}
+
+async function fixtureFileExists(fixtureName: string, path: string): Promise<boolean> {
+  return Bun.file(join(repoRoot, "fixtures", fixtureName, path)).exists();
+}
+
+function feature(
+  overrides: Pick<SkillsetFeatureEntry, "id"> &
+    Partial<Omit<SkillsetFeatureEntry, "id">>
+): SkillsetFeatureEntry {
+  const { id, ...rest } = overrides;
+  return {
+    docs: ["docs/features/test.md"],
+    evidence: [],
+    id,
+    kind: "workflow",
+    renderOwner: "packages/core/src/test.ts",
+    sourceShape: ".skillset/src/test",
+    status: "implemented",
+    summary: "Test feature.",
+    targetSupport: {
+      claude: { status: "native" },
+      codex: { status: "native" },
+    },
+    title: "Test Feature",
+    validationOwner: "packages/core/src/test.ts",
+    ...rest,
+  };
+}


### PR DESCRIPTION
## Context

This branch adds fixture coverage for the Workbench source-good/source-bad cases discussed for dogfooding and regression safety.

## Changes

- Adds positive and negative Workbench fixtures.
- Wires fixture expectations into tests.
- Covers both valid source authoring and intentionally bad inputs.

## Verification

- Local reviewer loop completed with final 5/5 and no P0-P3 findings.
- `bun run check`
- `bun run hooks:pre-push`
- Hosted CI required before leaving draft.

## Risks

Fixtures are intentionally focused on Workbench behavior, not external provider marketplace testing.
