### PR TITLE
feat: add adaptive hook contract registry

### DIFF
--- a/.changeset/adaptive-hook-contract.md
+++ b/.changeset/adaptive-hook-contract.md
@@ -1,0 +1,6 @@
+---
+"@skillset/core": patch
+"@skillset/schema": patch
+---
+
+Add the adaptive hook unit source contract and provider capability registry used by the upcoming hook attachment and rendering stack.

--- a/docs/reference/examples/adaptive-hook.yaml
+++ b/docs/reference/examples/adaptive-hook.yaml
@@ -1,0 +1,24 @@
+claude:
+  if: Bash(git *)
+codex:
+  matcher: Bash
+description: Checks shell commands before they run.
+events:
+  - PreToolUse
+match:
+  tool:
+    - Bash
+name: shell-policy
+providers:
+  - claude
+  - codex
+run:
+  args:
+    - --event
+    - pre-tool-use
+  command: node ./hooks/shell-policy/check.js
+  cwd: .
+  env:
+    SKILLSET_HOOK: shell-policy
+  script: ./check.js
+status: Checking shell policy

--- a/docs/reference/schemas/0.1.0/adaptive-hook.schema.json
+++ b/docs/reference/schemas/0.1.0/adaptive-hook.schema.json
@@ -1,0 +1,94 @@
+{
+  "$id": "https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas/0.1.0/adaptive-hook.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "claude": {
+      "type": "object"
+    },
+    "codex": {
+      "type": "object"
+    },
+    "description": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "events": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "match": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "name": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "providers": {
+      "items": {
+        "enum": [
+          "claude",
+          "codex"
+        ],
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "run": {
+      "additionalProperties": false,
+      "properties": {
+        "args": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "cwd": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "script": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "events",
+    "run"
+  ],
+  "title": "Adaptive Hook Unit",
+  "type": "object"
+}

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -1,5 +1,97 @@
 {
   "$defs": {
+    "adaptive-hook": {
+      "additionalProperties": false,
+      "properties": {
+        "claude": {
+          "type": "object"
+        },
+        "codex": {
+          "type": "object"
+        },
+        "description": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "events": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "match": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "providers": {
+          "items": {
+            "enum": [
+              "claude",
+              "codex"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "run": {
+          "additionalProperties": false,
+          "properties": {
+            "args": {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "command": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "cwd": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "script": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "status": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "events",
+        "run"
+      ],
+      "title": "Adaptive Hook Unit",
+      "type": "object"
+    },
     "agent-frontmatter": {
       "additionalProperties": false,
       "properties": {
@@ -1723,6 +1815,9 @@
     },
     {
       "$ref": "#/$defs/hook"
+    },
+    {
+      "$ref": "#/$defs/adaptive-hook"
     },
     {
       "$ref": "#/$defs/change-entry"

--- a/docs/reference/schemas/README.md
+++ b/docs/reference/schemas/README.md
@@ -16,6 +16,7 @@ The combined schema is [`skillset.schema.json`](./0.1.0/skillset.schema.json). U
 | `agent-frontmatter` | [`agent-frontmatter.schema.json`](./0.1.0/agent-frontmatter.schema.json) | Adaptive Skillset agent frontmatter. |
 | `instruction-frontmatter` | [`instruction-frontmatter.schema.json`](./0.1.0/instruction-frontmatter.schema.json) | Adaptive Skillset instruction/rules frontmatter. |
 | `hook` | [`hook.schema.json`](./0.1.0/hook.schema.json) | Skillset hook definition source contract for aggregate hook event maps. |
+| `adaptive-hook` | [`adaptive-hook.schema.json`](./0.1.0/adaptive-hook.schema.json) | Skillset adaptive hook unit source contract for reusable portable hooks. |
 | `change-entry` | [`change-entry.schema.json`](./0.1.0/change-entry.schema.json) | Pending Skillset change entry source contract. |
 
 ## Examples
@@ -30,6 +31,7 @@ The examples are generated from typed fixtures and checked against the same sche
 | `agent-frontmatter` | [`agent-frontmatter.yaml`](../examples/agent-frontmatter.yaml) | Adaptive project-agent frontmatter. |
 | `instruction-frontmatter` | [`instruction-frontmatter.yaml`](../examples/instruction-frontmatter.yaml) | Adaptive instruction/rules frontmatter. |
 | `hook` | [`hook.yaml`](../examples/hook.yaml) | Hook definition source object. |
+| `adaptive-hook` | [`adaptive-hook.yaml`](../examples/adaptive-hook.yaml) | Adaptive reusable hook unit. |
 | `change-entry` | [`change-entry.yaml`](../examples/change-entry.yaml) | Pending change entry frontmatter. |
 
 ## Editor Integration

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -25,6 +25,7 @@ import {
 
 const SEEDED_FEATURE_IDS = [
   "activation-probes",
+  "adaptive-hooks",
   "changes",
   "dependencies",
   "dev-watch",

--- a/packages/core/src/__tests__/hook-capabilities.test.ts
+++ b/packages/core/src/__tests__/hook-capabilities.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CODEX_HOOK_EVENTS,
+  classifyAdaptiveHookUnitPath,
+  hookEventSupported,
+  hookProviderCapabilities,
+  validateAdaptiveHookUnitPaths,
+} from "../hook-capabilities";
+
+describe("hook provider capabilities", () => {
+  test("records event-level Claude and Codex hook support", () => {
+    expect(hookEventSupported("claude", "Notification")).toBe(true);
+    expect(hookEventSupported("codex", "Notification")).toBe(false);
+    expect([...CODEX_HOOK_EVENTS].sort()).toEqual([
+      "PermissionRequest",
+      "PostCompact",
+      "PostToolUse",
+      "PreCompact",
+      "PreToolUse",
+      "SessionStart",
+      "Stop",
+      "SubagentStart",
+      "SubagentStop",
+      "UserPromptSubmit",
+    ]);
+  });
+
+  test("records Codex handler, matcher, and scope constraints", () => {
+    const codex = hookProviderCapabilities.codex;
+    expect([...codex.handlerTypes]).toEqual(["command"]);
+    expect(codex.asyncCommand).toBe(false);
+    expect(codex.matcherByEvent.PreToolUse).toBe("tool");
+    expect(codex.matcherByEvent.Stop).toBe("ignored");
+    expect(codex.matcherByEvent.UserPromptSubmit).toBe("ignored");
+    expect(codex.scopeSupport.plugin).toBe("native");
+    expect(codex.scopeSupport.skill).toBe("unsupported");
+    expect(codex.scopeSupport.agent).toBe("unsupported");
+  });
+});
+
+describe("adaptive hook unit path rules", () => {
+  test("classifies flat units, directory units, and native aggregate source", () => {
+    expect(classifyAdaptiveHookUnitPath("hooks/source-change-guard.json")).toEqual({
+      kind: "adaptive-unit",
+      name: "source-change-guard",
+      path: "hooks/source-change-guard.json",
+      shape: "flat",
+    });
+    expect(classifyAdaptiveHookUnitPath("hooks/source-change-guard/hook.json")).toEqual({
+      kind: "adaptive-unit",
+      name: "source-change-guard",
+      path: "hooks/source-change-guard/hook.json",
+      shape: "directory-hook",
+    });
+    expect(classifyAdaptiveHookUnitPath("hooks/source-change-guard/source-change-guard.json")).toEqual({
+      kind: "adaptive-unit",
+      name: "source-change-guard",
+      path: "hooks/source-change-guard/source-change-guard.json",
+      shape: "directory-named",
+    });
+    expect(classifyAdaptiveHookUnitPath("hooks/hooks.json")).toEqual({
+      kind: "native-aggregate",
+      path: "hooks/hooks.json",
+    });
+  });
+
+  test("reports duplicate names, ambiguous directory manifests, and aggregate collisions", () => {
+    expect(validateAdaptiveHookUnitPaths([
+      "hooks/hooks.json",
+      "hooks/.json",
+      "hooks/source-change-guard.json",
+      "hooks/source-change-guard/hook.json",
+      "hooks/session/session.json",
+      "hooks/session/hook.json",
+    ])).toEqual([
+      {
+        code: "hook-aggregate-collision",
+        message: "hooks/hooks.json is native aggregate source and cannot be combined with adaptive hook units for the same destination",
+        paths: [
+          "hooks/hooks.json",
+          "hooks/session/hook.json",
+          "hooks/session/session.json",
+          "hooks/source-change-guard.json",
+          "hooks/source-change-guard/hook.json",
+        ],
+      },
+      {
+        code: "hook-directory-ambiguous",
+        message: "adaptive hook directory session contains both hook.json and session.json",
+        paths: ["hooks/session/hook.json", "hooks/session/session.json"],
+      },
+      {
+        code: "hook-name-duplicate",
+        message: "adaptive hook name session is defined more than once",
+        paths: ["hooks/session/hook.json", "hooks/session/session.json"],
+      },
+      {
+        code: "hook-name-duplicate",
+        message: "adaptive hook name source-change-guard is defined more than once",
+        paths: ["hooks/source-change-guard.json", "hooks/source-change-guard/hook.json"],
+      },
+      {
+        code: "hook-name-invalid",
+        message: "adaptive hook path must derive a non-empty hook name",
+        paths: ["hooks/.json"],
+      },
+    ]);
+  });
+});

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -373,6 +373,46 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     title: "Plugin Hooks",
     validationOwner: "packages/core/src/hooks.ts",
   }),
+  feature({
+    docs: ["docs/features/adaptive-hooks.md", "docs/features/hooks.md"],
+    evidence: [
+      docs("docs/features/adaptive-hooks.md"),
+      source("packages/core/src/hook-capabilities.ts"),
+      source("packages/schema/src/contracts.ts"),
+      test("packages/core/src/__tests__/hook-capabilities.test.ts", "SET-117 provider capability and adaptive unit path coverage"),
+      test("packages/schema/src/__tests__/schema.test.ts", "SET-117 adaptive hook source contract coverage"),
+    ],
+    id: "adaptive-hooks",
+    kind: "source",
+    renderOwner: "future",
+    sourceShape: "hooks/<name>.json or hooks/<name>/hook.json adaptive hook units",
+    status: "planned",
+    summary: "Defines reusable adaptive hook units and provider/destination capability facts before attachment and rendering.",
+    targetSupport: {
+      claude: {
+        evidence: [
+          docs("docs/features/adaptive-hooks.md"),
+          providerSnapshot("claude-hooks"),
+          source("packages/core/src/hook-capabilities.ts"),
+        ],
+        provider: { destinationFormat: "claude-hooks" },
+        status: "planned",
+      },
+      codex: {
+        evidence: [
+          docs("docs/features/adaptive-hooks.md"),
+          providerSnapshot("codex-plugin"),
+          providerSchemaSnapshot("codex-hooks-schema"),
+          providerSchemaSnapshot("codex-hook-event-schemas"),
+          source("packages/core/src/hook-capabilities.ts"),
+        ],
+        provider: { destinationFormat: "codex-plugin", schemaSnapshots: ["codex-hooks-schema", "codex-hook-event-schemas"] },
+        status: "planned",
+      },
+    },
+    title: "Adaptive Hooks",
+    validationOwner: "packages/schema/src/validate.ts",
+  }),
   pluginCompanionFeature({
     docs: ["docs/features/lsp-servers.md", "docs/features/plugins.md"],
     id: "plugin-lsp-servers",

--- a/packages/core/src/hook-capabilities.ts
+++ b/packages/core/src/hook-capabilities.ts
@@ -1,0 +1,233 @@
+import { compareStrings } from "./path";
+import type { TargetName } from "./types";
+
+export type HookCapabilityProvider = TargetName;
+
+export type HookScope = "agent" | "plugin" | "project" | "skill" | "user";
+
+export type HookScopeSupport = "native" | "unsupported";
+
+export type HookMatcherKind =
+  | "agent-type"
+  | "compact-trigger"
+  | "ignored"
+  | "none"
+  | "session-source"
+  | "tool";
+
+export interface HookProviderCapability {
+  readonly asyncCommand: boolean;
+  readonly documentedEvents: ReadonlySet<string>;
+  readonly handlerTypes: ReadonlySet<string>;
+  readonly matcherByEvent: Readonly<Record<string, HookMatcherKind>>;
+  readonly provider: HookCapabilityProvider;
+  readonly scopeSupport: Readonly<Record<HookScope, HookScopeSupport>>;
+  readonly statusMessage: boolean;
+}
+
+export interface AdaptiveHookPathIssue {
+  readonly code: "hook-aggregate-collision" | "hook-directory-ambiguous" | "hook-name-duplicate" | "hook-name-invalid";
+  readonly message: string;
+  readonly paths: readonly string[];
+}
+
+export type AdaptiveHookUnitPath =
+  | {
+      readonly kind: "adaptive-unit";
+      readonly name: string;
+      readonly path: string;
+      readonly shape: "directory-hook" | "directory-named" | "flat";
+    }
+  | {
+      readonly kind: "native-aggregate";
+      readonly path: "hooks/hooks.json";
+    }
+  | {
+      readonly kind: "ignored";
+      readonly path: string;
+    };
+
+export const CLAUDE_HOOK_EVENTS: ReadonlySet<string> = new Set([
+  "ConfigChange",
+  "CwdChanged",
+  "Elicitation",
+  "ElicitationResult",
+  "FileChanged",
+  "InstructionsLoaded",
+  "MessageDisplay",
+  "Notification",
+  "PermissionDenied",
+  "PermissionRequest",
+  "PostCompact",
+  "PostToolBatch",
+  "PostToolUseFailure",
+  "PreToolUse",
+  "PostToolUse",
+  "PreCompact",
+  "SessionEnd",
+  "SessionStart",
+  "Setup",
+  "Stop",
+  "StopFailure",
+  "SubagentStart",
+  "SubagentStop",
+  "TaskCompleted",
+  "TaskCreated",
+  "TeammateIdle",
+  "UserPromptSubmit",
+  "UserPromptExpansion",
+  "WorktreeCreate",
+  "WorktreeRemove",
+]);
+
+export const CODEX_HOOK_EVENTS: ReadonlySet<string> = new Set([
+  "PreToolUse",
+  "PermissionRequest",
+  "PostToolUse",
+  "PreCompact",
+  "PostCompact",
+  "SessionStart",
+  "SubagentStart",
+  "SubagentStop",
+  "UserPromptSubmit",
+  "Stop",
+]);
+
+export const CODEX_HOOK_HANDLER_TYPES: ReadonlySet<string> = new Set(["command"]);
+
+export const hookProviderCapabilities: Readonly<Record<HookCapabilityProvider, HookProviderCapability>> = {
+  claude: {
+    asyncCommand: true,
+    documentedEvents: CLAUDE_HOOK_EVENTS,
+    handlerTypes: new Set(["agent", "command", "http", "mcp_tool", "prompt"]),
+    matcherByEvent: Object.fromEntries([...CLAUDE_HOOK_EVENTS].map((event) => [event, "none" as const])),
+    provider: "claude",
+    scopeSupport: {
+      agent: "native",
+      plugin: "native",
+      project: "native",
+      skill: "native",
+      user: "native",
+    },
+    statusMessage: true,
+  },
+  codex: {
+    asyncCommand: false,
+    documentedEvents: CODEX_HOOK_EVENTS,
+    handlerTypes: CODEX_HOOK_HANDLER_TYPES,
+    matcherByEvent: {
+      PermissionRequest: "tool",
+      PostCompact: "compact-trigger",
+      PostToolUse: "tool",
+      PreCompact: "compact-trigger",
+      PreToolUse: "tool",
+      SessionStart: "session-source",
+      Stop: "ignored",
+      SubagentStart: "agent-type",
+      SubagentStop: "agent-type",
+      UserPromptSubmit: "ignored",
+    },
+    provider: "codex",
+    scopeSupport: {
+      agent: "unsupported",
+      plugin: "native",
+      project: "native",
+      skill: "unsupported",
+      user: "native",
+    },
+    statusMessage: true,
+  },
+};
+
+export function hookEventSupported(provider: HookCapabilityProvider, event: string): boolean {
+  return hookProviderCapabilities[provider].documentedEvents.has(event);
+}
+
+export function classifyAdaptiveHookUnitPath(path: string): AdaptiveHookUnitPath {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\/+/, "");
+  if (normalized === "hooks/hooks.json") return { kind: "native-aggregate", path: "hooks/hooks.json" };
+  if (!normalized.startsWith("hooks/") || !normalized.endsWith(".json")) return { kind: "ignored", path };
+
+  const parts = normalized.split("/");
+  if (parts.length === 2) {
+    const fileName = parts[1] ?? "";
+    if (fileName === "hooks.json") return { kind: "ignored", path };
+    return {
+      kind: "adaptive-unit",
+      name: fileName.slice(0, -".json".length),
+      path,
+      shape: "flat",
+    };
+  }
+
+  if (parts.length === 3) {
+    const directory = parts[1] ?? "";
+    const fileName = parts[2] ?? "";
+    if (fileName === "hook.json") {
+      return { kind: "adaptive-unit", name: directory, path, shape: "directory-hook" };
+    }
+    if (fileName === `${directory}.json`) {
+      return { kind: "adaptive-unit", name: directory, path, shape: "directory-named" };
+    }
+  }
+
+  return { kind: "ignored", path };
+}
+
+export function validateAdaptiveHookUnitPaths(paths: readonly string[]): readonly AdaptiveHookPathIssue[] {
+  const classified = paths.map(classifyAdaptiveHookUnitPath);
+  const units = classified.filter((item): item is Extract<AdaptiveHookUnitPath, { kind: "adaptive-unit" }> => item.kind === "adaptive-unit");
+  const aggregate = classified.find((item): item is Extract<AdaptiveHookUnitPath, { kind: "native-aggregate" }> => item.kind === "native-aggregate");
+  const issues: AdaptiveHookPathIssue[] = [];
+  const validUnits = units.filter((unit) => {
+    if (unit.name.length > 0) return true;
+    issues.push({
+      code: "hook-name-invalid",
+      message: "adaptive hook path must derive a non-empty hook name",
+      paths: [unit.path],
+    });
+    return false;
+  });
+
+  if (aggregate !== undefined && validUnits.length > 0) {
+    issues.push({
+      code: "hook-aggregate-collision",
+      message: "hooks/hooks.json is native aggregate source and cannot be combined with adaptive hook units for the same destination",
+      paths: [aggregate.path, ...validUnits.map((unit) => unit.path)].sort(compareStrings),
+    });
+  }
+
+  for (const [name, nameUnits] of groupBy(validUnits, (unit) => unit.name)) {
+    if (nameUnits.length > 1) {
+      issues.push({
+        code: "hook-name-duplicate",
+        message: `adaptive hook name ${name} is defined more than once`,
+        paths: nameUnits.map((unit) => unit.path).sort(compareStrings),
+      });
+    }
+  }
+
+  for (const [directory, directoryUnits] of groupBy(validUnits.filter((unit) => unit.shape !== "flat"), (unit) => unit.name)) {
+    const shapes = new Set(directoryUnits.map((unit) => unit.shape));
+    if (shapes.has("directory-hook") && shapes.has("directory-named")) {
+      issues.push({
+        code: "hook-directory-ambiguous",
+        message: `adaptive hook directory ${directory} contains both hook.json and ${directory}.json`,
+        paths: directoryUnits.map((unit) => unit.path).sort(compareStrings),
+      });
+    }
+  }
+
+  return issues.sort((left, right) => compareStrings(left.code, right.code) || compareStrings(left.paths[0] ?? "", right.paths[0] ?? ""));
+}
+
+function groupBy<T>(items: readonly T[], keyFor: (item: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFor(item);
+    const group = grouped.get(key);
+    if (group === undefined) grouped.set(key, [item]);
+    else group.push(item);
+  }
+  return grouped;
+}

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,69 +1,14 @@
 import type { JsonRecord, JsonValue, TargetName } from "./types";
 import { isJsonRecord } from "./yaml";
-
-/**
- * Claude hook lifecycle events from the live Claude Code hooks reference. This
- * set is documented for source-reader fidelity only; Claude validation stays
- * broad because Claude's hook surface is larger and changes more frequently
- * than Codex's release behavior.
- */
-export const CLAUDE_HOOK_EVENTS: ReadonlySet<string> = new Set([
-  "ConfigChange",
-  "CwdChanged",
-  "Elicitation",
-  "ElicitationResult",
-  "FileChanged",
-  "InstructionsLoaded",
-  "MessageDisplay",
-  "Notification",
-  "PermissionDenied",
-  "PermissionRequest",
-  "PostCompact",
-  "PostToolBatch",
-  "PostToolUseFailure",
-  "PreToolUse",
-  "PostToolUse",
-  "PreCompact",
-  "SessionEnd",
-  "SessionStart",
-  "Setup",
-  "Stop",
-  "StopFailure",
-  "SubagentStart",
-  "SubagentStop",
-  "TaskCompleted",
-  "TaskCreated",
-  "TeammateIdle",
-  "UserPromptSubmit",
-  "UserPromptExpansion",
-  "WorktreeCreate",
-  "WorktreeRemove",
-]);
-
-/**
- * Codex hook lifecycle events from the live Codex hooks guide. Codex's set is
- * intentionally narrower than Claude's target-native hook surface.
- */
-export const CODEX_HOOK_EVENTS: ReadonlySet<string> = new Set([
-  "PreToolUse",
-  "PermissionRequest",
-  "PostToolUse",
-  "PreCompact",
-  "PostCompact",
-  "SessionStart",
-  "SubagentStart",
-  "SubagentStop",
-  "UserPromptSubmit",
-  "Stop",
-]);
-
-/**
- * Codex executes only synchronous command hook handlers. The hooks guide states
- * that prompt/agent handlers are parsed but skipped, and async command handlers
- * are parsed but skipped, so Codex-targeted definitions that rely on either
- * behavior must fail loudly.
- */
-export const CODEX_HOOK_HANDLER_TYPES: ReadonlySet<string> = new Set(["command"]);
+import {
+  CODEX_HOOK_EVENTS,
+  CODEX_HOOK_HANDLER_TYPES,
+} from "./hook-capabilities";
+export {
+  CLAUDE_HOOK_EVENTS,
+  CODEX_HOOK_EVENTS,
+  CODEX_HOOK_HANDLER_TYPES,
+} from "./hook-capabilities";
 
 /**
  * Validate a parsed hook definition for a target.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,22 @@ export {
   type HostLeakMatch,
 } from "./host-leak";
 export {
+  CLAUDE_HOOK_EVENTS,
+  CODEX_HOOK_EVENTS,
+  CODEX_HOOK_HANDLER_TYPES,
+  classifyAdaptiveHookUnitPath,
+  hookEventSupported,
+  hookProviderCapabilities,
+  validateAdaptiveHookUnitPaths,
+  type AdaptiveHookPathIssue,
+  type AdaptiveHookUnitPath,
+  type HookCapabilityProvider,
+  type HookMatcherKind,
+  type HookProviderCapability,
+  type HookScope,
+  type HookScopeSupport,
+} from "./hook-capabilities";
+export {
   inspectSkillset,
   lintBuildGraph,
   lintSkillset,

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   SKILLSET_SCHEMA_VERSION,
   agentFrontmatterContract,
+  adaptiveHookContract,
   changeEntryContract,
   deriveSkillsetExampleArtifacts,
   deriveSkillsetJsonSchemaArtifacts,
@@ -11,6 +12,7 @@ import {
   skillsetSchemaContracts,
   sourceMetadataContract,
   validateAgentFrontmatter,
+  validateAdaptiveHookUnitSource,
   validateChangeEntryFrontmatter,
   validateHookDefinitionSource,
   validateInstructionFrontmatter,
@@ -30,9 +32,11 @@ describe("@skillset/schema contracts", () => {
       "agent-frontmatter",
       "instruction-frontmatter",
       "hook",
+      "adaptive-hook",
       "change-entry",
     ]);
     expect(workspaceConfigContract.schema.$id).toBe("https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas/0.1.0/workspace-config.schema.json");
+    expect(adaptiveHookContract.schema.$id).toBe("https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas/0.1.0/adaptive-hook.schema.json");
   });
 
   it("derives deterministic JSON Schema artifacts", () => {
@@ -45,6 +49,7 @@ describe("@skillset/schema contracts", () => {
       "docs/reference/schemas/0.1.0/agent-frontmatter.schema.json",
       "docs/reference/schemas/0.1.0/instruction-frontmatter.schema.json",
       "docs/reference/schemas/0.1.0/hook.schema.json",
+      "docs/reference/schemas/0.1.0/adaptive-hook.schema.json",
       "docs/reference/schemas/0.1.0/change-entry.schema.json",
     ]);
 
@@ -61,10 +66,12 @@ describe("@skillset/schema contracts", () => {
       { $ref: "#/$defs/agent-frontmatter" },
       { $ref: "#/$defs/instruction-frontmatter" },
       { $ref: "#/$defs/hook" },
+      { $ref: "#/$defs/adaptive-hook" },
       { $ref: "#/$defs/change-entry" },
     ]);
     const defs = combined?.$defs as Record<string, Record<string, unknown>>;
     expect(Object.keys(defs).sort()).toEqual([
+      "adaptive-hook",
       "agent-frontmatter",
       "change-entry",
       "hook",
@@ -86,6 +93,7 @@ describe("@skillset/schema contracts", () => {
       "docs/reference/examples/agent-frontmatter.yaml",
       "docs/reference/examples/instruction-frontmatter.yaml",
       "docs/reference/examples/hook.yaml",
+      "docs/reference/examples/adaptive-hook.yaml",
       "docs/reference/examples/change-entry.yaml",
     ]);
 
@@ -96,6 +104,7 @@ describe("@skillset/schema contracts", () => {
     expect(validateAgentFrontmatter(byId["agent-frontmatter"]).diagnostics).toEqual([]);
     expect(validateInstructionFrontmatter(byId["instruction-frontmatter"]).diagnostics).toEqual([]);
     expect(validateHookDefinitionSource(byId.hook).diagnostics).toEqual([]);
+    expect(validateAdaptiveHookUnitSource(byId["adaptive-hook"]).diagnostics).toEqual([]);
     expect(validateChangeEntryFrontmatter(byId["change-entry"]).diagnostics).toEqual([]);
   });
 
@@ -198,6 +207,42 @@ describe("@skillset/schema contracts", () => {
         { required: ["id"] },
       ],
     });
+  });
+
+  it("validates adaptive hook unit source", () => {
+    expect(validateAdaptiveHookUnitSource({
+      events: ["PreToolUse"],
+      match: { tool: ["Bash"] },
+      providers: ["claude", "codex"],
+      run: {
+        args: ["--check"],
+        env: { HOOK: "shell-policy" },
+        script: "./check.js",
+      },
+      status: "Checking command",
+    }).diagnostics).toEqual([]);
+
+    expect(validateAdaptiveHookUnitSource({
+      events: ["PreToolUse", "PreToolUse", ""],
+      providers: ["claude", "bad", "claude"],
+      run: {
+        args: ["ok", 1],
+        command: "",
+        cwd: "../outside",
+        env: { OK: 1 },
+        script: "/tmp/check.js",
+      },
+    }).diagnostics.map((diagnostic) => diagnostic.code)).toEqual(expect.arrayContaining([
+      "schema/adaptive-hook/events",
+      "schema/adaptive-hook/events-duplicate",
+      "schema/adaptive-hook/providers",
+      "schema/adaptive-hook/providers-duplicate",
+      "schema/adaptive-hook/run-args",
+      "schema/adaptive-hook/run-command",
+      "schema/adaptive-hook/run-env",
+      "schema/adaptive-hook/path",
+      "schema/adaptive-hook/runtime-path-proof",
+    ]));
   });
 
   it("validates workspace config structure", () => {

--- a/packages/schema/src/artifacts.ts
+++ b/packages/schema/src/artifacts.ts
@@ -3,6 +3,7 @@ import type { SchemaJsonRecord, SkillsetSchemaContract, SkillsetSchemaContractId
 import {
   SKILLSET_SCHEMA_URI_BASE,
   SKILLSET_SCHEMA_VERSION,
+  adaptiveHookContract,
   agentFrontmatterContract,
   changeEntryContract,
   hookContract,
@@ -20,6 +21,7 @@ export interface SkillsetJsonSchemaArtifact {
 }
 
 const schemaFileNames = {
+  "adaptive-hook": "adaptive-hook.schema.json",
   "agent-frontmatter": "agent-frontmatter.schema.json",
   "change-entry": "change-entry.schema.json",
   hook: "hook.schema.json",
@@ -61,6 +63,7 @@ function combinedSchemaArtifact(): SkillsetJsonSchemaArtifact {
         { $ref: "#/$defs/agent-frontmatter" },
         { $ref: "#/$defs/instruction-frontmatter" },
         { $ref: "#/$defs/hook" },
+        { $ref: "#/$defs/adaptive-hook" },
         { $ref: "#/$defs/change-entry" },
       ],
       title: "Skillset Source Contracts",
@@ -87,4 +90,5 @@ export const skillsetSkillFrontmatterJsonSchema = skillFrontmatterContract.schem
 export const skillsetAgentFrontmatterJsonSchema = agentFrontmatterContract.schema;
 export const skillsetInstructionFrontmatterJsonSchema = instructionFrontmatterContract.schema;
 export const skillsetHookJsonSchema = hookContract.schema;
+export const skillsetAdaptiveHookJsonSchema = adaptiveHookContract.schema;
 export const skillsetChangeEntryJsonSchema = changeEntryContract.schema;

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -205,6 +205,35 @@ export const hookContract = contract("hook", "Hook Definition", "Skillset hook d
   type: "object",
 });
 
+export const adaptiveHookContract = contract("adaptive-hook", "Adaptive Hook Unit", "Skillset adaptive hook unit source contract for reusable portable hooks.", {
+  ...strictObjectSchema({
+    claude: { type: "object" },
+    codex: { type: "object" },
+    description: nonEmptyStringSchema(),
+    events: arraySchema(nonEmptyStringSchema(), { minItems: 1, uniqueItems: true }),
+    match: {
+      anyOf: [
+        nonEmptyStringSchema(),
+        { type: "object" },
+      ],
+    },
+    name: nonEmptyStringSchema(),
+    providers: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
+    run: strictObjectSchema({
+      args: arraySchema(nonEmptyStringSchema()),
+      command: nonEmptyStringSchema(),
+      cwd: nonEmptyStringSchema(),
+      env: {
+        additionalProperties: { type: "string" },
+        type: "object",
+      },
+      script: nonEmptyStringSchema(),
+    }),
+    status: nonEmptyStringSchema(),
+  }),
+  required: ["events", "run"],
+});
+
 export const changeEntryContract = contract("change-entry", "Change Entry", "Pending Skillset change entry source contract.", {
   additionalProperties: true,
   anyOf: [
@@ -243,6 +272,7 @@ export const skillsetSchemaContracts = [
   agentFrontmatterContract,
   instructionFrontmatterContract,
   hookContract,
+  adaptiveHookContract,
   changeEntryContract,
 ] as const satisfies readonly SkillsetSchemaContract[];
 

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -301,6 +301,36 @@ export const skillsetSchemaExamples = [
     },
   },
   {
+    description: "Adaptive reusable hook unit.",
+    id: "adaptive-hook",
+    path: "adaptive-hook.yaml",
+    value: {
+      claude: {
+        if: "Bash(git *)",
+      },
+      codex: {
+        matcher: "Bash",
+      },
+      description: "Checks shell commands before they run.",
+      events: ["PreToolUse"],
+      match: {
+        tool: ["Bash"],
+      },
+      name: "shell-policy",
+      providers: ["claude", "codex"],
+      run: {
+        args: ["--event", "pre-tool-use"],
+        command: "node ./hooks/shell-policy/check.js",
+        cwd: ".",
+        env: {
+          SKILLSET_HOOK: "shell-policy",
+        },
+        script: "./check.js",
+      },
+      status: "Checking shell policy",
+    },
+  },
+  {
     description: "Pending change entry frontmatter.",
     id: "change-entry",
     path: "change-entry.yaml",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -9,6 +9,7 @@ export {
   TARGET_NAMES,
   UNSUPPORTED_DESTINATION_POLICIES,
   WORKSPACE_CONFIG_KEYS,
+  adaptiveHookContract,
   agentFrontmatterContract,
   changeEntryContract,
   hookContract,
@@ -23,6 +24,7 @@ export { skillsetSchemaExamples } from "./examples";
 export {
   deriveSkillsetJsonSchemaArtifacts,
   getSkillsetJsonSchemaArtifact,
+  skillsetAdaptiveHookJsonSchema,
   skillsetAgentFrontmatterJsonSchema,
   skillsetChangeEntryJsonSchema,
   skillsetHookJsonSchema,
@@ -46,6 +48,7 @@ export type { SkillsetJsonSchemaArtifact } from "./artifacts";
 export type { SkillsetExampleArtifact } from "./examples";
 export {
   validateAgentFrontmatter,
+  validateAdaptiveHookUnitSource,
   validateChangeEntryFrontmatter,
   validateHookDefinitionSource,
   validateInstructionFrontmatter,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -6,6 +6,7 @@ export interface SchemaJsonRecord {
 }
 
 export type SkillsetSchemaContractId =
+  | "adaptive-hook"
   | "agent-frontmatter"
   | "change-entry"
   | "hook"

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -132,6 +132,23 @@ export function validateHookDefinitionSource(value: unknown, path = "$"): Skills
   return result(diagnostics);
 }
 
+export function validateAdaptiveHookUnitSource(value: unknown, path = "$"): SkillsetSchemaValidationResult {
+  const diagnostics: SkillsetSchemaDiagnostic[] = [];
+  if (!isSchemaRecord(value)) return result([diagnostic(path, "schema/adaptive-hook/type", "adaptive hook unit must contain an object")]);
+
+  checkAllowedKeys(value, new Set(["claude", "codex", "description", "events", "match", "name", "providers", "run", "status"]), path, "schema/adaptive-hook/key", diagnostics);
+  checkOptionalNonEmptyString(value.name, `${path}.name`, "schema/adaptive-hook/name", diagnostics);
+  checkOptionalNonEmptyString(value.description, `${path}.description`, "schema/adaptive-hook/description", diagnostics);
+  checkOptionalNonEmptyString(value.status, `${path}.status`, "schema/adaptive-hook/status", diagnostics);
+  checkAdaptiveHookEvents(value.events, `${path}.events`, diagnostics);
+  checkAdaptiveHookProviders(value.providers, `${path}.providers`, diagnostics);
+  checkAdaptiveHookMatch(value.match, `${path}.match`, diagnostics);
+  checkOptionalObject(value.claude, `${path}.claude`, "schema/adaptive-hook/provider-override", diagnostics);
+  checkOptionalObject(value.codex, `${path}.codex`, "schema/adaptive-hook/provider-override", diagnostics);
+  checkAdaptiveHookRun(value.run, `${path}.run`, diagnostics);
+  return result(diagnostics);
+}
+
 export function validateChangeEntryFrontmatter(value: unknown, path = "$"): SkillsetSchemaValidationResult {
   const diagnostics: SkillsetSchemaDiagnostic[] = [];
   if (!isSchemaRecord(value)) return result([diagnostic(path, "schema/change-entry/type", "change entry frontmatter must be an object")]);
@@ -487,6 +504,90 @@ function checkHookHandlers(handlers: readonly SchemaJsonValue[], event: string, 
     ) {
       diagnostics.push(diagnostic(`${handlerPath}.timeout`, "schema/hook/handler-timeout", `hook event ${event} timeout must be a non-negative integer when present`));
     }
+  }
+}
+
+function checkAdaptiveHookEvents(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!Array.isArray(value) || value.length === 0) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/events", "adaptive hook events must be a non-empty string array"));
+    return;
+  }
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      diagnostics.push(diagnostic(`${path}[${index}]`, "schema/adaptive-hook/events", "adaptive hook events entries must be non-empty strings"));
+      continue;
+    }
+    if (seen.has(item)) diagnostics.push(diagnostic(`${path}[${index}]`, "schema/adaptive-hook/events-duplicate", `duplicate adaptive hook event ${item}`));
+    seen.add(item);
+  }
+}
+
+function checkAdaptiveHookProviders(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.length === 0) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/providers", "adaptive hook providers must be a non-empty array when present"));
+    return;
+  }
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || !targetNames.has(item)) {
+      diagnostics.push(diagnostic(`${path}[${index}]`, "schema/adaptive-hook/providers", "adaptive hook providers entries must be claude or codex"));
+      continue;
+    }
+    if (seen.has(item)) diagnostics.push(diagnostic(`${path}[${index}]`, "schema/adaptive-hook/providers-duplicate", `duplicate adaptive hook provider ${item}`));
+    seen.add(item);
+  }
+}
+
+function checkAdaptiveHookMatch(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value !== undefined && typeof value !== "string" && !isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/match", "adaptive hook match must be a string or object when present"));
+  }
+  if (typeof value === "string" && value.trim().length === 0) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/match", "adaptive hook match must be non-empty when present"));
+  }
+}
+
+function checkAdaptiveHookRun(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/run", "adaptive hook run must be an object"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["args", "command", "cwd", "env", "script"]), path, "schema/adaptive-hook/run-key", diagnostics);
+  checkOptionalNonEmptyString(value.command, `${path}.command`, "schema/adaptive-hook/run-command", diagnostics);
+  checkOptionalNonEmptyString(value.script, `${path}.script`, "schema/adaptive-hook/run-script", diagnostics);
+  checkOptionalNonEmptyString(value.cwd, `${path}.cwd`, "schema/adaptive-hook/run-cwd", diagnostics);
+  checkOptionalNonEmptyStringArray(value.args, `${path}.args`, "schema/adaptive-hook/run-args", diagnostics);
+  checkStringRecord(value.env, `${path}.env`, "schema/adaptive-hook/run-env", diagnostics);
+  if (value.command === undefined && value.script === undefined) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/run-handler", "adaptive hook run must include command or script"));
+  }
+  if (typeof value.script === "string") checkRuntimePath(value.script, `${path}.script`, "script", diagnostics);
+  if (typeof value.cwd === "string") checkSafeRelativePath(value.cwd, `${path}.cwd`, "cwd", diagnostics);
+}
+
+function checkStringRecord(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, code, `${path} must be an object when present`));
+    return;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item !== "string") diagnostics.push(diagnostic(`${path}.${key}`, code, `${path}.${key} must be a string`));
+  }
+}
+
+function checkRuntimePath(value: string, path: string, label: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  checkSafeRelativePath(value, path, label, diagnostics);
+  if (!(value.startsWith("./") || value.startsWith("{{scripts.dir}}/"))) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/runtime-path-proof", `adaptive hook ${label} must use ./ or {{scripts.dir}}/`));
+  }
+}
+
+function checkSafeRelativePath(value: string, path: string, label: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.split(/[\\/]+/).includes("..")) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/path", `adaptive hook ${label} must not be absolute or escape with ..`));
   }
 }
 


### PR DESCRIPTION
## Context

Starts SET-117 for the adaptive hooks stack. This is the contract and capability-registry foundation only; attachment resolution and rendering stay in later issues.

## What changed

- Adds the `adaptive-hook` schema contract, validator, maximal example, generated schema artifact, and combined schema entry.
- Adds core hook provider capability facts for Claude and Codex, including Codex event, handler, matcher, and scope constraints.
- Adds adaptive hook source path classification and collision diagnostics for flat units, directory units, native aggregate collisions, duplicate names, ambiguous directory manifests, and empty derived names.
- Registers the planned `adaptive-hooks` feature with provider evidence and package Changeset coverage.

## Testing

- bun test packages/schema/src/__tests__/schema.test.ts packages/core/src/__tests__/hook-capabilities.test.ts packages/core/src/__tests__/feature-registry.test.ts
- bun run typecheck
- bun run schema:check
- bun run changeset:check
- bun run skillset:check
- bun run skillset:verify
- git diff --check
- bun run check
- pre-push hook: skillset ci and bun run check
- local review: `.agents/goals/2026-06-25-adaptive-hooks-stack/tmp/reviews/codex/set-117-round1.json`, 5/5 clean

## Risks / rollout

- Claude matcher details intentionally remain broad until SET-119 rendering, where target lowering can prove exact behavior.
- This PR does not discover, attach, or render adaptive hook units yet; SET-118 and later slices wire those behaviors.

Linear: SET-117