### PR TITLE
feat: prove adaptive hook script sources

### DIFF
--- a/.changeset/adaptive-hook-script-proof.md
+++ b/.changeset/adaptive-hook-script-proof.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Validate adaptive hook `run.script` references and record source script facts for later rendering.

--- a/docs/features/adaptive-hooks.md
+++ b/docs/features/adaptive-hooks.md
@@ -31,6 +31,19 @@ Directory hook units must resolve to the directory name. If both `hook.json` and
 
 Native aggregate mode and adaptive mode should not merge for the same generated destination in v1. If `hooks/hooks.json` and adaptive hook units would both write a provider plugin `hooks/hooks.json`, fail clearly and ask the author to choose one source model.
 
+## Scripts
+
+Adaptive hook `run.script` references have two source-backed forms:
+
+| Reference | Source proof |
+| --- | --- |
+| `./check.js` | Hook-local script beside a directory hook unit such as `hooks/<name>/hook.json` or `hooks/<name>/<name>.json`. |
+| `{{scripts.dir}}/check.js` | Shared script under the owner source directory's `scripts/` folder. Root hooks use `<source-root>/scripts/`; plugin hooks use `<plugin>/scripts/`; skill-local hooks use the skill directory's `scripts/`; project-agent-local hooks use the sibling agent directory's `scripts/`. |
+
+Flat hook units such as `hooks/<name>.json` cannot use `./...` hook-local scripts because they do not own a private sidecar directory. Use a directory hook unit for colocated sidecars or `{{scripts.dir}}/...` for owner-level shared scripts.
+
+The current compiler validates that these script references resolve to source files and records the source facts for later rendering. Provider-native command rewriting and output path proof land with adaptive rendering.
+
 ## Attachments
 
 Hook definitions should be reusable. Source units attach named hooks through event-keyed frontmatter or config:

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
 
 import {
@@ -137,6 +137,70 @@ Body.
 
     await expect(loadBuildGraph(root)).rejects.toThrow("adaptive hook attachment references missing hook missing");
   });
+
+  test("resolves hook-local and shared script references", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-scripts
+claude: true
+codex: false
+`,
+      ".skillset/hooks/session.json": JSON.stringify({ events: ["SessionStart"], run: { script: "{{scripts.dir}}/session.js" } }),
+      ".skillset/scripts/session.js": "process.exit(0);\n",
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+`,
+      ".skillset/plugins/demo/hooks/shell/hook.json": JSON.stringify({ events: ["PreToolUse"], run: { script: "./check.js" } }),
+      ".skillset/plugins/demo/hooks/shell/check.js": "process.exit(0);\n",
+    });
+    const graph = await loadBuildGraph(root);
+
+    expect(graph.adaptiveHooks.flatMap((hook) =>
+      hook.scriptReferences.map((reference) => `${hook.name}:${reference.kind}:${reference.runtimePath}:${relative(root, reference.sourcePath)}`)
+    )).toEqual([
+      "session:scripts-dir:{{scripts.dir}}/session.js:.skillset/scripts/session.js",
+      "shell:hook-local:./check.js:.skillset/plugins/demo/hooks/shell/check.js",
+    ]);
+  });
+
+  test("rejects missing hook script references", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-missing-script
+claude: true
+codex: false
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+`,
+      ".skillset/plugins/demo/hooks/shell/hook.json": JSON.stringify({ events: ["PreToolUse"], run: { script: "./missing.js" } }),
+    });
+
+    await expect(loadBuildGraph(root)).rejects.toThrow("adaptive hook run.script ./missing.js does not resolve to an existing source file");
+  });
+
+  test("rejects hook-local script references from flat hook units", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-flat-script
+claude: true
+codex: false
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+`,
+      ".skillset/plugins/demo/hooks/shell.json": JSON.stringify({ events: ["PreToolUse"], run: { script: "./check.js" } }),
+      ".skillset/plugins/demo/hooks/check.js": "process.exit(0);\n",
+    });
+
+    await expect(loadBuildGraph(root)).rejects.toThrow("hook-local scripts require a directory hook unit");
+  });
 });
 
 function hook(
@@ -149,6 +213,7 @@ function hook(
     events,
     frontmatter: { events: [...events], run: { command: "node ./hook.js" } },
     name,
+    scriptReferences: [],
     scope,
     sourcePath,
   };

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -379,7 +379,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       docs("docs/features/adaptive-hooks.md"),
       source("packages/core/src/hook-capabilities.ts"),
       source("packages/schema/src/contracts.ts"),
-      test("packages/core/src/__tests__/adaptive-hook-attachments.test.ts", "SET-118 hook attachment parsing and nearest-first resolution coverage"),
+      test("packages/core/src/__tests__/adaptive-hook-attachments.test.ts", "SET-118 attachment resolution and SET-127 script source proof coverage"),
       test("packages/core/src/__tests__/hook-capabilities.test.ts", "SET-117 provider capability and adaptive unit path coverage"),
       test("packages/schema/src/__tests__/schema.test.ts", "SET-117 adaptive hook source contract coverage"),
     ],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,6 +195,7 @@ export type {
   LintIssue,
   LintResult,
   SourceAdaptiveHook,
+  SourceAdaptiveHookScriptReference,
   SourceHookAttachment,
 } from "./types";
 export {

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -47,6 +47,7 @@ import type {
   OutputSelection,
   SkillsetOptions,
   SourceAdaptiveHook,
+  SourceAdaptiveHookScriptReference,
   SourceDialect,
   SourceOrigin,
   SourcePlugin,
@@ -691,12 +692,84 @@ async function loadAdaptiveHooks(
       frontmatter: parsed,
       name: classified.name,
       ...(providers === undefined ? {} : { providers }),
+      scriptReferences: await readAdaptiveHookScriptReferences(rootPath, ownerPath, file, classified.shape, parsed),
       scope,
       sourcePath: resolveInside(rootPath, relative(rootPath, file)),
     });
   }
 
   return hooks.sort((left, right) => compareStrings(left.name, right.name) || compareStrings(left.sourcePath, right.sourcePath));
+}
+
+async function readAdaptiveHookScriptReferences(
+  rootPath: string,
+  ownerPath: string,
+  hookSourcePath: string,
+  shape: "directory-hook" | "directory-named" | "flat",
+  parsed: JsonRecord
+): Promise<readonly SourceAdaptiveHookScriptReference[]> {
+  if (!isJsonRecord(parsed.run) || typeof parsed.run.script !== "string") return [];
+  const reference = parsed.run.script;
+  const sourcePath = resolveAdaptiveHookScriptPath(rootPath, ownerPath, hookSourcePath, shape, reference);
+  await validateAdaptiveHookScriptSource(rootPath, sourcePath, hookSourcePath, reference);
+  return [{
+    kind: reference.startsWith("{{scripts.dir}}/") ? "scripts-dir" : "hook-local",
+    reference,
+    runtimePath: reference,
+    sourcePath: resolveInside(rootPath, relative(rootPath, sourcePath)),
+  }];
+}
+
+function resolveAdaptiveHookScriptPath(
+  rootPath: string,
+  ownerPath: string,
+  hookSourcePath: string,
+  shape: "directory-hook" | "directory-named" | "flat",
+  reference: string
+): string {
+  if (reference.startsWith("{{scripts.dir}}/")) {
+    const relativeScriptPath = reference.slice("{{scripts.dir}}/".length);
+    return resolveInside(ownerPath, join("scripts", relativeScriptPath));
+  }
+  if (reference.startsWith("./")) {
+    if (shape === "flat") {
+      throw new SkillsetFeatureDiagnosticError({
+        code: "adaptive-hook-script-flat",
+        featureId: "adaptive-hooks",
+        message: "skillset: adaptive hook run.script uses ./, but hook-local scripts require a directory hook unit",
+        path: relative(rootPath, hookSourcePath),
+      });
+    }
+    return resolveInside(dirname(hookSourcePath), reference);
+  }
+  return resolveInside(ownerPath, reference);
+}
+
+async function validateAdaptiveHookScriptSource(
+  rootPath: string,
+  sourcePath: string,
+  hookSourcePath: string,
+  reference: string
+): Promise<void> {
+  let sourceStat;
+  try {
+    sourceStat = await stat(sourcePath);
+  } catch {
+    throw new SkillsetFeatureDiagnosticError({
+      code: "adaptive-hook-script-missing",
+      featureId: "adaptive-hooks",
+      message: `skillset: adaptive hook run.script ${reference} does not resolve to an existing source file`,
+      path: relative(rootPath, hookSourcePath),
+    });
+  }
+  if (!sourceStat.isFile()) {
+    throw new SkillsetFeatureDiagnosticError({
+      code: "adaptive-hook-script-invalid",
+      featureId: "adaptive-hooks",
+      message: `skillset: adaptive hook run.script ${reference} must resolve to a file`,
+      path: relative(rootPath, sourcePath),
+    });
+  }
 }
 
 function validateAdaptiveHookAttachments(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,7 +121,15 @@ export interface SourceAdaptiveHook {
   readonly frontmatter: JsonRecord;
   readonly name: string;
   readonly providers?: readonly TargetName[];
+  readonly scriptReferences: readonly SourceAdaptiveHookScriptReference[];
   readonly scope: AdaptiveHookScope;
+  readonly sourcePath: string;
+}
+
+export interface SourceAdaptiveHookScriptReference {
+  readonly kind: "hook-local" | "scripts-dir";
+  readonly reference: string;
+  readonly runtimePath: string;
   readonly sourcePath: string;
 }
 


### PR DESCRIPTION
## Context

Part of SET-127 in the adaptive hooks stack, stacked above SET-118. This is the pre-render script source proof slice that unblocks adaptive hook rendering work without trying to render provider-native hook outputs yet.

## What Changed

- Records `run.script` source facts on adaptive hook definitions via `SourceAdaptiveHook.scriptReferences`.
- Validates hook-local `./...` scripts for directory hook units such as `hooks/<name>/hook.json` and `hooks/<name>/<name>.json`.
- Validates owner-level `{{scripts.dir}}/...` scripts against the hook owner source directory's `scripts/` folder.
- Rejects missing script files and `./...` script references from flat hook units.
- Documents the source convention in `docs/features/adaptive-hooks.md`.
- Extends adaptive hook resolver tests and feature-registry evidence.

## Verification

- `bun test packages/core/src/__tests__/adaptive-hook-attachments.test.ts && bun run typecheck`
- `bun test packages/core/src/__tests__/adaptive-hook-attachments.test.ts packages/core/src/__tests__/feature-registry.test.ts packages/core/src/__tests__/feature-registry-check.test.ts && bun run typecheck && bun run changeset:check`
- `bun run skillset:check && bun run skillset:verify && git diff --check`
- `bun run check`
- Pre-push hook: `skillset ci` plus full `bun run check` passed with 715 tests.

## Local Review

- `.agents/goals/2026-06-25-adaptive-hooks-stack/tmp/reviews/codex/set-127-round1.json`
- Score: 5/5
- State: clean
- Open P0/P1/P2: 0

## Risks / Deferred Scope

- `run.command` parsing/rewrite remains deferred because arbitrary shell command analysis belongs with provider rendering.
- Destination path proof, script copying, provider fixtures, unsupported-destination policy, and generated guidance remain for SET-119/SET-121/SET-120.

Linear: SET-127
