### PR TITLE
refactor(runtime): share retained run plumbing

### DIFF
--- a/.changeset/retained-run-plumbing.md
+++ b/.changeset/retained-run-plumbing.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Share retained-run cache plumbing between `skillset test` and `skillset runtime-tester`.

--- a/apps/skillset/src/retained-runs.ts
+++ b/apps/skillset/src/retained-runs.ts
@@ -1,0 +1,135 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { createOperationalPathContext, resolveOperationalPath } from "@skillset/core";
+
+import { renderValidatedJson } from "./structured-output";
+import type { BuildGraph, JsonRecord, SkillsetOptions } from "./types";
+
+export interface RetainedRunIdOptions {
+  readonly fallbackName?: string;
+  readonly includeName?: boolean;
+}
+
+export interface RetainedRunRootPaths {
+  readonly absolute: {
+    readonly latestJsonPath: string;
+    readonly rootPath: string;
+    readonly runsRoot: string;
+  };
+  readonly logical: {
+    readonly latestJsonPath: string;
+    readonly rootPath: string;
+    readonly runsRoot: string;
+  };
+}
+
+export interface RetainedRunPaths extends RetainedRunRootPaths {
+  readonly absolute: RetainedRunRootPaths["absolute"] & {
+    readonly runPath: string;
+  };
+  readonly logical: RetainedRunRootPaths["logical"] & {
+    readonly runPath: string;
+  };
+}
+
+export function makeRetainedRunId(name: string, options: RetainedRunIdOptions = {}): string {
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  const safeName = slugifyRunName(name, options.fallbackName ?? "run");
+  const digest = createHash("sha256").update(`${safeName}:${stamp}:${randomBytes(8).toString("hex")}`).digest("hex").slice(0, 8);
+  return options.includeName === true ? `${stamp}-${safeName}-${digest}` : `${stamp}-${digest}`;
+}
+
+export function retainedRunRootPaths(
+  rootPath: string,
+  graph: BuildGraph,
+  logicalRoot: string,
+  xdg: SkillsetOptions["xdg"] = undefined
+): RetainedRunRootPaths {
+  const normalizedRoot = normalizeLogicalPath(logicalRoot);
+  const context = createOperationalPathContext(rootPath, {
+    ...(graph.root.workspace.cacheKey === undefined ? {} : { workspaceCacheKey: graph.root.workspace.cacheKey }),
+    ...(xdg?.env === undefined ? {} : { env: xdg.env }),
+    ...(xdg?.homeDir === undefined ? {} : { homeDir: xdg.homeDir }),
+  });
+  return {
+    absolute: {
+      latestJsonPath: resolveOperationalPath(context, join(normalizedRoot, "latest.json")),
+      rootPath: resolveOperationalPath(context, normalizedRoot),
+      runsRoot: resolveOperationalPath(context, join(normalizedRoot, "runs")),
+    },
+    logical: {
+      latestJsonPath: normalizeLogicalPath(join(normalizedRoot, "latest.json")),
+      rootPath: normalizedRoot,
+      runsRoot: normalizeLogicalPath(join(normalizedRoot, "runs")),
+    },
+  };
+}
+
+export function retainedRunPaths(
+  rootPath: string,
+  graph: BuildGraph,
+  logicalRoot: string,
+  runId: string,
+  xdg: SkillsetOptions["xdg"] = undefined
+): RetainedRunPaths {
+  const root = retainedRunRootPaths(rootPath, graph, logicalRoot, xdg);
+  return {
+    absolute: {
+      ...root.absolute,
+      runPath: join(root.absolute.runsRoot, runId),
+    },
+    logical: {
+      ...root.logical,
+      runPath: normalizeLogicalPath(join(root.logical.runsRoot, runId)),
+    },
+  };
+}
+
+export function resolveRetainedRunPath(
+  rootPath: string,
+  graph: BuildGraph,
+  logicalPath: string,
+  xdg: SkillsetOptions["xdg"] = undefined
+): string {
+  const context = createOperationalPathContext(rootPath, {
+    ...(graph.root.workspace.cacheKey === undefined ? {} : { workspaceCacheKey: graph.root.workspace.cacheKey }),
+    ...(xdg?.env === undefined ? {} : { env: xdg.env }),
+    ...(xdg?.homeDir === undefined ? {} : { homeDir: xdg.homeDir }),
+  });
+  return resolveOperationalPath(context, logicalPath);
+}
+
+export async function writeRetainedRunLatest(
+  paths: RetainedRunRootPaths,
+  record: JsonRecord
+): Promise<void> {
+  await mkdir(paths.absolute.rootPath, { recursive: true });
+  await writeFile(paths.absolute.latestJsonPath, renderValidatedJson(record, paths.logical.latestJsonPath), "utf8");
+}
+
+export async function readRetainedRunLatest(
+  rootPath: string,
+  graph: BuildGraph,
+  logicalRoot: string,
+  xdg: SkillsetOptions["xdg"] = undefined
+): Promise<JsonRecord> {
+  const paths = retainedRunRootPaths(rootPath, graph, logicalRoot, xdg);
+  const latest = JSON.parse(await readFile(paths.absolute.latestJsonPath, "utf8")) as unknown;
+  if (!isJsonRecord(latest)) throw new Error("skillset: retained run latest is malformed");
+  return latest;
+}
+
+function slugifyRunName(name: string, fallbackName: string): string {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : fallbackName;
+}
+
+function normalizeLogicalPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/skillset/src/runtime-tester.ts
+++ b/apps/skillset/src/runtime-tester.ts
@@ -1,16 +1,22 @@
 import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
-import { createHash, randomBytes } from "node:crypto";
 import { spawn as spawnNode } from "node:child_process";
 import { join, resolve } from "node:path";
 
 import {
   buildSkillset,
-  createOperationalPathContext,
   ISOLATED_OUT_ROOT,
-  resolveOperationalPath,
 } from "@skillset/core";
 
 import { compareStrings } from "./path";
+import {
+  makeRetainedRunId,
+  readRetainedRunLatest,
+  resolveRetainedRunPath,
+  retainedRunRootPaths,
+  retainedRunPaths,
+  writeRetainedRunLatest,
+  type RetainedRunPaths,
+} from "./retained-runs";
 import { loadBuildGraph } from "./resolver";
 import { renderValidatedJson } from "./structured-output";
 import type { BuildGraph, JsonRecord, SkillsetOptions, TargetName } from "./types";
@@ -81,6 +87,7 @@ export interface RuntimeTesterTailLine {
 }
 
 interface RuntimeTesterRunPaths {
+  readonly retained: RetainedRunPaths;
   readonly absolute: {
     readonly finalMessagePath: string;
     readonly latestJsonPath: string;
@@ -130,7 +137,7 @@ export async function startRuntimeTesterRun(
     throw new Error(`skillset: runtime tester target ${options.target} is not enabled by root target configuration`);
   }
   const name = options.name ?? `runtime-${options.target}`;
-  const runId = makeRunId(name);
+  const runId = makeRetainedRunId(name, { fallbackName: "runtime", includeName: true });
   const paths = runtimeTesterPaths(root, graph, runId, options.xdg);
   await mkdir(paths.absolute.runPath, { recursive: true });
 
@@ -263,8 +270,7 @@ export async function listRuntimeTesterRuns(
 ): Promise<readonly RuntimeTesterListEntry[]> {
   const root = resolve(rootPath);
   const graph = await loadBuildGraph(root, options);
-  const context = runtimePathContext(root, graph, options.xdg);
-  const runsRoot = resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "runs"));
+  const runsRoot = retainedRunRootPaths(root, graph, RUNTIME_TESTER_ROOT, options.xdg).absolute.runsRoot;
   if (!await pathExists(runsRoot)) return [];
   const entries = await readdir(runsRoot, { withFileTypes: true });
   const runs: RuntimeTesterListEntry[] = [];
@@ -315,7 +321,7 @@ function runtimeCommand(
   env: Record<string, string | undefined>,
   xdg: SkillsetOptions["xdg"]
 ): { readonly cmd: readonly string[]; readonly cwd: string; readonly display: readonly string[] } {
-  const latestRoot = resolveOperationalPath(runtimePathContext(rootPath, graph, xdg), ISOLATED_OUT_ROOT);
+  const latestRoot = resolveRetainedRunPath(rootPath, graph, ISOLATED_OUT_ROOT, xdg);
   if (config.target === "claude") {
     const bin = env.SKILLSET_RUNTIME_TESTER_CLAUDE_BIN ?? "claude";
     const pluginArgs = claudePluginDirs(graph, latestRoot, config.plugins).flatMap((pluginDir) => ["--plugin-dir", pluginDir]);
@@ -473,38 +479,29 @@ function runtimeTesterPaths(
   runId: string,
   xdg: SkillsetOptions["xdg"] = undefined
 ): RuntimeTesterRunPaths {
-  const context = runtimePathContext(rootPath, graph, xdg);
-  const logicalRunPath = join(RUNTIME_TESTER_ROOT, "runs", runId).replaceAll("\\", "/");
-  const absoluteRunPath = resolveOperationalPath(context, logicalRunPath);
+  const retained = retainedRunPaths(rootPath, graph, RUNTIME_TESTER_ROOT, runId, xdg);
   return {
+    retained,
     absolute: {
-      finalMessagePath: join(absoluteRunPath, "final-message.txt"),
-      latestJsonPath: resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "latest.json")),
-      outputPath: join(absoluteRunPath, "output.jsonl"),
-      promptPath: join(absoluteRunPath, "prompt.md"),
-      reportPath: join(absoluteRunPath, "report.json"),
-      runPath: absoluteRunPath,
-      runsRoot: resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "runs")),
-      statusPath: join(absoluteRunPath, "status.json"),
+      finalMessagePath: join(retained.absolute.runPath, "final-message.txt"),
+      latestJsonPath: retained.absolute.latestJsonPath,
+      outputPath: join(retained.absolute.runPath, "output.jsonl"),
+      promptPath: join(retained.absolute.runPath, "prompt.md"),
+      reportPath: join(retained.absolute.runPath, "report.json"),
+      runPath: retained.absolute.runPath,
+      runsRoot: retained.absolute.runsRoot,
+      statusPath: join(retained.absolute.runPath, "status.json"),
     },
     logical: {
-      finalMessagePath: join(logicalRunPath, "final-message.txt").replaceAll("\\", "/"),
-      latestJsonPath: join(RUNTIME_TESTER_ROOT, "latest.json").replaceAll("\\", "/"),
-      outputPath: join(logicalRunPath, "output.jsonl").replaceAll("\\", "/"),
-      promptPath: join(logicalRunPath, "prompt.md").replaceAll("\\", "/"),
-      reportPath: join(logicalRunPath, "report.json").replaceAll("\\", "/"),
-      runPath: logicalRunPath,
-      statusPath: join(logicalRunPath, "status.json").replaceAll("\\", "/"),
+      finalMessagePath: join(retained.logical.runPath, "final-message.txt").replaceAll("\\", "/"),
+      latestJsonPath: retained.logical.latestJsonPath,
+      outputPath: join(retained.logical.runPath, "output.jsonl").replaceAll("\\", "/"),
+      promptPath: join(retained.logical.runPath, "prompt.md").replaceAll("\\", "/"),
+      reportPath: join(retained.logical.runPath, "report.json").replaceAll("\\", "/"),
+      runPath: retained.logical.runPath,
+      statusPath: join(retained.logical.runPath, "status.json").replaceAll("\\", "/"),
     },
   };
-}
-
-function runtimePathContext(rootPath: string, graph: BuildGraph, xdg: SkillsetOptions["xdg"] = undefined) {
-  return createOperationalPathContext(rootPath, {
-    ...(graph.root.workspace.cacheKey === undefined ? {} : { workspaceCacheKey: graph.root.workspace.cacheKey }),
-    ...(xdg?.env === undefined ? {} : { env: xdg.env }),
-    ...(xdg?.homeDir === undefined ? {} : { homeDir: xdg.homeDir }),
-  });
 }
 
 async function updateRunState(
@@ -554,12 +551,12 @@ async function writeStatus(paths: RuntimeTesterRunPaths, status: RuntimeTesterSt
 
 async function writeLatest(paths: RuntimeTesterRunPaths, runId: string): Promise<void> {
   await mkdir(paths.absolute.runsRoot, { recursive: true });
-  await writeFile(paths.absolute.latestJsonPath, renderValidatedJson({
+  await writeRetainedRunLatest(paths.retained, {
     runId,
     runPath: paths.logical.runPath,
     schemaVersion: 1,
     statusPath: paths.logical.statusPath,
-  }, paths.logical.latestJsonPath), "utf8");
+  });
 }
 
 async function appendEvent(paths: RuntimeTesterRunPaths, stream: string, message: string): Promise<void> {
@@ -576,9 +573,7 @@ async function readLatestRunId(
   graph: BuildGraph,
   xdg: SkillsetOptions["xdg"] = undefined
 ): Promise<string> {
-  const context = runtimePathContext(rootPath, graph, xdg);
-  const latestPath = resolveOperationalPath(context, join(RUNTIME_TESTER_ROOT, "latest.json"));
-  const latest = JSON.parse(await readFile(latestPath, "utf8")) as unknown;
+  const latest = await readRetainedRunLatest(rootPath, graph, RUNTIME_TESTER_ROOT, xdg);
   if (!isRecord(latest) || typeof latest.runId !== "string") {
     throw new Error("skillset: runtime tester latest run is malformed");
   }
@@ -656,13 +651,6 @@ function runReport(
     statusPath: paths.logical.statusPath,
     tailPath: paths.logical.outputPath,
   };
-}
-
-function makeRunId(name: string): string {
-  const safeName = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "runtime";
-  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
-  const digest = createHash("sha256").update(`${safeName}:${stamp}:${randomBytes(8).toString("hex")}`).digest("hex").slice(0, 8);
-  return `${stamp}-${safeName}-${digest}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -1,13 +1,16 @@
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { createHash, randomBytes } from "node:crypto";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { tmpdir } from "node:os";
-
-import { createOperationalPathContext, resolveOperationalPath } from "@skillset/core";
 
 import { buildSkillset, diffSkillset } from "./build";
 import { readCompileTargets, readRecord, readString, resolveTargets, targetNames } from "./config";
 import { compareStrings, resolveInside } from "./path";
+import {
+  makeRetainedRunId,
+  retainedRunPaths,
+  writeRetainedRunLatest,
+  type RetainedRunPaths,
+} from "./retained-runs";
 import { detectWorkspaceSourceDir, loadBuildGraph } from "./resolver";
 import { renderValidatedJson } from "./structured-output";
 import type { BuildGraph, JsonRecord, JsonValue, SkillsetOptions, TargetName } from "./types";
@@ -104,16 +107,13 @@ export async function runSkillsetTest(
     targetFilter: declaration.targets,
   };
 
-  const runId = makeRunId(declaration.name);
-  const cacheContext = createOperationalPathContext(rootPath, {
-    ...(graph.root.workspace.cacheKey === undefined ? {} : { workspaceCacheKey: graph.root.workspace.cacheKey }),
-  });
+  const runId = makeRetainedRunId(declaration.name);
   const logicalBuildRoot = testBuildRoot(sourceDir);
-  const buildRoot = resolveOperationalPath(cacheContext, logicalBuildRoot);
-  const runsRoot = join(buildRoot, "runs");
-  const runPath = join(runsRoot, runId);
+  const paths = retainedRunPaths(rootPath, graph, logicalBuildRoot, runId, options.xdg);
+  const buildRoot = paths.absolute.rootPath;
+  const runPath = paths.absolute.runPath;
   const workspacePath = join(runPath, "workspace");
-  const logicalRunPath = join(logicalBuildRoot, "runs", runId).replaceAll("\\", "/");
+  const logicalRunPath = paths.logical.runPath;
   const logicalWorkspacePath = join(logicalRunPath, "workspace").replaceAll("\\", "/");
   const stagingRoot = await mkdtemp(join(tmpdir(), "skillset-test-"));
   const stagingWorkspacePath = join(stagingRoot, "workspace");
@@ -190,7 +190,7 @@ export async function runSkillsetTest(
 
     await writeFile(reportPath, renderValidatedJson(report, join(logicalRunPath, "report.json")), "utf8");
     await writeFile(reportMarkdownPath, renderMarkdownReport(report), "utf8");
-    await refreshLatest(buildRoot, runPath, latestPath, logicalBuildRoot, logicalLatestPath, logicalRunPath, report);
+    await refreshLatest(paths, latestPath, logicalLatestPath, report);
 
     return {
       ...(logicalActivationPath === undefined ? {} : { activationPath: logicalActivationPath }),
@@ -961,32 +961,25 @@ function slugifyProbeName(value: string): string {
 }
 
 async function refreshLatest(
-  buildRoot: string,
-  runPath: string,
+  paths: RetainedRunPaths,
   latestPath: string,
-  logicalBuildRoot: string,
   logicalLatestPath: string,
-  logicalRunPath: string,
   report: JsonRecord
 ): Promise<void> {
   await rm(latestPath, { force: true, recursive: true });
-  await cp(runPath, latestPath, { recursive: true });
+  await cp(paths.absolute.runPath, latestPath, { recursive: true });
   const latest = {
     name: report.name,
     ok: report.ok,
     reportPath: join(logicalLatestPath, "report.json").replaceAll("\\", "/"),
     runId: report.runId,
-    runPath: logicalRunPath,
+    runPath: paths.logical.runPath,
     schemaVersion: TEST_SCHEMA,
     selection: report.selection,
     source: report.source,
     workspacePath: join(logicalLatestPath, "workspace").replaceAll("\\", "/"),
   };
-  await writeFile(
-    join(buildRoot, "latest.json"),
-    renderValidatedJson(latest, join(logicalBuildRoot, "latest.json").replaceAll("\\", "/")),
-    "utf8"
-  );
+  await writeRetainedRunLatest(paths, latest);
 }
 
 function renderMarkdownReport(report: JsonRecord): string {
@@ -1163,12 +1156,6 @@ function sourceCacheRoot(_sourceDir: string): string {
 
 function sourceSnapshotsRoot(_sourceDir: string): string {
   return ".skillset/snapshots";
-}
-
-function makeRunId(name: string): string {
-  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
-  const digest = createHash("sha256").update(`${name}:${stamp}:${randomBytes(8).toString("hex")}`).digest("hex").slice(0, 8);
-  return `${stamp}-${digest}`;
 }
 
 function isSameOrInside(parentPath: string, candidatePath: string): boolean {


### PR DESCRIPTION
## Context

Follows SET-227 and the runtime tester cleanup audit after #206/#207 landed. `skillset test` and `skillset runtime-tester` were both maintaining their own retained-run IDs, XDG-backed cache paths, run directories, and `latest.json` pointers.

## What changed

- Add `apps/skillset/src/retained-runs.ts` for shared retained-run IDs, XDG-backed logical/absolute path resolution, and latest-pointer JSON writes.
- Rewire `skillset runtime-tester` to use the shared retained-run helper while preserving its existing run/status/tail/report schema.
- Rewire `skillset test` to use the same helper while preserving its `latest/` directory snapshot and `latest.json` contract.
- Add a patch changeset for the package-facing internal refactor.

## Verification

- `bun test apps/skillset/src/__tests__/runtime-tester.test.ts apps/skillset/src/__tests__/contract.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run hooks:pre-push`

## Notes

This intentionally does not fold runtime execution into `skillset test` activation probes yet. It removes the duplicated retained-run foundation first so a later activation bridge can build on one cache/run abstraction.
