### PR TITLE
fix(runtime): validate tester plugin selection

### DIFF
--- a/.changeset/runtime-tester-plugin-selection.md
+++ b/.changeset/runtime-tester-plugin-selection.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Fail loudly when `skillset runtime-tester --plugin` names an unknown or unsupported plugin.

--- a/apps/skillset/src/__tests__/runtime-tester.test.ts
+++ b/apps/skillset/src/__tests__/runtime-tester.test.ts
@@ -165,6 +165,77 @@ Use this skill to answer fixture questions.
   expect((await readRuntimeTesterStatus(root, fromOption.runId, { xdg })).command?.join(" ")).toContain("--setting-sources local");
 });
 
+test("runtime tester validates selected plugins before running", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-plugin-selector-fixture
+claude: true
+codex: true
+`,
+    ".skillset/plugins/acme/skillset.yaml": `
+skillset:
+  name: acme
+  title: Acme
+  summary: Acme plugin fixture.
+claude: true
+`,
+    ".skillset/plugins/acme/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo Claude runtime tester skill.
+---
+
+Use this skill to answer fixture questions.
+`,
+    ".skillset/plugins/codex-only/skillset.yaml": `
+skillset:
+  name: codex-only
+  title: Codex Only
+  summary: Codex-only plugin fixture.
+claude: false
+codex: true
+`,
+    ".skillset/plugins/codex-only/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo Codex-only runtime tester skill.
+---
+
+Use this skill to answer fixture questions.
+`,
+  });
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+
+  await expect(startRuntimeTesterRun(root, {
+    plugins: ["missing"],
+    prompt: "Inspect missing plugin.",
+    target: "claude",
+    xdg,
+  })).rejects.toThrow("unknown runtime tester plugin \"missing\"; available plugins: acme, codex-only");
+
+  await expect(startRuntimeTesterRun(root, {
+    plugins: ["acme", "acme"],
+    prompt: "Inspect duplicate plugin.",
+    target: "claude",
+    xdg,
+  })).rejects.toThrow("duplicate runtime tester plugin \"acme\"");
+
+  await expect(startRuntimeTesterRun(root, {
+    plugins: ["codex-only"],
+    prompt: "Inspect disabled plugin.",
+    target: "claude",
+    xdg,
+  })).rejects.toThrow("runtime tester plugin \"codex-only\" is not enabled for claude");
+
+  await expect(startRuntimeTesterRun(root, {
+    plugins: ["acme"],
+    prompt: "Inspect Codex plugin selection.",
+    target: "codex",
+    xdg,
+  })).rejects.toThrow("runtime tester --plugin is only supported for the claude target");
+});
+
 test("runtime tester CLI supports run, status, tail, and list", async () => {
   const root = await fixture({
     "skillset.yaml": `

--- a/apps/skillset/src/runtime-tester.ts
+++ b/apps/skillset/src/runtime-tester.ts
@@ -137,6 +137,7 @@ export async function startRuntimeTesterRun(
     throw new Error(`skillset: runtime tester target ${options.target} is not enabled by root target configuration`);
   }
   const name = options.name ?? `runtime-${options.target}`;
+  const plugins = validateRuntimeTesterPlugins(graph, options.target, options.plugins ?? []);
   const runId = makeRetainedRunId(name, { fallbackName: "runtime", includeName: true });
   const paths = runtimeTesterPaths(root, graph, runId, options.xdg);
   await mkdir(paths.absolute.runPath, { recursive: true });
@@ -144,7 +145,7 @@ export async function startRuntimeTesterRun(
   const config: RuntimeTesterStoredConfig = {
     ...(options.target === "claude" ? { claudeSettingSources: resolveClaudeSettingSources(options) } : {}),
     name,
-    plugins: [...(options.plugins ?? [])].sort(compareStrings),
+    plugins,
     prompt: options.prompt,
     ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
     target: options.target,
@@ -403,6 +404,34 @@ function claudePluginDirs(
     .filter((plugin) => enabled.has(plugin))
     .sort(compareStrings)
     .map((plugin) => join(latestRoot, graph.root.outputs.plugins.claude, "plugins", plugin));
+}
+
+function validateRuntimeTesterPlugins(
+  graph: BuildGraph,
+  target: TargetName,
+  plugins: readonly string[]
+): readonly string[] {
+  if (plugins.length === 0) return [];
+  if (target !== "claude") {
+    throw new Error("skillset: runtime tester --plugin is only supported for the claude target");
+  }
+  const seen = new Set<string>();
+  const selected: string[] = [];
+  const knownPlugins = graph.plugins.map((plugin) => plugin.id).sort(compareStrings);
+  for (const pluginId of plugins) {
+    if (seen.has(pluginId)) throw new Error(`skillset: duplicate runtime tester plugin ${JSON.stringify(pluginId)}`);
+    seen.add(pluginId);
+    const plugin = graph.plugins.find((candidate) => candidate.id === pluginId);
+    if (plugin === undefined) {
+      const available = knownPlugins.length === 0 ? "none configured" : knownPlugins.join(", ");
+      throw new Error(`skillset: unknown runtime tester plugin ${JSON.stringify(pluginId)}; available plugins: ${available}`);
+    }
+    if (!plugin.targets.claude.enabled) {
+      throw new Error(`skillset: runtime tester plugin ${JSON.stringify(pluginId)} is not enabled for claude`);
+    }
+    selected.push(pluginId);
+  }
+  return selected.sort(compareStrings);
 }
 
 async function runCommand(


### PR DESCRIPTION
## Context
Follow-up to #208 / SET-227. #208 shared retained-run plumbing, but SET-227 also requires runtime tester plugin selection to fail loudly instead of silently filtering unknown or unsupported plugins.

## What changed
- Validate runtime-tester `--plugin` selections before runs are created.
- Reject duplicate plugin ids, unknown plugin ids, Claude-disabled plugins, and `--plugin` with non-Claude targets.
- Keep default no-plugin behavior unchanged: Claude still uses all enabled Claude plugins.

## Verification
- `bun test apps/skillset/src/__tests__/runtime-tester.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run hooks:pre-push`