### PR TITLE
docs: add five-minute quickstart

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This directory holds durable documentation for the local Skillset compiler.
 
 - [Tenets](tenets.md): the slow-moving doctrine for how Skillset makes source-first Claude/Codex loadouts easier to author and safer to render.
 - [Architecture Decision Records](adrs/README.md): accepted decisions for source vocabulary, target rendering, compiler promises, and authoring workflows. Draft decisions live under [adrs/drafts](adrs/drafts/README.md).
+- [Five-Minute Quickstart](quickstart.md): a short first-author path from `init` to one built Claude and Codex skill.
 - [Feature Reference](features/README.md): the support registry layer for source features, target adapters, future-only surfaces, and feature-specific provenance.
 - [Layout](layout.md): the current source layout, generated output shape, shared-resource behavior, rules/instructions rendering, hooks, skill policy, and import flow.
 - [Schema Contracts](schema-contracts.md): the schema-first workflow, generated artifacts, and checklist for adding source/config/frontmatter fields without drift.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,140 @@
+# Five-Minute Quickstart
+
+This path starts in an existing repo and creates one standalone skill. It proves
+the source-first loop without installing, trusting, symlinking, or changing
+Claude or Codex runtime configuration.
+
+Use a dedicated source repo instead when the repo exists only to author
+Skillset loadouts:
+
+```bash
+skillset create my-skillset --yes
+cd my-skillset
+```
+
+For an existing content repo, stay in that repo and initialize the default
+nested `.skillset/` source layout:
+
+```bash
+skillset init --yes
+```
+
+That writes the workspace manifest at `.skillset/skillset.yaml`, source
+placeholders under `.skillset/src/`, tracked change state under
+`.skillset/changes/`, and repo-local operational sentinels for
+`.skillset/cache/` and `.skillset/snapshots/`. The cache payloads resolve to
+Skillset's XDG cache bucket; the logical `.skillset/cache/` path stays visible
+for reports and command output.
+
+## Create One Skill
+
+Create a skill source file:
+
+```bash
+skillset new skill "Review Notes" --yes
+```
+
+The source lands at:
+
+```text
+.skillset/src/skills/review-notes/SKILL.md
+```
+
+Open that file and replace the starter body with the guidance the skill should
+carry. A minimal skill looks like this:
+
+```markdown
+---
+name: review-notes
+title: Review Notes
+description: Use when summarizing meeting notes into decisions, follow-ups, and risks.
+---
+
+# Review Notes
+
+Use this skill when a notes document needs to become a short decision log.
+
+## Workflow
+
+- Identify the concrete decisions.
+- Pull out follow-ups with an owner when one is named.
+- Keep unresolved risks separate from agreed next steps.
+```
+
+The directory name is the stable identity. The top-level `name` may stay aligned
+with it; `title` is human-facing skill display text; `description` is the
+triggering text that renders into both target skill formats.
+
+## Check And Build
+
+Run the source authoring check:
+
+```bash
+skillset check
+```
+
+Preview generated output:
+
+```bash
+skillset build
+```
+
+On a fresh repo, the first build plan should list new generated files such as:
+
+```text
+.claude/skills/review-notes/SKILL.md
+.agents/skills/review-notes/SKILL.md
+skillset.lock
+```
+
+Write the generated output:
+
+```bash
+skillset build --yes
+```
+
+Then verify the generated files are current:
+
+```bash
+skillset verify
+```
+
+## Inspect The Output
+
+The default nested layout writes standalone skill output to:
+
+```text
+.claude/skills/review-notes/SKILL.md
+.agents/skills/review-notes/SKILL.md
+```
+
+Each target skill root also gets a `skillset.lock`, and the repo root gets a
+`skillset.lock`. Locks carry source paths, output paths, hashes, version state,
+target state, and generated metadata policy. They are review evidence for what
+Skillset rendered; the source remains `.skillset/src/skills/review-notes/`.
+
+Skillset does not make the generated skill live in a user runtime. It writes
+repo-local target-native files only. Activation, install, trust, and user-level
+Claude or Codex configuration stay separate.
+
+## Useful Next Commands
+
+```bash
+skillset diff
+skillset explain .skillset/src/skills/review-notes/SKILL.md
+skillset explain .claude/skills/review-notes/SKILL.md
+skillset doctor
+```
+
+Use `diff` to preview generated changes after editing source, `explain` to see
+why a source or generated path exists, and `doctor` for a broader local health
+summary.
+
+## Where To Go Deeper
+
+- [Layout](layout.md) covers nested versus root layout, generated roots, and
+  operational state.
+- [Skills](features/skills.md) covers skill frontmatter, resources, rendering,
+  diagnostics, and provenance.
+- [Workbench Check](features/workbench.md) explains `check` versus `verify`.
+- [CI](features/ci.md) explains the `skillset ci` gate and optional workflow.


### PR DESCRIPTION
## Context

SET-199 adds the first-author quickstart for the 0.16 onboarding stack. It is stacked on SET-203 / PR #178 so the docs path can follow the source vocabulary decisions without waiting on main.

## What changed

- Adds `docs/quickstart.md` with a five-minute path through `skillset init`, `skillset new skill`, `skillset check`, `skillset build`, generated output inspection, and `skillset verify`.
- Documents the default nested layout, generated Claude/Codex skill paths, lock files, and the no-runtime-mutation boundary.
- Links the quickstart from `docs/README.md`.

## Verification

- Temporary repo proof: `init --yes`, `new skill "Review Notes" --yes`, `check`, `build`, `build --yes`, `verify`
- `git diff --check`
- `bun ./apps/skillset/src/cli.ts change check --root .`
- pre-push hook: `skillset-ci`
- pre-push hook: `bun run check` (691 tests, `skillset:check`, `skillset:verify`, terminology guard)

## Notes

The README top-level restructuring remains for SET-201. This slice only adds the quickstart and the docs index link.

Linear: SET-199
