### PR TITLE
fix: adopt root native plugins into workspace plugins

### DIFF
--- a/.changeset/root-native-plugin-import.md
+++ b/.changeset/root-native-plugin-import.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Fix root native plugin adoption so `plugin:.` imports lift into `.skillset/plugins/<name>/` without copying root workspace config into plugin source.

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -215,6 +215,35 @@ test("adopt write mode imports everything, builds the mirror, and writes the rep
   expect(added.every((path) => path === "skillset.yaml" || path.startsWith(".skillset/"))).toBe(true);
 });
 
+test("adopt elevates a root native plugin without copying workspace config into plugin source", async () => {
+  const root = await fixture({
+    ".claude-plugin/plugin.json": JSON.stringify({
+      description: "Root plugin.",
+      name: "root-native",
+      version: "1.2.3",
+    }),
+    "README.md": "# Root native plugin\n",
+    "commands/hello.md": "---\ndescription: Say hello.\n---\n\nSay hello.\n",
+    "skills/helper/SKILL.md": "---\nname: helper\ndescription: Helper skill.\n---\n\nBody.\n",
+  });
+
+  const report = await adoptSkillset(root, { targets: ["claude"], write: true });
+
+  expect(report.ok).toBe(true);
+  expect(report.candidates).toContainEqual({ kind: "plugin", path: "." });
+  expect(report.imports.find((result) => result.candidate.kind === "plugin")?.ok).toBe(true);
+
+  const workspaceConfig = await readFile(join(root, "skillset.yaml"), "utf8");
+  expect(workspaceConfig).toContain("compile:");
+  const pluginConfig = await readFile(join(root, ".skillset/plugins/root-native/skillset.yaml"), "utf8");
+  expect(pluginConfig).not.toContain("compile:");
+  expect(pluginConfig).toContain("name: root-native");
+  expect(pluginConfig).toContain("path: .");
+  expect(await exists(join(root, ".skillset/plugins/root-native/.claude-plugin/plugin.json"))).toBe(true);
+  expect(await exists(join(root, ".skillset/plugins/root-native/commands/hello.md"))).toBe(true);
+  expect(await exists(join(root, ".skillset/plugins/root-native/skills/helper/SKILL.md"))).toBe(true);
+});
+
 test("adopt carries import render results into the persisted report", async () => {
   const root = await fixture({
     ".claude/skills/native/SKILL.md":

--- a/apps/skillset/src/import.ts
+++ b/apps/skillset/src/import.ts
@@ -158,7 +158,13 @@ export async function importSource(options: ImportOptions): Promise<ImportReport
   let committed = false;
 
   try {
-    const copiedFiles = await copyImportSource(sourcePath, stagingPath, options.kind, name);
+    const copiedFiles = await copyImportSource({
+      kind: options.kind,
+      name,
+      rootPath: options.rootPath,
+      sourcePath,
+      targetPath: stagingPath,
+    });
     if (options.sourceOrigin !== undefined) {
       await stampImportedOrigins(stagingPath, sourcePath, copiedFiles, options.kind, options.sourceOrigin);
     }
@@ -366,9 +372,15 @@ async function resolveImportName(sourcePath: string, options: ImportOptions): Pr
     );
   }
 
-  const configPath = await resolvePluginConfig(sourcePath);
+  const rootPluginImport = options.kind === "plugin" && await isSamePath(sourcePath, options.rootPath);
+  const configPath = rootPluginImport ? undefined : await resolvePluginConfig(sourcePath);
   if (configPath === undefined) {
-    return validateSlug(basename(sourcePath), "plugin directory");
+    const nativeManifest = await readNativePluginManifest(sourcePath);
+    const nativeName = readString(nativeManifest, "name");
+    return validateSlug(
+      nativeName !== undefined && isSlug(nativeName) ? nativeName : basename(sourcePath),
+      "plugin directory"
+    );
   }
 
   const config = parseYamlRecord(await readFile(configPath, "utf8"), configPath);
@@ -376,12 +388,14 @@ async function resolveImportName(sourcePath: string, options: ImportOptions): Pr
   return validateSlug(readSkillsetName(metadata, basename(sourcePath), configPath), `skillset.name in ${configPath}`);
 }
 
-async function copyImportSource(
-  sourcePath: string,
-  targetPath: string,
-  kind: SingularImportKind,
-  name: string
-): Promise<readonly string[]> {
+async function copyImportSource(options: {
+  readonly kind: SingularImportKind;
+  readonly name: string;
+  readonly rootPath: string;
+  readonly sourcePath: string;
+  readonly targetPath: string;
+}): Promise<readonly string[]> {
+  const { kind, name, rootPath, sourcePath, targetPath } = options;
   const stats = await stat(sourcePath);
   if (stats.isFile()) {
     if (kind !== "skill" || basename(sourcePath) !== "SKILL.md") {
@@ -390,8 +404,10 @@ async function copyImportSource(
   }
 
   const copyRoot = stats.isFile() ? dirname(sourcePath) : sourcePath;
+  const rootPluginImport = kind === "plugin" && await isSamePath(copyRoot, rootPath);
   const copied: string[] = [];
-  for (const file of await collectFiles(copyRoot)) {
+  const exclude = rootPluginImport ? (path: string) => isRootPluginImportScaffold(copyRoot, path) : undefined;
+  for (const file of await collectFiles(copyRoot, exclude)) {
     const relativePath = relativeImportPath(copyRoot, file, kind);
     await mkdir(dirname(join(targetPath, relativePath)), { recursive: true });
     await writeFile(join(targetPath, relativePath), await readFile(file));
@@ -460,6 +476,30 @@ function relativeImportPath(sourceRoot: string, file: string, kind: SingularImpo
   return relativePath;
 }
 
+async function isSamePath(left: string, right: string): Promise<boolean> {
+  try {
+    return await realpath(left) === await realpath(right);
+  } catch {
+    return resolve(left) === resolve(right);
+  }
+}
+
+function isSlug(value: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*$/.test(value);
+}
+
+function isRootPluginImportScaffold(rootPath: string, path: string): boolean {
+  const relativePath = relative(rootPath, path).replaceAll("\\", "/");
+  return (
+    relativePath === ".git" ||
+    relativePath.startsWith(".git/") ||
+    relativePath === ".skillset" ||
+    relativePath.startsWith(".skillset/") ||
+    relativePath === "skillset.yaml" ||
+    relativePath === "skillset.lock"
+  );
+}
+
 async function resolveSkillFile(sourcePath: string): Promise<string> {
   const stats = await stat(sourcePath);
   if (stats.isFile()) return sourcePath;
@@ -474,13 +514,14 @@ async function resolvePluginConfig(sourcePath: string): Promise<string | undefin
   return undefined;
 }
 
-async function collectFiles(root: string): Promise<readonly string[]> {
+async function collectFiles(root: string, exclude?: (path: string) => boolean): Promise<readonly string[]> {
   const entries = await readdir(root, { withFileTypes: true });
   const files: string[] = [];
   for (const entry of entries.sort((left, right) => compareStrings(left.name, right.name))) {
     const path = join(root, entry.name);
+    if (exclude?.(path)) continue;
     if (entry.isDirectory()) {
-      files.push(...(await collectFiles(path)));
+      files.push(...(await collectFiles(path, exclude)));
     } else if (entry.isFile() && entry.name !== ".DS_Store") {
       files.push(path);
     }


### PR DESCRIPTION
## Summary
- keep canonical Skillset plugin source under `.skillset/plugins/<plugin>`
- fix root native plugin adoption (`plugin:.`) so it imports into `.skillset/plugins/<name>`
- avoid copying root workspace scaffolding like `skillset.yaml`, `skillset.lock`, `.skillset/`, and `.git/` into plugin-local source
- add an adopt regression covering the root native plugin case

## Verification
- `bun test apps/skillset/src/__tests__/adopt.test.ts`
- `bun test scripts/fixtures/__tests__/external.test.ts packages/workbench/src/__tests__/fixtures.test.ts`
- `bun run conformance:external`
- `bun run check`
- `bun ./apps/skillset/src/cli.ts ci --root . --since "$(scripts/git-trunk.sh)" --report .skillset/cache/reports/skillset-ci-report.md`
- pre-push hook: changeset guard, workflow lint, `skillset ci`, `check`

## Notes
This replaces the earlier singular-layout attempt. `.skillset/plugin` is not the contract; `.skillset/plugins/<plugin>` remains canonical.