### PR TITLE
fix(cache): derive deterministic xdg cache keys

### DIFF
--- a/.changeset/deterministic-cache-key.md
+++ b/.changeset/deterministic-cache-key.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Derive safer automatic XDG cache bucket keys from host-qualified remotes or hashed host-and-path local fallbacks so ordinary workspaces no longer need `workspace.cacheKey`.

--- a/.changeset/deterministic-cache-key.md
+++ b/.changeset/deterministic-cache-key.md
@@ -2,4 +2,4 @@
 "skillset": patch
 ---
 
-Derive safer automatic XDG cache bucket keys from host-qualified remotes or hashed host-and-path local fallbacks so ordinary workspaces no longer need `workspace.cacheKey`.
+Derive safer automatic XDG cache bucket keys from hashed host-and-path checkout identity so ordinary workspaces no longer need `workspace.cacheKey`.

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -121,10 +121,9 @@ Global Skillset state uses Skillset-owned XDG directories, never provider runtim
 Per-repo global cache buckets live directly under `$XDG_CACHE_HOME/skillset/<repo-key>/`; Skillset does not add a default `repos/` layer. Repo keys resolve in this order:
 
 1. `workspace.cacheKey` from the workspace manifest, when a repo intentionally needs a stable override.
-2. Host-qualified Git remote path components, rendered as `<host>--<namespace>--<repo>` for ordinary owner/repo remotes or `<host>--<group>--<subgroup>--<repo>` for nested namespaces.
-3. Local fallback `<basename>--local-<sha12>`, where the hash is derived from the normalized host name and normalized absolute repo path.
+2. Automatic local key `<basename>--local-<sha12>`, where the hash is derived from the normalized host name and normalized absolute repo path.
 
-Most repos should not set `workspace.cacheKey`: remote-derived keys are portable, and the local fallback is deterministic for a given machine and checkout path without leaking the raw path into the cache bucket name. The local fallback is intentionally local because host names and absolute checkout paths vary across machines.
+Most repos should not set `workspace.cacheKey`: the automatic key is deterministic for a given machine and checkout path without leaking the raw path into the cache bucket name. It is intentionally local because operational cache contents belong to the concrete filesystem checkout, and host names and absolute checkout paths vary across machines.
 
 Operational cache callers keep reporting logical paths such as `.skillset/cache/latest/`, `.skillset/cache/tests/`, `.skillset/cache/adopt/`, `.skillset/cache/fixtures/`, and `.skillset/cache/reports/`. When those paths are read or written by Skillset commands, they resolve to `$XDG_CACHE_HOME/skillset/<repo-key>/latest/`, `tests/`, `adopt/`, `fixtures/`, and `reports/` respectively.
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -120,12 +120,11 @@ Global Skillset state uses Skillset-owned XDG directories, never provider runtim
 
 Per-repo global cache buckets live directly under `$XDG_CACHE_HOME/skillset/<repo-key>/`; Skillset does not add a default `repos/` layer. Repo keys resolve in this order:
 
-1. `workspace.cacheKey` from the workspace manifest.
-2. Canonical Git remote path components, rendered as `<namespace>--<repo>` for ordinary owner/repo remotes or `<group>--<subgroup>--<repo>` for nested namespaces.
-3. Host-qualified Git remote path components, rendered as `<host>--<namespace>--<repo>`, when a caller needs to avoid cross-host collisions.
-4. Local fallback `<basename>--<sha12>`, where the hash is derived from the normalized absolute repo path.
+1. `workspace.cacheKey` from the workspace manifest, when a repo intentionally needs a stable override.
+2. Host-qualified Git remote path components, rendered as `<host>--<namespace>--<repo>` for ordinary owner/repo remotes or `<host>--<group>--<subgroup>--<repo>` for nested namespaces.
+3. Local fallback `<basename>--local-<sha12>`, where the hash is derived from the normalized host name and normalized absolute repo path.
 
-Explicit and remote-derived keys are portable enough to share in docs and team config. The local fallback is deterministic on one machine, but it is intentionally local because absolute checkout paths vary across machines.
+Most repos should not set `workspace.cacheKey`: remote-derived keys are portable, and the local fallback is deterministic for a given machine and checkout path without leaking the raw path into the cache bucket name. The local fallback is intentionally local because host names and absolute checkout paths vary across machines.
 
 Operational cache callers keep reporting logical paths such as `.skillset/cache/latest/`, `.skillset/cache/tests/`, `.skillset/cache/adopt/`, `.skillset/cache/fixtures/`, and `.skillset/cache/reports/`. When those paths are read or written by Skillset commands, they resolve to `$XDG_CACHE_HOME/skillset/<repo-key>/latest/`, `tests/`, `adopt/`, `fixtures/`, and `reports/` respectively.
 

--- a/docs/reference/examples/workspace-config.yaml
+++ b/docs/reference/examples/workspace-config.yaml
@@ -66,5 +66,3 @@ supports:
       onMismatch: warn
       range: ^1.0.0
       source: repo:package.json
-workspace:
-  cacheKey: example--team-skillset

--- a/packages/core/src/__tests__/xdg.test.ts
+++ b/packages/core/src/__tests__/xdg.test.ts
@@ -63,7 +63,7 @@ describe("XDG path helpers", () => {
 });
 
 describe("repo cache keys", () => {
-  test("uses explicit workspace cache keys before remote-derived keys", () => {
+  test("uses explicit workspace cache keys before automatic keys", () => {
     expect(resolveRepoCachePath({
       env: { XDG_CACHE_HOME: "/xdg/cache" },
       homeDir: "/home/matt",
@@ -78,51 +78,7 @@ describe("repo cache keys", () => {
     });
   });
 
-  test("derives owner repo keys from hosted git remotes", () => {
-    expect(resolveRepoCacheKey({
-      remoteUrl: "git@github.com:Acme/docs-cli.git",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "github.com--acme--docs-cli", source: "remote" });
-
-    expect(resolveRepoCacheKey({
-      remoteUrl: "https://github.com/Acme/docs-cli.git",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "github.com--acme--docs-cli", source: "remote" });
-
-    expect(resolveRepoCacheKey({
-      remoteUrl: "https://github.com/Acme/docs-cli.git/",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "github.com--acme--docs-cli", source: "remote" });
-  });
-
-  test("can opt out of host-qualified remote keys", () => {
-    expect(resolveRepoCacheKey({
-      hostQualified: false,
-      remoteUrl: "git@github.com:Acme/docs-cli.git",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "acme--docs-cli", source: "remote" });
-  });
-
-  test("qualifies remote keys by host to avoid cross-host collisions", () => {
-    expect(resolveRepoCacheKey({
-      remoteUrl: "ssh://git@gitlab.com/Acme/docs-cli.git",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "gitlab.com--acme--docs-cli", source: "remote" });
-  });
-
-  test("preserves nested remote namespaces in repo cache keys", () => {
-    expect(resolveRepoCacheKey({
-      remoteUrl: "https://gitlab.com/group-a/team/docs-cli.git",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "gitlab.com--group-a--team--docs-cli", source: "remote" });
-
-    expect(resolveRepoCacheKey({
-      remoteUrl: "https://gitlab.com/group-b/team/docs-cli.git",
-      rootPath: "/work/docs-cli",
-    })).toEqual({ key: "gitlab.com--group-b--team--docs-cli", source: "remote" });
-  });
-
-  test("uses a durable host-and-path local fallback when no canonical remote exists", () => {
+  test("uses a durable host-and-path automatic key", () => {
     const first = resolveRepoCacheKey({ hostName: "devbox.local", rootPath: "/work/private/docs-cli" });
     const second = resolveRepoCacheKey({ hostName: "devbox.local", rootPath: "/work/private/docs-cli" });
     const otherPath = resolveRepoCacheKey({ hostName: "devbox.local", rootPath: "/work/private/other" });
@@ -133,6 +89,28 @@ describe("repo cache keys", () => {
     expect(first.key).toMatch(/^docs-cli--local-[0-9a-f]{12}$/);
     expect(otherPath.key).not.toBe(first.key);
     expect(otherHost.key).not.toBe(first.key);
+  });
+
+  test("derives automatic keys from local storage identity instead of remotes", () => {
+    const github = resolveRepoCacheKey({
+      hostName: "devbox.local",
+      remoteUrl: "git@github.com:Acme/docs-cli.git",
+      rootPath: "/work/private/docs-cli",
+    });
+    const gitlab = resolveRepoCacheKey({
+      hostName: "devbox.local",
+      remoteUrl: "ssh://git@gitlab.com/Other/docs-cli.git",
+      rootPath: "/work/private/docs-cli",
+    });
+    const otherCheckout = resolveRepoCacheKey({
+      hostName: "devbox.local",
+      remoteUrl: "git@github.com:Acme/docs-cli.git",
+      rootPath: "/work/other/docs-cli",
+    });
+
+    expect(github).toEqual(gitlab);
+    expect(github.source).toBe("fallback");
+    expect(otherCheckout.key).not.toBe(github.key);
   });
 });
 

--- a/packages/core/src/__tests__/xdg.test.ts
+++ b/packages/core/src/__tests__/xdg.test.ts
@@ -82,22 +82,29 @@ describe("repo cache keys", () => {
     expect(resolveRepoCacheKey({
       remoteUrl: "git@github.com:Acme/docs-cli.git",
       rootPath: "/work/docs-cli",
-    })).toEqual({ key: "acme--docs-cli", source: "remote" });
+    })).toEqual({ key: "github.com--acme--docs-cli", source: "remote" });
 
     expect(resolveRepoCacheKey({
       remoteUrl: "https://github.com/Acme/docs-cli.git",
       rootPath: "/work/docs-cli",
-    })).toEqual({ key: "acme--docs-cli", source: "remote" });
+    })).toEqual({ key: "github.com--acme--docs-cli", source: "remote" });
 
     expect(resolveRepoCacheKey({
       remoteUrl: "https://github.com/Acme/docs-cli.git/",
       rootPath: "/work/docs-cli",
+    })).toEqual({ key: "github.com--acme--docs-cli", source: "remote" });
+  });
+
+  test("can opt out of host-qualified remote keys", () => {
+    expect(resolveRepoCacheKey({
+      hostQualified: false,
+      remoteUrl: "git@github.com:Acme/docs-cli.git",
+      rootPath: "/work/docs-cli",
     })).toEqual({ key: "acme--docs-cli", source: "remote" });
   });
 
-  test("can qualify remote keys by host to avoid cross-host collisions", () => {
+  test("qualifies remote keys by host to avoid cross-host collisions", () => {
     expect(resolveRepoCacheKey({
-      hostQualified: true,
       remoteUrl: "ssh://git@gitlab.com/Acme/docs-cli.git",
       rootPath: "/work/docs-cli",
     })).toEqual({ key: "gitlab.com--acme--docs-cli", source: "remote" });
@@ -105,27 +112,27 @@ describe("repo cache keys", () => {
 
   test("preserves nested remote namespaces in repo cache keys", () => {
     expect(resolveRepoCacheKey({
-      hostQualified: true,
       remoteUrl: "https://gitlab.com/group-a/team/docs-cli.git",
       rootPath: "/work/docs-cli",
     })).toEqual({ key: "gitlab.com--group-a--team--docs-cli", source: "remote" });
 
     expect(resolveRepoCacheKey({
-      hostQualified: true,
       remoteUrl: "https://gitlab.com/group-b/team/docs-cli.git",
       rootPath: "/work/docs-cli",
     })).toEqual({ key: "gitlab.com--group-b--team--docs-cli", source: "remote" });
   });
 
-  test("uses a durable local fallback when no canonical remote exists", () => {
-    const first = resolveRepoCacheKey({ rootPath: "/work/private/docs-cli" });
-    const second = resolveRepoCacheKey({ rootPath: "/work/private/docs-cli" });
-    const other = resolveRepoCacheKey({ rootPath: "/work/private/other" });
+  test("uses a durable host-and-path local fallback when no canonical remote exists", () => {
+    const first = resolveRepoCacheKey({ hostName: "devbox.local", rootPath: "/work/private/docs-cli" });
+    const second = resolveRepoCacheKey({ hostName: "devbox.local", rootPath: "/work/private/docs-cli" });
+    const otherPath = resolveRepoCacheKey({ hostName: "devbox.local", rootPath: "/work/private/other" });
+    const otherHost = resolveRepoCacheKey({ hostName: "laptop.local", rootPath: "/work/private/docs-cli" });
 
     expect(first).toEqual(second);
     expect(first.source).toBe("fallback");
-    expect(first.key).toMatch(/^docs-cli--[0-9a-f]{12}$/);
-    expect(other.key).not.toBe(first.key);
+    expect(first.key).toMatch(/^docs-cli--local-[0-9a-f]{12}$/);
+    expect(otherPath.key).not.toBe(first.key);
+    expect(otherHost.key).not.toBe(first.key);
   });
 });
 

--- a/packages/core/src/xdg.ts
+++ b/packages/core/src/xdg.ts
@@ -27,8 +27,10 @@ export interface SkillsetXdgPaths {
 }
 
 export interface RepoCacheKeyOptions {
+  /** @deprecated Remote identity no longer affects operational cache bucket keys. */
   readonly hostQualified?: boolean;
   readonly hostName?: string;
+  /** @deprecated Remote identity no longer affects operational cache bucket keys. */
   readonly remoteUrl?: string;
   readonly rootPath: string;
   readonly workspaceCacheKey?: string;
@@ -44,11 +46,6 @@ export interface RepoCachePathOptions extends RepoCacheKeyOptions, SkillsetXdgOp
 export interface RepoCachePathResult extends RepoCacheKeyResult {
   readonly path: string;
   readonly xdgCacheBase: string;
-}
-
-interface ParsedRemote {
-  readonly host: string;
-  readonly pathParts: readonly string[];
 }
 
 export function readSkillsetWorkspaceConfig(record: JsonRecord, label: string): SkillsetWorkspaceConfig {
@@ -87,17 +84,6 @@ export function resolveRepoCacheKey(options: RepoCacheKeyOptions): RepoCacheKeyR
     };
   }
 
-  const remote = parseGitRemote(options.remoteUrl);
-  if (remote !== undefined) {
-    const pathKey = remote.pathParts.map((part) => slugPart(part, "git remote path")).join("--");
-    return {
-      key: options.hostQualified === false
-        ? pathKey
-        : `${slugPart(remote.host, "git remote host")}--${pathKey}`,
-      source: "remote",
-    };
-  }
-
   return {
     key: `${slugPart(basename(resolve(options.rootPath)), "repo basename")}--local-${fallbackHash(options.rootPath, options.hostName ?? hostname())}`,
     source: "fallback",
@@ -119,46 +105,6 @@ function readXdgBase(value: string | undefined, home: string, fallback: string):
     return join(home, fallback);
   }
   return value;
-}
-
-function parseGitRemote(remoteUrl: string | undefined): ParsedRemote | undefined {
-  if (remoteUrl === undefined || remoteUrl.trim().length === 0) return undefined;
-  const trimmed = remoteUrl.trim();
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
-    try {
-      const url = new URL(trimmed);
-      if (url.hostname.length === 0) return undefined;
-      return parsedRemoteFromParts(url.hostname, url.pathname);
-    } catch {
-      return undefined;
-    }
-  }
-
-  const scpLike = /^(?:[^@/:]+@)?([^/:]+):(.+)$/.exec(trimmed);
-  if (scpLike !== null) return parsedRemoteFromParts(scpLike[1], scpLike[2]);
-
-  try {
-    const url = new URL(trimmed);
-    if (url.hostname.length === 0) return undefined;
-    return parsedRemoteFromParts(url.hostname, url.pathname);
-  } catch {
-    return undefined;
-  }
-}
-
-function parsedRemoteFromParts(host: string | undefined, rawPath: string | undefined): ParsedRemote | undefined {
-  if (host === undefined || rawPath === undefined) return undefined;
-  const normalizedPath = rawPath.replace(/^\/+|\/+$/g, "");
-  const parts = normalizedPath.split("/").filter(Boolean);
-  if (parts.length < 2) return undefined;
-  const last = parts.at(-1);
-  if (last !== undefined) {
-    parts[parts.length - 1] = last.replace(/\.git$/i, "");
-  }
-  return {
-    host: host.toLowerCase(),
-    pathParts: parts,
-  };
 }
 
 function slugPart(value: string, label: string): string {

--- a/packages/core/src/xdg.ts
+++ b/packages/core/src/xdg.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
 
 import { readRecord } from "./config";
@@ -28,6 +28,7 @@ export interface SkillsetXdgPaths {
 
 export interface RepoCacheKeyOptions {
   readonly hostQualified?: boolean;
+  readonly hostName?: string;
   readonly remoteUrl?: string;
   readonly rootPath: string;
   readonly workspaceCacheKey?: string;
@@ -90,15 +91,15 @@ export function resolveRepoCacheKey(options: RepoCacheKeyOptions): RepoCacheKeyR
   if (remote !== undefined) {
     const pathKey = remote.pathParts.map((part) => slugPart(part, "git remote path")).join("--");
     return {
-      key: options.hostQualified === true
-        ? `${slugPart(remote.host, "git remote host")}--${pathKey}`
-        : pathKey,
+      key: options.hostQualified === false
+        ? pathKey
+        : `${slugPart(remote.host, "git remote host")}--${pathKey}`,
       source: "remote",
     };
   }
 
   return {
-    key: `${slugPart(basename(resolve(options.rootPath)), "repo basename")}--${fallbackHash(options.rootPath)}`,
+    key: `${slugPart(basename(resolve(options.rootPath)), "repo basename")}--local-${fallbackHash(options.rootPath, options.hostName ?? hostname())}`,
     source: "fallback",
   };
 }
@@ -176,6 +177,12 @@ function validateRepoCacheKey(value: string, label: string): string {
   return trimmed;
 }
 
-function fallbackHash(rootPath: string): string {
-  return createHash("sha256").update(resolve(rootPath)).digest("hex").slice(0, FALLBACK_HASH_LENGTH);
+function fallbackHash(rootPath: string, hostName: string): string {
+  const normalizedHost = hostName.trim().toLowerCase();
+  return createHash("sha256")
+    .update(normalizedHost)
+    .update("\0")
+    .update(resolve(rootPath))
+    .digest("hex")
+    .slice(0, FALLBACK_HASH_LENGTH);
 }

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -108,9 +108,6 @@ export const skillsetSchemaExamples = [
           },
         ],
       },
-      workspace: {
-        cacheKey: "example--team-skillset",
-      },
     },
   },
   {

--- a/skillset.yaml
+++ b/skillset.yaml
@@ -12,5 +12,3 @@ skillset:
   summary: Self-hosted source for developing and using the skillset compiler.
   title: Skillset
   version: 0.1.0
-workspace:
-  cacheKey: outfitter--skillset

--- a/skillset/changes/4a8c4b5ae357.md
+++ b/skillset/changes/4a8c4b5ae357.md
@@ -6,7 +6,7 @@ evidence:
   - scope: codex.hooks:hooks/hooks.json
     sourceHash: sha256:6ca86c5ba32c2d51e8b4abd3ed930a8fadeee76482ef9ba66067d4e5aae7f416
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: plugin.skillset.skill:use-skillset
     sourceHash: sha256:85e65b4c916230d474a94c19ddab08b34ffe4c26a04ec2130b09532bc94dd6a4
   - scope: plugin:skillset
@@ -18,11 +18,11 @@ evidence:
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: skill:skillset-claude-development
     sourceHash: sha256:928e9f38d443121e53774dbfcb1376b2a38aa53e1872c14ced9d20d8e248210c
   - scope: skill:skillset-codex-development

--- a/skillset/changes/93a167d3f52a.md
+++ b/skillset/changes/93a167d3f52a.md
@@ -6,7 +6,7 @@ evidence:
   - scope: codex.hooks:hooks/hooks.json
     sourceHash: sha256:6ca86c5ba32c2d51e8b4abd3ed930a8fadeee76482ef9ba66067d4e5aae7f416
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: plugin.skillset.config:root
     sourceHash: sha256:a3266fa6406bc5c44193531790bc4dc08509ca11085d30694d9ff69c671bcfb4
   - scope: plugin.skillset.skill:use-skillset

--- a/skillset/changes/9c9460ab4879.md
+++ b/skillset/changes/9c9460ab4879.md
@@ -6,7 +6,7 @@ evidence:
   - scope: codex.hooks:hooks/hooks.json
     sourceHash: sha256:6ca86c5ba32c2d51e8b4abd3ed930a8fadeee76482ef9ba66067d4e5aae7f416
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: plugin.skillset.skill:use-skillset
     sourceHash: sha256:85e65b4c916230d474a94c19ddab08b34ffe4c26a04ec2130b09532bc94dd6a4
   - scope: plugin.skillset.skill:use-skillset
@@ -26,11 +26,11 @@ evidence:
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: skill:skillset-claude-development
     sourceHash: sha256:928e9f38d443121e53774dbfcb1376b2a38aa53e1872c14ced9d20d8e248210c
   - scope: skill:skillset-codex-development

--- a/skillset/changes/b8daf9369912.md
+++ b/skillset/changes/b8daf9369912.md
@@ -2,13 +2,13 @@
 bump: minor
 evidence:
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: instruction:fixtures
     sourceHash: sha256:247809b60e25cb5a3948a439f60464505af61894e883652b4c3fc01a073b5f2e
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
 group: SET-176
 id: b8daf9369912
 scopes:

--- a/skillset/changes/bce95ede3c62.md
+++ b/skillset/changes/bce95ede3c62.md
@@ -2,7 +2,7 @@
 bump: minor
 evidence:
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
 group: SET-184
 id: bce95ede3c62
 scope: config:root

--- a/skillset/changes/bfa509c23eee.md
+++ b/skillset/changes/bfa509c23eee.md
@@ -7,4 +7,4 @@ id: bfa509c23eee
 scope: config:root
 ---
 
-Stop requiring self-hosted workspaces to pin workspace.cacheKey now that automatic XDG cache keys include host-qualified remotes and host/path local fallback hashes.
+Stop requiring self-hosted workspaces to pin workspace.cacheKey now that automatic XDG cache keys derive from deterministic host/path checkout identity.

--- a/skillset/changes/bfa509c23eee.md
+++ b/skillset/changes/bfa509c23eee.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+evidence:
+  - scope: config:root
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
+id: bfa509c23eee
+scope: config:root
+---
+
+Stop requiring self-hosted workspaces to pin workspace.cacheKey now that automatic XDG cache keys include host-qualified remotes and host/path local fallback hashes.

--- a/skillset/changes/c5a4125709da.md
+++ b/skillset/changes/c5a4125709da.md
@@ -6,11 +6,11 @@ evidence:
   - scope: codex.hooks:hooks/hooks.json
     sourceHash: sha256:6ca86c5ba32c2d51e8b4abd3ed930a8fadeee76482ef9ba66067d4e5aae7f416
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: plugin.skillset.companion:README.md
     sourceHash: sha256:f27a7bbcd9c099ce05b9d57b5ecf6b9bd7a79bc72d5305a1452dc50ef6545f16
   - scope: plugin.skillset.companion:README.md
@@ -88,11 +88,11 @@ evidence:
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: skill:skillset-repo-test-fixtures
     sourceHash: sha256:60544d3c72757c4f46c7d3ecf70461b56b26c0618c89e8552f001441985170ee
   - scope: config:root
-    sourceHash: sha256:a24b10f0eff25edc8c367e46be2f997b8aec1a4fab138420da1f5b02f3329218
+    sourceHash: sha256:de21482cecafbeea2bb243a43c74d5532c9df62b1985473c68c977423254cbdb
   - scope: skill:skillset-claude-development
     sourceHash: sha256:928e9f38d443121e53774dbfcb1376b2a38aa53e1872c14ced9d20d8e248210c
   - scope: skill:skillset-codex-development


### PR DESCRIPTION
## Context

`workspace.cacheKey` should be an escape hatch, not required setup. The automatic XDG cache bucket should be deterministic from the concrete local checkout that owns the operational state.

## What changed

- Derive automatic repo cache buckets as `<basename>--local-<sha12>`, where the hash comes from the normalized host name and absolute repo path.
- Keep `workspace.cacheKey` as an explicit override for repos that intentionally need a pinned bucket.
- Stop using Git remote identity to choose the operational cache bucket, so two checkouts of the same remote do not collide.
- Remove the self-hosted `workspace.cacheKey` from this repo and from generated workspace examples.
- Document `workspace.cacheKey` as an intentional override rather than normal configuration.

## Verification

- `bun test packages/core/src/__tests__/xdg.test.ts`
- `bun ./apps/skillset/src/cli.ts change check --root . --since main`
- `bun run changeset:check`
- `bun ./apps/skillset/src/cli.ts ci --root . --since main`
- `bun run check`
- pre-push hook via `gt submit --stack --draft --restack --no-edit --no-interactive`
