### PR TITLE
feat(workbench): add markdown fence diagnostics

### DIFF
--- a/.changeset/workbench-markdown-fences.md
+++ b/.changeset/workbench-markdown-fences.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add Workbench Markdown diagnostics for nested backtick code fences so skill and reference docs can catch broken rendered examples before build output is trusted.

--- a/docs/features/workbench.md
+++ b/docs/features/workbench.md
@@ -57,6 +57,8 @@ Current public CLI selection stays intentionally small; `skillset check` runs th
 
 Workbench parser helpers use Bun-backed JSON, YAML, and TOML parsing plus Markdown/frontmatter extraction. Syntax diagnostics carry file and line information where the parser exposes it, and Markdown heading extraction ignores fenced code blocks so body facts stay stable.
 
+Workbench Markdown diagnostics also check code fence nesting inside Markdown-labeled examples. When a fenced Markdown example needs to show another fenced code block, the outer fence must use more backticks than any inner fence. For example, use four backticks around a `markdown`, `md`, `mdx`, or `gfm` snippet that contains triple-backtick examples. The `markdown/code-fence-nesting` rule reports the outer fence and the conflicting inner fence so authors can increment the outer fence length by one backtick beyond the longest inner fence.
+
 Schema checks cover representative source contracts:
 
 - ordinary workspace config files such as `.skillset/skillset.yaml`;
@@ -102,5 +104,6 @@ These fixtures are internal compiler fixtures, not public `.skillset/tests/` sou
 - Parser/schema tests: `packages/workbench/src/__tests__/parser.test.ts`, `packages/workbench/src/__tests__/schema.test.ts`
 - Resource/runtime/provider tests: `packages/workbench/src/__tests__/resource-runtime.test.ts`, `packages/workbench/src/__tests__/compatibility.test.ts`
 - ast-grep proof tests: `packages/workbench/src/__tests__/ast-grep.test.ts`
+- Markdown rule tests: `packages/workbench/src/__tests__/markdown.test.ts`
 - Fixture tests: `packages/workbench/src/__tests__/fixtures.test.ts`
 - CLI command split tests: `apps/skillset/src/__tests__/contract.test.ts`, `apps/skillset/src/__tests__/runtime-hooks.test.ts`

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -684,6 +684,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       test("packages/workbench/src/__tests__/resource-runtime.test.ts", "Workbench resource and runtime diagnostics"),
       test("packages/workbench/src/__tests__/fixtures.test.ts", "Workbench clean and invalid fixtures"),
       test("packages/workbench/src/__tests__/ast-grep.test.ts", "Workbench ast-grep adapter proof"),
+      test("packages/workbench/src/__tests__/markdown.test.ts", "Workbench Markdown diagnostics"),
     ],
     id: "workflows",
     kind: "workflow",

--- a/packages/workbench/src/__tests__/markdown.test.ts
+++ b/packages/workbench/src/__tests__/markdown.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkWorkbenchSyntax,
+  workbenchDiagnosticsFromMarkdownCodeFences,
+} from "../index";
+
+describe("workbench Markdown diagnostics", () => {
+  test("reports nested backtick fences that are as long as the outer fence", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "# Skill",
+        "",
+        "```markdown",
+        "Use this example:",
+        "```ts",
+        "console.log('hello');",
+        "```",
+        "```",
+        "",
+      ].join("\n"),
+      path: ".skillset/src/skills/docs/SKILL.md",
+    });
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        fix: {
+          kind: "manual",
+          message: "Use at least 4 backticks for the outer fence.",
+        },
+        location: expect.objectContaining({
+          endLine: 5,
+          line: 3,
+          path: ".skillset/src/skills/docs/SKILL.md",
+        }),
+        message:
+          "outer 3-backtick fence is not long enough for inner 3-backtick fence on line 5",
+        ruleId: "markdown/code-fence-nesting",
+        ruleLevel: "standard",
+        scope: "source",
+        severity: "warning",
+        subject: { kind: "markdown", path: ".skillset/src/skills/docs/SKILL.md" },
+      }),
+    ]);
+  });
+
+  test("reports likely unlabeled inner fences in Markdown examples", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "```markdown",
+        "Use this example:",
+        "```",
+        "name: Demo",
+        "```",
+        "```",
+        "",
+      ].join("\n"),
+      path: ".skillset/src/skills/docs/SKILL.md",
+    });
+
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ endLine: 3, line: 1 }),
+        message: "outer 3-backtick fence is not long enough for inner 3-backtick fence on line 3",
+        ruleId: "markdown/code-fence-nesting",
+      })
+    );
+  });
+
+  test("reports unlabeled inner fences even when their first content line is blank", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "```markdown",
+        "Use this example:",
+        "```",
+        "",
+        "name: Demo",
+        "```",
+        "```",
+        "",
+      ].join("\n"),
+      path: ".skillset/src/skills/docs/SKILL.md",
+    });
+
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ endLine: 3, line: 1 }),
+        message: "outer 3-backtick fence is not long enough for inner 3-backtick fence on line 3",
+        ruleId: "markdown/code-fence-nesting",
+      })
+    );
+  });
+
+  test("accepts outer fences that are longer than nested examples", () => {
+    const diagnostics = workbenchDiagnosticsFromMarkdownCodeFences({
+      content: [
+        "````markdown",
+        "Use this example:",
+        "```ts",
+        "console.log('hello');",
+        "```",
+        "````",
+        "",
+      ].join("\n"),
+      path: ".skillset/src/skills/docs/references/example.md",
+    });
+
+      expect(diagnostics).toEqual([]);
+  });
+
+  test("checks reference and examples files without requiring a skill directory", () => {
+    for (const path of ["REFERENCE.md", "EXAMPLES.md"]) {
+      const diagnostics = workbenchDiagnosticsFromMarkdownCodeFences({
+        content: [
+          "```markdown",
+          "Template:",
+          "```yaml",
+          "name: Demo",
+          "```",
+          "```",
+          "",
+        ].join("\n"),
+        path,
+      });
+
+      expect(diagnostics).toContainEqual(
+        expect.objectContaining({
+          location: expect.objectContaining({ line: 1, path }),
+          ruleId: "markdown/code-fence-nesting",
+        })
+      );
+    }
+  });
+
+  test("checks docs paths through the syntax diagnostic surface", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "```markdown",
+        "Example:",
+        "```yaml",
+        "name: Demo",
+        "```",
+        "```",
+        "",
+      ].join("\n"),
+      path: "docs/features/example.md",
+    });
+
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        location: expect.objectContaining({ line: 1, path: "docs/features/example.md" }),
+        ruleId: "markdown/code-fence-nesting",
+      })
+    );
+  });
+
+  test("does not report ordinary adjacent fenced blocks", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: ["```ts", "one();", "```", "", "```ts", "two();", "```", ""].join("\n"),
+      path: "SKILL.md",
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("does not report a completed Markdown example followed by a plain block", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "```markdown",
+        "Use this example.",
+        "```",
+        "",
+        "Then run:",
+        "```",
+        "skillset check",
+        "```",
+        "",
+      ].join("\n"),
+      path: "docs/features/example.md",
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("does not report literal fence text inside non-Markdown code blocks", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "```text",
+        "This documentation literally mentions ```ts here.",
+        "```ts",
+        "```",
+        "",
+      ].join("\n"),
+      path: "docs/features/example.md",
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("does not treat invalid backtick info strings as fence openers", () => {
+    const diagnostics = checkWorkbenchSyntax({
+      content: [
+        "``` ```",
+        "not fenced",
+        "```ts",
+        "inside",
+        "```",
+        "",
+      ].join("\n"),
+      path: "SKILL.md",
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/workbench/src/__tests__/schema.test.ts
+++ b/packages/workbench/src/__tests__/schema.test.ts
@@ -54,6 +54,30 @@ describe("workbench source contract schema checks", () => {
     ]);
   });
 
+  test("reports Markdown warnings alongside schema diagnostics", () => {
+    const diagnostics = checkWorkbenchSourceContract({
+      content: [
+        "---",
+        "name: demo",
+        "---",
+        "```markdown",
+        "Use this example:",
+        "```ts",
+        "console.log('hello');",
+        "```",
+        "```",
+        "",
+      ].join("\n"),
+      kind: "skill",
+      path: ".skillset/src/skills/demo/SKILL.md",
+    });
+
+    expect(diagnostics.map(formatWorkbenchDiagnostic)).toEqual([
+      ".skillset/src/skills/demo/SKILL.md:1: error: schema/skill-frontmatter: skill needs description, summary, title, or skillset descriptive metadata",
+      ".skillset/src/skills/demo/SKILL.md:4:1: warning: markdown/code-fence-nesting: outer 3-backtick fence is not long enough for inner 3-backtick fence on line 6",
+    ]);
+  });
+
   test("accepts derivable skill descriptions and rejects nested skill identity", () => {
     expect(checkWorkbenchSourceContract({
       content: "---\ntitle: Demo Skill\n---\nUse this skill.\n",

--- a/packages/workbench/src/index.ts
+++ b/packages/workbench/src/index.ts
@@ -24,6 +24,7 @@ export {
   type WorkbenchResourceDiagnosticOptions,
   type WorkbenchRuntimeSupportDiagnosticOptions,
 } from "./resource-runtime";
+export { workbenchDiagnosticsFromMarkdownCodeFences } from "./markdown";
 export {
   getWorkbenchPreset,
   isWorkbenchPresetId,

--- a/packages/workbench/src/markdown.ts
+++ b/packages/workbench/src/markdown.ts
@@ -1,0 +1,122 @@
+import { createWorkbenchDiagnostic } from "./diagnostics";
+import type { WorkbenchDiagnostic } from "./types";
+
+interface FenceLine {
+  readonly column: number;
+  readonly info: string;
+  readonly length: number;
+  readonly line: number;
+}
+
+export function workbenchDiagnosticsFromMarkdownCodeFences(args: {
+  readonly content: string;
+  readonly path: string;
+}): readonly WorkbenchDiagnostic[] {
+  const normalized = args.content.replaceAll(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  const diagnostics: WorkbenchDiagnostic[] = [];
+  let fence: FenceLine | undefined;
+
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+    if (fence === undefined) {
+      const openedFence = readBacktickFenceLine(line, lineNumber);
+      if (openedFence !== undefined) fence = openedFence;
+      continue;
+    }
+
+    const candidate = readBacktickFenceLine(line, lineNumber);
+    if (candidate === undefined) continue;
+    if (candidate.length < fence.length) continue;
+    if (!isMarkdownInfo(fence.info)) {
+      if (candidate.info.trim() === "") fence = undefined;
+      continue;
+    }
+
+    const isClosingFence = candidate.info.trim() === "";
+    if (isClosingFence) {
+      if (looksLikeUnlabeledNestedFence(lines, index, fence)) {
+        diagnostics.push(codeFenceNestingDiagnostic(args.path, fence, candidate));
+        fence = undefined;
+        continue;
+      }
+      fence = undefined;
+      continue;
+    }
+
+    diagnostics.push(codeFenceNestingDiagnostic(args.path, fence, candidate));
+    fence = undefined;
+  }
+
+  return diagnostics;
+}
+
+function codeFenceNestingDiagnostic(
+  path: string,
+  fence: FenceLine,
+  candidate: FenceLine
+): WorkbenchDiagnostic {
+  return createWorkbenchDiagnostic({
+    fix: {
+      kind: "manual",
+      message: `Use at least ${candidate.length + 1} backticks for the outer fence.`,
+    },
+    help: [
+      "Nested Markdown examples need the outer code fence to be longer than any inner backtick fence.",
+      `The outer fence on line ${fence.line} uses ${fence.length} backticks; line ${candidate.line} starts an inner ${candidate.length}-backtick fence.`,
+    ],
+    location: {
+      column: fence.column,
+      endColumn: candidate.column + candidate.length - 1,
+      endLine: candidate.line,
+      line: fence.line,
+      path,
+    },
+    message: `outer ${fence.length}-backtick fence is not long enough for inner ${candidate.length}-backtick fence on line ${candidate.line}`,
+    ruleId: "markdown/code-fence-nesting",
+    ruleLevel: "standard",
+    scope: "source",
+    severity: "warning",
+    subject: { kind: "markdown", path },
+  });
+}
+
+function looksLikeUnlabeledNestedFence(
+  lines: readonly string[],
+  candidateIndex: number,
+  fence: FenceLine
+): boolean {
+  if (!isMarkdownInfo(fence.info)) return false;
+
+  for (let index = candidateIndex + 1; index < lines.length; index += 1) {
+    const laterFence = readBacktickFenceLine(lines[index]!, index + 1);
+    if (laterFence === undefined || laterFence.length < fence.length) continue;
+    if (laterFence.info.trim() !== "") return false;
+
+    const outerCloseLine = lines[index + 1];
+    if (outerCloseLine === undefined) return false;
+    const outerClose = readBacktickFenceLine(outerCloseLine, index + 2);
+    return outerClose !== undefined && outerClose.length >= fence.length && outerClose.info.trim() === "";
+  }
+
+  return false;
+}
+
+function isMarkdownInfo(info: string): boolean {
+  const language = info.trim().split(/\s+/u)[0]?.toLowerCase();
+  return language === "markdown" || language === "md" || language === "mdx" || language === "gfm";
+}
+
+function readBacktickFenceLine(line: string, lineNumber: number): FenceLine | undefined {
+  const match = /^( {0,3})(`{3,})(.*)$/u.exec(line);
+  if (match === null) return undefined;
+  const sequence = match[2]!;
+  const info = match[3]!;
+  if (info.includes("`")) return undefined;
+  return {
+    column: match[1]!.length + 1,
+    info,
+    length: sequence.length,
+    line: lineNumber,
+  };
+}

--- a/packages/workbench/src/parser.ts
+++ b/packages/workbench/src/parser.ts
@@ -1,4 +1,5 @@
 import { createWorkbenchDiagnostic } from "./diagnostics";
+import { workbenchDiagnosticsFromMarkdownCodeFences } from "./markdown";
 import type {
   WorkbenchDiagnostic,
   WorkbenchMarkdownHeading,
@@ -90,11 +91,15 @@ function parseYaml(path: string, content: string): WorkbenchParseResult {
 function parseMarkdown(path: string, content: string): WorkbenchParseResult {
   const normalized = content.replaceAll(/\r\n?/g, "\n");
   const lines = normalized.split("\n");
+  const markdownDiagnostics = workbenchDiagnosticsFromMarkdownCodeFences({
+    content: normalized,
+    path,
+  });
   if (!isFrontmatterDelimiter(lines[0] ?? "")) {
     return {
       body: normalized,
       bodyStartLine: 1,
-      diagnostics: [],
+      diagnostics: markdownDiagnostics,
       headings: markdownHeadings(lines, 1),
       kind: "markdown",
       path,
@@ -113,6 +118,7 @@ function parseMarkdown(path: string, content: string): WorkbenchParseResult {
           "frontmatter starts with --- but never closes",
           { line: 1 }
         ),
+        ...markdownDiagnostics,
       ],
       headings: [],
       kind: "markdown",
@@ -138,6 +144,7 @@ function parseMarkdown(path: string, content: string): WorkbenchParseResult {
           ...location,
           line: location.line + 1,
         }),
+        ...markdownDiagnostics,
       ],
       headings: markdownHeadings(bodyLines, bodyStartLine),
       kind: "markdown",
@@ -153,6 +160,7 @@ function parseMarkdown(path: string, content: string): WorkbenchParseResult {
         syntaxDiagnostic(path, "syntax/markdown-frontmatter", "frontmatter must be a YAML object", {
           line: 2,
         }),
+        ...markdownDiagnostics,
       ],
       headings: markdownHeadings(bodyLines, bodyStartLine),
       kind: "markdown",
@@ -163,7 +171,7 @@ function parseMarkdown(path: string, content: string): WorkbenchParseResult {
   return {
     body,
     bodyStartLine,
-    diagnostics: [],
+    diagnostics: markdownDiagnostics,
     frontmatter: parsed ?? {},
     headings: markdownHeadings(bodyLines, bodyStartLine),
     kind: "markdown",

--- a/packages/workbench/src/schema.ts
+++ b/packages/workbench/src/schema.ts
@@ -41,12 +41,21 @@ export function checkWorkbenchSourceContract(
     kind: parseKindForContract(input.kind),
     path: input.path,
   });
-  if (parsed.diagnostics.length > 0) return parsed.diagnostics;
+  const parseDiagnostics = [...parsed.diagnostics];
+  if (parseDiagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+    return sortWorkbenchDiagnostics(parseDiagnostics);
+  }
 
-  if (input.kind === "agent") return sortWorkbenchDiagnostics(checkAgentContract(parsed, input.path));
-  if (input.kind === "hook") return sortWorkbenchDiagnostics(checkHookContract(parsed, input.path));
-  if (input.kind === "skill") return sortWorkbenchDiagnostics(checkSkillContract(parsed, input.path));
-  return sortWorkbenchDiagnostics(checkWorkspaceConfigContract(parsed, input.path));
+  if (input.kind === "agent") {
+    return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkAgentContract(parsed, input.path)]);
+  }
+  if (input.kind === "hook") {
+    return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkHookContract(parsed, input.path)]);
+  }
+  if (input.kind === "skill") {
+    return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkSkillContract(parsed, input.path)]);
+  }
+  return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkWorkspaceConfigContract(parsed, input.path)]);
 }
 
 function parseKindForContract(kind: WorkbenchSourceContractKind): WorkbenchParseKind {


### PR DESCRIPTION
## Context

First branch in the Workbench follow-up stack. This adds authoring diagnostics for nested Markdown code fences so skill/reference docs can catch examples that would render incorrectly before trusting generated output.

## Changes

- Adds Workbench Markdown fence diagnostics for nested backtick fences that are not shorter than the outer fence.
- Wires Markdown diagnostics into the source-contract schema surface without blocking ordinary parse/schema checks.
- Registers feature evidence and updates Workbench documentation.

## Verification

- Local reviewer loop: 5/5, no P0-P3 findings.
- `bun run check` passed locally: 613 tests, Ultracite doctor, `skillset check`, `skillset verify`, `git diff --check`, terminology guard.
- `bun run hooks:pre-push` passed from the stack tip after restack.

## Notes

This branch carries `.changeset/workbench-markdown-fences.md` because it also updates the published core feature registry evidence.
