### PR TITLE
feat: add lookup reference cli

### DIFF
--- a/.changeset/lookup-static-cli.md
+++ b/.changeset/lookup-static-cli.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add `skillset lookup` as a read-only static reference command for source fields, hook events, and target compatibility facts.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -6623,7 +6623,7 @@ Audit body.
 
   const misplacedJson = await runSkillsetCli("list", "--json");
   expect(misplacedJson.exitCode).toBe(1);
-  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, or features");
+  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, or lookup");
 });
 
 test("SET-78: feature capability inspection surfaces registry ids in explain, doctor, and features", async () => {

--- a/apps/skillset/src/__tests__/lookup-cli.test.ts
+++ b/apps/skillset/src/__tests__/lookup-cli.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+
+test("SET-220: lookup without a subject lists static reference subjects", async () => {
+  const result = await runSkillsetCli("lookup");
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("skillset lookup subjects");
+  expect(result.stdout).toContain("skill: Adaptive skill source frontmatter");
+  expect(result.stdout).toContain("--frontmatter --fields --field <path>");
+});
+
+test("SET-220: lookup skill frontmatter renders schema-backed fields", async () => {
+  const text = await runSkillsetCli("lookup", "skill", "--frontmatter");
+  const json = await runSkillsetCli("lookup", "skill", "--frontmatter", "--json");
+
+  expect(text.exitCode).toBe(0);
+  expect(text.stdout).toContain("skillset lookup skill");
+  expect(text.stdout).toContain("description: string");
+  expect(text.stdout).toContain("resources:");
+
+  expect(json.exitCode).toBe(0);
+  const report = JSON.parse(json.stdout) as {
+    readonly fields: readonly { readonly contractId: string; readonly path: string }[];
+  };
+  expect(report.fields.map((field) => `${field.contractId}:${field.path}`)).toContain("skill-frontmatter:resources");
+});
+
+test("SET-220: lookup workspace nested field values", async () => {
+  const result = await runSkillsetCli("lookup", "workspace", "--field", "compile.targets", "--values", "--json");
+
+  expect(result.exitCode).toBe(0);
+  const report = JSON.parse(result.stdout) as {
+    readonly fields: readonly { readonly path: string; readonly values?: readonly string[] }[];
+  };
+  expect(report.fields).toEqual([
+    expect.objectContaining({
+      path: "compile.targets",
+      values: ["claude", "codex"],
+    }),
+  ]);
+});
+
+test("SET-220: lookup hooks events and Codex compatibility", async () => {
+  const result = await runSkillsetCli("lookup", "hooks", "--events", "--compat", "codex");
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("[codex] pre-tool-use.command.input");
+  expect(result.stdout).toContain("[codex] plugin-hooks: pass_through");
+});
+
+test("SET-220: lookup plugin bin compatibility reports Codex unsupported reason", async () => {
+  const result = await runSkillsetCli("lookup", "plugin", "bin", "--compat", "codex", "--json");
+
+  expect(result.exitCode).toBe(0);
+  const report = JSON.parse(result.stdout) as {
+    readonly compatibility: readonly { readonly featureId: string; readonly reason?: string; readonly status: string; readonly target: string }[];
+  };
+  expect(report.compatibility).toEqual([
+    expect.objectContaining({
+      featureId: "plugin-bin",
+      status: "unsupported",
+      target: "codex",
+    }),
+  ]);
+  expect(report.compatibility[0]?.reason).toContain("Codex plugins");
+});
+
+test("SET-220: lookup target lens aliases filter non-compat views", async () => {
+  const result = await runSkillsetCli("lookup", "hooks", "--events", "--claude", "--json");
+
+  expect(result.exitCode).toBe(0);
+  const report = JSON.parse(result.stdout) as {
+    readonly diagnostics: readonly { readonly code: string; readonly severity: string }[];
+    readonly events: readonly unknown[];
+    readonly targets: readonly string[];
+  };
+  expect(report.targets).toEqual(["claude"]);
+  expect(report.events).toEqual([]);
+  expect(report.diagnostics).toContainEqual(expect.objectContaining({
+    code: "lookup/events/not-enumerated",
+    severity: "warning",
+  }));
+});
+
+test("SET-220: lookup invalid combinations and targets produce helpful diagnostics", async () => {
+  const invalidView = await runSkillsetCli("lookup", "workspace", "--frontmatter", "--json");
+  const invalidTarget = await runSkillsetCli("lookup", "hooks", "--compat", "cursor");
+
+  expect(invalidView.exitCode).toBe(1);
+  const report = JSON.parse(invalidView.stdout) as {
+    readonly diagnostics: readonly { readonly code: string; readonly message: string; readonly severity: string }[];
+  };
+  expect(report.diagnostics).toContainEqual({
+    code: "lookup/frontmatter/not-applicable",
+    message: "Workspace configuration uses fields; use --fields or --field instead of --frontmatter.",
+    severity: "error",
+  });
+
+  expect(invalidTarget.exitCode).toBe(1);
+  expect(invalidTarget.stderr).toContain("unknown lookup compatibility target cursor");
+});
+
+async function runSkillsetCli(...args: readonly string[]): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1,7 +1,24 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 
-import { auditVersions, buildSkillsetResult, verifySkillsetResult, diffSkillsetResult, planDistributions, restoreOutputBackup, createOperationalPathContext, isRepoOperationalCachePath, resolveOperationalPath, type DistributionPlanReport, type OutputBackupRestoreReport, type VersionAuditReport } from "@skillset/core";
+import {
+  auditVersions,
+  buildSkillsetResult,
+  createOperationalPathContext,
+  diffSkillsetResult,
+  isRepoOperationalCachePath,
+  lookupSkillsetReference,
+  planDistributions,
+  resolveOperationalPath,
+  restoreOutputBackup,
+  verifySkillsetResult,
+  type DistributionPlanReport,
+  type LookupReport,
+  type LookupSubject,
+  type LookupView,
+  type OutputBackupRestoreReport,
+  type VersionAuditReport,
+} from "@skillset/core";
 
 import { changeCheck, type ChangeBump, type ChangeCheckReport } from "./change-entries";
 import { changeStatus, type ChangeStatusReport } from "./change-status";
@@ -71,7 +88,7 @@ import { renderValidatedJson } from "./structured-output";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
 import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, SourceOrigin, TargetName } from "./types";
 
-type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "new" | "providers" | "release" | "restore" | "suggest-source" | "test" | "update" | "verify";
+type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "new" | "providers" | "release" | "restore" | "suggest-source" | "test" | "update" | "verify";
 type DistributionSubcommand = "plan";
 
 const USAGE = [
@@ -102,6 +119,7 @@ const USAGE = [
   "       skillset providers <check|diff|update> [--yes|--dry-run] [--root <path>]",
   "       skillset update [--yes|--dry-run] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset features [feature-id] [--json]",
+  "       skillset lookup [subject] [aspect...] [--frontmatter] [--fields] [--field <path>] [--values] [--events] [--compat [claude|codex...]] [--examples] [--schema] [--claude] [--codex] [--json]",
   "       skillset test [name] [--root <path>] [--source <dir>]",
   "       skillset hooks print --runner <lefthook|husky|pre-commit|git> [--pre-commit] [--pre-push]",
   "       skillset hooks print --target <claude|codex> --agent-runtime",
@@ -153,6 +171,11 @@ export async function runCli(
     importName,
     importProvider,
     jsonOutput,
+    lookupAspects,
+    lookupField,
+    lookupSubject,
+    lookupTargets,
+    lookupViews,
     newContainer,
     newId,
     newKind,
@@ -565,6 +588,23 @@ export async function runCli(
     return;
   }
 
+  if (command === "lookup") {
+    const report = lookupSkillsetReference({
+      ...(lookupAspects.length === 0 ? {} : { aspects: lookupAspects }),
+      ...(lookupField === undefined ? {} : { field: lookupField }),
+      ...(lookupSubject === undefined ? {} : { subject: lookupSubject }),
+      ...(lookupTargets.length === 0 ? {} : { targets: lookupTargets }),
+      ...(lookupViews.length === 0 ? {} : { views: lookupViews }),
+    });
+    if (jsonOutput) {
+      process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset lookup"));
+    } else {
+      printLookupReport(report);
+    }
+    if (report.diagnostics.some((diagnostic) => diagnostic.severity === "error")) process.exitCode = 1;
+    return;
+  }
+
   if (command === "explain") {
     if (importPath === undefined) {
       throw new Error("skillset: expected a path to explain");
@@ -723,6 +763,11 @@ interface ParsedArgs {
   readonly importPath?: string;
   readonly importProvider?: ImportProvider;
   readonly jsonOutput: boolean;
+  readonly lookupAspects: readonly string[];
+  readonly lookupField?: string;
+  readonly lookupSubject?: LookupSubject;
+  readonly lookupTargets: readonly TargetName[];
+  readonly lookupViews: readonly LookupView[];
   readonly newContainer?: string;
   readonly newId?: string;
   readonly newKind?: NewSourceKind;
@@ -1215,6 +1260,63 @@ function formatFeatureSupport(support: FeatureCapability["targetSupport"]["claud
   return `${support.status}${reason}${note}`;
 }
 
+function printLookupReport(report: LookupReport): void {
+  if (report.subject === undefined) {
+    console.log("skillset lookup subjects");
+    for (const subject of report.subjects) {
+      console.log(`  ${subject.subject}: ${subject.description}`);
+      console.log(`    views: ${subject.defaultViews.join(", ")}`);
+    }
+    console.log("  flags: --frontmatter --fields --field <path> --values --events --compat [claude|codex...] --examples --schema --claude --codex --json");
+    console.log(`skillset: listed ${report.subjects.length} lookup subjects`);
+    return;
+  }
+
+  console.log(`skillset lookup ${report.subject}${report.aspects.length === 0 ? "" : ` ${report.aspects.join(" ")}`}`);
+  for (const diagnostic of report.diagnostics) {
+    console.log(`  ${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`);
+  }
+  if (report.fields.length > 0) {
+    console.log("  fields:");
+    for (const field of report.fields) {
+      const required = field.required ? " required" : "";
+      const values = field.values === undefined ? "" : ` values: ${field.values.map(formatLookupValue).join(", ")}`;
+      console.log(`    ${field.path}: ${field.type}${required}${values}`);
+    }
+  }
+  if (report.events.length > 0) {
+    console.log("  events:");
+    for (const event of report.events) {
+      const required = event.fields.filter((field) => field.required).map((field) => field.name);
+      const suffix = required.length === 0 ? "" : ` required: ${required.join(", ")}`;
+      console.log(`    [${event.target}] ${event.name}${suffix}`);
+    }
+  }
+  if (report.compatibility.length > 0) {
+    console.log("  compatibility:");
+    for (const item of report.compatibility) {
+      const reason = item.reason === undefined ? "" : ` (${item.reason})`;
+      const note = item.note === undefined ? "" : ` note: ${item.note}`;
+      console.log(`    [${item.target}] ${item.featureId}: ${item.status}${reason}${note}`);
+    }
+  }
+  if (report.examples.length > 0) {
+    console.log("  examples:");
+    for (const example of report.examples) {
+      console.log(`    ${example.path}: ${example.description}`);
+    }
+  }
+  if (report.schema !== undefined) {
+    console.log(`  schema: ${report.schema.id} (${report.schema.title})`);
+  }
+  console.log(`skillset: lookup ${report.diagnostics.some((diagnostic) => diagnostic.severity === "error") ? "reported diagnostics" : "complete"}`);
+}
+
+function formatLookupValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
 function formatCountSummary(counts: Readonly<Record<string, number>>): string {
   return Object.entries(counts)
     .sort(([left], [right]) => left.localeCompare(right))
@@ -1268,6 +1370,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "init" &&
     command !== "lint" &&
     command !== "list" &&
+    command !== "lookup" &&
     command !== "new" &&
     command !== "providers" &&
     command !== "release" &&
@@ -1278,7 +1381,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "verify"
   ) {
     throw new Error(
-        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, new, providers, release, restore, suggest-source, test, update, or verify\n" +
+        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, new, providers, release, restore, suggest-source, test, update, or verify\n" +
         USAGE
     );
   }
@@ -1312,6 +1415,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let importPath: string | undefined;
   let importProvider: ImportProvider | undefined;
   let jsonOutput = false;
+  let lookupAspects: string[] = [];
+  let lookupField: string | undefined;
+  let lookupSubject: LookupSubject | undefined;
+  let lookupTargets: TargetName[] = [];
+  let lookupViews: LookupView[] = [];
   let newContainer: string | undefined;
   let newId: string | undefined;
   let newKind: NewSourceKind | undefined;
@@ -1446,6 +1554,19 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     }
   }
 
+  if (command === "lookup") {
+    const rawSubject = args[index];
+    if (rawSubject !== undefined && !rawSubject.startsWith("--")) {
+      lookupSubject = readLookupSubject(rawSubject);
+      index += 1;
+      while (args[index] !== undefined && !args[index]?.startsWith("--")) {
+        const aspect = args[index];
+        if (aspect !== undefined) lookupAspects = [...lookupAspects, aspect];
+        index += 1;
+      }
+    }
+  }
+
   if (command === "restore") {
     const rawBackupId = args[index];
     if (rawBackupId === undefined || rawBackupId.startsWith("--")) {
@@ -1520,9 +1641,34 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag !== "--pre-commit" &&
       flag !== "--pre-push" &&
       flag !== "--write" &&
-      flag !== "--watch"
+      flag !== "--watch" &&
+      flag !== "--frontmatter" &&
+      flag !== "--fields" &&
+      flag !== "--field" &&
+      flag !== "--values" &&
+      flag !== "--events" &&
+      flag !== "--compat" &&
+      flag !== "--examples" &&
+      flag !== "--schema" &&
+      flag !== "--claude" &&
+      flag !== "--codex"
     ) {
       throw new Error(`skillset: unknown option ${arg}`);
+    }
+
+    if (flag === "--compat") {
+      lookupViews = addLookupView(lookupViews, "compat");
+      if (inlineValue !== undefined) {
+        lookupTargets = addLookupTargets(lookupTargets, inlineValue);
+        continue;
+      }
+      while (args[index + 1] !== undefined && !args[index + 1]?.startsWith("--")) {
+        const value = args[index + 1];
+        if (value === undefined) break;
+        lookupTargets = addLookupTargets(lookupTargets, value);
+        index += 1;
+      }
+      continue;
     }
 
     if (
@@ -1540,7 +1686,15 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag === "--pre-commit" ||
       flag === "--pre-push" ||
       flag === "--write" ||
-      flag === "--watch"
+      flag === "--watch" ||
+      flag === "--frontmatter" ||
+      flag === "--fields" ||
+      flag === "--values" ||
+      flag === "--events" ||
+      flag === "--examples" ||
+      flag === "--schema" ||
+      flag === "--claude" ||
+      flag === "--codex"
     ) {
       if (inlineValue !== undefined) throw new Error(`skillset: ${flag} does not take a value`);
       if (flag === "--yes") yes = true;
@@ -1558,6 +1712,14 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       if (flag === "--pre-push") hookPrePush = true;
       if (flag === "--write") sourceSuggestionWrite = true;
       if (flag === "--watch") devWatch = true;
+      if (flag === "--frontmatter") lookupViews = addLookupView(lookupViews, "frontmatter");
+      if (flag === "--fields") lookupViews = addLookupView(lookupViews, "fields");
+      if (flag === "--values") lookupViews = addLookupView(lookupViews, "values");
+      if (flag === "--events") lookupViews = addLookupView(lookupViews, "events");
+      if (flag === "--examples") lookupViews = addLookupView(lookupViews, "examples");
+      if (flag === "--schema") lookupViews = addLookupView(lookupViews, "schema");
+      if (flag === "--claude") lookupTargets = addLookupTarget(lookupTargets, "claude");
+      if (flag === "--codex") lookupTargets = addLookupTarget(lookupTargets, "codex");
       continue;
     }
 
@@ -1604,6 +1766,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     }
     if (flag === "--bump") changeBump = readChangeBump(value);
     if (flag === "--report") ciReportPath = value;
+    if (flag === "--field") lookupField = setLookupField(lookupField, value);
     if (flag === "--runner") hookRunner = readHookRunner(value);
     if (flag === "--target") hookTarget = readHookTarget(value);
     if (flag === "--targets") setupTargets = readSetupTargets(value);
@@ -1697,6 +1860,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(scopes === undefined ? {} : { scopes }),
   });
   validateJsonFlags(command, jsonOutput);
+  validateLookupFlags(command, {
+    ...(lookupField === undefined ? {} : { field: lookupField }),
+    targets: lookupTargets,
+    views: lookupViews,
+  });
   validateSourceDiagnosticFlags(command, {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(distDir === undefined ? {} : { distDir }),
@@ -1806,6 +1974,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(importPath === undefined ? {} : { importPath }),
     ...(importProvider === undefined ? {} : { importProvider }),
     jsonOutput,
+    lookupAspects,
+    ...(lookupField === undefined ? {} : { lookupField }),
+    ...(lookupSubject === undefined ? {} : { lookupSubject }),
+    lookupTargets,
+    lookupViews,
     ...(newContainer === undefined ? {} : { newContainer }),
     ...(newId === undefined ? {} : { newId }),
     ...(newKind === undefined ? {} : { newKind }),
@@ -1850,6 +2023,46 @@ function isProviderMaintenanceSubcommand(value: string | undefined): value is Pr
 
 function isNewSourceKind(value: string | undefined): value is NewSourceKind {
   return value === "agent" || value === "hook" || value === "skill";
+}
+
+function readLookupSubject(value: string): LookupSubject {
+  if (
+    value === "agent" ||
+    value === "hooks" ||
+    value === "instruction" ||
+    value === "plugin" ||
+    value === "skill" ||
+    value === "workspace"
+  ) {
+    return value;
+  }
+  throw new Error("skillset: expected lookup subject skill, agent, instruction, workspace, hooks, or plugin");
+}
+
+function readLookupTarget(value: string): TargetName {
+  if (value === "claude" || value === "codex") return value;
+  throw new Error(`skillset: unknown lookup compatibility target ${value}; expected claude or codex`);
+}
+
+function addLookupTarget(targets: readonly TargetName[], target: TargetName): TargetName[] {
+  return [...new Set([...targets, target])];
+}
+
+function addLookupTargets(targets: readonly TargetName[], value: string): TargetName[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .reduce((current, item) => addLookupTarget(current, readLookupTarget(item)), [...targets]);
+}
+
+function addLookupView(views: readonly LookupView[], view: LookupView): LookupView[] {
+  return [...new Set([...views, view])];
+}
+
+function setLookupField(current: string | undefined, value: string): string {
+  if (current !== undefined) throw new Error("skillset: pass only one --field value");
+  return value;
 }
 
 function readNewSourceScope(value: string): NewSourceScope {
@@ -2364,8 +2577,22 @@ function validateAdoptFlags(
 
 function validateJsonFlags(command: Command, jsonOutput: boolean): void {
   if (!jsonOutput) return;
-  if (command === "doctor" || command === "explain" || command === "features") return;
-  throw new Error("skillset: --json is only supported with doctor, explain, or features");
+  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup") return;
+  throw new Error("skillset: --json is only supported with doctor, explain, features, or lookup");
+}
+
+function validateLookupFlags(
+  command: Command,
+  lookup: {
+    readonly field?: string;
+    readonly targets: readonly TargetName[];
+    readonly views: readonly LookupView[];
+  }
+): void {
+  if (command === "lookup") return;
+  if (lookup.field !== undefined || lookup.targets.length > 0 || lookup.views.length > 0) {
+    throw new Error("skillset: lookup flags are only supported with lookup");
+  }
 }
 
 function isImportKind(value: string): value is ImportKind {


### PR DESCRIPTION
## Context

SET-220 exposes the SET-219 lookup reference model as a read-only CLI command.

## What changed

- Added `skillset lookup [subject] [aspect...]` to the CLI.
- Added lookup flags: `--frontmatter`, `--fields`, `--field <path>`, `--values`, `--events`, `--compat`, `--examples`, `--schema`, `--claude`, `--codex`, and `--json`.
- Rendered text output for subjects, fields, hook events, compatibility facts, examples, schema summaries, and diagnostics.
- Added focused CLI coverage and updated the existing JSON allowlist assertion.
- Added a package changeset.

## Testing

- `bun test apps/skillset/src/__tests__/lookup-cli.test.ts`
- `bun test apps/skillset/src/__tests__/contract.test.ts --test-name-pattern "SET-83"`
- `bun run typecheck`
- `bun run changeset:check`
- `bun run check`
- pre-push hook: `changesets`, `skillset ci`, and `check` passed
- local-review: `tmp/reviews/codex/set-220/round-1.json`, score 5/5 clean
- full-stack local-review: `tmp/reviews/codex/full-stack/round-1.json`, score 5/5 clean

## Stack

Stacked on #201 / SET-219.

## Risks

The command is intentionally a static reference lookup in this slice; future work can expand the prose/explanation layer without changing the model contract.