### PR TITLE
feat: resolve adaptive hook attachments

### DIFF
--- a/.changeset/adaptive-hook-attachments.md
+++ b/.changeset/adaptive-hook-attachments.md
@@ -1,0 +1,7 @@
+---
+"@skillset/core": patch
+"@skillset/schema": patch
+"skillset": patch
+---
+
+Add adaptive hook frontmatter attachment parsing and nearest-first source resolution.

--- a/apps/skillset/src/change-status.ts
+++ b/apps/skillset/src/change-status.ts
@@ -1193,6 +1193,7 @@ function regionsForRecord(record: JsonRecord): readonly SourceUnitRegion[] {
   }
   if (record.mcp !== undefined) regions.push({ name: "mcp", severityBearing: true });
   if (record.bin !== undefined) regions.push({ name: "bin", severityBearing: true });
+  if (record.hooks !== undefined) regions.push({ name: "hooks", severityBearing: true });
   return regions.sort((left, right) => compareStrings(left.name, right.name));
 }
 

--- a/docs/reference/examples/agent-frontmatter.yaml
+++ b/docs/reference/examples/agent-frontmatter.yaml
@@ -3,6 +3,9 @@ claude:
 codex:
   model: gpt-5.1-codex
 description: Use this agent for release review.
+hooks:
+  auto:
+    - session-metadata
 initialPrompt: Review the release notes before changing code.
 metadata:
   generated: skillset-schema@0.1.0

--- a/docs/reference/examples/skill-frontmatter.yaml
+++ b/docs/reference/examples/skill-frontmatter.yaml
@@ -17,6 +17,20 @@ dependencies:
       range: ^1.0.0
 description: Use when working with the docs CLI.
 dialect: claude
+hooks:
+  PreToolUse:
+    - shell-policy
+  Stop:
+    - hook: source-change-guard
+      match:
+        tool:
+          - Bash
+      providers:
+        - claude
+        - codex
+      status: Checking shell changes
+  auto:
+    - session-metadata
 implicit_invocation:
   claude: true
   codex: false

--- a/docs/reference/schemas/0.1.0/agent-frontmatter.schema.json
+++ b/docs/reference/schemas/0.1.0/agent-frontmatter.schema.json
@@ -27,6 +27,107 @@
       "minLength": 1,
       "type": "string"
     },
+    "hooks": {
+      "additionalProperties": {
+        "items": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "hook": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "match": {
+                  "anyOf": [
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
+                },
+                "providers": {
+                  "items": {
+                    "enum": [
+                      "claude",
+                      "codex"
+                    ],
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "uniqueItems": true
+                },
+                "status": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "type": "array"
+      },
+      "properties": {
+        "auto": {
+          "items": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "hook": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "match": {
+                    "anyOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "providers": {
+                    "items": {
+                      "enum": [
+                        "claude",
+                        "codex"
+                      ],
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
+                  },
+                  "status": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "initialPrompt": {
       "minLength": 1,
       "type": "string"

--- a/docs/reference/schemas/0.1.0/skill-frontmatter.schema.json
+++ b/docs/reference/schemas/0.1.0/skill-frontmatter.schema.json
@@ -143,6 +143,107 @@
       ],
       "type": "string"
     },
+    "hooks": {
+      "additionalProperties": {
+        "items": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "hook": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "match": {
+                  "anyOf": [
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
+                },
+                "providers": {
+                  "items": {
+                    "enum": [
+                      "claude",
+                      "codex"
+                    ],
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "uniqueItems": true
+                },
+                "status": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "type": "array"
+      },
+      "properties": {
+        "auto": {
+          "items": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "hook": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "match": {
+                    "anyOf": [
+                      {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      {
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "providers": {
+                    "items": {
+                      "enum": [
+                        "claude",
+                        "codex"
+                      ],
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
+                  },
+                  "status": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "implicit_invocation": {
       "anyOf": [
         {

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -119,6 +119,107 @@
           "minLength": 1,
           "type": "string"
         },
+        "hooks": {
+          "additionalProperties": {
+            "items": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "hook": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "match": {
+                      "anyOf": [
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        {
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "providers": {
+                      "items": {
+                        "enum": [
+                          "claude",
+                          "codex"
+                        ],
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    },
+                    "status": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "properties": {
+            "auto": {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "hook": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "match": {
+                        "anyOf": [
+                          {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          {
+                            "type": "object"
+                          }
+                        ]
+                      },
+                      "providers": {
+                        "items": {
+                          "enum": [
+                            "claude",
+                            "codex"
+                          ],
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      },
+                      "status": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
         "initialPrompt": {
           "minLength": 1,
           "type": "string"
@@ -1034,6 +1135,107 @@
             "claude"
           ],
           "type": "string"
+        },
+        "hooks": {
+          "additionalProperties": {
+            "items": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "hook": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "match": {
+                      "anyOf": [
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        {
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "providers": {
+                      "items": {
+                        "enum": [
+                          "claude",
+                          "codex"
+                        ],
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    },
+                    "status": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "properties": {
+            "auto": {
+              "items": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "hook": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "match": {
+                        "anyOf": [
+                          {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          {
+                            "type": "object"
+                          }
+                        ]
+                      },
+                      "providers": {
+                        "items": {
+                          "enum": [
+                            "claude",
+                            "codex"
+                          ],
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      },
+                      "status": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
         },
         "implicit_invocation": {
           "anyOf": [

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
+
+import {
+  resolveAdaptiveHookAttachments,
+  type SourceAdaptiveHook,
+  type SourceHookAttachment,
+} from "@skillset/core";
+import { loadBuildGraph } from "../resolver";
+
+describe("adaptive hook attachment resolution", () => {
+  test("resolves nearest definitions and expands auto attachments", () => {
+    const root = hook("shared", ["SessionStart"], { kind: "root" }, "root/hooks/shared.json");
+    const plugin = hook("shared", ["Stop"], { kind: "plugin", pluginId: "demo" }, "plugins/demo/hooks/shared.json");
+    const skill = hook("shared", ["PreToolUse"], { kind: "skill", pluginId: "demo", skillId: "writer" }, "plugins/demo/skills/writer/hooks/shared.json");
+    const attachments: SourceHookAttachment[] = [
+      { event: "PreToolUse", hook: "shared", scope: { kind: "skill", pluginId: "demo", skillId: "writer" }, sourcePath: "plugins/demo/skills/writer/SKILL.md" },
+      { hook: "shared", scope: { kind: "plugin", pluginId: "demo" }, sourcePath: "plugins/demo/skillset.yaml" },
+      { hook: "shared", scope: { kind: "agent", agentId: "helper" }, sourcePath: "agents/helper.md" },
+    ];
+
+    const resolution = resolveAdaptiveHookAttachments([root, plugin, skill], attachments);
+    expect(resolution.issues).toEqual([]);
+    expect(resolution.resolved.map((item) => `${item.definition.sourcePath}:${item.event}`)).toEqual([
+      "root/hooks/shared.json:SessionStart",
+      "plugins/demo/skills/writer/hooks/shared.json:PreToolUse",
+      "plugins/demo/hooks/shared.json:Stop",
+    ]);
+  });
+
+  test("reports missing, broadening, ambiguous, and duplicate attachment problems", () => {
+    const root = hook("shared", ["SessionStart"], { kind: "root" }, "hooks/shared.json");
+    const duplicateRoot = hook("shared", ["Stop"], { kind: "root" }, "hooks/shared-again.json");
+    const attachment = { event: "PreToolUse", hook: "shared", scope: { kind: "agent", agentId: "helper" }, sourcePath: "agents/helper.md" } satisfies SourceHookAttachment;
+    const missing = { event: "Stop", hook: "missing", scope: { kind: "agent", agentId: "helper" }, sourcePath: "agents/helper.md" } satisfies SourceHookAttachment;
+
+    expect(resolveAdaptiveHookAttachments([root, duplicateRoot], [attachment, missing]).issues.map((issue) => issue.code)).toEqual([
+      "adaptive-hook-attachment-ambiguous",
+      "adaptive-hook-attachment-missing",
+      "adaptive-hook-duplicate-name",
+    ]);
+    expect(resolveAdaptiveHookAttachments([root], [attachment]).issues).toContainEqual(expect.objectContaining({
+      code: "adaptive-hook-attachment-event",
+    }));
+  });
+});
+
+describe("adaptive hook graph loading", () => {
+  test("loads root, plugin, and skill-local definitions plus frontmatter attachments", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-graph
+claude: true
+codex: false
+`,
+      ".skillset/hooks/session.json": JSON.stringify({ events: ["SessionStart"], run: { command: "node ./session.js" } }),
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+`,
+      ".skillset/plugins/demo/hooks/shell.json": JSON.stringify({ events: ["Stop"], run: { command: "node ./shell.js" } }),
+      ".skillset/plugins/demo/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  PreToolUse:
+    - local-shell
+  Stop:
+    - shell
+  auto:
+    - session
+---
+
+Body.
+`,
+      ".skillset/plugins/demo/skills/writer/hooks/local-shell.json": JSON.stringify({ events: ["PreToolUse"], run: { command: "node ./local.js" } }),
+    }));
+
+    expect(graph.adaptiveHooks.map((hook) => hook.name)).toEqual(["session", "shell", "local-shell"]);
+    expect(graph.hookAttachments.map((attachment) => `${attachment.event ?? "auto"}:${attachment.hook}`)).toEqual([
+      "PreToolUse:local-shell",
+      "Stop:shell",
+      "auto:session",
+    ]);
+  });
+
+  test("loads project-agent local hook definitions from a sibling hook directory", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-agent-hooks
+claude: true
+codex: false
+`,
+      ".skillset/agents/helper.md": `
+---
+description: Demo helper.
+hooks:
+  SessionStart:
+    - helper-session
+---
+
+Body.
+`,
+      ".skillset/agents/helper/hooks/helper-session.json": JSON.stringify({ events: ["SessionStart"], run: { command: "node ./session.js" } }),
+    }));
+
+    expect(graph.adaptiveHooks.map((hook) => `${hook.scope.kind}:${hook.name}`)).toEqual(["agent:helper-session"]);
+    expect(graph.hookAttachments.map((attachment) => `${attachment.scope.kind}:${attachment.event}:${attachment.hook}`)).toEqual(["agent:SessionStart:helper-session"]);
+  });
+
+  test("rejects unresolved hook attachments while loading the graph", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-missing
+claude: true
+codex: false
+`,
+      ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+hooks:
+  PreToolUse:
+    - missing
+---
+
+Body.
+`,
+    });
+
+    await expect(loadBuildGraph(root)).rejects.toThrow("adaptive hook attachment references missing hook missing");
+  });
+});
+
+function hook(
+  name: string,
+  events: readonly string[],
+  scope: SourceAdaptiveHook["scope"],
+  sourcePath: string
+): SourceAdaptiveHook {
+  return {
+    events,
+    frontmatter: { events: [...events], run: { command: "node ./hook.js" } },
+    name,
+    scope,
+    sourcePath,
+  };
+}
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-adaptive-hooks-"));
+  for (const [path, content] of Object.entries(normalizeSkillsetFixtureFiles(files))) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}

--- a/packages/core/src/__tests__/lookup.test.ts
+++ b/packages/core/src/__tests__/lookup.test.ts
@@ -34,6 +34,7 @@ describe("lookupSkillsetReference", () => {
       "dependencies",
       "description",
       "dialect",
+      "hooks",
       "implicit_invocation",
       "mcp",
       "metadata",

--- a/packages/core/src/adaptive-hook-attachments.ts
+++ b/packages/core/src/adaptive-hook-attachments.ts
@@ -1,0 +1,179 @@
+import { compareStrings } from "./path";
+import { isJsonRecord } from "./yaml";
+import type {
+  AdaptiveHookScope,
+  JsonValue,
+  SourceAdaptiveHook,
+  SourceHookAttachment,
+  TargetName,
+} from "./types";
+
+export interface AdaptiveHookAttachmentIssue {
+  readonly code:
+    | "adaptive-hook-attachment-ambiguous"
+    | "adaptive-hook-attachment-event"
+    | "adaptive-hook-attachment-missing"
+    | "adaptive-hook-duplicate-name";
+  readonly message: string;
+  readonly paths: readonly string[];
+}
+
+export interface ResolvedAdaptiveHookAttachment {
+  readonly attachment: SourceHookAttachment;
+  readonly definition: SourceAdaptiveHook;
+  readonly event: string;
+}
+
+export interface AdaptiveHookResolution {
+  readonly issues: readonly AdaptiveHookAttachmentIssue[];
+  readonly resolved: readonly ResolvedAdaptiveHookAttachment[];
+}
+
+export function readHookAttachments(
+  value: JsonValue | undefined,
+  scope: AdaptiveHookScope,
+  sourcePath: string
+): readonly SourceHookAttachment[] {
+  if (!isJsonRecord(value)) return [];
+  const attachments: SourceHookAttachment[] = [];
+  for (const [event, entries] of Object.entries(value).sort(([left], [right]) => compareStrings(left, right))) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const attachment = readHookAttachmentEntry(entry, event, scope, sourcePath);
+      if (attachment !== undefined) attachments.push(attachment);
+    }
+  }
+  return attachments;
+}
+
+export function resolveAdaptiveHookAttachments(
+  definitions: readonly SourceAdaptiveHook[],
+  attachments: readonly SourceHookAttachment[]
+): AdaptiveHookResolution {
+  const issues: AdaptiveHookAttachmentIssue[] = [...duplicateDefinitionIssues(definitions)];
+  const resolved: ResolvedAdaptiveHookAttachment[] = [];
+
+  for (const attachment of attachments) {
+    const candidates = visibleDefinitions(definitions, attachment.scope).filter((definition) => definition.name === attachment.hook);
+    if (candidates.length === 0) {
+      issues.push({
+        code: "adaptive-hook-attachment-missing",
+        message: `adaptive hook attachment references missing hook ${attachment.hook}`,
+        paths: [attachment.sourcePath],
+      });
+      continue;
+    }
+
+    const nearestRank = Math.min(...candidates.map((definition) => scopeRank(attachment.scope, definition.scope)));
+    const nearest = candidates.filter((definition) => scopeRank(attachment.scope, definition.scope) === nearestRank);
+    if (nearest.length > 1) {
+      issues.push({
+        code: "adaptive-hook-attachment-ambiguous",
+        message: `adaptive hook attachment ${attachment.hook} is ambiguous in the nearest visible scope`,
+        paths: [attachment.sourcePath, ...nearest.map((definition) => definition.sourcePath)].sort(compareStrings),
+      });
+      continue;
+    }
+
+    const definition = nearest[0];
+    if (definition === undefined) continue;
+    const events = attachment.event === undefined ? definition.events : [attachment.event];
+    for (const event of events) {
+      if (!definition.events.includes(event)) {
+        issues.push({
+          code: "adaptive-hook-attachment-event",
+          message: `adaptive hook attachment ${attachment.hook} uses event ${event}, but the hook declares ${definition.events.join(", ")}`,
+          paths: [attachment.sourcePath, definition.sourcePath].sort(compareStrings),
+        });
+        continue;
+      }
+      resolved.push({ attachment, definition, event });
+    }
+  }
+
+  return {
+    issues: issues.sort((left, right) => compareStrings(left.code, right.code) || compareStrings(left.paths[0] ?? "", right.paths[0] ?? "")),
+    resolved: resolved.sort((left, right) =>
+      compareStrings(left.attachment.sourcePath, right.attachment.sourcePath) ||
+      compareStrings(left.attachment.hook, right.attachment.hook) ||
+      compareStrings(left.event, right.event)
+    ),
+  };
+}
+
+function readHookAttachmentEntry(
+  entry: JsonValue,
+  event: string,
+  scope: AdaptiveHookScope,
+  sourcePath: string
+): SourceHookAttachment | undefined {
+  const hook = typeof entry === "string" ? entry : isJsonRecord(entry) && typeof entry.hook === "string" ? entry.hook : undefined;
+  if (hook === undefined || hook.trim().length === 0) return undefined;
+  const object = isJsonRecord(entry) ? entry : {};
+  const match = object.match;
+  const status = typeof object.status === "string" ? object.status : undefined;
+  const providers = readProviders(object.providers);
+  return {
+    ...(event === "auto" ? {} : { event }),
+    hook,
+    ...(match === undefined ? {} : { match }),
+    ...(providers === undefined ? {} : { providers }),
+    scope,
+    sourcePath,
+    ...(status === undefined ? {} : { status }),
+  };
+}
+
+function readProviders(value: JsonValue | undefined): readonly TargetName[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const providers = value.filter((item): item is TargetName => item === "claude" || item === "codex");
+  return providers.length === 0 ? undefined : providers;
+}
+
+function duplicateDefinitionIssues(definitions: readonly SourceAdaptiveHook[]): readonly AdaptiveHookAttachmentIssue[] {
+  const byScopeAndName = new Map<string, SourceAdaptiveHook[]>();
+  for (const definition of definitions) {
+    const key = `${scopeKey(definition.scope)}:${definition.name}`;
+    const group = byScopeAndName.get(key);
+    if (group === undefined) byScopeAndName.set(key, [definition]);
+    else group.push(definition);
+  }
+  return [...byScopeAndName.values()]
+    .filter((group) => group.length > 1)
+    .map((group) => ({
+      code: "adaptive-hook-duplicate-name" as const,
+      message: `adaptive hook name ${group[0]?.name ?? ""} is defined more than once in the same resolution scope`,
+      paths: group.map((definition) => definition.sourcePath).sort(compareStrings),
+    }));
+}
+
+function visibleDefinitions(
+  definitions: readonly SourceAdaptiveHook[],
+  attachmentScope: AdaptiveHookScope
+): readonly SourceAdaptiveHook[] {
+  return definitions.filter((definition) => scopeRank(attachmentScope, definition.scope) < Number.POSITIVE_INFINITY);
+}
+
+function scopeRank(attachmentScope: AdaptiveHookScope, definitionScope: AdaptiveHookScope): number {
+  if (sameScope(attachmentScope, definitionScope)) return 0;
+  if (attachmentScope.kind === "skill") {
+    if (definitionScope.kind === "plugin" && definitionScope.pluginId === attachmentScope.pluginId) return 1;
+    if (definitionScope.kind === "root") return 2;
+  }
+  if (attachmentScope.kind === "agent" && definitionScope.kind === "root") return 1;
+  if (attachmentScope.kind === "plugin" && definitionScope.kind === "root") return 1;
+  return Number.POSITIVE_INFINITY;
+}
+
+function sameScope(left: AdaptiveHookScope, right: AdaptiveHookScope): boolean {
+  return scopeKey(left) === scopeKey(right);
+}
+
+function scopeKey(scope: AdaptiveHookScope): string {
+  return [
+    scope.kind,
+    scope.pluginId ?? "",
+    scope.skillId ?? "",
+    scope.agentId ?? "",
+  ].join(":");
+}

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -379,6 +379,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       docs("docs/features/adaptive-hooks.md"),
       source("packages/core/src/hook-capabilities.ts"),
       source("packages/schema/src/contracts.ts"),
+      test("packages/core/src/__tests__/adaptive-hook-attachments.test.ts", "SET-118 hook attachment parsing and nearest-first resolution coverage"),
       test("packages/core/src/__tests__/hook-capabilities.test.ts", "SET-117 provider capability and adaptive unit path coverage"),
       test("packages/schema/src/__tests__/schema.test.ts", "SET-117 adaptive hook source contract coverage"),
     ],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,13 @@ export {
   type SkillsetDiffResult,
 } from "./build";
 export {
+  readHookAttachments,
+  resolveAdaptiveHookAttachments,
+  type AdaptiveHookAttachmentIssue,
+  type AdaptiveHookResolution,
+  type ResolvedAdaptiveHookAttachment,
+} from "./adaptive-hook-attachments";
+export {
   assertAdapterConformance,
   checkAdapterConformance,
   formatAdapterConformanceReport,
@@ -183,8 +190,12 @@ export {
   workspaceChangesDir,
 } from "./workspace-state";
 export type {
+  AdaptiveHookScope,
+  AdaptiveHookScopeKind,
   LintIssue,
   LintResult,
+  SourceAdaptiveHook,
+  SourceHookAttachment,
 } from "./types";
 export {
   RENDER_RESULT_SCHEMA,

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -3,11 +3,16 @@ import { basename, dirname, join, relative, sep } from "node:path";
 
 import {
   validateAgentFrontmatter,
+  validateAdaptiveHookUnitSource,
   validateInstructionFrontmatter,
   validateSkillFrontmatter,
   type SkillsetSchemaDiagnostic,
 } from "@skillset/schema";
 
+import {
+  readHookAttachments,
+  resolveAdaptiveHookAttachments,
+} from "./adaptive-hook-attachments";
 import {
   applyFeatureTargetDefaults,
   readCompileConfig,
@@ -26,6 +31,10 @@ import {
   validateWorkspaceConfigDocument,
 } from "./config";
 import { readPluginDependencies, validatePluginDependencyGraph } from "./dependencies";
+import {
+  classifyAdaptiveHookUnitPath,
+  validateAdaptiveHookUnitPaths,
+} from "./hook-capabilities";
 import { SkillsetFeatureDiagnosticError } from "./operation-result";
 import { compareStrings, resolveInside, validateSlug } from "./path";
 import { readReleaseState } from "./release-state";
@@ -34,8 +43,10 @@ import { validateSupports } from "./supports";
 import type {
   BuildGraph,
   JsonRecord,
+  JsonValue,
   OutputSelection,
   SkillsetOptions,
+  SourceAdaptiveHook,
   SourceDialect,
   SourceOrigin,
   SourcePlugin,
@@ -138,6 +149,7 @@ export async function loadBuildGraph(
   await rejectLegacySourceLayout(rootPath, sourceDir, sourceRootDir);
   await validateSupports(sourceManifest.supports, { label: metadataLabel, rootPath, warnings });
   const releaseState = await readReleaseState(rootPath, { ...options, sourceDir });
+  const rootAdaptiveHooks = await loadAdaptiveHooks(rootPath, sourceRootPath, { kind: "root" });
   const plugins = await loadPlugins(rootPath, sourceDir, sourceRootDir, filteredTargets, warnings, outputs);
   try {
     validatePluginDependencyGraph(plugins);
@@ -152,6 +164,19 @@ export async function loadBuildGraph(
   const { rules, instructionsDir } = await loadInstructions(rootPath, sourceDir, sourceRootDir, filteredTargets, warnings);
   const projectAgents = await loadProjectAgents(rootPath, sourceDir, sourceRootDir, filteredTargets, warnings);
   const projectIslands = await loadProjectIslands(rootPath, sourceDir, sourceRootDir, plugins);
+  const adaptiveHooks = [
+    ...rootAdaptiveHooks,
+    ...plugins.flatMap((plugin) => plugin.adaptiveHooks),
+    ...plugins.flatMap((plugin) => plugin.skills.flatMap((skill) => skill.adaptiveHooks)),
+    ...standaloneSkills.flatMap((skill) => skill.adaptiveHooks),
+    ...projectAgents.flatMap((agent) => agent.adaptiveHooks),
+  ];
+  const hookAttachments = [
+    ...plugins.flatMap((plugin) => plugin.skills.flatMap((skill) => skill.hookAttachments)),
+    ...standaloneSkills.flatMap((skill) => skill.hookAttachments),
+    ...projectAgents.flatMap((agent) => agent.hookAttachments),
+  ];
+  validateAdaptiveHookAttachments(adaptiveHooks, hookAttachments);
 
   if (plugins.length === 0 && standaloneSkills.length === 0 && rules.length === 0 && projectAgents.length === 0 && projectIslands.length === 0) {
     throw new Error(`skillset: no source plugins, skills, rules, project agents, or provider source found under ${sourceRoot}/`);
@@ -166,6 +191,8 @@ export async function loadBuildGraph(
   validateProjectRoots(rootPath, protectedRoots, outputRoots, filteredTargets, projectAgents, projectIslands);
 
   return {
+    adaptiveHooks,
+    hookAttachments,
     instructionsDir,
     outputRoots: outputRoots.map((outputRoot) => outputRoot.path),
     plugins,
@@ -431,6 +458,9 @@ async function loadProjectAgent(
   await validateSupports(parts.frontmatter.supports, { label: sourceLabel, rootPath, warnings });
   const name = readString(parts.frontmatter, "name") ?? basename(sourcePath, ".md");
   const outputName = sanitizeProjectAgentName(name, sourcePath);
+  const scope = { agentId: outputName, kind: "agent" as const };
+  const hookAttachments = readHookAttachments(parts.frontmatter.hooks, scope, sourceLabel);
+  const adaptiveHooks = await loadAdaptiveHooks(rootPath, join(agentsPath, basename(sourcePath, ".md")), scope);
   const description = readString(parts.frontmatter, "description");
   if (description === undefined) {
     throw new Error(`skillset: ${sourceLabel} project agent requires description`);
@@ -447,9 +477,11 @@ async function loadProjectAgent(
   warnPortableModel(parts.frontmatter, targets, rootPath, sourcePath, warnings);
 
   return {
+    adaptiveHooks,
     body: parts.body,
     filename: basename(sourcePath),
     frontmatter: parts.frontmatter,
+    hookAttachments,
     name,
     outputName,
     relativePath: relative(agentsPath, sourcePath),
@@ -585,6 +617,109 @@ function normalizeRuleFrontmatter(frontmatter: SourceRule["frontmatter"], label:
   return frontmatter;
 }
 
+async function loadAdaptiveHooks(
+  rootPath: string,
+  ownerPath: string,
+  scope: SourceAdaptiveHook["scope"]
+): Promise<readonly SourceAdaptiveHook[]> {
+  const hooksPath = join(ownerPath, "hooks");
+  if (!(await exists(hooksPath))) return [];
+
+  const files = await collectFiles(hooksPath);
+  const relativeHookPaths = files.map((file) => normalizeWorkspacePath(join("hooks", relative(hooksPath, file))));
+  const pathIssues = validateAdaptiveHookUnitPaths(relativeHookPaths);
+  if (pathIssues.length > 0) {
+    const firstIssue = pathIssues[0];
+    throw new SkillsetFeatureDiagnosticError({
+      code: firstIssue?.code ?? "adaptive-hook-path-invalid",
+      featureId: "adaptive-hooks",
+      message: `skillset: ${firstIssue?.message ?? "adaptive hook paths are invalid"}`,
+      path: firstIssue?.paths[0] === undefined ? relative(rootPath, hooksPath) : relative(rootPath, join(ownerPath, firstIssue.paths[0])),
+    });
+  }
+
+  const hooks: SourceAdaptiveHook[] = [];
+  for (const file of files) {
+    const relativeHookPath = normalizeWorkspacePath(join("hooks", relative(hooksPath, file)));
+    const classified = classifyAdaptiveHookUnitPath(relativeHookPath);
+    if (classified.kind !== "adaptive-unit") continue;
+
+    const label = relative(rootPath, file);
+    let parsed: JsonValue;
+    try {
+      parsed = JSON.parse(await readFile(file, "utf8")) as JsonValue;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SkillsetFeatureDiagnosticError({
+        code: "adaptive-hook-invalid-json",
+        featureId: "adaptive-hooks",
+        message: `skillset: adaptive hook ${label} is not valid JSON: ${message}`,
+        path: label,
+      });
+    }
+    if (!isJsonRecord(parsed)) {
+      throw new SkillsetFeatureDiagnosticError({
+        code: "adaptive-hook-invalid",
+        featureId: "adaptive-hooks",
+        message: `skillset: adaptive hook ${label} must contain a JSON object`,
+        path: label,
+      });
+    }
+    const diagnostics = validateAdaptiveHookUnitSource(parsed, label).diagnostics;
+    if (diagnostics.length > 0) {
+      throw new SkillsetFeatureDiagnosticError({
+        code: "adaptive-hook-invalid",
+        featureId: "adaptive-hooks",
+        message: `skillset: adaptive hook ${label} failed schema validation: ${diagnostics.map((diagnostic) => diagnostic.message).join("; ")}`,
+        path: label,
+      });
+    }
+
+    const declaredName = readString(parsed, "name");
+    if (declaredName !== undefined && declaredName !== classified.name) {
+      throw new SkillsetFeatureDiagnosticError({
+        code: "adaptive-hook-name-mismatch",
+        featureId: "adaptive-hooks",
+        message: `skillset: adaptive hook ${label} declares name ${declaredName}, but its path resolves to ${classified.name}`,
+        path: label,
+      });
+    }
+    const events = readStringArray(parsed, "events") ?? [];
+    const providers = readTargetArray(parsed.providers);
+    hooks.push({
+      events,
+      frontmatter: parsed,
+      name: classified.name,
+      ...(providers === undefined ? {} : { providers }),
+      scope,
+      sourcePath: resolveInside(rootPath, relative(rootPath, file)),
+    });
+  }
+
+  return hooks.sort((left, right) => compareStrings(left.name, right.name) || compareStrings(left.sourcePath, right.sourcePath));
+}
+
+function validateAdaptiveHookAttachments(
+  hooks: readonly SourceAdaptiveHook[],
+  attachments: BuildGraph["hookAttachments"]
+): void {
+  const resolution = resolveAdaptiveHookAttachments(hooks, attachments);
+  const issue = resolution.issues[0];
+  if (issue === undefined) return;
+  throw new SkillsetFeatureDiagnosticError({
+    code: issue.code,
+    featureId: "adaptive-hooks",
+    message: `skillset: ${issue.message}`,
+    ...(issue.paths[0] === undefined ? {} : { path: issue.paths[0] }),
+  });
+}
+
+function readTargetArray(value: JsonValue | undefined): readonly TargetName[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const targets = value.filter((item): item is TargetName => item === "claude" || item === "codex");
+  return targets.length === 0 ? undefined : targets;
+}
+
 async function loadPlugins(
   rootPath: string,
   sourceDir: string,
@@ -662,7 +797,8 @@ async function loadPlugin(
     id,
     configuredOutputRoots(outputs)
   );
-  const skills = await loadSkills(rootPath, sourceDir, sourceRootDir, pluginPath, inheritedTargets, warnings);
+  const adaptiveHooks = await loadAdaptiveHooks(rootPath, pluginPath, { kind: "plugin", pluginId: id });
+  const skills = await loadSkills(rootPath, sourceDir, sourceRootDir, pluginPath, inheritedTargets, warnings, id);
 
   if (await exists(join(pluginPath, "hooks.json"))) {
     const path = relative(rootPath, join(pluginPath, "hooks.json"));
@@ -675,6 +811,7 @@ async function loadPlugin(
   }
   return {
     configPath,
+    adaptiveHooks,
     dependencies,
     features,
     id,
@@ -826,11 +963,12 @@ async function loadSkills(
   sourceRootDir: string,
   pluginPath: string,
   parentTargets: SourcePlugin["targets"],
-  warnings: string[]
+  warnings: string[],
+  pluginId: string
 ): Promise<SourceSkill[]> {
   const skillsPath = join(pluginPath, SKILLS_DIR);
   if (!(await exists(skillsPath))) return [];
-  return loadSkillsFromDirectory(rootPath, sourceDir, sourceRootDir, skillsPath, pluginPath, parentTargets, warnings, pluginPath);
+  return loadSkillsFromDirectory(rootPath, sourceDir, sourceRootDir, skillsPath, pluginPath, parentTargets, warnings, { kind: "plugin", pluginId }, pluginPath);
 }
 
 async function loadSkillsFromDirectory(
@@ -841,6 +979,7 @@ async function loadSkillsFromDirectory(
   relativeBasePath: string,
   parentTargets: SourcePlugin["targets"],
   warnings: string[],
+  parentScope: SourceAdaptiveHook["scope"],
   pluginPath?: string
 ): Promise<SourceSkill[]> {
   const skillFiles = await findSkillFiles(skillsPath);
@@ -867,6 +1006,13 @@ async function loadSkillsFromDirectory(
       readString(parts.frontmatter, "name") ?? basename(dirname(sourcePath)),
       `skill id in ${sourcePath}`
     );
+    const scope = {
+      ...parentScope,
+      kind: "skill" as const,
+      skillId: id,
+    };
+    const hookAttachments = readHookAttachments(parts.frontmatter.hooks, scope, relative(rootPath, sourcePath));
+    const adaptiveHooks = await loadAdaptiveHooks(rootPath, dirname(sourcePath), scope);
     const targets = resolveFeatureTargets(parentTargets, parts.frontmatter, sourcePath, "skills");
     warnPortableModel(parts.frontmatter, targets, rootPath, sourcePath, warnings);
     const relativePath = relative(relativeBasePath, sourcePath);
@@ -879,9 +1025,11 @@ async function loadSkillsFromDirectory(
     const dialect = readDialect(parts.frontmatter, relative(rootPath, sourcePath));
 
     skills.push({
+      adaptiveHooks,
       body: parts.body,
       ...(dialect === undefined ? {} : { dialect }),
       frontmatter: parts.frontmatter,
+      hookAttachments,
       id,
       metadata,
       relativePath,
@@ -947,7 +1095,7 @@ async function loadStandaloneSkills(
   const skillsPath = resolveInside(rootPath, join(sourceDir, sourceRootDir, SKILLS_DIR));
   if (!(await exists(skillsPath))) return [];
 
-  const skills = await loadSkillsFromDirectory(rootPath, sourceDir, sourceRootDir, skillsPath, skillsPath, rootTargets, warnings);
+  const skills = await loadSkillsFromDirectory(rootPath, sourceDir, sourceRootDir, skillsPath, skillsPath, rootTargets, warnings, { kind: "root" });
   return skills;
 }
 
@@ -1121,6 +1269,10 @@ function outputIncludes(selection: OutputSelection, name: string): boolean {
   if (selection === true) return true;
   if (selection === false) return false;
   return selection.includes(name);
+}
+
+function normalizeWorkspacePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
 }
 
 function isInsidePath(path: string, root: string): boolean {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -97,10 +97,40 @@ export interface PluginConfig {
  */
 export type SourceDialect = "claude";
 
+export type AdaptiveHookScopeKind = "agent" | "plugin" | "root" | "skill";
+
+export interface AdaptiveHookScope {
+  readonly agentId?: string;
+  readonly kind: AdaptiveHookScopeKind;
+  readonly pluginId?: string;
+  readonly skillId?: string;
+}
+
+export interface SourceHookAttachment {
+  readonly event?: string;
+  readonly hook: string;
+  readonly match?: JsonValue;
+  readonly providers?: readonly TargetName[];
+  readonly scope: AdaptiveHookScope;
+  readonly sourcePath: string;
+  readonly status?: string;
+}
+
+export interface SourceAdaptiveHook {
+  readonly events: readonly string[];
+  readonly frontmatter: JsonRecord;
+  readonly name: string;
+  readonly providers?: readonly TargetName[];
+  readonly scope: AdaptiveHookScope;
+  readonly sourcePath: string;
+}
+
 export interface SourceSkill {
+  readonly adaptiveHooks: readonly SourceAdaptiveHook[];
   readonly body: string;
   readonly dialect?: SourceDialect;
   readonly frontmatter: JsonRecord;
+  readonly hookAttachments: readonly SourceHookAttachment[];
   readonly id: string;
   readonly metadata: JsonRecord;
   readonly relativePath: string;
@@ -127,6 +157,7 @@ export interface SourcePluginDependency {
 }
 
 export interface SourcePlugin {
+  readonly adaptiveHooks: readonly SourceAdaptiveHook[];
   readonly configPath: string;
   readonly dependencies: readonly SourcePluginDependency[];
   readonly features: readonly SourcePluginFeature[];
@@ -170,9 +201,11 @@ export interface SourceIslandFile {
 }
 
 export interface SourceProjectAgent {
+  readonly adaptiveHooks: readonly SourceAdaptiveHook[];
   readonly body: string;
   readonly filename: string;
   readonly frontmatter: JsonRecord;
+  readonly hookAttachments: readonly SourceHookAttachment[];
   readonly name: string;
   readonly outputName: string;
   readonly relativePath: string;
@@ -194,6 +227,8 @@ export interface TargetOutputConfig {
 }
 
 export interface BuildGraph {
+  readonly adaptiveHooks: readonly SourceAdaptiveHook[];
+  readonly hookAttachments: readonly SourceHookAttachment[];
   /** The source subdirectory instructions were loaded from. */
   readonly instructionsDir: string;
   readonly outputRoots: readonly string[];

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -401,6 +401,18 @@ describe("@skillset/schema contracts", () => {
       bin: false,
       dependencies: { plugins: ["plugin:base"] },
       description: "Demo skill.",
+      hooks: {
+        PreToolUse: ["shell-policy"],
+        Stop: [
+          {
+            hook: "source-change-guard",
+            match: { tool: ["Bash"] },
+            providers: ["claude", "codex"],
+            status: "Checking shell changes",
+          },
+        ],
+        auto: ["session-metadata"],
+      },
       implicit_invocation: true,
       mcp: { source: "repo:.mcp.json" },
       metadata: { generated: "skillset@0.1.0", version: "1.0.0" },
@@ -416,6 +428,7 @@ describe("@skillset/schema contracts", () => {
 
     expect(validateAgentFrontmatter({
       description: "Demo agent.",
+      hooks: { auto: ["session-metadata"] },
       initialPrompt: "{{partials.prompts.demo}}",
       model: "sonnet",
       name: "demo",
@@ -466,6 +479,21 @@ describe("@skillset/schema contracts", () => {
       "schema/skill-frontmatter/tool-intent",
       "schema/skill-frontmatter/version",
     ]));
+    expect(validateSkillFrontmatter({
+      hooks: {
+        "": [""],
+        PreToolUse: [
+          "",
+          { hook: "", match: "", providers: ["claude", "bad", "claude"], status: "" },
+          { hook: "ok", unknown: true },
+        ],
+        Stop: "bad",
+      },
+    }).diagnostics.map((diagnostic) => diagnostic.code)).toEqual(expect.arrayContaining([
+      "schema/skill-frontmatter/hooks",
+      "schema/skill-frontmatter/hooks-duplicate",
+      "schema/skill-frontmatter/hooks-key",
+    ]));
     expect(validateSkillFrontmatter({ dependencies: { plugins: [{ name: 1, unknown: true }] } }).diagnostics.map((diagnostic) => diagnostic.code)).toEqual(expect.arrayContaining([
       "schema/skill-frontmatter/dependencies-name",
       "schema/skill-frontmatter/dependencies-plugin-key",
@@ -499,6 +527,9 @@ describe("@skillset/schema contracts", () => {
       "schema/agent-frontmatter/initialPrompt",
       "schema/agent-frontmatter/skills",
       "schema/agent-frontmatter/target",
+    ]));
+    expect(validateAgentFrontmatter({ description: "Demo agent.", hooks: { auto: [{ hook: "", providers: [] }] } }).diagnostics.map((diagnostic) => diagnostic.code)).toEqual(expect.arrayContaining([
+      "schema/agent-frontmatter/hooks",
     ]));
     expect(validateAgentFrontmatter({ name: "missing-description", skills: ["one", 2] }).diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
       "schema/agent-frontmatter/description",

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -55,6 +55,7 @@ export const COMMON_FRONTMATTER_KEYS = [
   "dependencies",
   "description",
   "dialect",
+  "hooks",
   "implicit_invocation",
   "mcp",
   "metadata",
@@ -74,6 +75,7 @@ export const AGENT_FRONTMATTER_KEYS = [
   "claude",
   "codex",
   "description",
+  "hooks",
   "initialPrompt",
   "metadata",
   "model",
@@ -139,6 +141,7 @@ export const skillFrontmatterContract = contract("skill-frontmatter", "Skill Fro
     description: nonEmptyStringSchema(),
     dialect: { enum: ["claude"], type: "string" },
     implicit_invocation: implicitInvocationSchema(),
+    hooks: hookAttachmentSchema(),
     mcp: targetFeatureSchema(),
     metadata: generatedMetadataSchema(),
     model: nonEmptyStringSchema(),
@@ -166,6 +169,7 @@ export const agentFrontmatterContract = contract("agent-frontmatter", "Agent Fro
     claude: targetOverrideSchema(),
     codex: targetOverrideSchema(),
     description: nonEmptyStringSchema(),
+    hooks: hookAttachmentSchema(),
     initialPrompt: nonEmptyStringSchema(),
     metadata: generatedMetadataSchema(),
     model: nonEmptyStringSchema(),
@@ -410,6 +414,33 @@ function resourceDeclarationSchema(): SchemaJsonRecord {
         type: "object",
       },
     ],
+  };
+}
+
+function hookAttachmentSchema(): SchemaJsonRecord {
+  const attachmentObject = strictObjectSchema({
+    hook: nonEmptyStringSchema(),
+    match: {
+      anyOf: [
+        nonEmptyStringSchema(),
+        { type: "object" },
+      ],
+    },
+    providers: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
+    status: nonEmptyStringSchema(),
+  });
+  const attachmentEntry: SchemaJsonRecord = {
+    anyOf: [
+      nonEmptyStringSchema(),
+      attachmentObject,
+    ],
+  };
+  return {
+    additionalProperties: arraySchema(attachmentEntry),
+    properties: {
+      auto: arraySchema(attachmentEntry),
+    },
+    type: "object",
   };
 }
 

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -180,6 +180,20 @@ export const skillsetSchemaExamples = [
       },
       description: "Use when working with the docs CLI.",
       dialect: "claude",
+      hooks: {
+        PreToolUse: ["shell-policy"],
+        Stop: [
+          {
+            hook: "source-change-guard",
+            match: {
+              tool: ["Bash"],
+            },
+            providers: ["claude", "codex"],
+            status: "Checking shell changes",
+          },
+        ],
+        auto: ["session-metadata"],
+      },
       implicit_invocation: {
         claude: true,
         codex: false,
@@ -233,6 +247,9 @@ export const skillsetSchemaExamples = [
         model: "gpt-5.1-codex",
       },
       description: "Use this agent for release review.",
+      hooks: {
+        auto: ["session-metadata"],
+      },
       initialPrompt: "Review the release notes before changing code.",
       metadata: {
         generated: "skillset-schema@0.1.0",

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -70,6 +70,7 @@ export function validateSkillFrontmatter(value: unknown, path = "$"): SkillsetSc
   checkOptionalStringOrPositiveInteger(value.schema, `${path}.schema`, "schema/skill-frontmatter/schema", diagnostics);
   checkTargetBlock(value.claude, `${path}.claude`, "schema/skill-frontmatter/target", diagnostics);
   checkTargetBlock(value.codex, `${path}.codex`, "schema/skill-frontmatter/target", diagnostics);
+  checkHookAttachments(value.hooks, `${path}.hooks`, "schema/skill-frontmatter/hooks", diagnostics);
   checkImplicitInvocation(value.implicit_invocation, `${path}.implicit_invocation`, diagnostics);
   checkAllowedTools(value.allowed_tools, `${path}.allowed_tools`, diagnostics);
   checkOptionalObject(value.tool_intent, `${path}.tool_intent`, "schema/skill-frontmatter/tool-intent", diagnostics);
@@ -93,6 +94,7 @@ export function validateAgentFrontmatter(value: unknown, path = "$"): SkillsetSc
   checkOptionalNonEmptyStringArray(value.skills, `${path}.skills`, "schema/agent-frontmatter/skills", diagnostics);
   checkTargetBlock(value.claude, `${path}.claude`, "schema/agent-frontmatter/target", diagnostics);
   checkTargetBlock(value.codex, `${path}.codex`, "schema/agent-frontmatter/target", diagnostics);
+  checkHookAttachments(value.hooks, `${path}.hooks`, "schema/agent-frontmatter/hooks", diagnostics);
   checkSourceMetadata(value.skillset, `${path}.skillset`, diagnostics);
   checkSupports(value.supports, `${path}.supports`, diagnostics);
   return result(diagnostics);
@@ -504,6 +506,70 @@ function checkHookHandlers(handlers: readonly SchemaJsonValue[], event: string, 
     ) {
       diagnostics.push(diagnostic(`${handlerPath}.timeout`, "schema/hook/handler-timeout", `hook event ${event} timeout must be a non-negative integer when present`));
     }
+  }
+}
+
+function checkHookAttachments(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, code, "hooks must be an object keyed by event name or auto"));
+    return;
+  }
+  for (const [event, entries] of Object.entries(value).sort(([left], [right]) => left.localeCompare(right))) {
+    if (event.trim().length === 0) {
+      diagnostics.push(diagnostic(`${path}.${event}`, code, "hook attachment event names must be non-empty"));
+    }
+    if (!Array.isArray(entries) || entries.length === 0) {
+      diagnostics.push(diagnostic(`${path}.${event}`, code, "hook attachment entries must be a non-empty array"));
+      continue;
+    }
+    for (const [index, entry] of entries.entries()) {
+      checkHookAttachmentEntry(entry, `${path}.${event}[${index}]`, code, diagnostics);
+    }
+  }
+}
+
+function checkHookAttachmentEntry(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (typeof value === "string") {
+    if (value.trim().length === 0) diagnostics.push(diagnostic(path, code, "hook attachment references must be non-empty strings"));
+    return;
+  }
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, code, "hook attachment entries must be strings or objects"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["hook", "match", "providers", "status"]), path, `${code}-key`, diagnostics);
+  if (typeof value.hook !== "string" || value.hook.trim().length === 0) {
+    diagnostics.push(diagnostic(`${path}.hook`, code, "hook attachment objects must include a non-empty hook"));
+  }
+  checkHookAttachmentMatch(value.match, `${path}.match`, code, diagnostics);
+  checkHookAttachmentProviders(value.providers, `${path}.providers`, code, diagnostics);
+  checkOptionalNonEmptyString(value.status, `${path}.status`, code, diagnostics);
+}
+
+function checkHookAttachmentMatch(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value !== undefined && typeof value !== "string" && !isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, code, "hook attachment match must be a string or object when present"));
+  }
+  if (typeof value === "string" && value.trim().length === 0) {
+    diagnostics.push(diagnostic(path, code, "hook attachment match must be non-empty when present"));
+  }
+}
+
+function checkHookAttachmentProviders(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.length === 0) {
+    diagnostics.push(diagnostic(path, code, "hook attachment providers must be a non-empty array when present"));
+    return;
+  }
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || !targetNames.has(item)) {
+      diagnostics.push(diagnostic(`${path}[${index}]`, code, "hook attachment providers entries must be claude or codex"));
+      continue;
+    }
+    if (seen.has(item)) diagnostics.push(diagnostic(`${path}[${index}]`, `${code}-duplicate`, `duplicate hook attachment provider ${item}`));
+    seen.add(item);
   }
 }
 


### PR DESCRIPTION
## Context

Part of SET-118 in the adaptive hooks stack. This sits above SET-117 and keeps rendering out of scope for the next slice.

## What Changed

- Added schema-backed `hooks:` frontmatter attachments for skills and project agents.
- Added adaptive hook attachment parsing and nearest-first resolution in `@skillset/core`.
- Loads root, plugin, skill-local, and project-agent-local adaptive hook definitions into the build graph.
- Validates missing, ambiguous, duplicate, and event-broadening attachment problems during graph load.
- Adds `hooks` as a severity-bearing change-status region and refreshes generated schema/example artifacts.
- Adds focused resolver and graph-loading tests plus feature registry evidence.

## Verification

- `bun test packages/schema/src/__tests__/schema.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts && bun run typecheck`
- `bun run schema:generate`
- `bun test packages/schema/src/__tests__/schema.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts packages/core/src/__tests__/feature-registry.test.ts packages/core/src/__tests__/feature-registry-check.test.ts && bun run typecheck && bun run changeset:check`
- `bun run schema:check && bun run skillset:check && bun run skillset:verify && git diff --check`
- `bun run check`
- Pre-push hook: `skillset ci` plus full `bun run check` passed with 712 tests.

## Local Review

- `.agents/goals/2026-06-25-adaptive-hooks-stack/tmp/reviews/codex/set-118-round1.json`
- Score: 5/5
- State: clean
- Open P0/P1/P2: 0

## Risks / Deferred Scope

- Provider/destination unsupported-scope outcomes are intentionally deferred to SET-119/SET-121 rendering and policy work.
- This PR parses provider filters and proves source graph resolution; it does not render adaptive hooks yet.

Linear: SET-118
