### PR TITLE
feat: render claude adaptive hook frontmatter

### DIFF
--- a/.changeset/adaptive-frontmatter-hook-render.md
+++ b/.changeset/adaptive-frontmatter-hook-render.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Render Claude skill and project-agent adaptive command hooks into native frontmatter hook groups.

--- a/docs/features/adaptive-hooks.md
+++ b/docs/features/adaptive-hooks.md
@@ -77,7 +77,7 @@ hooks:
 
 `hooks.auto` expands from the hook definition's declared events. Attachment-level matchers can narrow a definition but cannot broaden its declared event, matcher, handler, or provider support.
 
-The first implemented render slice supports plugin-level command hooks. When a plugin attachment resolves to a provider-compatible adaptive hook, Skillset writes provider-native `hooks/hooks.json` into the generated Claude and Codex plugin outputs and declares `hooks` in the plugin manifest. Skill-local, agent-local, project/root, degraded, skipped, and unsupported destination reporting remain later SET-119/SET-121 work.
+The implemented render slices support plugin-level command/script hooks and Claude frontmatter command hooks. When a plugin attachment resolves to a provider-compatible adaptive hook, Skillset writes provider-native `hooks/hooks.json` into the generated Claude and Codex plugin outputs and declares `hooks` in the plugin manifest. When a Claude skill-local or project-agent-local attachment resolves to a command hook, Skillset writes provider-native `hooks` frontmatter for the generated skill or agent. Codex skill/agent no-faithful-destination policy, project/root hooks, degraded/skipped outcomes, and structured unsupported destination reporting remain later SET-119/SET-121 work.
 
 Resolution is nearest-first for named hook references:
 
@@ -154,7 +154,7 @@ The implementation stack should stay small enough to review:
 
 - SET-117 defines the adaptive hook unit schema and provider/destination capability registry. It should seed registry data from official provider docs plus Codex generated schemas, then add fixtures for capability proof.
 - SET-118 adds event-keyed attachments, `hooks.auto`, provider scoping, and nearest-first resolution.
-- SET-119 renders adaptive hooks to provider-native outputs and component frontmatter. The first implemented slice writes plugin-level command hooks to Claude and Codex plugin `hooks/hooks.json`; later slices add skill/agent surfaces and structured render results for transformed, degraded, skipped, and unsupported destinations.
+- SET-119 renders adaptive hooks to provider-native outputs and component frontmatter. Implemented slices write plugin-level command/script hooks to Claude and Codex plugin `hooks/hooks.json` and Claude skill/project-agent command hooks to frontmatter; later slices add remaining destination policy and structured render results for transformed, degraded, skipped, and unsupported destinations.
 - SET-127 handles hook-adjacent scripts, `bin`, and stable runtime variables only after SET-117 has encoded the path-proof requirements.
 
 The first merged slice should make provider capability facts inspectable and testable before rendering new hook output.

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -12,6 +12,7 @@ import {
 import { renderBuildGraph } from "../render";
 import { loadBuildGraph } from "../resolver";
 import type { JsonRecord } from "../types";
+import { parseMarkdown } from "../yaml";
 
 describe("adaptive hook attachment resolution", () => {
   test("resolves nearest definitions and expands auto attachments", () => {
@@ -290,6 +291,96 @@ hooks:
     ]));
   });
 
+  test("renders Claude skill and project-agent adaptive hooks into frontmatter", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-frontmatter-render
+claude: true
+codex: false
+`,
+      ".skillset/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  PreToolUse:
+    - hook: local-shell
+      match: Bash
+      status: Checking skill shell
+---
+
+Body.
+`,
+      ".skillset/skills/writer/hooks/local-shell.json": JSON.stringify({
+        events: ["PreToolUse"],
+        run: { command: "echo skill" },
+      }),
+      ".skillset/agents/helper.md": `
+---
+description: Demo helper.
+hooks:
+  Stop:
+    - hook: local-stop
+      status: Checking agent stop
+---
+
+Body.
+`,
+      ".skillset/agents/helper/hooks/local-stop.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo agent" },
+      }),
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    const skillFrontmatter = renderedMarkdown(rendered, ".claude/skills/writer/SKILL.md").frontmatter;
+    const agentFrontmatter = renderedMarkdown(rendered, ".claude/agents/helper.md").frontmatter;
+
+    expect(skillFrontmatter.hooks).toEqual({
+      PreToolUse: [{
+        hooks: [{ command: "echo skill", type: "command" }],
+        matcher: "Bash",
+        statusMessage: "Checking skill shell",
+      }],
+    });
+    expect(agentFrontmatter.hooks).toEqual({
+      Stop: [{
+        hooks: [{ command: "echo agent", type: "command" }],
+        statusMessage: "Checking agent stop",
+      }],
+    });
+  });
+
+  test("rejects frontmatter adaptive hook scripts without stable path proof", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-frontmatter-script
+claude: true
+codex: false
+`,
+      ".skillset/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  Stop:
+    - local-stop
+---
+
+Body.
+`,
+      ".skillset/skills/writer/hooks/local-stop/hook.json": JSON.stringify({
+        events: ["Stop"],
+        run: { script: "./stop.sh" },
+      }),
+      ".skillset/skills/writer/hooks/local-stop/stop.sh": "#!/bin/sh\nexit 0\n",
+    }));
+
+    await expect(renderBuildGraph(graph)).rejects.toThrow("frontmatter hook rendering does not have stable runtime path proof");
+  });
+
   test("rejects adaptive plugin hook output colliding with native hooks aggregate", async () => {
     await expect(loadBuildGraph(await fixture({
       "skillset.yaml": `
@@ -339,4 +430,10 @@ function renderedJson(files: readonly { readonly content: Uint8Array; readonly p
   const file = files.find((candidate) => candidate.path === path);
   expect(file).toBeDefined();
   return JSON.parse(new TextDecoder().decode(file?.content)) as JsonRecord;
+}
+
+function renderedMarkdown(files: readonly { readonly content: Uint8Array; readonly path: string }[], path: string) {
+  const file = files.find((candidate) => candidate.path === path);
+  expect(file).toBeDefined();
+  return parseMarkdown(new TextDecoder().decode(file?.content), path);
 }

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -646,6 +646,17 @@ async function renderClaudeProjectAgent(
   const targetOptions = agent.targets.claude.options;
   const initialPrompt = readString(targetOptions, "initialPrompt") ?? readString(agent.frontmatter, "initialPrompt");
   const skills = readStringArray(targetOptions, "skills") ?? readStringArray(agent.frontmatter, "skills");
+  const adaptiveHooks = renderAdaptiveFrontmatterHooks(
+    graph,
+    { agentId: agent.outputName, kind: "agent" },
+    "claude",
+    relative(graph.rootPath, agent.sourcePath)
+  );
+  if (adaptiveHooks !== undefined && targetOptions.hooks !== undefined) {
+    throw new Error(
+      `skillset: ${relative(graph.rootPath, agent.sourcePath)} cannot combine adaptive hook attachments with claude.hooks`
+    );
+  }
   const frontmatter = mergeRecords(
     mergeRecords(
       mergeRecords(stripAgentTargetOptions(stripSourceFrontmatter(agent.frontmatter, agent.sourcePath)), {
@@ -653,6 +664,7 @@ async function renderClaudeProjectAgent(
         description: readString(targetOptions, "description") ?? readString(agent.frontmatter, "description") ?? agent.name,
         ...(skills === undefined ? {} : { skills: [...skills] }),
         ...(initialPrompt === undefined ? {} : { initialPrompt }),
+        ...(adaptiveHooks === undefined ? {} : { hooks: adaptiveHooks }),
       }),
       stripAgentTargetOptions(targetOptions)
     ),
@@ -1104,12 +1116,24 @@ async function renderSkillMarkdown(
   const withReferences = references === undefined ? base : mergeRecords(base, { references });
   const withClaudePolicy =
     target === "claude" ? mergeRecords(withReferences, renderClaudeSkillPolicy(skill, targetOptions)) : withReferences;
+  const adaptiveHooks = target === "claude"
+    ? renderAdaptiveFrontmatterHooks(graph, skillScope(plugin, skill), target, relative(graph.rootPath, skill.sourcePath))
+    : undefined;
+  const withAdaptiveHooks = adaptiveHooks === undefined
+    ? withClaudePolicy
+    : mergeRecords(withClaudePolicy, { hooks: adaptiveHooks });
   const withPortable = graph.root.compile.skillset.metadata
-    ? mergeRecords(withClaudePolicy, { metadata: { generated: GENERATED_BY, version } })
-    : withClaudePolicy;
+    ? mergeRecords(withAdaptiveHooks, { metadata: { generated: GENERATED_BY, version } })
+    : withAdaptiveHooks;
+  const targetFrontmatter = readRecord(targetOptions, "frontmatter") ?? {};
+  if (adaptiveHooks !== undefined && targetFrontmatter.hooks !== undefined) {
+    throw new Error(
+      `skillset: ${relative(graph.rootPath, skill.sourcePath)} cannot combine adaptive hook attachments with ${target}.frontmatter.hooks`
+    );
+  }
   const withTargetFrontmatter = mergeRecords(
     withPortable,
-    readRecord(targetOptions, "frontmatter") ?? {}
+    targetFrontmatter
   );
   const frontmatter = graph.root.compile.skillset.metadata
     ? mergeRecords(withTargetFrontmatter, {
@@ -1792,6 +1816,110 @@ function providerListAllows(providers: readonly TargetName[] | undefined, target
 
 function hasAdaptivePluginHookSources(plugin: SourcePlugin): boolean {
   return plugin.adaptiveHooks.length > 0 || plugin.hookAttachments.length > 0;
+}
+
+function renderAdaptiveFrontmatterHooks(
+  graph: BuildGraph,
+  scope: ResolvedAdaptiveHookAttachment["attachment"]["scope"],
+  target: TargetName,
+  sourceLabel: string
+): JsonRecord | undefined {
+  const resolved = adaptiveHookAttachmentsForScope(graph, scope, target);
+  if (resolved.length === 0) return undefined;
+
+  const hooks: Record<string, JsonValue[]> = {};
+  for (const item of resolved) {
+    const eventGroups = hooks[item.event] ?? [];
+    eventGroups.push(renderAdaptiveFrontmatterHookGroup(item, target));
+    hooks[item.event] = eventGroups;
+  }
+
+  validateHookDefinition({ hooks }, { sourcePath: `${sourceLabel} adaptive hooks`, target });
+  return hooks;
+}
+
+function renderAdaptiveFrontmatterHookGroup(
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName
+): JsonRecord {
+  validateSupportedAdaptiveFrontmatterHookFields(item, target);
+  const matcher = item.attachment.match ?? item.definition.frontmatter.match;
+  const statusMessage = item.attachment.status ?? readString(item.definition.frontmatter, "status");
+  return {
+    ...(matcher === undefined ? {} : { matcher }),
+    ...(statusMessage === undefined ? {} : { statusMessage }),
+    hooks: [{
+      command: adaptiveFrontmatterHookCommand(item),
+      type: "command",
+    }],
+  };
+}
+
+function validateSupportedAdaptiveFrontmatterHookFields(
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName
+): void {
+  const providerOverride = item.definition.frontmatter[target];
+  if (providerOverride !== undefined) {
+    throw new Error(
+      `skillset: adaptive hook ${item.definition.name} uses ${target} provider overrides, but frontmatter hook rendering does not support overrides yet`
+    );
+  }
+
+  const run = readRecord(item.definition.frontmatter, "run") ?? {};
+  for (const key of ["args", "cwd", "env"] as const) {
+    if (run[key] !== undefined) {
+      throw new Error(
+        `skillset: adaptive hook ${item.definition.name} uses run.${key}, but frontmatter hook rendering only supports run.command yet`
+      );
+    }
+  }
+  if (run.script !== undefined) {
+    throw new Error(
+      `skillset: adaptive hook ${item.definition.name} uses run.script, but frontmatter hook rendering does not have stable runtime path proof yet`
+    );
+  }
+}
+
+function adaptiveFrontmatterHookCommand(item: ResolvedAdaptiveHookAttachment): string {
+  const run = readRecord(item.definition.frontmatter, "run") ?? {};
+  const command = readString(run, "command");
+  if (command === undefined) {
+    throw new Error(`skillset: adaptive hook ${item.definition.name} must define run.command for frontmatter hook rendering`);
+  }
+  return command;
+}
+
+function adaptiveHookAttachmentsForScope(
+  graph: BuildGraph,
+  scope: ResolvedAdaptiveHookAttachment["attachment"]["scope"],
+  target: TargetName
+): readonly ResolvedAdaptiveHookAttachment[] {
+  return resolveAdaptiveHookAttachments(graph.adaptiveHooks, graph.hookAttachments).resolved.filter((item) =>
+    sameAdaptiveHookScope(item.attachment.scope, scope) &&
+    supportsAdaptiveHookTarget(item, target)
+  );
+}
+
+function sameAdaptiveHookScope(
+  left: ResolvedAdaptiveHookAttachment["attachment"]["scope"],
+  right: ResolvedAdaptiveHookAttachment["attachment"]["scope"]
+): boolean {
+  return left.kind === right.kind &&
+    left.pluginId === right.pluginId &&
+    left.skillId === right.skillId &&
+    left.agentId === right.agentId;
+}
+
+function skillScope(
+  plugin: SourcePlugin | undefined,
+  skill: SourceSkill
+): ResolvedAdaptiveHookAttachment["attachment"]["scope"] {
+  return {
+    kind: "skill",
+    ...(plugin === undefined ? {} : { pluginId: plugin.id }),
+    skillId: skill.id,
+  };
 }
 
 async function renderPluginFeatureFiles(


### PR DESCRIPTION
## Context

This is the next SET-119 slice stacked above PR #192. PR #192 renders plugin-level adaptive hooks; this slice handles Claude skill-local and project-agent-local command hook destinations.

## What Changed

- Render Claude skill-local adaptive command hooks into generated `SKILL.md` `hooks` frontmatter.
- Render Claude project-agent-local adaptive command hooks into generated agent Markdown `hooks` frontmatter.
- Preserve the same resolution/provider filtering used by plugin adaptive hook rendering.
- Fail loudly for frontmatter `run.script` until stable runtime path proof exists for skill/agent scopes.
- Document the implemented frontmatter slice and add a package Changeset.

## Verification

- `bun test packages/core/src/__tests__/adaptive-hook-attachments.test.ts && bun run typecheck`
- `bun test packages/core/src/__tests__/adaptive-hook-attachments.test.ts packages/core/src/__tests__/hook-capabilities.test.ts packages/core/src/__tests__/provider-format-conformance.test.ts packages/core/src/__tests__/render-result-build.test.ts apps/skillset/src/__tests__/contract.test.ts && bun run changeset:check && bun run skillset:check && bun run skillset:verify && git diff --check`
- `bun run check` (720 tests)
- pre-push hook: `skillset ci` + full `bun run check` (720 tests)

## Risks / Deferred

- Codex skill/agent hook attachments still need explicit no-faithful-destination policy/provenance.
- Frontmatter `run.script` remains blocked until scope-specific runtime path proof is designed.
- Structured unsupported/degraded render-result handling remains for SET-121.
