### PR TITLE
chore(workbench): record final verification cleanup

### DIFF
--- a/.agents/plans/2026-06-20-workbench-check-authoring-correctness/REFS.md
+++ b/.agents/plans/2026-06-20-workbench-check-authoring-correctness/REFS.md
@@ -42,7 +42,7 @@
 - `bun run typecheck` - TypeScript type safety.
 - `bun run skillset:build` - regenerate self-hosted outputs.
 - `bun run skillset:lint` - existing lint checks until folded into Workbench.
-- `bun run skillset:check` - current generated-output freshness until M1 rename.
+- `bun run skillset:check` - source authoring diagnostics after the M1 rename.
 - `bun run check` - full repo gate.
 - `bun ./apps/skillset/src/cli.ts check --root .` - Workbench smoke after M1/M2.
 - `bun ./apps/skillset/src/cli.ts verify --root .` - generated-output smoke after M1.

--- a/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
+++ b/.agents/plans/2026-06-20-workbench-check-authoring-correctness/RETRO.md
@@ -78,7 +78,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 - Changed: Split public CLI semantics so `skillset check` runs the source authoring/lint surface and `skillset verify` runs generated-output freshness.
 - Changed: Updated repo scripts, runtime hook dispatch, hook snippets, tests, active docs, README, self-hosted source guidance, and generated guidance to call both check and verify where appropriate.
 - Changed: Added a patch Changeset for the package-facing command semantics.
-- Decision: Left core `checkSkillset*` API names in place for this branch; M1 is a public command cutover, while deeper Workbench package/API naming belongs to later milestones.
+- Decision: Started with the public command cutover, then completed the deeper generated-output API rename in the stack so generated freshness is consistently `verify` in CLI and core operation results.
 - Verified: Targeted text sweep identified stale generated-output wording and docs were updated before tests.
 - Next: Rebuild generated guidance, run focused tests, then run the M1 local review loop.
 - Blockers: none.
@@ -309,6 +309,7 @@ Use this as the durable execution ledger. For stacked work, this should normally
 | Hilbert | 3/5 | P2/P3 | Workbench docs and generated skill guidance overstated how much public `skillset check` is wired to package-level Workbench parser/schema/presets, and fixture wording overstated script-read evidence. | Make docs say `check` uses current lint authoring path, split `change check`/`verify` responsibilities, and soften fixture evidence. | Narrowed CLI claims, updated generated guidance, and changed fixture wording to declaration/existence checks without execution. | Focused tests, generated verification, and final review pass |
 | Sartre | 4/5 | P3 | Registry evidence still missed presets/lint-bridge/resource-runtime/compatibility, and Codex development guidance still said source/workspace correctness. | Add missing evidence refs and rename guidance to current source authoring diagnostics. | Added missing evidence refs, updated source guidance, and rebuilt generated output. | Focused tests and final review pass |
 | Schrodinger | 5/5 | none | No remaining P0-P3 findings after SET-163 review fixes. | n/a | SET-163 review loop clean. | Targeted tests, `skillset:check`, `skillset:verify`, and staged whitespace clean |
+| Codex read-only final review | 5/5 | P3 fixed | A draft changelog ADR, target-surface matrix row, and the Workbench REFS packet still described `check` as generated-output freshness. | Update stale wording to the final `check`/`verify` split. | ADR wording now says generated changelogs are refreshed by build and checked by verify; target surfaces now assigns unsupported-destination freshness to build/diff/verify; REFS now says `skillset:check` is source authoring diagnostics after M1. | Narrow re-review reached 5/5 with no P0-P3 findings |
 
 ## Forbidden Actions Audit
 

--- a/.skillset/changes/60e0d67e91cb.md
+++ b/.skillset/changes/60e0d67e91cb.md
@@ -9,6 +9,10 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
 group: SET-148
 id: 60e0d67e91cb
 scopes:

--- a/.skillset/changes/7910d31a7f0b.md
+++ b/.skillset/changes/7910d31a7f0b.md
@@ -5,6 +5,10 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
 group: SET-128
 id: 7910d31a7f0b
 scopes:

--- a/.skillset/changes/8ad8eb800c3e.md
+++ b/.skillset/changes/8ad8eb800c3e.md
@@ -41,6 +41,10 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
 group: SET-55
 id: 8ad8eb800c3e
 scopes:

--- a/.skillset/changes/a6645ed7fb06.md
+++ b/.skillset/changes/a6645ed7fb06.md
@@ -49,6 +49,12 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
+  - scope: skill:skillset-codex-development
+    sourceHash: sha256:555869dec3610f0369e3a812d195c679eb223aa2230b7954a2cfa7509e58005b
 group: SET-19
 id: a6645ed7fb06
 scopes:

--- a/.skillset/changes/c5a4125709da.md
+++ b/.skillset/changes/c5a4125709da.md
@@ -33,6 +33,12 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
+  - scope: skill:skillset-codex-development
+    sourceHash: sha256:555869dec3610f0369e3a812d195c679eb223aa2230b7954a2cfa7509e58005b
 group: SET-138
 id: c5a4125709da
 scopes:

--- a/.skillset/changes/d3d8741ca5f5.md
+++ b/.skillset/changes/d3d8741ca5f5.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+evidence:
+  - scope: skill:skillset-claude-development
+    sourceHash: sha256:d55a81e7ee92c3f661be3a4733d416f3c0265e58ef9efb355b2bd32ea46b707c
+group: SET-163
+id: d3d8741ca5f5
+scope: skill:skillset-claude-development
+---
+
+Document Workbench check and verify guidance in the Claude development skill so generated contributor instructions match the new CLI contract.

--- a/.skillset/changes/dddfa5e5ccc2.md
+++ b/.skillset/changes/dddfa5e5ccc2.md
@@ -17,6 +17,10 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
 group: SET-139
 id: dddfa5e5ccc2
 scopes:

--- a/.skillset/changes/e577d18297b7.md
+++ b/.skillset/changes/e577d18297b7.md
@@ -37,6 +37,10 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
 group: SET-54
 id: e577d18297b7
 scopes:

--- a/.skillset/changes/e75c9c55abea.md
+++ b/.skillset/changes/e75c9c55abea.md
@@ -37,6 +37,12 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
+  - scope: skill:skillset-codex-development
+    sourceHash: sha256:555869dec3610f0369e3a812d195c679eb223aa2230b7954a2cfa7509e58005b
 group: SET-125
 id: e75c9c55abea
 scopes:

--- a/.skillset/changes/f9182a2db886.md
+++ b/.skillset/changes/f9182a2db886.md
@@ -41,6 +41,12 @@ evidence:
     sourceHash: sha256:dbe55f7a3ae5e23a463bf685b9e2a2ca53dbe39710e30e9a33304bbf1ff4c998
   - scope: plugin:skillset
     sourceHash: sha256:40b6c11b653a62939c76776a99f91c7b87bec855ea044942adc66a38de09e28f
+  - scope: plugin.skillset.skill:use-skillset
+    sourceHash: sha256:15e801a68fbdd5f3959c1de9d3608ae012217e56ff28dc4f6e9b8374a6d4fd1e
+  - scope: plugin:skillset
+    sourceHash: sha256:033d977d93abd75c0b6991ab4d90859026839772b83c0d49c0fb88597b60e07b
+  - scope: skill:skillset-codex-development
+    sourceHash: sha256:555869dec3610f0369e3a812d195c679eb223aa2230b7954a2cfa7509e58005b
 group: SET-137
 id: f9182a2db886
 scopes:

--- a/docs/adrs/drafts/20260604-changelog-and-versioning.md
+++ b/docs/adrs/drafts/20260604-changelog-and-versioning.md
@@ -30,7 +30,7 @@ Three independent semver axes already exist in source; this proposal names their
 
 `skillset.schema` (SET-3) is orthogonal: it versions the *source contract*, not content, and never participates in changelog/version bumps.
 
-Resolution order is unchanged: skill `version` → plugin version → root version. `skillset check` already reports drift when a generated manifest/skill version is stale relative to source.
+Resolution order is unchanged: skill `version` → plugin version → root version. `skillset verify` reports drift when a generated manifest/skill version is stale relative to source.
 
 ## Changelog authoring model
 
@@ -59,7 +59,7 @@ Why entry files, not a single changelog:
 - They carry intent (scope + bump) that `skillset changes version` can apply deterministically.
 - They are source, so they review like everything else.
 
-Generated, per-scope `CHANGELOG.md` files are **derived output** (like skills and manifests): written into the relevant generated root, tracked by `.skillset.lock`, and refreshed by build/check. They are not hand-edited source truth.
+Generated, per-scope `CHANGELOG.md` files are **derived output** (like skills and manifests): written into the relevant generated root, tracked by `.skillset.lock`, refreshed by build, and checked for freshness by verify. They are not hand-edited source truth.
 
 ## `skillset changes` command (proposed)
 
@@ -69,7 +69,7 @@ Three subcommands, all local and non-activating (consistent with "builds do not 
 - `skillset changes version` — consume entries, bump the affected source `version` fields (root/plugin/skill), append to the generated `CHANGELOG.md` for each scope, and delete the consumed entries. Writes only `.skillset/` source versions + generated changelogs; never publishes.
 - `skillset changes status` / `check` — report pending entries and whether any shipped change lacks an entry (a lint-style guard, opt-in).
 
-`skillset build`/`check` keep their current jobs; changelog generation can run as part of `version` and be verified by `check` (stale generated `CHANGELOG.md` is drift like any other generated file).
+`skillset build`/`verify` keep their current jobs; changelog generation can run as part of `version` and be verified by `verify` (stale generated `CHANGELOG.md` is drift like any other generated file).
 
 ## Target-specific bumps when one target is skipped then resynced
 

--- a/docs/target-surfaces.md
+++ b/docs/target-surfaces.md
@@ -32,7 +32,7 @@ Default behavior for unsupported or lossy build results is fail-loud. Softer mod
 | `compile.build: updated/all` | normalized build mode in lock provenance | Implemented | Parser, CLI overrides, plan-first writes, and lock metadata are implemented. |
 | `compile.features.promptArguments` | `{{$ARGUMENTS...}}` adaptive command placeholders | Implemented | Defaults to `true`; set to `false` to reject the source markers. |
 | `compile.skillset.metadata: false` | suppress generated skill `metadata.generated` / `metadata.version` | Implemented | Source metadata remains source-only; locks record `skillsetMetadata`. |
-| `compile.unsupportedDestination: error` | build/diff/check unsupported destination policy | Implemented | Default policy; preserves current fail-loud unsupported behavior. |
+| `compile.unsupportedDestination: error` | build/diff/verify unsupported destination policy | Implemented | Default policy; preserves current fail-loud unsupported behavior. |
 | `compile.unsupportedDestination: warn/skip/force` | doctor/lock provenance | Reserved | Recognized names that fail until non-error unsupported destination policy semantics are implemented and documented. |
 | omitted `compile.targets` | all supported provider outputs | Implemented | Shorthand for the default provider plan; equivalent to `compile.targets: [claude, codex]` while both providers are supported. |
 | `claude.projectRoot` / `codex.projectRoot` | provider adapter metadata | Implemented | Parsed and inherited with provider blocks; build still does not mutate user-level config. |


### PR DESCRIPTION
## Context

This branch records final verification cleanup for the full Workbench stack.

## Changes

- Refreshes generated/source evidence after the final restack.
- Adds the final change record needed for the self-hosted skillset guidance update.
- Cleans stale wording in docs so the stack uses the current check/verify terminology.

## Verification

- Local reviewer loop completed with final 5/5 and no P0-P3 findings.
- `bun run check`
- `bun run hooks:pre-push`
- `skillset ci --root . --since "$(scripts/git-trunk.sh)" --report .skillset/build/skillset-ci-report.md`
- Hosted CI required before leaving draft.

## Risks

This branch is cleanup/evidence only; functional Workbench behavior lands in the lower branches.
