### PR TITLE
fix(release): split adaptive hook attachment changeset

### DIFF
--- a/.changeset/adaptive-hook-attachments.md
+++ b/.changeset/adaptive-hook-attachments.md
@@ -1,6 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
 "skillset": patch
 ---
 


### PR DESCRIPTION
## Summary
- remove ignored private packages from the adaptive hook attachment changeset
- let Changesets compute the follow-up public skillset release

## Verification
- bun changeset status --output /tmp/skillset-changeset-status.json
- bun run publish:check