### PR TITLE
docs: add first-author share-ready checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Write repo-local generated output only when you explicitly run
 
 - [Five-Minute Quickstart](docs/quickstart.md): the shortest first-author path from source scaffold to generated output.
 - [First Author Example](examples/first-author/README.md): a minimal root-layout source repo that builds one skill and one rule to Claude and Codex.
+- [Share-Ready Checklist](docs/quickstart.md#share-ready-checklist): the 0.16 author handoff bar before hooks or runtime activation enter the path.
 - [Dev Watch](docs/features/dev-watch.md): the preview-only `skillset dev --watch` authoring loop.
 - [Skillset Design Tenets](docs/tenets.md): the slow-moving doctrine for source-first loadout authoring and target-native rendering.
 - [Architecture Decision Records](docs/adrs/README.md): accepted and proposed decisions for source vocabulary, unsupported destination policy, and generated-output promises.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory holds durable documentation for the local Skillset compiler.
 - [Tenets](tenets.md): the slow-moving doctrine for how Skillset makes source-first Claude/Codex loadouts easier to author and safer to render.
 - [Architecture Decision Records](adrs/README.md): accepted decisions for source vocabulary, target rendering, compiler promises, and authoring workflows. Draft decisions live under [adrs/drafts](adrs/drafts/README.md).
 - [Five-Minute Quickstart](quickstart.md): a short first-author path from `init` to one built Claude and Codex skill.
+- [Share-Ready Checklist](quickstart.md#share-ready-checklist): the 0.16 author handoff bar before hooks or runtime activation enter the path.
 - [First Author Example](../examples/first-author/README.md): a cloneable root-layout source repo with one skill and one rule that builds to Claude and Codex.
 - [Feature Reference](features/README.md): the support registry layer for source features, target adapters, future-only surfaces, and feature-specific provenance.
 - [Layout](layout.md): the current source layout, generated output shape, shared-resource behavior, rules/instructions rendering, hooks, skill policy, and import flow.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -137,6 +137,22 @@ see why a source or generated path exists, and `doctor` for a broader local
 health summary. The watch loop is preview-only; use `skillset build --yes` when
 you want to write generated output.
 
+## Share-Ready Checklist
+
+Before sharing a 0.16-era Skillset source repo with another author, make sure:
+
+- `skillset check` passes for source authoring diagnostics.
+- `skillset build` shows the generated-output plan you expect.
+- `skillset build --yes` has refreshed repo-local Claude and Codex output.
+- `skillset verify` passes so checked-in generated output matches source.
+- The generated output locations are visible in review, usually `.claude/`,
+  `.agents/`, and `skillset.lock` for the default nested path.
+- Runtime activation is deliberately out of band: do not ask authors to install,
+  trust, symlink, or mutate user-level Claude/Codex config as part of this path.
+- Hook-dependent sharing stays deferred to the hook guardrail work. If a repo
+  has local Git or runtime hooks, document them separately from the compiler
+  quickstart.
+
 ## Where To Go Deeper
 
 - [Layout](layout.md) covers nested versus root layout, generated roots, and


### PR DESCRIPTION
## Context

SET-198's child issues for the 0.16 onboarding path are done, but the parent acceptance criteria still called out a share-ready checklist for first authors who do not need hook-dependent sharing yet.

## What changed

- Added a Share-Ready Checklist to the five-minute quickstart.
- Linked the checklist from the root README and docs index.
- Kept the guidance explicit that runtime activation, install/trust/symlink/user config mutation, and hook-dependent sharing are outside this first-author path.

## Verification

- bun run check
- pre-push hook: changeset guard, workflow lint, skillset ci, bun run check

Resolves SET-198.