### PR TITLE
feat: add runtime tester harness

### DIFF
--- a/.changeset/runtime-tester.md
+++ b/.changeset/runtime-tester.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add `skillset runtime-tester` for retained non-interactive Claude and Codex prompt runs against isolated generated output, with Claude setting sources configurable by CLI flag or environment variable.

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,3 +1,16 @@
-# Copy this file to .envrc and replace the placeholder with a granular npm token.
-# Then run `direnv allow` from this directory, or source/export NPM_TOKEN manually.
+# Copy this file to .envrc and replace only the values you need.
+# Then run `direnv allow` from this directory. For one-off commands from tools
+# that do not load your shell hook, prefix with `direnv exec .`.
+
+# Package release preflight / publish recovery.
 export NPM_TOKEN="npm_REPLACE_ME"
+
+# Claude Code non-interactive runtime tester.
+# `claude setup-token` prints this export line for subscription-backed CLI use.
+export CLAUDE_CODE_OAUTH_TOKEN="REPLACE_WITH_CLAUDE_SETUP_TOKEN"
+# Optional: isolated is the default; alternatives are user, project, or local.
+# export SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES="isolated"
+
+# API-key fallback for Claude SDK/API workflows. Usually leave unset when using
+# CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.
+# export ANTHROPIC_API_KEY="sk-ant_REPLACE_ME"

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -6623,7 +6623,7 @@ Audit body.
 
   const misplacedJson = await runSkillsetCli("list", "--json");
   expect(misplacedJson.exitCode).toBe(1);
-  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, or lookup");
+  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, lookup, or runtime-tester");
 });
 
 test("SET-78: feature capability inspection surfaces registry ids in explain, doctor, and features", async () => {

--- a/apps/skillset/src/__tests__/runtime-tester.test.ts
+++ b/apps/skillset/src/__tests__/runtime-tester.test.ts
@@ -1,0 +1,331 @@
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { expect, test } from "bun:test";
+import { createOperationalPathContext, resolveOperationalPath } from "@skillset/core";
+
+import {
+  listRuntimeTesterRuns,
+  readRuntimeTesterStatus,
+  startRuntimeTesterRun,
+  tailRuntimeTesterRun,
+} from "../runtime-tester";
+
+test("runtime tester runs a Codex prompt and records inspectable artifacts", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-fixture
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo runtime tester skill.
+---
+
+Use this skill to answer fixture questions.
+`,
+  });
+  const bin = await fakeCodexBin(root);
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+
+  const report = await startRuntimeTesterRun(root, {
+    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CODEX_BIN: bin },
+    prompt: "List the available fixture skills.",
+    target: "codex",
+    xdg,
+  });
+
+  expect(report.ok).toBe(true);
+  expect(report.state).toBe("passed");
+  expect(report.runPath).toStartWith(".skillset/cache/runtime-tester/runs/");
+  expect(await exists(cachePath(root, xdg, report.tailPath))).toBe(true);
+  expect(await readFile(cachePath(root, xdg, report.reportPath), "utf8")).toContain("fake codex final");
+
+  const status = await readRuntimeTesterStatus(root, report.runId, { xdg });
+  expect(status.state).toBe("passed");
+  expect(status.command?.join(" ")).toContain("--output-last-message");
+  expect(status.command?.join(" ")).toContain("--skip-git-repo-check");
+  expect(status.finalMessagePath).toBeDefined();
+
+  const tail = await tailRuntimeTesterRun(root, report.runId, 20, { xdg });
+  expect(tail.map((line) => line.stream)).toContain("stdout");
+  expect(tail.some((line) => line.message.includes("List the available fixture skills."))).toBe(true);
+
+  const runs = await listRuntimeTesterRuns(root, { xdg });
+  expect(runs.map((run) => run.runId)).toContain(report.runId);
+});
+
+test("runtime tester runs a Claude prompt with isolated settings and explicit plugin dirs", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-claude-fixture
+claude: true
+`,
+    ".skillset/plugins/acme/skillset.yaml": `
+skillset:
+  name: acme
+  title: Acme
+  summary: Acme plugin fixture.
+claude: true
+`,
+    ".skillset/plugins/acme/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo Claude runtime tester skill.
+---
+
+Use this skill to answer fixture questions.
+`,
+  });
+  const bin = await fakeClaudeBin(root);
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+
+  const report = await startRuntimeTesterRun(root, {
+    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin },
+    plugins: ["acme"],
+    prompt: "Inspect Claude fixture.",
+    target: "claude",
+    xdg,
+  });
+
+  expect(report.ok).toBe(true);
+  expect(report.state).toBe("passed");
+
+  const status = await readRuntimeTesterStatus(root, report.runId, { xdg });
+  const command = status.command?.join(" ");
+  expect(command).toContain("--setting-sources \"\"");
+  expect(command).toContain("--plugin-dir");
+  expect(command).toContain("plugins-claude/plugins/acme");
+
+  const tail = await tailRuntimeTesterRun(root, report.runId, 20, { xdg });
+  expect(tail.some((line) => line.message.includes("fake-claude prompt=Inspect Claude fixture."))).toBe(true);
+});
+
+test("runtime tester resolves Claude setting sources from defaults, env, and CLI options", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-claude-config-fixture
+claude: true
+`,
+    ".skillset/plugins/acme/skillset.yaml": `
+skillset:
+  name: acme
+  title: Acme
+  summary: Acme plugin fixture.
+claude: true
+`,
+    ".skillset/plugins/acme/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo Claude runtime tester skill.
+---
+
+Use this skill to answer fixture questions.
+`,
+  });
+  const bin = await fakeClaudeBin(root);
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+
+  const fromDefault = await startRuntimeTesterRun(root, {
+    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin },
+    prompt: "Inspect Claude default fixture.",
+    target: "claude",
+    xdg,
+  });
+  expect((await readRuntimeTesterStatus(root, fromDefault.runId, { xdg })).command?.join(" ")).toContain("--setting-sources \"\"");
+
+  const fromEnv = await startRuntimeTesterRun(root, {
+    env: {
+      ...process.env,
+      SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin,
+      SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES: "user",
+    },
+    prompt: "Inspect Claude env fixture.",
+    target: "claude",
+    xdg,
+  });
+  expect((await readRuntimeTesterStatus(root, fromEnv.runId, { xdg })).command?.join(" ")).toContain("--setting-sources user");
+
+  const fromOption = await startRuntimeTesterRun(root, {
+    claudeSettingSources: "local",
+    env: {
+      ...process.env,
+      SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin,
+      SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES: "user",
+    },
+    prompt: "Inspect Claude option fixture.",
+    target: "claude",
+    xdg,
+  });
+  expect((await readRuntimeTesterStatus(root, fromOption.runId, { xdg })).command?.join(" ")).toContain("--setting-sources local");
+});
+
+test("runtime tester CLI supports run, status, tail, and list", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-cli-fixture
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo runtime tester CLI skill.
+---
+
+CLI fixture body.
+`,
+  });
+  const bin = await fakeCodexBin(root);
+  const env = {
+    ...process.env,
+    SKILLSET_RUNTIME_TESTER_CODEX_BIN: bin,
+    XDG_CACHE_HOME: join(root, "xdg-cache"),
+  };
+
+  const run = await runSkillsetCli(env, "runtime-tester", "run", "--target", "codex", "--prompt", "Inspect CLI fixture.", "--json", "--root", root);
+  expect(run.exitCode).toBe(0);
+  const report = JSON.parse(run.stdout) as { runId: string; state: string };
+  expect(report.state).toBe("passed");
+
+  const status = await runSkillsetCli(env, "runtime-tester", "status", report.runId, "--json", "--root", root);
+  expect(status.exitCode).toBe(0);
+  expect(JSON.parse(status.stdout)).toEqual(expect.objectContaining({ runId: report.runId, state: "passed" }));
+
+  const tail = await runSkillsetCli(env, "runtime-tester", "tail", report.runId, "--lines", "10", "--json", "--root", root);
+  expect(tail.exitCode).toBe(0);
+  expect(tail.stdout).toContain("Inspect CLI fixture.");
+
+  const list = await runSkillsetCli(env, "runtime-tester", "list", "--json", "--root", root);
+  expect(list.exitCode).toBe(0);
+  expect(list.stdout).toContain(report.runId);
+});
+
+test("runtime tester CLI supports Claude setting source override", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-cli-claude-fixture
+claude: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo runtime tester CLI Claude skill.
+---
+
+CLI Claude fixture body.
+`,
+  });
+  const bin = await fakeClaudeBin(root);
+  const env = {
+    ...process.env,
+    SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin,
+    XDG_CACHE_HOME: join(root, "xdg-cache"),
+  };
+
+  const run = await runSkillsetCli(
+    env,
+    "runtime-tester",
+    "run",
+    "--target",
+    "claude",
+    "--prompt",
+    "Inspect CLI Claude fixture.",
+    "--claude-setting-sources",
+    "local",
+    "--json",
+    "--root",
+    root
+  );
+  expect(run.exitCode).toBe(0);
+  const report = JSON.parse(run.stdout) as { runId: string; state: string };
+  expect(report.state).toBe("passed");
+
+  const status = await runSkillsetCli(env, "runtime-tester", "status", report.runId, "--json", "--root", root);
+  expect(status.exitCode).toBe(0);
+  expect(JSON.parse(status.stdout).command.join(" ")).toContain("--setting-sources local");
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-runtime-tester-"));
+  for (const [path, content] of Object.entries(files)) {
+    const fullPath = join(root, path);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, `${content.trim()}\n`, "utf8");
+  }
+  return root;
+}
+
+async function fakeCodexBin(root: string): Promise<string> {
+  const bin = join(root, "bin", "fake-codex");
+  await mkdir(dirname(bin), { recursive: true });
+  await writeFile(bin, `#!/bin/sh
+last=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--output-last-message" ]; then
+    last="$arg"
+  fi
+  prev="$arg"
+done
+input="$(cat)"
+echo "fake-codex cwd=$(pwd)"
+echo "fake-codex prompt=$input"
+if [ -n "$last" ]; then
+  printf 'fake codex final\\n' > "$last"
+fi
+`, "utf8");
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function fakeClaudeBin(root: string): Promise<string> {
+  const bin = join(root, "bin", "fake-claude");
+  await mkdir(dirname(bin), { recursive: true });
+  await writeFile(bin, `#!/bin/sh
+last=""
+for arg in "$@"; do
+  last="$arg"
+done
+echo "fake-claude cwd=$(pwd)"
+echo "fake-claude prompt=$last"
+`, "utf8");
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+function cachePath(
+  root: string,
+  xdg: { readonly env: { readonly XDG_CACHE_HOME: string } },
+  logicalPath: string
+): string {
+  return resolveOperationalPath(createOperationalPathContext(root, { env: xdg.env }), logicalPath);
+}
+
+async function exists(path: string): Promise<boolean> {
+  return Bun.file(path).exists();
+}
+
+async function runSkillsetCli(
+  env: Record<string, string | undefined>,
+  ...args: readonly string[]
+): Promise<{ readonly exitCode: number; readonly stderr: string; readonly stdout: string }> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    env,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 
 import {
@@ -82,13 +82,28 @@ import {
   renderProviderFormatUpdateReport,
   runProviderFormatUpdates,
 } from "./provider-format-updates";
+import {
+  executeRuntimeTesterRun,
+  listRuntimeTesterRuns,
+  readClaudeSettingSources,
+  readRuntimeTesterStatus,
+  startRuntimeTesterRun,
+  tailRuntimeTesterRun,
+  type RuntimeTesterClaudeSettingSources,
+  type RuntimeTesterListEntry,
+  type RuntimeTesterRunReport,
+  type RuntimeTesterState,
+  type RuntimeTesterStatus,
+  type RuntimeTesterSubcommand,
+  type RuntimeTesterTailLine,
+} from "./runtime-tester";
 import { createSkillset, initSkillset, type SetupInclude, type SetupLayoutOption, type SetupReport } from "./setup";
 import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "./source-unit-selector";
 import { renderValidatedJson } from "./structured-output";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
 import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, SourceOrigin, TargetName } from "./types";
 
-type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "new" | "providers" | "release" | "restore" | "suggest-source" | "test" | "update" | "verify";
+type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "new" | "providers" | "release" | "restore" | "runtime-tester" | "suggest-source" | "test" | "update" | "verify";
 type DistributionSubcommand = "plan";
 
 const USAGE = [
@@ -121,6 +136,9 @@ const USAGE = [
   "       skillset features [feature-id] [--json]",
   "       skillset lookup [subject] [aspect...] [--frontmatter] [--fields] [--field <path>] [--values] [--events] [--compat [claude|codex...]] [--examples] [--schema] [--claude] [--codex] [--json]",
   "       skillset test [name] [--root <path>] [--source <dir>]",
+  "       skillset runtime-tester run --target <claude|codex> [--prompt <text>|--prompt-file <path>] [--plugin <id>] [--name <name>] [--timeout-ms <ms>] [--claude-setting-sources <isolated|user|project|local>] [--background] [--json] [--root <path>] [--source <dir>]",
+  "       skillset runtime-tester <status|tail> [run-id] [--lines <count>] [--json] [--root <path>]",
+  "       skillset runtime-tester list [--json] [--root <path>]",
   "       skillset hooks print --runner <lefthook|husky|pre-commit|git> [--pre-commit] [--pre-push]",
   "       skillset hooks print --target <claude|codex> --agent-runtime",
   "       skillset hooks run <post-tool-use|stop> [--root <path>]",
@@ -189,6 +207,17 @@ export async function runCli(
     releaseSubcommand,
     releaseReason,
     releaseRef,
+    runtimeTesterBackground,
+    runtimeTesterClaudeSettingSources,
+    runtimeTesterLines,
+    runtimeTesterName,
+    runtimeTesterPlugins,
+    runtimeTesterPrompt,
+    runtimeTesterPromptFile,
+    runtimeTesterRunId,
+    runtimeTesterSubcommand,
+    runtimeTesterTarget,
+    runtimeTesterTimeoutMs,
     setupGlobal,
     setupIncludes,
     setupLayout,
@@ -242,6 +271,49 @@ export async function runCli(
     if (!devWatch) throw new Error("skillset: dev currently requires --watch");
     await runDevWatch(rootPath, options);
     return;
+  }
+
+  if (command === "runtime-tester") {
+    if (runtimeTesterSubcommand === "run") {
+      const report = await startRuntimeTesterRun(rootPath, {
+        ...options,
+        background: runtimeTesterBackground,
+        ...(runtimeTesterClaudeSettingSources === undefined ? {} : { claudeSettingSources: runtimeTesterClaudeSettingSources }),
+        ...(runtimeTesterName === undefined ? {} : { name: runtimeTesterName }),
+        plugins: runtimeTesterPlugins,
+        prompt: await readRuntimeTesterPrompt(rootPath, runtimeTesterPrompt, runtimeTesterPromptFile),
+        target: requireRuntimeTesterTarget(runtimeTesterTarget),
+        ...(runtimeTesterTimeoutMs === undefined ? {} : { timeoutMs: runtimeTesterTimeoutMs }),
+      });
+      if (jsonOutput) console.log(renderValidatedJson(report as unknown as JsonRecord, "runtime tester run"));
+      else printRuntimeTesterRun(report);
+      if (!report.ok) process.exitCode = 1;
+      return;
+    }
+    if (runtimeTesterSubcommand === "worker") {
+      if (runtimeTesterRunId === undefined) throw new Error("skillset: runtime-tester worker requires run id");
+      await executeRuntimeTesterRun(rootPath, runtimeTesterRunId);
+      return;
+    }
+    if (runtimeTesterSubcommand === "status") {
+      const status = await readRuntimeTesterStatus(rootPath, runtimeTesterRunId);
+      if (jsonOutput) console.log(renderValidatedJson(status as unknown as JsonRecord, "runtime tester status"));
+      else printRuntimeTesterStatus(status);
+      if (status.state === "failed") process.exitCode = 1;
+      return;
+    }
+    if (runtimeTesterSubcommand === "tail") {
+      const lines = await tailRuntimeTesterRun(rootPath, runtimeTesterRunId, runtimeTesterLines ?? 40);
+      if (jsonOutput) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "runtime tester tail"));
+      else printRuntimeTesterTail(lines);
+      return;
+    }
+    if (runtimeTesterSubcommand === "list") {
+      const entries = await listRuntimeTesterRuns(rootPath);
+      if (jsonOutput) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "runtime tester list"));
+      else printRuntimeTesterList(entries);
+      return;
+    }
   }
 
   if (command === "change") {
@@ -779,6 +851,17 @@ interface ParsedArgs {
   readonly releaseSubcommand?: ReleaseSubcommand;
   readonly releaseReason?: ChangeReasonInput;
   readonly releaseRef?: string;
+  readonly runtimeTesterBackground: boolean;
+  readonly runtimeTesterClaudeSettingSources?: RuntimeTesterClaudeSettingSources;
+  readonly runtimeTesterLines?: number;
+  readonly runtimeTesterName?: string;
+  readonly runtimeTesterPlugins: readonly string[];
+  readonly runtimeTesterPrompt?: string;
+  readonly runtimeTesterPromptFile?: string;
+  readonly runtimeTesterRunId?: string;
+  readonly runtimeTesterSubcommand?: RuntimeTesterSubcommand;
+  readonly runtimeTesterTarget?: TargetName;
+  readonly runtimeTesterTimeoutMs?: number;
   readonly rootExplicit: boolean;
   readonly rootPath: string;
   readonly setupGlobal: boolean;
@@ -1237,6 +1320,56 @@ function printSkillsetTest(report: SkillsetTestReport): void {
   if (report.activationPath !== undefined) console.log(`  activation: ${report.activationPath}`);
 }
 
+function printRuntimeTesterRun(report: RuntimeTesterRunReport): void {
+  console.log(`skillset: runtime tester ${formatRuntimeTesterState(report.state)}${report.background ? " in background" : ""}`);
+  console.log(`  run: ${report.runPath}`);
+  console.log(`  latest: ${report.latestPath}`);
+  console.log(`  status: ${report.statusPath}`);
+  console.log(`  tail: ${report.tailPath}`);
+  console.log(`  report: ${report.reportPath}`);
+}
+
+function printRuntimeTesterStatus(status: RuntimeTesterStatus): void {
+  console.log(`skillset: runtime tester ${status.runId} ${formatRuntimeTesterState(status.state)}`);
+  console.log(`  target: ${status.target}`);
+  console.log(`  name: ${status.name}`);
+  if (status.pid !== undefined) console.log(`  pid: ${status.pid}`);
+  if (status.command !== undefined) console.log(`  command: ${status.command.join(" ")}`);
+  if (status.exitCode !== undefined) console.log(`  exit: ${status.exitCode}`);
+  if (status.error !== undefined) console.log(`  error: ${status.error}`);
+  console.log(`  started: ${status.startedAt}`);
+  if (status.endedAt !== undefined) console.log(`  ended: ${status.endedAt}`);
+  console.log(`  updated: ${status.updatedAt}`);
+  console.log(`  run: ${status.runPath}`);
+  console.log(`  latest: ${status.latestRoot}`);
+  console.log(`  prompt: ${status.promptPath}`);
+  console.log(`  tail: ${status.outputPath}`);
+  console.log(`  report: ${status.reportPath}`);
+  if (status.finalMessagePath !== undefined) console.log(`  final: ${status.finalMessagePath}`);
+}
+
+function printRuntimeTesterTail(lines: readonly RuntimeTesterTailLine[]): void {
+  for (const line of lines) {
+    const prefix = line.timestamp.length === 0 ? line.stream : `${line.timestamp} ${line.stream}`;
+    process.stdout.write(`${prefix}: ${line.message.endsWith("\n") ? line.message : `${line.message}\n`}`);
+  }
+}
+
+function printRuntimeTesterList(entries: readonly RuntimeTesterListEntry[]): void {
+  if (entries.length === 0) {
+    console.log("skillset: no runtime tester runs");
+    return;
+  }
+  for (const entry of entries) {
+    const ended = entry.endedAt === undefined ? "" : ` ended ${entry.endedAt}`;
+    console.log(`${entry.runId} ${entry.target} ${formatRuntimeTesterState(entry.state)} started ${entry.startedAt}${ended} ${entry.name}`);
+  }
+}
+
+function formatRuntimeTesterState(state: RuntimeTesterState): string {
+  return state;
+}
+
 function formatTestSelection(selection: SkillsetTestReport["selection"]): string {
   const parts = [
     selection.plugins.length === 0 ? undefined : `plugins ${selection.plugins.join(", ")}`,
@@ -1375,13 +1508,14 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "providers" &&
     command !== "release" &&
     command !== "restore" &&
+    command !== "runtime-tester" &&
     command !== "suggest-source" &&
     command !== "test" &&
     command !== "update" &&
     command !== "verify"
   ) {
     throw new Error(
-        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, new, providers, release, restore, suggest-source, test, update, or verify\n" +
+        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, new, providers, release, restore, runtime-tester, suggest-source, test, update, or verify\n" +
         USAGE
     );
   }
@@ -1392,6 +1526,17 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let releaseSubcommand: ReleaseSubcommand | undefined;
   let releaseReason: ChangeReasonInput | undefined;
   let releaseRef: string | undefined;
+  let runtimeTesterBackground = false;
+  let runtimeTesterClaudeSettingSources: RuntimeTesterClaudeSettingSources | undefined;
+  let runtimeTesterLines: number | undefined;
+  let runtimeTesterName: string | undefined;
+  let runtimeTesterPlugins: string[] = [];
+  let runtimeTesterPrompt: string | undefined;
+  let runtimeTesterPromptFile: string | undefined;
+  let runtimeTesterRunId: string | undefined;
+  let runtimeTesterSubcommand: RuntimeTesterSubcommand | undefined;
+  let runtimeTesterTarget: TargetName | undefined;
+  let runtimeTesterTimeoutMs: number | undefined;
   let changeAppend = false;
   let changeBump: ChangeBump | undefined;
   let changeGroup: string | undefined;
@@ -1506,6 +1651,20 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     }
     providerSubcommand = subcommand;
     index += 1;
+  }
+
+  if (command === "runtime-tester") {
+    const subcommand = args[index];
+    if (!isRuntimeTesterSubcommand(subcommand)) {
+      throw new Error("skillset: expected runtime-tester subcommand list, run, status, tail, or worker");
+    }
+    runtimeTesterSubcommand = subcommand;
+    index += 1;
+    const rawRunId = args[index];
+    if ((subcommand === "status" || subcommand === "tail" || subcommand === "worker") && rawRunId !== undefined && !rawRunId.startsWith("--")) {
+      runtimeTesterRunId = rawRunId;
+      index += 1;
+    }
   }
 
   if (command === "import") {
@@ -1651,7 +1810,14 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag !== "--examples" &&
       flag !== "--schema" &&
       flag !== "--claude" &&
-      flag !== "--codex"
+      flag !== "--codex" &&
+      flag !== "--prompt" &&
+      flag !== "--prompt-file" &&
+      flag !== "--plugin" &&
+      flag !== "--claude-setting-sources" &&
+      flag !== "--timeout-ms" &&
+      flag !== "--lines" &&
+      flag !== "--background"
     ) {
       throw new Error(`skillset: unknown option ${arg}`);
     }
@@ -1694,7 +1860,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag === "--examples" ||
       flag === "--schema" ||
       flag === "--claude" ||
-      flag === "--codex"
+      flag === "--codex" ||
+      flag === "--background"
     ) {
       if (inlineValue !== undefined) throw new Error(`skillset: ${flag} does not take a value`);
       if (flag === "--yes") yes = true;
@@ -1720,6 +1887,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       if (flag === "--schema") lookupViews = addLookupView(lookupViews, "schema");
       if (flag === "--claude") lookupTargets = addLookupTarget(lookupTargets, "claude");
       if (flag === "--codex") lookupTargets = addLookupTarget(lookupTargets, "codex");
+      if (flag === "--background") runtimeTesterBackground = true;
       continue;
     }
 
@@ -1768,7 +1936,18 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--report") ciReportPath = value;
     if (flag === "--field") lookupField = setLookupField(lookupField, value);
     if (flag === "--runner") hookRunner = readHookRunner(value);
-    if (flag === "--target") hookTarget = readHookTarget(value);
+    if (flag === "--target") {
+      if (command === "runtime-tester") runtimeTesterTarget = readHookTarget(value);
+      else hookTarget = readHookTarget(value);
+    }
+    if (flag === "--prompt") runtimeTesterPrompt = value;
+    if (flag === "--prompt-file") runtimeTesterPromptFile = value;
+    if (flag === "--plugin") runtimeTesterPlugins = [...runtimeTesterPlugins, value];
+    if (flag === "--claude-setting-sources") {
+      runtimeTesterClaudeSettingSources = readClaudeSettingSources(value, "--claude-setting-sources");
+    }
+    if (flag === "--timeout-ms") runtimeTesterTimeoutMs = readPositiveInteger(value, "--timeout-ms");
+    if (flag === "--lines") runtimeTesterLines = readPositiveInteger(value, "--lines");
     if (flag === "--targets") setupTargets = readSetupTargets(value);
     if (flag === "--include") setupIncludes = mergeSetupIncludes(setupIncludes, value);
     if (flag === "--layout") setupLayout = readSetupLayout(value);
@@ -1776,6 +1955,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--in") newContainer = value;
     if (flag === "--name") {
       if (command === "new") newName = value;
+      else if (command === "runtime-tester") runtimeTesterName = value;
       else importName = value;
     }
     if (flag === "--preset") newPresets = [...(newPresets ?? []), value];
@@ -1858,6 +2038,22 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   validateAdoptFlags(command, {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(scopes === undefined ? {} : { scopes }),
+  });
+  validateRuntimeTesterFlags(command, runtimeTesterSubcommand, {
+    background: runtimeTesterBackground,
+    ...(buildMode === undefined ? {} : { buildMode }),
+    ...(runtimeTesterClaudeSettingSources === undefined ? {} : { claudeSettingSources: runtimeTesterClaudeSettingSources }),
+    ...(distDir === undefined ? {} : { distDir }),
+    dryRun,
+    ...(runtimeTesterLines === undefined ? {} : { lines: runtimeTesterLines }),
+    ...(runtimeTesterName === undefined ? {} : { name: runtimeTesterName }),
+    plugins: runtimeTesterPlugins,
+    ...(runtimeTesterPrompt === undefined ? {} : { prompt: runtimeTesterPrompt }),
+    ...(runtimeTesterPromptFile === undefined ? {} : { promptFile: runtimeTesterPromptFile }),
+    ...(scopes === undefined ? {} : { scopes }),
+    ...(runtimeTesterTarget === undefined ? {} : { target: runtimeTesterTarget }),
+    ...(runtimeTesterTimeoutMs === undefined ? {} : { timeoutMs: runtimeTesterTimeoutMs }),
+    yes,
   });
   validateJsonFlags(command, jsonOutput);
   validateLookupFlags(command, {
@@ -1990,6 +2186,17 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
     ...(releaseReason === undefined ? {} : { releaseReason }),
     ...(releaseRef === undefined ? {} : { releaseRef }),
+    runtimeTesterBackground,
+    ...(runtimeTesterClaudeSettingSources === undefined ? {} : { runtimeTesterClaudeSettingSources }),
+    ...(runtimeTesterLines === undefined ? {} : { runtimeTesterLines }),
+    ...(runtimeTesterName === undefined ? {} : { runtimeTesterName }),
+    runtimeTesterPlugins,
+    ...(runtimeTesterPrompt === undefined ? {} : { runtimeTesterPrompt }),
+    ...(runtimeTesterPromptFile === undefined ? {} : { runtimeTesterPromptFile }),
+    ...(runtimeTesterRunId === undefined ? {} : { runtimeTesterRunId }),
+    ...(runtimeTesterSubcommand === undefined ? {} : { runtimeTesterSubcommand }),
+    ...(runtimeTesterTarget === undefined ? {} : { runtimeTesterTarget }),
+    ...(runtimeTesterTimeoutMs === undefined ? {} : { runtimeTesterTimeoutMs }),
     rootExplicit,
     rootPath: resolve(rootPath),
     setupGlobal,
@@ -2019,6 +2226,10 @@ function isChangeSubcommand(value: string | undefined): value is ChangeSubcomman
 
 function isProviderMaintenanceSubcommand(value: string | undefined): value is ProviderMaintenanceSubcommand {
   return value === "check" || value === "diff" || value === "update";
+}
+
+function isRuntimeTesterSubcommand(value: string | undefined): value is RuntimeTesterSubcommand {
+  return value === "list" || value === "run" || value === "status" || value === "tail" || value === "worker";
 }
 
 function isNewSourceKind(value: string | undefined): value is NewSourceKind {
@@ -2079,6 +2290,30 @@ function readChangeScopes(value: string): readonly string[] {
 function readChangeBump(value: string): ChangeBump {
   if (value === "major" || value === "minor" || value === "none" || value === "patch") return value;
   throw new Error("skillset: expected --bump major, minor, patch, or none");
+}
+
+function readPositiveInteger(value: string, flag: string): number {
+  if (!/^[0-9]+$/u.test(value)) throw new Error(`skillset: expected ${flag} to be a positive integer`);
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`skillset: expected ${flag} to be a positive integer`);
+  }
+  return parsed;
+}
+
+async function readRuntimeTesterPrompt(
+  rootPath: string,
+  prompt: string | undefined,
+  promptFile: string | undefined
+): Promise<string> {
+  if (prompt !== undefined) return prompt;
+  if (promptFile === undefined) throw new Error("skillset: runtime-tester run requires --prompt or --prompt-file");
+  return readFile(resolve(rootPath, promptFile), "utf8");
+}
+
+function requireRuntimeTesterTarget(target: TargetName | undefined): TargetName {
+  if (target === undefined) throw new Error("skillset: runtime-tester run requires --target claude or codex");
+  return target;
 }
 
 function setChangeReason(current: ChangeReasonInput | undefined, next: ChangeReasonInput): ChangeReasonInput {
@@ -2246,6 +2481,58 @@ function validateTestFlags(
     test.yes
   ) {
     throw new Error("skillset: build/write options are not supported with test; test output always writes under logical .skillset/cache/tests");
+  }
+}
+
+function validateRuntimeTesterFlags(
+  command: Command,
+  subcommand: RuntimeTesterSubcommand | undefined,
+  runtime: {
+    readonly background: boolean;
+    readonly buildMode?: CompileBuildMode;
+    readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+    readonly distDir?: string;
+    readonly dryRun: boolean;
+    readonly lines?: number;
+    readonly name?: string;
+    readonly plugins: readonly string[];
+    readonly prompt?: string;
+    readonly promptFile?: string;
+    readonly scopes?: readonly BuildScope[];
+    readonly target?: TargetName;
+    readonly timeoutMs?: number;
+    readonly yes: boolean;
+  }
+): void {
+  const hasRuntimeFlag = runtime.background ||
+    runtime.claudeSettingSources !== undefined ||
+    runtime.lines !== undefined ||
+    runtime.name !== undefined ||
+    runtime.plugins.length > 0 ||
+    runtime.prompt !== undefined ||
+    runtime.promptFile !== undefined ||
+    runtime.target !== undefined ||
+    runtime.timeoutMs !== undefined;
+  if (hasRuntimeFlag && command !== "runtime-tester") {
+    throw new Error("skillset: runtime tester options are only supported with runtime-tester");
+  }
+  if (command !== "runtime-tester") return;
+  if (subcommand === undefined) throw new Error("skillset: expected runtime-tester subcommand");
+  if (runtime.buildMode !== undefined || runtime.distDir !== undefined || runtime.dryRun || runtime.scopes !== undefined || runtime.yes) {
+    throw new Error("skillset: build/write options are not supported with runtime-tester; runtime tester builds an isolated projection under logical .skillset/cache/runtime-tester");
+  }
+  if (subcommand === "run") {
+    if (runtime.target === undefined) throw new Error("skillset: runtime-tester run requires --target claude or codex");
+    if ((runtime.prompt === undefined && runtime.promptFile === undefined) || (runtime.prompt !== undefined && runtime.promptFile !== undefined)) {
+      throw new Error("skillset: runtime-tester run requires exactly one of --prompt or --prompt-file");
+    }
+    return;
+  }
+  if (runtime.background || runtime.claudeSettingSources !== undefined || runtime.name !== undefined || runtime.plugins.length > 0 || runtime.prompt !== undefined || runtime.promptFile !== undefined || runtime.target !== undefined || runtime.timeoutMs !== undefined) {
+    throw new Error(`skillset: runtime tester run options are not supported with ${subcommand}`);
+  }
+  if (runtime.lines !== undefined && subcommand !== "tail") {
+    throw new Error("skillset: --lines is only supported with runtime-tester tail");
   }
 }
 
@@ -2577,8 +2864,8 @@ function validateAdoptFlags(
 
 function validateJsonFlags(command: Command, jsonOutput: boolean): void {
   if (!jsonOutput) return;
-  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup") return;
-  throw new Error("skillset: --json is only supported with doctor, explain, features, or lookup");
+  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup" || command === "runtime-tester") return;
+  throw new Error("skillset: --json is only supported with doctor, explain, features, lookup, or runtime-tester");
 }
 
 function validateLookupFlags(

--- a/apps/skillset/src/runtime-tester.ts
+++ b/apps/skillset/src/runtime-tester.ts
@@ -1,0 +1,674 @@
+import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
+import { spawn as spawnNode } from "node:child_process";
+import { join, resolve } from "node:path";
+
+import {
+  buildSkillset,
+  createOperationalPathContext,
+  ISOLATED_OUT_ROOT,
+  resolveOperationalPath,
+} from "@skillset/core";
+
+import { compareStrings } from "./path";
+import { loadBuildGraph } from "./resolver";
+import { renderValidatedJson } from "./structured-output";
+import type { BuildGraph, JsonRecord, SkillsetOptions, TargetName } from "./types";
+
+export type RuntimeTesterSubcommand = "list" | "run" | "status" | "tail" | "worker";
+export type RuntimeTesterState = "building" | "failed" | "passed" | "queued" | "running";
+export type RuntimeTesterClaudeSettingSources = "isolated" | "local" | "project" | "user";
+
+export interface RuntimeTesterRunOptions extends SkillsetOptions {
+  readonly background?: boolean;
+  readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+  readonly env?: Record<string, string | undefined>;
+  readonly name?: string;
+  readonly plugins?: readonly string[];
+  readonly prompt: string;
+  readonly target: TargetName;
+  readonly timeoutMs?: number;
+}
+
+export interface RuntimeTesterStatus {
+  readonly command?: readonly string[];
+  readonly endedAt?: string;
+  readonly error?: string;
+  readonly exitCode?: number;
+  readonly finalMessagePath?: string;
+  readonly latestRoot: string;
+  readonly name: string;
+  readonly outputPath: string;
+  readonly pid?: number;
+  readonly promptPath: string;
+  readonly reportPath: string;
+  readonly runId: string;
+  readonly runPath: string;
+  readonly schemaVersion: 1;
+  readonly startedAt: string;
+  readonly state: RuntimeTesterState;
+  readonly target: TargetName;
+  readonly timeoutMs: number;
+  readonly updatedAt: string;
+}
+
+export interface RuntimeTesterRunReport {
+  readonly background: boolean;
+  readonly latestPath: string;
+  readonly ok: boolean;
+  readonly reportPath: string;
+  readonly runId: string;
+  readonly runPath: string;
+  readonly state: RuntimeTesterState;
+  readonly statusPath: string;
+  readonly tailPath: string;
+}
+
+export interface RuntimeTesterListEntry {
+  readonly endedAt?: string;
+  readonly name: string;
+  readonly runId: string;
+  readonly runPath: string;
+  readonly startedAt: string;
+  readonly state: RuntimeTesterState;
+  readonly target: TargetName;
+}
+
+export interface RuntimeTesterTailLine {
+  readonly message: string;
+  readonly stream: string;
+  readonly timestamp: string;
+}
+
+interface RuntimeTesterRunPaths {
+  readonly absolute: {
+    readonly finalMessagePath: string;
+    readonly latestJsonPath: string;
+    readonly outputPath: string;
+    readonly promptPath: string;
+    readonly reportPath: string;
+    readonly runPath: string;
+    readonly runsRoot: string;
+    readonly statusPath: string;
+  };
+  readonly logical: {
+    readonly finalMessagePath: string;
+    readonly latestJsonPath: string;
+    readonly outputPath: string;
+    readonly promptPath: string;
+    readonly reportPath: string;
+    readonly runPath: string;
+    readonly statusPath: string;
+  };
+}
+
+interface RuntimeTesterStoredConfig {
+  readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+  readonly name: string;
+  readonly plugins: readonly string[];
+  readonly prompt: string;
+  readonly sourceDir?: string;
+  readonly target: TargetName;
+  readonly timeoutMs: number;
+}
+
+const RUNTIME_TESTER_ROOT = ".skillset/cache/runtime-tester";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_CLAUDE_SETTING_SOURCES: RuntimeTesterClaudeSettingSources = "isolated";
+const RUNTIME_TESTER_CLAUDE_SETTING_SOURCES_ENV = "SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES";
+// Empty --setting-sources keeps Claude probes independent from user/project/local settings while preserving env auth and explicit --plugin-dir inputs.
+const ISOLATED_CLAUDE_SETTING_SOURCES_ARG = "";
+const CLAUDE_SETTING_SOURCES_DISPLAY = "\"\"";
+
+export async function startRuntimeTesterRun(
+  rootPath: string,
+  options: RuntimeTesterRunOptions
+): Promise<RuntimeTesterRunReport> {
+  const root = resolve(rootPath);
+  const graph = await loadBuildGraph(root, options);
+  if (!graph.root.targets[options.target].enabled) {
+    throw new Error(`skillset: runtime tester target ${options.target} is not enabled by root target configuration`);
+  }
+  const name = options.name ?? `runtime-${options.target}`;
+  const runId = makeRunId(name);
+  const paths = runtimeTesterPaths(root, graph, runId, options.xdg);
+  await mkdir(paths.absolute.runPath, { recursive: true });
+
+  const config: RuntimeTesterStoredConfig = {
+    ...(options.target === "claude" ? { claudeSettingSources: resolveClaudeSettingSources(options) } : {}),
+    name,
+    plugins: [...(options.plugins ?? [])].sort(compareStrings),
+    prompt: options.prompt,
+    ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
+    target: options.target,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+  await writeFile(
+    join(paths.absolute.runPath, "config.json"),
+    renderValidatedJson(config as unknown as JsonRecord, join(paths.logical.runPath, "config.json")),
+    "utf8"
+  );
+  await writeFile(paths.absolute.promptPath, options.prompt, "utf8");
+  await writeStatus(paths, {
+    latestRoot: ISOLATED_OUT_ROOT,
+    name,
+    outputPath: paths.logical.outputPath,
+    promptPath: paths.logical.promptPath,
+    reportPath: paths.logical.reportPath,
+    runId,
+    runPath: paths.logical.runPath,
+    schemaVersion: 1,
+    startedAt: new Date().toISOString(),
+    state: "queued",
+    target: options.target,
+    timeoutMs: config.timeoutMs,
+    updatedAt: new Date().toISOString(),
+  });
+  await writeLatest(paths, runId);
+
+  if (options.background === true) {
+    const pid = spawnRuntimeWorker(root, runId);
+    const status = await readStatus(paths.absolute.statusPath);
+    await writeStatus(paths, {
+      ...status,
+      ...(pid === undefined ? {} : { pid }),
+      state: "queued",
+      updatedAt: new Date().toISOString(),
+    });
+    return runReport(paths, runId, "queued", true);
+  }
+
+  await executeRuntimeTesterRun(root, runId, options.env, options.xdg);
+  const status = await readStatus(paths.absolute.statusPath);
+  return runReport(paths, runId, status.state, false);
+}
+
+export async function executeRuntimeTesterRun(
+  rootPath: string,
+  runId: string,
+  env: Record<string, string | undefined> = process.env,
+  xdg: SkillsetOptions["xdg"] = undefined
+): Promise<void> {
+  const root = resolve(rootPath);
+  const paths = runtimeTesterPaths(root, await loadBuildGraph(root, xdg === undefined ? {} : { xdg }), runId, xdg);
+  const config = await readConfig(join(paths.absolute.runPath, "config.json"));
+  const target = config.target;
+  const runOptions: SkillsetOptions = {
+    buildMode: "all",
+    isolated: true,
+    ...(config.sourceDir === undefined ? {} : { sourceDir: config.sourceDir }),
+    targetFilter: [target],
+    ...(xdg === undefined ? {} : { xdg }),
+  };
+
+  let status = await readStatus(paths.absolute.statusPath);
+  await appendEvent(paths, "status", "building isolated target output");
+  status = await updateRunState(paths, status, "building");
+  try {
+    await buildSkillset(root, runOptions);
+  } catch (error) {
+    await failRun(paths, status, messageFor(error));
+    return;
+  }
+
+  const graph = await loadBuildGraph(root, runOptions);
+  const command = runtimeCommand(root, graph, paths, config, env, xdg);
+  await appendEvent(paths, "status", `running ${target} non-interactive prompt`);
+  status = await updateRunState(paths, status, "running", { command: command.display });
+  const result = await runCommand(command, config.prompt, paths, config.timeoutMs, env);
+  const finalMessage = await readOptional(paths.absolute.finalMessagePath);
+  const report: JsonRecord = {
+    command: [...command.display],
+    endedAt: new Date().toISOString(),
+    exitCode: result.exitCode,
+    finalMessage,
+    name: config.name,
+    ok: result.exitCode === 0 && !result.timedOut,
+    runId,
+    schemaVersion: 1,
+    state: result.exitCode === 0 && !result.timedOut ? "passed" : "failed",
+    target,
+    timedOut: result.timedOut,
+  };
+  await writeFile(paths.absolute.reportPath, renderValidatedJson(report, paths.logical.reportPath), "utf8");
+  const nextState: RuntimeTesterState = report.ok === true ? "passed" : "failed";
+  await writeStatus(paths, {
+    ...status,
+    endedAt: String(report.endedAt),
+    exitCode: result.exitCode,
+    finalMessagePath: paths.logical.finalMessagePath,
+    reportPath: paths.logical.reportPath,
+    state: nextState,
+    updatedAt: new Date().toISOString(),
+    ...(result.timedOut ? { error: `runtime tester command timed out after ${config.timeoutMs}ms` } : {}),
+  });
+  await appendEvent(paths, "status", `runtime tester ${nextState}`);
+}
+
+export async function readRuntimeTesterStatus(
+  rootPath: string,
+  runId?: string,
+  options: Pick<SkillsetOptions, "xdg"> = {}
+): Promise<RuntimeTesterStatus> {
+  const root = resolve(rootPath);
+  const graph = await loadBuildGraph(root, options);
+  const resolvedRunId = runId ?? await readLatestRunId(root, graph, options.xdg);
+  const paths = runtimeTesterPaths(root, graph, resolvedRunId, options.xdg);
+  return readStatus(paths.absolute.statusPath);
+}
+
+export async function listRuntimeTesterRuns(
+  rootPath: string,
+  options: Pick<SkillsetOptions, "xdg"> = {}
+): Promise<readonly RuntimeTesterListEntry[]> {
+  const root = resolve(rootPath);
+  const graph = await loadBuildGraph(root, options);
+  const context = runtimePathContext(root, graph, options.xdg);
+  const runsRoot = resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "runs"));
+  if (!await pathExists(runsRoot)) return [];
+  const entries = await readdir(runsRoot, { withFileTypes: true });
+  const runs: RuntimeTesterListEntry[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const status = await readStatus(join(runsRoot, entry.name, "status.json"));
+      runs.push({
+        ...(status.endedAt === undefined ? {} : { endedAt: status.endedAt }),
+        name: status.name,
+        runId: status.runId,
+        runPath: status.runPath,
+        startedAt: status.startedAt,
+        state: status.state,
+        target: status.target,
+      });
+    } catch {
+      // Ignore incomplete run directories; status is the durable record.
+    }
+  }
+  return runs.sort((left, right) => compareStrings(right.startedAt, left.startedAt));
+}
+
+export async function tailRuntimeTesterRun(
+  rootPath: string,
+  runId: string | undefined,
+  lines: number,
+  options: Pick<SkillsetOptions, "xdg"> = {}
+): Promise<readonly RuntimeTesterTailLine[]> {
+  const root = resolve(rootPath);
+  const graph = await loadBuildGraph(root, options);
+  const resolvedRunId = runId ?? await readLatestRunId(root, graph, options.xdg);
+  const paths = runtimeTesterPaths(root, graph, resolvedRunId, options.xdg);
+  const raw = await readOptional(paths.absolute.outputPath);
+  if (raw === undefined) return [];
+  return raw
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .slice(-Math.max(0, lines))
+    .map(parseTailLine);
+}
+
+function runtimeCommand(
+  rootPath: string,
+  graph: BuildGraph,
+  paths: RuntimeTesterRunPaths,
+  config: RuntimeTesterStoredConfig,
+  env: Record<string, string | undefined>,
+  xdg: SkillsetOptions["xdg"]
+): { readonly cmd: readonly string[]; readonly cwd: string; readonly display: readonly string[] } {
+  const latestRoot = resolveOperationalPath(runtimePathContext(rootPath, graph, xdg), ISOLATED_OUT_ROOT);
+  if (config.target === "claude") {
+    const bin = env.SKILLSET_RUNTIME_TESTER_CLAUDE_BIN ?? "claude";
+    const pluginArgs = claudePluginDirs(graph, latestRoot, config.plugins).flatMap((pluginDir) => ["--plugin-dir", pluginDir]);
+    const settingSourcesArg = claudeSettingSourcesArg(config.claudeSettingSources ?? DEFAULT_CLAUDE_SETTING_SOURCES);
+    const cmd = [
+      bin,
+      "--print",
+      "--output-format",
+      "json",
+      "--setting-sources",
+      settingSourcesArg,
+      "--no-session-persistence",
+      "--permission-mode",
+      "dontAsk",
+      ...pluginArgs,
+      config.prompt,
+    ];
+    return {
+      cmd,
+      cwd: latestRoot,
+      display: cmd.map((arg) => arg === ISOLATED_CLAUDE_SETTING_SOURCES_ARG ? CLAUDE_SETTING_SOURCES_DISPLAY : arg),
+    };
+  }
+
+  const bin = env.SKILLSET_RUNTIME_TESTER_CODEX_BIN ?? "codex";
+  const cmd = [
+    bin,
+    "exec",
+    "--cd",
+    latestRoot,
+    "--ephemeral",
+    "--ignore-user-config",
+    "--json",
+    "--skip-git-repo-check",
+    "--output-last-message",
+    paths.absolute.finalMessagePath,
+    "-",
+  ];
+  return { cmd, cwd: latestRoot, display: cmd };
+}
+
+function resolveClaudeSettingSources(options: RuntimeTesterRunOptions): RuntimeTesterClaudeSettingSources {
+  const env = options.env ?? process.env;
+  return options.claudeSettingSources ??
+    readClaudeSettingSources(env[RUNTIME_TESTER_CLAUDE_SETTING_SOURCES_ENV], RUNTIME_TESTER_CLAUDE_SETTING_SOURCES_ENV) ??
+    DEFAULT_CLAUDE_SETTING_SOURCES;
+}
+
+function claudeSettingSourcesArg(value: RuntimeTesterClaudeSettingSources): string {
+  return value === "isolated" ? ISOLATED_CLAUDE_SETTING_SOURCES_ARG : value;
+}
+
+export function readClaudeSettingSources(
+  value: string | undefined,
+  label: string
+): RuntimeTesterClaudeSettingSources | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (normalized === "isolated" || normalized === "user" || normalized === "project" || normalized === "local") {
+    return normalized;
+  }
+  throw new Error(`skillset: expected ${label} to be isolated, user, project, or local`);
+}
+
+function claudePluginDirs(
+  graph: BuildGraph,
+  latestRoot: string,
+  plugins: readonly string[]
+): readonly string[] {
+  const selected = plugins.length === 0
+    ? graph.plugins.map((plugin) => plugin.id)
+    : plugins;
+  const enabled = new Set(
+    graph.plugins
+      .filter((plugin) => plugin.targets.claude.enabled)
+      .map((plugin) => plugin.id)
+  );
+  return selected
+    .filter((plugin) => enabled.has(plugin))
+    .sort(compareStrings)
+    .map((plugin) => join(latestRoot, graph.root.outputs.plugins.claude, "plugins", plugin));
+}
+
+async function runCommand(
+  command: { readonly cmd: readonly string[]; readonly cwd: string },
+  prompt: string,
+  paths: RuntimeTesterRunPaths,
+  timeoutMs: number,
+  env: Record<string, string | undefined>
+): Promise<{ readonly exitCode: number; readonly timedOut: boolean }> {
+  const proc = Bun.spawn([...command.cmd], {
+    cwd: command.cwd,
+    env: cleanEnv(env),
+    stderr: "pipe",
+    stdin: "pipe",
+    stdout: "pipe",
+  });
+  await appendEvent(paths, "process", `pid ${proc.pid}`);
+  proc.stdin.write(prompt);
+  proc.stdin.end();
+  let timedOut = false;
+  const timer = timeoutMs <= 0
+    ? undefined
+    : setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, timeoutMs);
+  const [exitCode] = await Promise.all([
+    proc.exited,
+    collectStream(paths, "stdout", proc.stdout),
+    collectStream(paths, "stderr", proc.stderr),
+  ]);
+  if (timer !== undefined) clearTimeout(timer);
+  return { exitCode, timedOut };
+}
+
+async function collectStream(
+  paths: RuntimeTesterRunPaths,
+  streamName: "stderr" | "stdout",
+  stream: ReadableStream<Uint8Array>
+): Promise<void> {
+  const decoder = new TextDecoder();
+  for await (const chunk of stream) {
+    const text = decoder.decode(chunk);
+    if (text.length === 0) continue;
+    await appendEvent(paths, streamName, text);
+    await appendFile(join(paths.absolute.runPath, `${streamName}.txt`), text, "utf8");
+  }
+}
+
+function cleanEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const cleaned: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+function spawnRuntimeWorker(rootPath: string, runId: string): number | undefined {
+  const cliPath = process.argv[1];
+  if (cliPath === undefined) throw new Error("skillset: runtime tester cannot locate CLI entrypoint for background worker");
+  const child = spawnNode(process.execPath, [cliPath, "runtime-tester", "worker", runId, "--root", rootPath], {
+    cwd: rootPath,
+    detached: true,
+    env: process.env,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child.pid;
+}
+
+function runtimeTesterPaths(
+  rootPath: string,
+  graph: BuildGraph,
+  runId: string,
+  xdg: SkillsetOptions["xdg"] = undefined
+): RuntimeTesterRunPaths {
+  const context = runtimePathContext(rootPath, graph, xdg);
+  const logicalRunPath = join(RUNTIME_TESTER_ROOT, "runs", runId).replaceAll("\\", "/");
+  const absoluteRunPath = resolveOperationalPath(context, logicalRunPath);
+  return {
+    absolute: {
+      finalMessagePath: join(absoluteRunPath, "final-message.txt"),
+      latestJsonPath: resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "latest.json")),
+      outputPath: join(absoluteRunPath, "output.jsonl"),
+      promptPath: join(absoluteRunPath, "prompt.md"),
+      reportPath: join(absoluteRunPath, "report.json"),
+      runPath: absoluteRunPath,
+      runsRoot: resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "runs")),
+      statusPath: join(absoluteRunPath, "status.json"),
+    },
+    logical: {
+      finalMessagePath: join(logicalRunPath, "final-message.txt").replaceAll("\\", "/"),
+      latestJsonPath: join(RUNTIME_TESTER_ROOT, "latest.json").replaceAll("\\", "/"),
+      outputPath: join(logicalRunPath, "output.jsonl").replaceAll("\\", "/"),
+      promptPath: join(logicalRunPath, "prompt.md").replaceAll("\\", "/"),
+      reportPath: join(logicalRunPath, "report.json").replaceAll("\\", "/"),
+      runPath: logicalRunPath,
+      statusPath: join(logicalRunPath, "status.json").replaceAll("\\", "/"),
+    },
+  };
+}
+
+function runtimePathContext(rootPath: string, graph: BuildGraph, xdg: SkillsetOptions["xdg"] = undefined) {
+  return createOperationalPathContext(rootPath, {
+    ...(graph.root.workspace.cacheKey === undefined ? {} : { workspaceCacheKey: graph.root.workspace.cacheKey }),
+    ...(xdg?.env === undefined ? {} : { env: xdg.env }),
+    ...(xdg?.homeDir === undefined ? {} : { homeDir: xdg.homeDir }),
+  });
+}
+
+async function updateRunState(
+  paths: RuntimeTesterRunPaths,
+  status: RuntimeTesterStatus,
+  state: RuntimeTesterState,
+  updates: Partial<RuntimeTesterStatus> = {}
+): Promise<RuntimeTesterStatus> {
+  const next = { ...status, ...updates, state, updatedAt: new Date().toISOString() };
+  await writeStatus(paths, next);
+  return next;
+}
+
+async function failRun(
+  paths: RuntimeTesterRunPaths,
+  status: RuntimeTesterStatus,
+  error: string
+): Promise<void> {
+  const endedAt = new Date().toISOString();
+  const report: JsonRecord = {
+    endedAt,
+    error,
+    exitCode: 1,
+    name: status.name,
+    ok: false,
+    runId: status.runId,
+    schemaVersion: 1,
+    state: "failed",
+    target: status.target,
+  };
+  await writeFile(paths.absolute.reportPath, renderValidatedJson(report, paths.logical.reportPath), "utf8");
+  await writeStatus(paths, {
+    ...status,
+    endedAt,
+    error,
+    exitCode: 1,
+    state: "failed",
+    updatedAt: endedAt,
+  });
+  await appendEvent(paths, "status", `runtime tester failed: ${error}`);
+}
+
+async function writeStatus(paths: RuntimeTesterRunPaths, status: RuntimeTesterStatus): Promise<void> {
+  await mkdir(paths.absolute.runPath, { recursive: true });
+  await writeFile(paths.absolute.statusPath, renderValidatedJson(status as unknown as JsonRecord, paths.logical.statusPath), "utf8");
+}
+
+async function writeLatest(paths: RuntimeTesterRunPaths, runId: string): Promise<void> {
+  await mkdir(paths.absolute.runsRoot, { recursive: true });
+  await writeFile(paths.absolute.latestJsonPath, renderValidatedJson({
+    runId,
+    runPath: paths.logical.runPath,
+    schemaVersion: 1,
+    statusPath: paths.logical.statusPath,
+  }, paths.logical.latestJsonPath), "utf8");
+}
+
+async function appendEvent(paths: RuntimeTesterRunPaths, stream: string, message: string): Promise<void> {
+  const event = {
+    message,
+    stream,
+    timestamp: new Date().toISOString(),
+  };
+  await appendFile(paths.absolute.outputPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+async function readLatestRunId(
+  rootPath: string,
+  graph: BuildGraph,
+  xdg: SkillsetOptions["xdg"] = undefined
+): Promise<string> {
+  const context = runtimePathContext(rootPath, graph, xdg);
+  const latestPath = resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "latest.json"));
+  const latest = JSON.parse(await readFile(latestPath, "utf8")) as unknown;
+  if (!isRecord(latest) || typeof latest.runId !== "string") {
+    throw new Error("skillset: runtime tester latest run is malformed");
+  }
+  return latest.runId;
+}
+
+async function readConfig(path: string): Promise<RuntimeTesterStoredConfig> {
+  const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
+  if (!isRecord(raw)) throw new Error("skillset: runtime tester config is malformed");
+  if (raw.target !== "claude" && raw.target !== "codex") throw new Error("skillset: runtime tester config target is malformed");
+  if (typeof raw.prompt !== "string") throw new Error("skillset: runtime tester config prompt is malformed");
+  const claudeSettingSources = typeof raw.claudeSettingSources === "string"
+    ? readClaudeSettingSources(raw.claudeSettingSources, "runtime tester config claudeSettingSources")
+    : undefined;
+  return {
+    ...(claudeSettingSources === undefined ? {} : { claudeSettingSources }),
+    name: typeof raw.name === "string" ? raw.name : `runtime-${raw.target}`,
+    plugins: Array.isArray(raw.plugins) ? raw.plugins.filter((item): item is string => typeof item === "string") : [],
+    prompt: raw.prompt,
+    ...(typeof raw.sourceDir === "string" ? { sourceDir: raw.sourceDir } : {}),
+    target: raw.target,
+    timeoutMs: typeof raw.timeoutMs === "number" && Number.isFinite(raw.timeoutMs) ? raw.timeoutMs : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+async function readStatus(path: string): Promise<RuntimeTesterStatus> {
+  const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
+  if (!isRecord(raw) || typeof raw.runId !== "string" || (raw.target !== "claude" && raw.target !== "codex")) {
+    throw new Error("skillset: runtime tester status is malformed");
+  }
+  return raw as unknown as RuntimeTesterStatus;
+}
+
+async function readOptional(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseTailLine(line: string): RuntimeTesterTailLine {
+  const parsed = JSON.parse(line) as unknown;
+  if (!isRecord(parsed)) return { message: line, stream: "raw", timestamp: "" };
+  return {
+    message: typeof parsed.message === "string" ? parsed.message : "",
+    stream: typeof parsed.stream === "string" ? parsed.stream : "raw",
+    timestamp: typeof parsed.timestamp === "string" ? parsed.timestamp : "",
+  };
+}
+
+function runReport(
+  paths: RuntimeTesterRunPaths,
+  runId: string,
+  state: RuntimeTesterState,
+  background: boolean
+): RuntimeTesterRunReport {
+  return {
+    background,
+    latestPath: paths.logical.latestJsonPath,
+    ok: state === "passed" || background,
+    reportPath: paths.logical.reportPath,
+    runId,
+    runPath: paths.logical.runPath,
+    state,
+    statusPath: paths.logical.statusPath,
+    tailPath: paths.logical.outputPath,
+  };
+}
+
+function makeRunId(name: string): string {
+  const safeName = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "runtime";
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  const digest = createHash("sha256").update(`${safeName}:${stamp}:${randomBytes(8).toString("hex")}`).digest("hex").slice(0, 8);
+  return `${stamp}-${safeName}-${digest}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function messageFor(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -8,7 +8,7 @@ Runtime adapters describe how a Skillset rendering can be used by an actual agen
 
 ## Status
 
-Runtime adapter records are `planned`. The registry can now describe runtime support, but Skillset still only builds the Claude and Codex target renderings. Gemini, Cursor, Devin, Droid, and OpenCode are tracked as runtime candidates, not build targets.
+Runtime adapter records are `planned`. The registry can now describe runtime support, and `skillset runtime-tester` can run non-interactive Claude or Codex prompts against isolated local renderings, but Skillset still only builds the Claude and Codex target renderings. Gemini, Cursor, Devin, Droid, and OpenCode are tracked as runtime candidates, not build targets.
 
 ## Authoring
 
@@ -50,7 +50,7 @@ Runtime support records live in the feature registry as `runtimeSupport` rows. A
 | Build target | A provider rendering Skillset can render directly. | `claude`, `codex` |
 | Runtime adapter | A concrete runtime or harness that can consume a rendering or compatibility shim. | `claude-code`, `codex-cli`, `codex-app` |
 | Distribution surface | A repo, marketplace, extension root, or package shape a rendering may be synced into. | Implemented `distributions.*` plan config; sync/publish remains future |
-| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation probe assets under `skillset test`; runtime execution remains future |
+| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation probe assets under `skillset test`; implemented live non-interactive prompt runs through `skillset runtime-tester` |
 
 The test: adding a runtime must not make `compile.targets` accept a new value. It should add evidence and support records first, then a specific adapter or distribution flow only when the target behavior is proven.
 
@@ -72,6 +72,8 @@ The test: adding a runtime must not make `compile.targets` accept a new value. I
 Runtime support diagnostics should name whether behavior is native, pass-through, transformed, shimmed, degraded, lossy, externally managed, unsupported, or planned.
 
 When behavior is shimmed, diagnostics must identify the mechanism and caveat. For example, a Codex agent can receive an instruction to load skills first, but Skillset should not say Codex has native Claude-style agent `skills` metadata.
+
+`skillset runtime-tester status` reports live harness state as `queued`, `building`, `running`, `passed`, or `failed`, and `skillset runtime-tester tail` reads retained output from the logical `.skillset/cache/runtime-tester` path backed by XDG storage.
 
 ## Provenance
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -17,15 +17,16 @@ Skillset currently uses internal compiler fixtures and validation commands:
 | Validation commands | `skillset check`, `skillset verify`, `doctor`, `diff`, `change check`, `release plan` | `implemented` | Public commands that validate real source and generated output. |
 | Dogfooding | repo scripts, Linear acceptance criteria, real Skillset source changes | internal practice | Proves workflows by using them on this repo. |
 | `skillset test` | `<source-root>/tests.yaml` and `<source-root>/tests/*.yaml` | `implemented` | Deterministic isolated projection and check runner for authored source. |
+| `skillset runtime-tester` | `.skillset/cache/runtime-tester/` logical reports backed by XDG cache storage | `implemented` / maintainer harness | Runs non-interactive Claude or Codex prompts against an isolated rendering and retains status, output, tail, and report files. |
 | `.skillset/evals/` | n/a | `future` | Future adapter-aware behavioral eval declarations or pointers. |
 
-Checked-in internal fixtures use `fixtures/<case>/skillset.yaml` as the workspace manifest and `fixtures/<case>/.skillset/` as the source root. Inline temp fixtures should use the same shape unless they are explicitly testing legacy migration rejection or normalization.
+Checked-in internal fixtures use the current workspace layout: `fixtures/<case>/skillset.yaml` as the workspace manifest and `fixtures/<case>/.skillset/` as the source root.
 
 ## Deterministic Tests
 
 `skillset test` runs isolated deterministic scenarios. It compiles selected source units in a run workspace and checks generated files, provider manifests, and drift without touching live target output.
 
-The implemented v1 shape is selector-driven and source-root owned. Repos use `.skillset/tests.yaml` or `.skillset/tests/*.yaml`. A single `tests.yaml` can hold many named tests; each split file is one test named from the file stem. Test declarations reference existing source units rather than duplicating skills, plugins, agents, or instructions.
+The implemented v1 shape is selector-driven and source-root owned. Workspaces use `.skillset/tests.yaml` or `.skillset/tests/*.yaml`. A single `tests.yaml` can hold many named tests; each split file is one test named from the file stem. Test declarations reference existing source units rather than duplicating skills, plugins, agents, or instructions.
 
 ```yaml
 self-hosted:
@@ -69,7 +70,7 @@ primary-skills:
 
 `select.skills.plugin` is available for plugin-bound skills, but `select.plugins.skills` is the clearer spelling when the test starts from plugins. `targets` filters provider renderings; `select` filters source units. `--scope` continues to mean generated-destination filtering, not source selection, and `skillset test` rejects build/write flags such as `--scope`, `--yes`, `--dry-run`, `--updated`, `--all`, and `--dist`.
 
-The test runner copies only source-relevant files into an isolated run workspace: root `skillset.yaml`, `.skillset/`, and `.skillset/changes/`. It then prunes unselected source units before building. It does not stage operational `.skillset/cache/` or `.skillset/snapshots/` contents. If the repo has an existing workspace `skillset.lock`, the test stages that lock too so source-adjacent generated files such as entity `CHANGELOG.md` files remain recognized as managed inside the run.
+The test runner copies only source-relevant files into an isolated run workspace: root `skillset.yaml`, `.skillset/`, and source-adjacent state such as `.skillset/changes/`. It then prunes unselected source units before building. It does not stage operational `.skillset/cache/` or `.skillset/snapshots/` contents. If the repo has an existing workspace `skillset.lock`, the test stages that lock too so source-adjacent generated files such as entity `CHANGELOG.md` files remain recognized as managed inside the run.
 
 Generated test output uses the logical cache root in reports and `latest.json`; Skillset stores the physical files in the repo's XDG cache bucket:
 
@@ -137,6 +138,51 @@ Each probe requires `prompt` and `expect`. The v1 `expect` object must name exac
 `latest/` receives the same activation directory when the run refreshes. Claude probes are rendered as manual native harness prompts. Codex probes are rendered as manual shim-aware prompts because Codex can follow generated loading instructions, but Skillset should not pretend that every Claude-style activation signal is target-enforced in Codex. Future Codex plugin-eval integration can consume the same `probes.json` shape once that runner boundary is proven.
 
 Edge cases stay explicit: multiple matching skills should be disambiguated in the expected selector, provider source may need target-specific probes, missing plugin dependencies should appear as activation setup failures rather than build successes, and compatibility shims should be reported as shims in the generated probe material.
+
+## Runtime Tester
+
+`skillset runtime-tester` is the first live runtime harness. It is separate from `skillset test`: deterministic tests prove projection and generated files, while the runtime tester builds an isolated latest rendering and asks a real local runtime a non-interactive prompt.
+
+```bash
+skillset runtime-tester run --target codex --prompt "What skills can you see?"
+skillset runtime-tester run --target claude --prompt-file prompts/smoke.md --claude-setting-sources isolated --background
+skillset runtime-tester status
+skillset runtime-tester tail --lines 80
+skillset runtime-tester list
+```
+
+Runs write retained artifacts under the logical repo cache path:
+
+```text
+.skillset/cache/runtime-tester/
+  latest.json
+  runs/<run-id>/
+    config.json
+    prompt.md
+    status.json
+    output.jsonl
+    stdout.txt
+    stderr.txt
+    final-message.txt
+    report.json
+```
+
+The physical files live in the repo's XDG-backed Skillset cache bucket. Reports keep logical `.skillset/cache/...` paths so humans, issue comments, and future eval tooling can refer to stable locations without depending on a machine-specific cache root.
+
+`status` reports `queued`, `building`, `running`, `passed`, or `failed`; `tail` streams the retained JSONL output after the fact; and `list` shows recent retained runs. `--background` starts a worker and returns as soon as the queued run is recorded, so long-running probes can be checked later without watching the whole process.
+
+The tester does not install, trust, publish, or enable generated artifacts. It invokes local runtimes against the isolated `latest` rendering. Claude probes default to `--claude-setting-sources isolated`, which passes an explicit empty Claude `--setting-sources` list and loads generated plugins with `--plugin-dir`, so env auth and the rendered plugin directories are the only intended Claude inputs.
+
+Claude setting sources can be overridden for probes that intentionally need more runtime context. Precedence is CLI flag, then env var, then the isolated default:
+
+```bash
+skillset runtime-tester run --target claude --claude-setting-sources user --prompt "What do you see?"
+SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES=project skillset runtime-tester run --target claude --prompt "What do you see?"
+```
+
+Override runtime binaries with `SKILLSET_RUNTIME_TESTER_CODEX_BIN` or `SKILLSET_RUNTIME_TESTER_CLAUDE_BIN` for tests, shims, or machine-specific installs.
+
+For Claude Code non-interactive runs, the CLI process must see a non-interactive credential. If `claude --print` reports `Not logged in`, run `claude setup-token`, put the printed `CLAUDE_CODE_OAUTH_TOKEN` export in the repo-local ignored `.envrc`, and run `direnv allow`. The committed `.envrc.example` shows the expected shape without storing secrets. From shells or automation that do not load the direnv hook, run the tester through `direnv exec . skillset runtime-tester ...`.
 
 ## Compiler Determinism and Adapter Conformance
 


### PR DESCRIPTION
## Context

Adds a maintainer-facing `skillset runtime-tester` command for live, non-interactive Codex and Claude probes against isolated generated output. This intentionally keeps the first slice CLI/env-driven: no `runtimeTester` workspace schema/config key, and no separate hooks-support command.

## What changed

- Added `apps/skillset/src/runtime-tester.ts` for retained run state, reports, output tails, and XDG-backed logical `.skillset/cache/runtime-tester` paths.
- Added CLI subcommands: `run`, `status`, `tail`, `list`, and internal `worker`.
- Dogfoods existing isolated build output through `ISOLATED_OUT_ROOT` instead of adding another cache resolver.
- Documents runtime tester behavior in `docs/features/tests-and-evals.md` and runtime-adapter status notes.
- Updates `.envrc.example` for Claude `setup-token` use without committing secrets.

## Verification

- `bun test apps/skillset/src/__tests__/runtime-tester.test.ts apps/skillset/src/__tests__/lookup-cli.test.ts packages/core/src/__tests__/lookup.test.ts`
- `bun test apps/skillset/src/__tests__/contract.test.ts`
- `bun run typecheck`
- `bun run check`
- Pre-push hook: `skillset ci` + full `check`
- Live Codex smoke: `20260629T012711Z-runtime-codex-7c896544` passed with final message `runtime tester smoke ok`.
- Live Claude smoke: `20260629T012730Z-runtime-claude-d9a2afe9` passed via `direnv exec`/`CLAUDE_CODE_OAUTH_TOKEN`; retained stdout result was `runtime tester smoke ok`.
- Local review: `/tmp/agent-reviews/runtime-tester-harness/codex/round-1.json`, 5/5 clean.

## Notes

The next stack slice should consolidate hooks docs/lookup behavior and drop the separate hooks-support idea; this PR only lands the runtime tester harness cleanly.