### PR TITLE
feat: render adaptive plugin hooks

### DIFF
--- a/.changeset/adaptive-plugin-hook-render.md
+++ b/.changeset/adaptive-plugin-hook-render.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Render plugin-level adaptive hook attachments to provider-native `hooks/hooks.json` files for Claude and Codex.

--- a/docs/features/adaptive-hooks.md
+++ b/docs/features/adaptive-hooks.md
@@ -42,7 +42,7 @@ Adaptive hook `run.script` references have two source-backed forms:
 
 Flat hook units such as `hooks/<name>.json` cannot use `./...` hook-local scripts because they do not own a private sidecar directory. Use a directory hook unit for colocated sidecars or `{{scripts.dir}}/...` for owner-level shared scripts.
 
-The current compiler validates that these script references resolve to source files and records the source facts for later rendering. Provider-native command rewriting and output path proof land with adaptive rendering.
+The current compiler validates that these script references resolve to source files and records the source facts for rendering. Plugin-level adaptive hook rendering copies referenced scripts into the generated plugin root and rewrites commands to provider runtime roots: `$CLAUDE_PLUGIN_ROOT` for Claude plugin hooks and `$PLUGIN_ROOT` for Codex plugin hooks.
 
 ## Attachments
 
@@ -62,7 +62,22 @@ hooks:
     - session-metadata
 ```
 
+Plugin-level attachments live in the plugin `skillset.yaml` next to plugin metadata:
+
+```yaml
+skillset:
+  name: source-guard
+hooks:
+  PreToolUse:
+    - hook: shell-policy
+      match: Bash
+      status: Checking shell command
+      providers: [claude, codex]
+```
+
 `hooks.auto` expands from the hook definition's declared events. Attachment-level matchers can narrow a definition but cannot broaden its declared event, matcher, handler, or provider support.
+
+The first implemented render slice supports plugin-level command hooks. When a plugin attachment resolves to a provider-compatible adaptive hook, Skillset writes provider-native `hooks/hooks.json` into the generated Claude and Codex plugin outputs and declares `hooks` in the plugin manifest. Skill-local, agent-local, project/root, degraded, skipped, and unsupported destination reporting remain later SET-119/SET-121 work.
 
 Resolution is nearest-first for named hook references:
 
@@ -139,7 +154,7 @@ The implementation stack should stay small enough to review:
 
 - SET-117 defines the adaptive hook unit schema and provider/destination capability registry. It should seed registry data from official provider docs plus Codex generated schemas, then add fixtures for capability proof.
 - SET-118 adds event-keyed attachments, `hooks.auto`, provider scoping, and nearest-first resolution.
-- SET-119 renders adaptive hooks to provider-native outputs and component frontmatter, using structured render results for transformed, degraded, skipped, and unsupported destinations.
+- SET-119 renders adaptive hooks to provider-native outputs and component frontmatter. The first implemented slice writes plugin-level command hooks to Claude and Codex plugin `hooks/hooks.json`; later slices add skill/agent surfaces and structured render results for transformed, degraded, skipped, and unsupported destinations.
 - SET-127 handles hook-adjacent scripts, `bin`, and stable runtime variables only after SET-117 has encoded the path-proof requirements.
 
 The first merged slice should make provider capability facts inspectable and testable before rendering new hook output.

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -9,7 +9,9 @@ import {
   type SourceAdaptiveHook,
   type SourceHookAttachment,
 } from "@skillset/core";
+import { renderBuildGraph } from "../render";
 import { loadBuildGraph } from "../resolver";
+import type { JsonRecord } from "../types";
 
 describe("adaptive hook attachment resolution", () => {
   test("resolves nearest definitions and expands auto attachments", () => {
@@ -61,6 +63,9 @@ codex: false
       ".skillset/plugins/demo/skillset.yaml": `
 skillset:
   name: demo
+hooks:
+  Stop:
+    - shell
 `,
       ".skillset/plugins/demo/hooks/shell.json": JSON.stringify({ events: ["Stop"], run: { command: "node ./shell.js" } }),
       ".skillset/plugins/demo/skills/writer/SKILL.md": `
@@ -83,6 +88,7 @@ Body.
 
     expect(graph.adaptiveHooks.map((hook) => hook.name)).toEqual(["session", "shell", "local-shell"]);
     expect(graph.hookAttachments.map((attachment) => `${attachment.event ?? "auto"}:${attachment.hook}`)).toEqual([
+      "Stop:shell",
       "PreToolUse:local-shell",
       "Stop:shell",
       "auto:session",
@@ -201,6 +207,108 @@ skillset:
 
     await expect(loadBuildGraph(root)).rejects.toThrow("hook-local scripts require a directory hook unit");
   });
+
+  test("fails loudly for adaptive plugin hook render fields that are not supported yet", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-unsupported-render-fields
+claude: true
+codex: false
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - shell-policy
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        claude: { status: "Checking" },
+        events: ["Stop"],
+        run: { command: "echo ok" },
+      }),
+    }));
+
+    await expect(renderBuildGraph(graph)).rejects.toThrow("provider overrides");
+  });
+
+  test("renders plugin-level adaptive hooks to native Claude and Codex hook files", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-render
+claude: true
+codex: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  PreToolUse:
+    - hook: shell-policy
+      match: Bash
+      status: Checking shell command
+      providers: [claude, codex]
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        events: ["PreToolUse"],
+        run: { script: "{{scripts.dir}}/check.sh" },
+      }),
+      ".skillset/plugins/demo/scripts/check.sh": "#!/bin/sh\nexit 0\n",
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    const claudeHooks = renderedJson(rendered, "plugins-claude/plugins/demo/hooks/hooks.json");
+    const codexHooks = renderedJson(rendered, "plugins-codex/plugins/demo/hooks/hooks.json");
+    const claudeManifest = renderedJson(rendered, "plugins-claude/plugins/demo/.claude-plugin/plugin.json");
+    const codexManifest = renderedJson(rendered, "plugins-codex/plugins/demo/.codex-plugin/plugin.json");
+
+    expect(claudeManifest.hooks).toBe("./hooks/hooks.json");
+    expect(codexManifest.hooks).toBe("./hooks/hooks.json");
+    expect(claudeHooks).toEqual({
+      hooks: {
+        PreToolUse: [{
+          hooks: [{ command: "$CLAUDE_PLUGIN_ROOT/scripts/check.sh", type: "command" }],
+          matcher: "Bash",
+          statusMessage: "Checking shell command",
+        }],
+      },
+    });
+    expect(codexHooks).toEqual({
+      hooks: {
+        PreToolUse: [{
+          hooks: [{ command: "$PLUGIN_ROOT/scripts/check.sh", type: "command" }],
+          matcher: "Bash",
+          statusMessage: "Checking shell command",
+        }],
+      },
+    });
+    expect(rendered.map((file) => file.path)).toEqual(expect.arrayContaining([
+      "plugins-claude/plugins/demo/scripts/check.sh",
+      "plugins-codex/plugins/demo/scripts/check.sh",
+    ]));
+  });
+
+  test("rejects adaptive plugin hook output colliding with native hooks aggregate", async () => {
+    await expect(loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-collision
+claude: true
+codex: false
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - shell-policy
+`,
+      ".skillset/plugins/demo/hooks/hooks.json": JSON.stringify({ hooks: { Stop: [] } }),
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({ events: ["Stop"], run: { command: "echo ok" } }),
+    }))).rejects.toThrow("native aggregate source and cannot be combined with adaptive hook units");
+  });
 });
 
 function hook(
@@ -225,4 +333,10 @@ async function fixture(files: Record<string, string>): Promise<string> {
     await Bun.write(join(root, path), `${content.trim()}\n`);
   }
   return root;
+}
+
+function renderedJson(files: readonly { readonly content: Uint8Array; readonly path: string }[], path: string): JsonRecord {
+  const file = files.find((candidate) => candidate.path === path);
+  expect(file).toBeDefined();
+  return JSON.parse(new TextDecoder().decode(file?.content)) as JsonRecord;
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -28,6 +28,7 @@ export type FeatureSurface = "agents" | "instructions" | "plugins" | "skills";
 
 const DEFAULT_SURFACES = new Set<FeatureSurface>(["agents", "instructions", "plugins", "skills"]);
 const CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "defaults", "dependencies", "skillset", "supports"]);
+const PLUGIN_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "hooks"]);
 const ROOT_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "compile", "distributions", "workspace"]);
 const WORKSPACE_CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "compile", "defaults", "dependencies", "distributions", "workspace"]);
 const ROOT_SOURCE_MANIFEST_TOP_LEVEL_KEYS = new Set(["dependencies", "skillset", "supports"]);
@@ -55,6 +56,7 @@ const SOURCE_ONLY_KEYS = new Set([
   "distributions",
   "dialect",
   "implicit_invocation",
+  "hooks",
   "mcp",
   "model",
   "resources",
@@ -267,9 +269,13 @@ export function readDistributionConfig(
 export function validateConfigDocument(
   record: JsonRecord,
   label: string,
-  options: { readonly allowCompile?: boolean; readonly featureKeys?: readonly string[] } = {}
+  options: { readonly allowCompile?: boolean; readonly allowHooks?: boolean; readonly featureKeys?: readonly string[] } = {}
 ): void {
-  const supportedKeys = options.allowCompile === true ? ROOT_CONFIG_TOP_LEVEL_KEYS : CONFIG_TOP_LEVEL_KEYS;
+  const supportedKeys = options.allowCompile === true
+    ? ROOT_CONFIG_TOP_LEVEL_KEYS
+    : options.allowHooks === true
+      ? PLUGIN_CONFIG_TOP_LEVEL_KEYS
+      : CONFIG_TOP_LEVEL_KEYS;
   const featureKeys = new Set(options.featureKeys ?? []);
   if (options.allowCompile === true) {
     validateWorkspaceSchemaDocument(record, label, supportedKeys, "top-level");

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -6,6 +6,10 @@ import { basename, dirname, join, relative } from "node:path";
 import { lowerTransform, recognizeTransforms } from "@skillset/transforms";
 
 import {
+  resolveAdaptiveHookAttachments,
+  type ResolvedAdaptiveHookAttachment,
+} from "./adaptive-hook-attachments";
+import {
   isOutputSelected,
   mergeRecords,
   readRecord,
@@ -344,6 +348,7 @@ async function renderPluginTarget(
   }
 
   rendered.push(...(await renderPluginFeatureFiles(graph, plugin, target, basePath, outputRoot, lockRoots)));
+  rendered.push(...(await renderAdaptivePluginHookFiles(graph, plugin, target, basePath)));
   rendered.push(...(await copyPluginCompanionFiles(graph, plugin, target, basePath)));
   rendered.push(...(await renderPluginIslands(graph, plugin, target, basePath, outputRoot, lockRoots)));
   return rendered;
@@ -394,8 +399,8 @@ function renderPluginManifest(
 
   const targetBase =
     target === "claude"
-      ? withOptionalSurfacePaths(mergeRecords(base, dependencies === undefined ? {} : { dependencies }), plugin, enabledSkills, target)
-      : mergeRecords(withOptionalSurfacePaths(base, plugin, enabledSkills, target), {
+      ? withOptionalSurfacePaths(graph, mergeRecords(base, dependencies === undefined ? {} : { dependencies }), plugin, enabledSkills, target)
+      : mergeRecords(withOptionalSurfacePaths(graph, base, plugin, enabledSkills, target), {
           interface: renderCodexInterface(graph, plugin),
         });
   const withOverrides = mergeRecords(targetBase, manifestOverrides);
@@ -470,6 +475,7 @@ function readPresentationString(record: JsonRecord, ...keys: readonly string[]):
 }
 
 function withOptionalSurfacePaths(
+  graph: BuildGraph,
   manifest: JsonRecord,
   plugin: SourcePlugin,
   enabledSkills: readonly SourceSkill[],
@@ -484,7 +490,7 @@ function withOptionalSurfacePaths(
   if (target === "claude") {
     if (pluginHasPath(plugin, "commands")) withPaths.commands = "./commands";
     if (pluginHasPath(plugin, "agents")) withPaths.agents = "./agents";
-    if (pluginHasPath(plugin, "hooks/hooks.json")) withPaths.hooks = "./hooks/hooks.json";
+    if (pluginHasPath(plugin, "hooks/hooks.json") || hasAdaptivePluginHookOutput(graph, plugin, target)) withPaths.hooks = "./hooks/hooks.json";
     if (pluginHasFeature(plugin, "mcp")) withPaths.mcpServers = "./.mcp.json";
     if (pluginHasPath(plugin, ".lsp.json")) withPaths.lspServers = "./.lsp.json";
     if (pluginHasPath(plugin, "output-styles")) withPaths.outputStyles = "./output-styles/";
@@ -497,7 +503,7 @@ function withOptionalSurfacePaths(
     }
     if (Object.keys(experimental).length > 0) withPaths.experimental = experimental;
   } else {
-    if (pluginHasPath(plugin, "hooks/hooks.json")) {
+    if (pluginHasPath(plugin, "hooks/hooks.json") || hasAdaptivePluginHookOutput(graph, plugin, target)) {
       withPaths.hooks = "./hooks/hooks.json";
     }
     if (pluginHasFeature(plugin, "mcp")) withPaths.mcpServers = "./.mcp.json";
@@ -1618,6 +1624,14 @@ async function copyPluginCompanionFiles(
     if (!(await exists(sourcePath))) continue;
 
     if (target === "claude" && candidate === "hooks") {
+      if (hasAdaptivePluginHookSources(plugin)) {
+        const nativeHookPath = join(sourcePath, "hooks.json");
+        await validateHookJson(graph, nativeHookPath, "claude");
+        if (await exists(nativeHookPath)) {
+          rendered.push(...(await copyPath(nativeHookPath, join(basePath, "hooks", "hooks.json"))));
+        }
+        continue;
+      }
       await validateHookJson(graph, join(sourcePath, "hooks.json"), "claude");
     }
 
@@ -1625,6 +1639,159 @@ async function copyPluginCompanionFiles(
   }
 
   return rendered.filter((file) => !file.path.endsWith(".gitkeep"));
+}
+
+async function renderAdaptivePluginHookFiles(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName,
+  basePath: string
+): Promise<readonly RenderedFile[]> {
+  const resolved = adaptivePluginHookAttachments(graph, plugin, target);
+  if (resolved.length === 0) return [];
+  const nativeSource = join(plugin.path, "hooks", "hooks.json");
+  if (await exists(nativeSource)) {
+    throw new Error(
+      `skillset: plugin ${plugin.id} cannot combine adaptive hook attachments with native hooks/hooks.json for ${target}; choose one hook source model`
+    );
+  }
+
+  const hooks: Record<string, JsonValue[]> = {};
+  const scriptFiles = new Map<string, RenderedFile>();
+  for (const item of resolved) {
+    const eventGroups = hooks[item.event] ?? [];
+    eventGroups.push(renderAdaptiveHookGroup(graph, plugin, target, item, basePath, scriptFiles));
+    hooks[item.event] = eventGroups;
+  }
+
+  const normalized = { hooks };
+  validateHookDefinition(normalized, {
+    sourcePath: `${plugin.id} adaptive hooks -> ${join(basePath, "hooks", "hooks.json")}`,
+    target,
+  });
+
+  return [
+    textFile(
+      join(basePath, "hooks", "hooks.json"),
+      renderValidatedJson(normalized, `${plugin.id} ${target} adaptive hooks`),
+      relative(graph.rootPath, plugin.configPath)
+    ),
+    ...[...scriptFiles.values()].sort((left, right) => compareStrings(left.path, right.path)),
+  ];
+}
+
+function renderAdaptiveHookGroup(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName,
+  item: ResolvedAdaptiveHookAttachment,
+  basePath: string,
+  scriptFiles: Map<string, RenderedFile>
+): JsonRecord {
+  validateSupportedAdaptiveHookRenderFields(item, target);
+  const matcher = item.attachment.match ?? item.definition.frontmatter.match;
+  const statusMessage = item.attachment.status ?? readString(item.definition.frontmatter, "status");
+  const group: JsonRecord = {
+    ...(matcher === undefined ? {} : { matcher }),
+    ...(statusMessage === undefined ? {} : { statusMessage }),
+    hooks: [{
+      command: adaptiveHookCommand(graph, plugin, target, item, basePath, scriptFiles),
+      type: "command",
+    }],
+  };
+  return group;
+}
+
+function validateSupportedAdaptiveHookRenderFields(
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName
+): void {
+  const providerOverride = item.definition.frontmatter[target];
+  if (providerOverride !== undefined) {
+    throw new Error(
+      `skillset: adaptive hook ${item.definition.name} uses ${target} provider overrides, but plugin hook rendering does not support overrides yet`
+    );
+  }
+
+  const run = readRecord(item.definition.frontmatter, "run") ?? {};
+  for (const key of ["args", "cwd", "env"] as const) {
+    if (run[key] !== undefined) {
+      throw new Error(
+        `skillset: adaptive hook ${item.definition.name} uses run.${key}, but plugin hook rendering only supports run.command and run.script yet`
+      );
+    }
+  }
+}
+
+function adaptiveHookCommand(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName,
+  item: ResolvedAdaptiveHookAttachment,
+  basePath: string,
+  scriptFiles: Map<string, RenderedFile>
+): string {
+  const run = readRecord(item.definition.frontmatter, "run") ?? {};
+  const command = readString(run, "command");
+  if (command !== undefined) return command;
+
+  const script = readString(run, "script");
+  if (script === undefined) {
+    throw new Error(`skillset: adaptive hook ${item.definition.name} must define run.command or run.script`);
+  }
+  const reference = item.definition.scriptReferences.find((candidate) => candidate.reference === script);
+  if (reference === undefined) {
+    throw new Error(`skillset: adaptive hook ${item.definition.name} has unresolved run.script ${script}`);
+  }
+  const relativeScriptPath = relative(plugin.path, reference.sourcePath).replaceAll("\\", "/");
+  if (relativeScriptPath.startsWith("../") || relativeScriptPath === "..") {
+    throw new Error(`skillset: adaptive hook ${item.definition.name} script must stay inside plugin ${plugin.id}`);
+  }
+  const outputPath = join(basePath, relativeScriptPath);
+  if (!scriptFiles.has(outputPath)) {
+    scriptFiles.set(outputPath, {
+      content: readFileSync(reference.sourcePath),
+      path: outputPath,
+      sourcePath: relative(graph.rootPath, reference.sourcePath),
+    });
+  }
+  const pluginRoot = target === "claude" ? "$CLAUDE_PLUGIN_ROOT" : "$PLUGIN_ROOT";
+  return `${pluginRoot}/${relativeScriptPath}`;
+}
+
+function hasAdaptivePluginHookOutput(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName
+): boolean {
+  return adaptivePluginHookAttachments(graph, plugin, target).length > 0;
+}
+
+function adaptivePluginHookAttachments(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName
+): readonly ResolvedAdaptiveHookAttachment[] {
+  return resolveAdaptiveHookAttachments(graph.adaptiveHooks, graph.hookAttachments).resolved.filter((item) =>
+    item.attachment.scope.kind === "plugin" &&
+    item.attachment.scope.pluginId === plugin.id &&
+    supportsAdaptiveHookTarget(item, target)
+  );
+}
+
+function supportsAdaptiveHookTarget(
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName
+): boolean {
+  return providerListAllows(item.definition.providers, target) && providerListAllows(item.attachment.providers, target);
+}
+
+function providerListAllows(providers: readonly TargetName[] | undefined, target: TargetName): boolean {
+  return providers === undefined || providers.includes(target);
+}
+
+function hasAdaptivePluginHookSources(plugin: SourcePlugin): boolean {
+  return plugin.adaptiveHooks.length > 0 || plugin.hookAttachments.length > 0;
 }
 
 async function renderPluginFeatureFiles(

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -173,6 +173,7 @@ export async function loadBuildGraph(
     ...projectAgents.flatMap((agent) => agent.adaptiveHooks),
   ];
   const hookAttachments = [
+    ...plugins.flatMap((plugin) => plugin.hookAttachments),
     ...plugins.flatMap((plugin) => plugin.skills.flatMap((skill) => skill.hookAttachments)),
     ...standaloneSkills.flatMap((skill) => skill.hookAttachments),
     ...projectAgents.flatMap((agent) => agent.hookAttachments),
@@ -836,7 +837,7 @@ async function loadPlugin(
   let inheritedTargets: BuildGraph["root"]["targets"];
   let targets: SourcePlugin["targets"];
   try {
-    validateConfigDocument(config, configPath, { featureKeys: PLUGIN_FEATURE_KEYS });
+    validateConfigDocument(config, configPath, { allowHooks: true, featureKeys: PLUGIN_FEATURE_KEYS });
     await validateSupports(config.supports, { label: configRelativePath, rootPath, warnings });
     dependencies = readPluginDependencies(config.dependencies, configRelativePath);
     metadata = readSkillsetMetadata(config, configPath);
@@ -870,6 +871,7 @@ async function loadPlugin(
     id,
     configuredOutputRoots(outputs)
   );
+  const hookAttachments = readHookAttachments(config.hooks, { kind: "plugin", pluginId: id }, configRelativePath);
   const adaptiveHooks = await loadAdaptiveHooks(rootPath, pluginPath, { kind: "plugin", pluginId: id });
   const skills = await loadSkills(rootPath, sourceDir, sourceRootDir, pluginPath, inheritedTargets, warnings, id);
 
@@ -887,6 +889,7 @@ async function loadPlugin(
     adaptiveHooks,
     dependencies,
     features,
+    hookAttachments,
     id,
     metadata,
     path: pluginPath,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -169,6 +169,7 @@ export interface SourcePlugin {
   readonly configPath: string;
   readonly dependencies: readonly SourcePluginDependency[];
   readonly features: readonly SourcePluginFeature[];
+  readonly hookAttachments: readonly SourceHookAttachment[];
   readonly id: string;
   readonly metadata: JsonRecord;
   readonly path: string;


### PR DESCRIPTION
## Context

SET-119 starts adaptive hook rendering. This slice keeps the scope intentionally narrow: plugin-level adaptive attachments render to provider-native plugin hook files, while skill/agent/root destination policy remains for the next slices.

## What Changed

- Load plugin config `hooks:` as plugin-scope adaptive hook attachments.
- Render compatible plugin-level adaptive command/script hooks to Claude and Codex `hooks/hooks.json`.
- Declare generated hook files in Claude/Codex plugin manifests.
- Copy referenced plugin scripts into generated plugin roots and rewrite commands to `` / ``.
- Fail loudly for adaptive provider overrides and unsupported `run.args`, `run.cwd`, and `run.env` fields instead of silently dropping them.
- Document the implemented plugin-level slice and add a package Changeset.

## Verification

- `bun test packages/core/src/__tests__/adaptive-hook-attachments.test.ts && bun run typecheck`
- `bun test packages/core/src/__tests__/adaptive-hook-attachments.test.ts packages/core/src/__tests__/hook-capabilities.test.ts packages/core/src/__tests__/provider-format-conformance.test.ts packages/core/src/__tests__/render-result-build.test.ts apps/skillset/src/__tests__/contract.test.ts && bun run changeset:check && bun run skillset:check && bun run skillset:verify && git diff --check`
- `bun run check` (718 tests)
- pre-push hook: `skillset ci` + full `bun run check` (718 tests)

## Risks / Deferred

- Skill-local, agent-local, and project/root hook destinations are still deferred.
- Structured unsupported/degraded render-result policy remains for SET-121.
- Provider-specific override lowering and `run.args`/`run.cwd`/`run.env` mapping are deliberately not silently rendered yet.
