### PR TITLE
feat: report adaptive hook unsupported destinations

### DIFF
--- a/.changeset/adaptive-hook-unsupported-policy.md
+++ b/.changeset/adaptive-hook-unsupported-policy.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Record unsupported render results for Codex skill-local and project-agent adaptive hook attachments instead of silently omitting no-faithful-destination hook scopes.

--- a/docs/features/adaptive-hooks.md
+++ b/docs/features/adaptive-hooks.md
@@ -77,7 +77,7 @@ hooks:
 
 `hooks.auto` expands from the hook definition's declared events. Attachment-level matchers can narrow a definition but cannot broaden its declared event, matcher, handler, or provider support.
 
-The implemented render slices support plugin-level command/script hooks and Claude frontmatter command hooks. When a plugin attachment resolves to a provider-compatible adaptive hook, Skillset writes provider-native `hooks/hooks.json` into the generated Claude and Codex plugin outputs and declares `hooks` in the plugin manifest. When a Claude skill-local or project-agent-local attachment resolves to a command hook, Skillset writes provider-native `hooks` frontmatter for the generated skill or agent. Codex skill/agent no-faithful-destination policy, project/root hooks, degraded/skipped outcomes, and structured unsupported destination reporting remain later SET-119/SET-121 work.
+The implemented render slices support plugin-level command/script hooks and Claude frontmatter command hooks. When a plugin attachment resolves to a provider-compatible adaptive hook, Skillset writes provider-native `hooks/hooks.json` into the generated Claude and Codex plugin outputs and declares `hooks` in the plugin manifest. When a Claude skill-local or project-agent-local attachment resolves to a command hook, Skillset writes provider-native `hooks` frontmatter for the generated skill or agent. Codex skill/agent no-faithful-destination cases now produce structured unsupported render results instead of silently widening or dropping the attachment. Project/root hooks, degraded/skipped outcomes, and structured policy for unsupported event, matcher, handler, and runtime-path cases remain later SET-121 work.
 
 Resolution is nearest-first for named hook references:
 

--- a/docs/features/render-results.md
+++ b/docs/features/render-results.md
@@ -93,6 +93,7 @@ The remaining status values are intentionally documented deferrals rather than f
 - Unsupported, lossy, and failed render results fail by default for enabled targets unless a scoped opt-out or future explicit unsupported destination policy applies.
 - Degraded render results should remain visible because they represent useful but weaker behavior.
 - Skipped render results need policy provenance so a clean build is not confused with silent omission.
+- Adaptive hook attachments that target Codex skill-local or project-agent scopes produce `adaptive-hooks` `unsupported:error` render results, because Codex has no faithful component-local hook destination for those scopes.
 - Friendly warning text can coexist with structured render-result refs when the warning is about target rendering. For example, Codex `AGENTS.md` size warnings remain readable diagnostics and also attach `codex-agents-size` refs to the matching `project-instructions` render result.
 - Import reports keep unrecognized frontmatter warnings separate, but target-native Claude tool-policy fields such as `allowed-tools` and `disable-model-invocation` also produce `tool-intent` `target_native` render-result records.
 - Adopt survey skips for recognized native surfaces produce `intentionally_skipped` render-result records in the report so planned migrations are visible without pretending the dry-run rendered output.

--- a/packages/core/src/__tests__/render-result-build.test.ts
+++ b/packages/core/src/__tests__/render-result-build.test.ts
@@ -567,6 +567,136 @@ echo alpha
     });
   });
 
+  it("enforces unsupported adaptive hook outcomes for Codex component scopes", async () => {
+    const skillRoot = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-policy-skill
+claude: false
+codex: true
+`,
+      ".skillset/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  Stop:
+    - local-stop
+---
+
+Body.
+`,
+      ".skillset/skills/writer/hooks/local-stop.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo skill" },
+      }),
+    });
+    await expectUnsupportedOutcome(skillRoot, {
+      destination: "skill-frontmatter",
+      featureId: "adaptive-hooks",
+      reason: "Codex has no faithful skill-local hook destination for adaptive hook attachments.",
+      sourceUnit: "skill:writer",
+    });
+
+    const pluginSkillRoot = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-policy-plugin-skill
+claude: false
+codex: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+`,
+      ".skillset/plugins/demo/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  Stop:
+    - local-stop
+---
+
+Body.
+`,
+      ".skillset/plugins/demo/skills/writer/hooks/local-stop.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo plugin skill" },
+      }),
+    });
+    await expectUnsupportedOutcome(pluginSkillRoot, {
+      destination: "skill-frontmatter",
+      featureId: "adaptive-hooks",
+      reason: "Codex has no faithful skill-local hook destination for adaptive hook attachments.",
+      sourceUnit: "plugin.demo.skill:writer",
+    });
+
+    const agentRoot = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-policy-agent
+claude: false
+codex: true
+`,
+      ".skillset/agents/helper.md": `
+---
+description: Demo helper.
+hooks:
+  Stop:
+    - local-stop
+---
+
+Body.
+`,
+      ".skillset/agents/helper/hooks/local-stop.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo agent" },
+      }),
+    });
+    await expectUnsupportedOutcome(agentRoot, {
+      destination: "agent-frontmatter",
+      featureId: "adaptive-hooks",
+      reason: "Codex has no faithful project-agent hook destination for adaptive hook attachments.",
+      sourceUnit: "agent:helper",
+    });
+  });
+
+  it("does not report unsupported Codex hook outcomes for Claude-scoped adaptive attachments", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-policy-provider-scope
+claude: true
+codex: true
+`,
+      ".skillset/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  Stop:
+    - hook: local-stop
+      providers: [claude]
+---
+
+Body.
+`,
+      ".skillset/skills/writer/hooks/local-stop.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo skill" },
+      }),
+    });
+
+    const preview = await diffSkillsetResult(root);
+
+    expect(preview.renderResults).not.toContainEqual(expect.objectContaining({
+      featureId: "adaptive-hooks",
+      status: "unsupported",
+      target: "codex",
+    }));
+  });
+
   it("separates target (provider) from destination (concrete output scope)", async () => {
     const root = await fixture(OUTCOME_FIXTURE);
     const preview = await diffSkillsetResult(root);

--- a/packages/core/src/render-result-collector.ts
+++ b/packages/core/src/render-result-collector.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import { resolveAdaptiveHookAttachments } from "./adaptive-hook-attachments";
 import { readString, isOutputSelected } from "./config";
 import { getSkillsetFeature } from "./feature-registry";
 import {
@@ -20,7 +21,7 @@ import {
   selectorForStandaloneSkill,
   selectorForTargetNativeIsland,
 } from "./source-unit-selector";
-import type { BuildGraph, BuildScope, JsonRecord, RenderedFile, SourceSkill, TargetName } from "./types";
+import type { AdaptiveHookScope, BuildGraph, BuildScope, JsonRecord, RenderedFile, SourceSkill, TargetName } from "./types";
 import { isJsonRecord } from "./yaml";
 
 const LOCK_FILE = "skillset.lock";
@@ -82,6 +83,7 @@ export function collectRenderResults(
   }
 
   outcomes.push(...unsupportedPluginFeatureOutcomes(graph, options.scopes));
+  outcomes.push(...unsupportedAdaptiveHookOutcomes(graph, options.scopes));
 
   return outcomes.sort((left, right) =>
     compareStrings(
@@ -276,6 +278,104 @@ function sourceSkillForLockItem(graph: BuildGraph, item: RenderedLockItem): Sour
   return graph.plugins
     .find((plugin) => plugin.id === item.plugin)
     ?.skills.find((skill) => skill.id === item.name);
+}
+
+function unsupportedAdaptiveHookOutcomes(
+  graph: BuildGraph,
+  scopes: readonly BuildScope[] | undefined
+): readonly SkillsetRenderResult[] {
+  if (scopes !== undefined && !scopes.includes("plugins") && !scopes.includes("project") && !scopes.includes("user")) {
+    return [];
+  }
+
+  const featureId = "adaptive-hooks";
+  const evidence = evidenceFor(featureId, "codex");
+  const outcomes: SkillsetRenderResult[] = [];
+  for (const item of resolveAdaptiveHookAttachments(graph.adaptiveHooks, graph.hookAttachments).resolved) {
+    if (!providerListAllows(item.definition.providers, "codex") || !providerListAllows(item.attachment.providers, "codex")) {
+      continue;
+    }
+    if (!isAdaptiveHookScopeRenderedForTarget(graph, item.attachment.scope, "codex", scopes)) continue;
+    const destination = unsupportedAdaptiveHookDestination(item.attachment.scope);
+    if (destination === undefined) continue;
+
+    const sourceUnit = sourceUnitForAdaptiveHookScope(item.attachment.scope);
+    if (sourceUnit === undefined) continue;
+    const sourcePath = normalizeSourcePath(graph, item.attachment.sourcePath);
+    const reason = unsupportedAdaptiveHookReason(item.attachment.scope);
+    outcomes.push(
+      defineRenderResult({
+        destination,
+        ...(evidence === undefined ? {} : { evidence }),
+        featureId,
+        policy: "unsupported:error",
+        reason,
+        sourcePath,
+        sourceUnit,
+        status: "unsupported",
+        target: "codex",
+        diagnostics: [{ code: "adaptive-hook-destination-unsupported", message: reason, path: sourcePath }],
+      })
+    );
+  }
+  return outcomes;
+}
+
+function unsupportedAdaptiveHookDestination(scope: AdaptiveHookScope): string | undefined {
+  if (scope.kind === "skill") return "skill-frontmatter";
+  if (scope.kind === "agent") return "agent-frontmatter";
+  return undefined;
+}
+
+function unsupportedAdaptiveHookReason(scope: AdaptiveHookScope): string {
+  if (scope.kind === "skill") {
+    return "Codex has no faithful skill-local hook destination for adaptive hook attachments.";
+  }
+  return "Codex has no faithful project-agent hook destination for adaptive hook attachments.";
+}
+
+function isAdaptiveHookScopeRenderedForTarget(
+  graph: BuildGraph,
+  scope: AdaptiveHookScope,
+  target: TargetName,
+  scopes: readonly BuildScope[] | undefined
+): boolean {
+  if (scope.kind === "skill") {
+    if (scope.pluginId !== undefined) {
+      if (scopes !== undefined && !scopes.includes("plugins")) return false;
+      const plugin = graph.plugins.find((candidate) => candidate.id === scope.pluginId);
+      const skill = plugin?.skills.find((candidate) => candidate.id === scope.skillId);
+      return plugin !== undefined &&
+        skill !== undefined &&
+        pluginTargetSelected(graph, plugin.id, target) &&
+        skill.targets[target].enabled;
+    }
+
+    if (scopes !== undefined && !scopes.includes("user")) return false;
+    const skill = graph.standaloneSkills.find((candidate) => candidate.id === scope.skillId);
+    return skill !== undefined &&
+      skill.targets[target].enabled &&
+      isOutputSelected(graph.root.outputs.targetOutputs[target].skills, skill.id);
+  }
+
+  if (scope.kind === "agent") {
+    if (scopes !== undefined && !scopes.includes("project")) return false;
+    const agent = graph.projectAgents.find((candidate) => candidate.outputName === scope.agentId);
+    return agent !== undefined && agent.targets[target].enabled;
+  }
+
+  return false;
+}
+
+function sourceUnitForAdaptiveHookScope(scope: AdaptiveHookScope): string | undefined {
+  if (scope.kind === "skill") {
+    if (scope.skillId === undefined) return undefined;
+    return scope.pluginId === undefined
+      ? selectorForStandaloneSkill(scope.skillId)
+      : selectorForPluginSkill(scope.pluginId, scope.skillId);
+  }
+  if (scope.kind === "agent" && scope.agentId !== undefined) return selectorForProjectAgent(scope.agentId);
+  return undefined;
 }
 
 function featureOutcome(args: {
@@ -557,6 +657,10 @@ function pluginTargetSelected(graph: BuildGraph, pluginId: string, target: Targe
   return plugin !== undefined && plugin.targets[target].enabled && isOutputSelected(graph.root.outputs.targetOutputs[target].plugins, pluginId);
 }
 
+function providerListAllows(providers: readonly TargetName[] | undefined, target: TargetName): boolean {
+  return providers === undefined || providers.includes(target);
+}
+
 function evidenceFor(featureId: string, target: TargetName | undefined) {
   const feature = getSkillsetFeature(featureId);
   if (feature === undefined) return undefined;
@@ -594,6 +698,10 @@ function isInsideOutputRoot(path: string, outputRoot: string): boolean {
 
 function normalizePath(path: string): string {
   return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function normalizeSourcePath(graph: BuildGraph, path: string): string {
+  return normalizePath(path.startsWith(graph.rootPath) ? relative(graph.rootPath, path) : path);
 }
 
 function stringField(record: JsonRecord, key: string): string {

--- a/packages/core/src/render-result-policy.ts
+++ b/packages/core/src/render-result-policy.ts
@@ -43,6 +43,9 @@ function formatBlockedOutcome(outcome: SkillsetRenderResult): string {
 }
 
 function suggestionForBlockedOutcome(outcome: SkillsetRenderResult): string {
+  if (outcome.target === "codex" && outcome.featureId === "adaptive-hooks") {
+    return "scope the hook attachment to Claude with providers, disable Codex for this source, or wait for a documented Codex hook destination";
+  }
   if (outcome.target === "codex" && outcome.featureId === "plugin-agents") {
     return "set codex: false for the plugin, move portable project agents to .skillset/agents, or keep Claude-only files in Claude provider source";
   }


### PR DESCRIPTION
## Context

This is the SET-121 policy slice stacked above PR #193. The prior SET-119 slices render supported plugin hooks and Claude skill/agent frontmatter hooks; this slice makes Codex no-faithful component scopes visible through structured render results.

## What Changed

- Emit `adaptive-hooks` `unsupported:error` render results for Codex standalone skill, plugin skill, and project-agent adaptive hook attachments.
- Preserve provider-scoped Claude-only attachments without emitting Codex unsupported noise.
- Add an adaptive-hook-specific unsupported destination suggestion.
- Document the implemented fail-loud policy behavior and add a package Changeset.

## Verification

- `bun test packages/core/src/__tests__/render-result-build.test.ts packages/core/src/__tests__/render-result-policy.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts && bun run typecheck && bun run changeset:check`
- `bun run skillset:check && bun run skillset:verify && git diff --check`
- `bun run check` (722 tests)
- pre-push hook: `skillset ci` + full `bun run check` (722 tests)
- local review: `.agents/goals/2026-06-25-adaptive-hooks-stack/tmp/reviews/codex/set-121-round1.json`, score 5/5, no P0/P1/P2 findings

## Risks / Deferred

- Unsupported event, matcher, handler, provider override, `run.args`/`run.cwd`/`run.env`, and runtime path proof cases still need structured render-result conversion.
- Non-error `compile.unsupportedDestination` modes remain reserved by schema validation.
- Remote CI/review not watched after opening this draft.
