### PR TITLE
refactor(cli): extract lookup and runtime tester commands

### DIFF
--- a/.changeset/cli-command-islands.md
+++ b/.changeset/cli-command-islands.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Extract lookup and runtime tester CLI command islands from the shared CLI core.

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 
 import {
@@ -7,13 +7,11 @@ import {
   createOperationalPathContext,
   diffSkillsetResult,
   isRepoOperationalCachePath,
-  lookupSkillsetReference,
   planDistributions,
   resolveOperationalPath,
   restoreOutputBackup,
   verifySkillsetResult,
   type DistributionPlanReport,
-  type LookupReport,
   type LookupSubject,
   type LookupView,
   type OutputBackupRestoreReport,
@@ -58,6 +56,14 @@ import {
 } from "./runtime-hooks";
 import { importSources, type ImportKind, type ImportProvider, type ImportReport } from "./import";
 import { lintSkillset } from "./lint";
+import {
+  addLookupTarget,
+  addLookupTargets,
+  addLookupView,
+  readLookupSubject,
+  runLookupCommand,
+  setLookupField,
+} from "./lookup-cli";
 import { loadBuildGraph } from "./resolver";
 import {
   scaffoldSourceUnit,
@@ -82,21 +88,12 @@ import {
   renderProviderFormatUpdateReport,
   runProviderFormatUpdates,
 } from "./provider-format-updates";
+import { readClaudeSettingSources, type RuntimeTesterClaudeSettingSources, type RuntimeTesterSubcommand } from "./runtime-tester";
 import {
-  executeRuntimeTesterRun,
-  listRuntimeTesterRuns,
-  readClaudeSettingSources,
-  readRuntimeTesterStatus,
-  startRuntimeTesterRun,
-  tailRuntimeTesterRun,
-  type RuntimeTesterClaudeSettingSources,
-  type RuntimeTesterListEntry,
-  type RuntimeTesterRunReport,
-  type RuntimeTesterState,
-  type RuntimeTesterStatus,
-  type RuntimeTesterSubcommand,
-  type RuntimeTesterTailLine,
-} from "./runtime-tester";
+  isRuntimeTesterSubcommand,
+  runRuntimeTesterCommand,
+  validateRuntimeTesterFlags,
+} from "./runtime-tester-cli";
 import { createSkillset, initSkillset, type SetupInclude, type SetupLayoutOption, type SetupReport } from "./setup";
 import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "./source-unit-selector";
 import { renderValidatedJson } from "./structured-output";
@@ -274,46 +271,22 @@ export async function runCli(
   }
 
   if (command === "runtime-tester") {
-    if (runtimeTesterSubcommand === "run") {
-      const report = await startRuntimeTesterRun(rootPath, {
-        ...options,
-        background: runtimeTesterBackground,
-        ...(runtimeTesterClaudeSettingSources === undefined ? {} : { claudeSettingSources: runtimeTesterClaudeSettingSources }),
-        ...(runtimeTesterName === undefined ? {} : { name: runtimeTesterName }),
-        plugins: runtimeTesterPlugins,
-        prompt: await readRuntimeTesterPrompt(rootPath, runtimeTesterPrompt, runtimeTesterPromptFile),
-        target: requireRuntimeTesterTarget(runtimeTesterTarget),
-        ...(runtimeTesterTimeoutMs === undefined ? {} : { timeoutMs: runtimeTesterTimeoutMs }),
-      });
-      if (jsonOutput) console.log(renderValidatedJson(report as unknown as JsonRecord, "runtime tester run"));
-      else printRuntimeTesterRun(report);
-      if (!report.ok) process.exitCode = 1;
-      return;
-    }
-    if (runtimeTesterSubcommand === "worker") {
-      if (runtimeTesterRunId === undefined) throw new Error("skillset: runtime-tester worker requires run id");
-      await executeRuntimeTesterRun(rootPath, runtimeTesterRunId);
-      return;
-    }
-    if (runtimeTesterSubcommand === "status") {
-      const status = await readRuntimeTesterStatus(rootPath, runtimeTesterRunId);
-      if (jsonOutput) console.log(renderValidatedJson(status as unknown as JsonRecord, "runtime tester status"));
-      else printRuntimeTesterStatus(status);
-      if (status.state === "failed") process.exitCode = 1;
-      return;
-    }
-    if (runtimeTesterSubcommand === "tail") {
-      const lines = await tailRuntimeTesterRun(rootPath, runtimeTesterRunId, runtimeTesterLines ?? 40);
-      if (jsonOutput) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "runtime tester tail"));
-      else printRuntimeTesterTail(lines);
-      return;
-    }
-    if (runtimeTesterSubcommand === "list") {
-      const entries = await listRuntimeTesterRuns(rootPath);
-      if (jsonOutput) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "runtime tester list"));
-      else printRuntimeTesterList(entries);
-      return;
-    }
+    await runRuntimeTesterCommand(rootPath, {
+      background: runtimeTesterBackground,
+      ...(runtimeTesterClaudeSettingSources === undefined ? {} : { claudeSettingSources: runtimeTesterClaudeSettingSources }),
+      json: jsonOutput,
+      ...(runtimeTesterLines === undefined ? {} : { lines: runtimeTesterLines }),
+      ...(runtimeTesterName === undefined ? {} : { name: runtimeTesterName }),
+      plugins: runtimeTesterPlugins,
+      ...(runtimeTesterPrompt === undefined ? {} : { prompt: runtimeTesterPrompt }),
+      ...(runtimeTesterPromptFile === undefined ? {} : { promptFile: runtimeTesterPromptFile }),
+      ...(runtimeTesterRunId === undefined ? {} : { runId: runtimeTesterRunId }),
+      skillsetOptions: options,
+      ...(runtimeTesterSubcommand === undefined ? {} : { subcommand: runtimeTesterSubcommand }),
+      ...(runtimeTesterTarget === undefined ? {} : { target: runtimeTesterTarget }),
+      ...(runtimeTesterTimeoutMs === undefined ? {} : { timeoutMs: runtimeTesterTimeoutMs }),
+    });
+    return;
   }
 
   if (command === "change") {
@@ -661,19 +634,14 @@ export async function runCli(
   }
 
   if (command === "lookup") {
-    const report = lookupSkillsetReference({
-      ...(lookupAspects.length === 0 ? {} : { aspects: lookupAspects }),
+    runLookupCommand({
+      aspects: lookupAspects,
       ...(lookupField === undefined ? {} : { field: lookupField }),
+      json: jsonOutput,
       ...(lookupSubject === undefined ? {} : { subject: lookupSubject }),
-      ...(lookupTargets.length === 0 ? {} : { targets: lookupTargets }),
-      ...(lookupViews.length === 0 ? {} : { views: lookupViews }),
+      targets: lookupTargets,
+      views: lookupViews,
     });
-    if (jsonOutput) {
-      process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset lookup"));
-    } else {
-      printLookupReport(report);
-    }
-    if (report.diagnostics.some((diagnostic) => diagnostic.severity === "error")) process.exitCode = 1;
     return;
   }
 
@@ -1320,56 +1288,6 @@ function printSkillsetTest(report: SkillsetTestReport): void {
   if (report.activationPath !== undefined) console.log(`  activation: ${report.activationPath}`);
 }
 
-function printRuntimeTesterRun(report: RuntimeTesterRunReport): void {
-  console.log(`skillset: runtime tester ${formatRuntimeTesterState(report.state)}${report.background ? " in background" : ""}`);
-  console.log(`  run: ${report.runPath}`);
-  console.log(`  latest: ${report.latestPath}`);
-  console.log(`  status: ${report.statusPath}`);
-  console.log(`  tail: ${report.tailPath}`);
-  console.log(`  report: ${report.reportPath}`);
-}
-
-function printRuntimeTesterStatus(status: RuntimeTesterStatus): void {
-  console.log(`skillset: runtime tester ${status.runId} ${formatRuntimeTesterState(status.state)}`);
-  console.log(`  target: ${status.target}`);
-  console.log(`  name: ${status.name}`);
-  if (status.pid !== undefined) console.log(`  pid: ${status.pid}`);
-  if (status.command !== undefined) console.log(`  command: ${status.command.join(" ")}`);
-  if (status.exitCode !== undefined) console.log(`  exit: ${status.exitCode}`);
-  if (status.error !== undefined) console.log(`  error: ${status.error}`);
-  console.log(`  started: ${status.startedAt}`);
-  if (status.endedAt !== undefined) console.log(`  ended: ${status.endedAt}`);
-  console.log(`  updated: ${status.updatedAt}`);
-  console.log(`  run: ${status.runPath}`);
-  console.log(`  latest: ${status.latestRoot}`);
-  console.log(`  prompt: ${status.promptPath}`);
-  console.log(`  tail: ${status.outputPath}`);
-  console.log(`  report: ${status.reportPath}`);
-  if (status.finalMessagePath !== undefined) console.log(`  final: ${status.finalMessagePath}`);
-}
-
-function printRuntimeTesterTail(lines: readonly RuntimeTesterTailLine[]): void {
-  for (const line of lines) {
-    const prefix = line.timestamp.length === 0 ? line.stream : `${line.timestamp} ${line.stream}`;
-    process.stdout.write(`${prefix}: ${line.message.endsWith("\n") ? line.message : `${line.message}\n`}`);
-  }
-}
-
-function printRuntimeTesterList(entries: readonly RuntimeTesterListEntry[]): void {
-  if (entries.length === 0) {
-    console.log("skillset: no runtime tester runs");
-    return;
-  }
-  for (const entry of entries) {
-    const ended = entry.endedAt === undefined ? "" : ` ended ${entry.endedAt}`;
-    console.log(`${entry.runId} ${entry.target} ${formatRuntimeTesterState(entry.state)} started ${entry.startedAt}${ended} ${entry.name}`);
-  }
-}
-
-function formatRuntimeTesterState(state: RuntimeTesterState): string {
-  return state;
-}
-
 function formatTestSelection(selection: SkillsetTestReport["selection"]): string {
   const parts = [
     selection.plugins.length === 0 ? undefined : `plugins ${selection.plugins.join(", ")}`,
@@ -1391,63 +1309,6 @@ function formatFeatureSupport(support: FeatureCapability["targetSupport"]["claud
   const reason = support.reason === undefined ? "" : ` (${support.reason})`;
   const note = support.note === undefined ? "" : ` note: ${support.note}`;
   return `${support.status}${reason}${note}`;
-}
-
-function printLookupReport(report: LookupReport): void {
-  if (report.subject === undefined) {
-    console.log("skillset lookup subjects");
-    for (const subject of report.subjects) {
-      console.log(`  ${subject.subject}: ${subject.description}`);
-      console.log(`    views: ${subject.defaultViews.join(", ")}`);
-    }
-    console.log("  flags: --frontmatter --fields --field <path> --values --events --compat [claude|codex...] --examples --schema --claude --codex --json");
-    console.log(`skillset: listed ${report.subjects.length} lookup subjects`);
-    return;
-  }
-
-  console.log(`skillset lookup ${report.subject}${report.aspects.length === 0 ? "" : ` ${report.aspects.join(" ")}`}`);
-  for (const diagnostic of report.diagnostics) {
-    console.log(`  ${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`);
-  }
-  if (report.fields.length > 0) {
-    console.log("  fields:");
-    for (const field of report.fields) {
-      const required = field.required ? " required" : "";
-      const values = field.values === undefined ? "" : ` values: ${field.values.map(formatLookupValue).join(", ")}`;
-      console.log(`    ${field.path}: ${field.type}${required}${values}`);
-    }
-  }
-  if (report.events.length > 0) {
-    console.log("  events:");
-    for (const event of report.events) {
-      const required = event.fields.filter((field) => field.required).map((field) => field.name);
-      const suffix = required.length === 0 ? "" : ` required: ${required.join(", ")}`;
-      console.log(`    [${event.target}] ${event.name}${suffix}`);
-    }
-  }
-  if (report.compatibility.length > 0) {
-    console.log("  compatibility:");
-    for (const item of report.compatibility) {
-      const reason = item.reason === undefined ? "" : ` (${item.reason})`;
-      const note = item.note === undefined ? "" : ` note: ${item.note}`;
-      console.log(`    [${item.target}] ${item.featureId}: ${item.status}${reason}${note}`);
-    }
-  }
-  if (report.examples.length > 0) {
-    console.log("  examples:");
-    for (const example of report.examples) {
-      console.log(`    ${example.path}: ${example.description}`);
-    }
-  }
-  if (report.schema !== undefined) {
-    console.log(`  schema: ${report.schema.id} (${report.schema.title})`);
-  }
-  console.log(`skillset: lookup ${report.diagnostics.some((diagnostic) => diagnostic.severity === "error") ? "reported diagnostics" : "complete"}`);
-}
-
-function formatLookupValue(value: unknown): string {
-  if (typeof value === "string") return value;
-  return JSON.stringify(value);
 }
 
 function formatCountSummary(counts: Readonly<Record<string, number>>): string {
@@ -2228,52 +2089,8 @@ function isProviderMaintenanceSubcommand(value: string | undefined): value is Pr
   return value === "check" || value === "diff" || value === "update";
 }
 
-function isRuntimeTesterSubcommand(value: string | undefined): value is RuntimeTesterSubcommand {
-  return value === "list" || value === "run" || value === "status" || value === "tail" || value === "worker";
-}
-
 function isNewSourceKind(value: string | undefined): value is NewSourceKind {
   return value === "agent" || value === "hook" || value === "skill";
-}
-
-function readLookupSubject(value: string): LookupSubject {
-  if (
-    value === "agent" ||
-    value === "hooks" ||
-    value === "instruction" ||
-    value === "plugin" ||
-    value === "skill" ||
-    value === "workspace"
-  ) {
-    return value;
-  }
-  throw new Error("skillset: expected lookup subject skill, agent, instruction, workspace, hooks, or plugin");
-}
-
-function readLookupTarget(value: string): TargetName {
-  if (value === "claude" || value === "codex") return value;
-  throw new Error(`skillset: unknown lookup compatibility target ${value}; expected claude or codex`);
-}
-
-function addLookupTarget(targets: readonly TargetName[], target: TargetName): TargetName[] {
-  return [...new Set([...targets, target])];
-}
-
-function addLookupTargets(targets: readonly TargetName[], value: string): TargetName[] {
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0)
-    .reduce((current, item) => addLookupTarget(current, readLookupTarget(item)), [...targets]);
-}
-
-function addLookupView(views: readonly LookupView[], view: LookupView): LookupView[] {
-  return [...new Set([...views, view])];
-}
-
-function setLookupField(current: string | undefined, value: string): string {
-  if (current !== undefined) throw new Error("skillset: pass only one --field value");
-  return value;
 }
 
 function readNewSourceScope(value: string): NewSourceScope {
@@ -2299,21 +2116,6 @@ function readPositiveInteger(value: string, flag: string): number {
     throw new Error(`skillset: expected ${flag} to be a positive integer`);
   }
   return parsed;
-}
-
-async function readRuntimeTesterPrompt(
-  rootPath: string,
-  prompt: string | undefined,
-  promptFile: string | undefined
-): Promise<string> {
-  if (prompt !== undefined) return prompt;
-  if (promptFile === undefined) throw new Error("skillset: runtime-tester run requires --prompt or --prompt-file");
-  return readFile(resolve(rootPath, promptFile), "utf8");
-}
-
-function requireRuntimeTesterTarget(target: TargetName | undefined): TargetName {
-  if (target === undefined) throw new Error("skillset: runtime-tester run requires --target claude or codex");
-  return target;
 }
 
 function setChangeReason(current: ChangeReasonInput | undefined, next: ChangeReasonInput): ChangeReasonInput {
@@ -2481,58 +2283,6 @@ function validateTestFlags(
     test.yes
   ) {
     throw new Error("skillset: build/write options are not supported with test; test output always writes under logical .skillset/cache/tests");
-  }
-}
-
-function validateRuntimeTesterFlags(
-  command: Command,
-  subcommand: RuntimeTesterSubcommand | undefined,
-  runtime: {
-    readonly background: boolean;
-    readonly buildMode?: CompileBuildMode;
-    readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
-    readonly distDir?: string;
-    readonly dryRun: boolean;
-    readonly lines?: number;
-    readonly name?: string;
-    readonly plugins: readonly string[];
-    readonly prompt?: string;
-    readonly promptFile?: string;
-    readonly scopes?: readonly BuildScope[];
-    readonly target?: TargetName;
-    readonly timeoutMs?: number;
-    readonly yes: boolean;
-  }
-): void {
-  const hasRuntimeFlag = runtime.background ||
-    runtime.claudeSettingSources !== undefined ||
-    runtime.lines !== undefined ||
-    runtime.name !== undefined ||
-    runtime.plugins.length > 0 ||
-    runtime.prompt !== undefined ||
-    runtime.promptFile !== undefined ||
-    runtime.target !== undefined ||
-    runtime.timeoutMs !== undefined;
-  if (hasRuntimeFlag && command !== "runtime-tester") {
-    throw new Error("skillset: runtime tester options are only supported with runtime-tester");
-  }
-  if (command !== "runtime-tester") return;
-  if (subcommand === undefined) throw new Error("skillset: expected runtime-tester subcommand");
-  if (runtime.buildMode !== undefined || runtime.distDir !== undefined || runtime.dryRun || runtime.scopes !== undefined || runtime.yes) {
-    throw new Error("skillset: build/write options are not supported with runtime-tester; runtime tester builds an isolated projection under logical .skillset/cache/runtime-tester");
-  }
-  if (subcommand === "run") {
-    if (runtime.target === undefined) throw new Error("skillset: runtime-tester run requires --target claude or codex");
-    if ((runtime.prompt === undefined && runtime.promptFile === undefined) || (runtime.prompt !== undefined && runtime.promptFile !== undefined)) {
-      throw new Error("skillset: runtime-tester run requires exactly one of --prompt or --prompt-file");
-    }
-    return;
-  }
-  if (runtime.background || runtime.claudeSettingSources !== undefined || runtime.name !== undefined || runtime.plugins.length > 0 || runtime.prompt !== undefined || runtime.promptFile !== undefined || runtime.target !== undefined || runtime.timeoutMs !== undefined) {
-    throw new Error(`skillset: runtime tester run options are not supported with ${subcommand}`);
-  }
-  if (runtime.lines !== undefined && subcommand !== "tail") {
-    throw new Error("skillset: --lines is only supported with runtime-tester tail");
   }
 }
 

--- a/apps/skillset/src/lookup-cli.ts
+++ b/apps/skillset/src/lookup-cli.ts
@@ -1,0 +1,131 @@
+import {
+  lookupSkillsetReference,
+  type LookupReport,
+  type LookupSubject,
+  type LookupView,
+} from "@skillset/core";
+
+import { renderValidatedJson } from "./structured-output";
+import type { JsonRecord, TargetName } from "./types";
+
+export interface LookupCommandOptions {
+  readonly aspects: readonly string[];
+  readonly field?: string;
+  readonly json: boolean;
+  readonly subject?: LookupSubject;
+  readonly targets: readonly TargetName[];
+  readonly views: readonly LookupView[];
+}
+
+export function runLookupCommand(options: LookupCommandOptions): void {
+  const report = lookupSkillsetReference({
+    ...(options.aspects.length === 0 ? {} : { aspects: options.aspects }),
+    ...(options.field === undefined ? {} : { field: options.field }),
+    ...(options.subject === undefined ? {} : { subject: options.subject }),
+    ...(options.targets.length === 0 ? {} : { targets: options.targets }),
+    ...(options.views.length === 0 ? {} : { views: options.views }),
+  });
+  if (options.json) {
+    process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset lookup"));
+  } else {
+    printLookupReport(report);
+  }
+  if (report.diagnostics.some((diagnostic) => diagnostic.severity === "error")) process.exitCode = 1;
+}
+
+export function readLookupSubject(value: string): LookupSubject {
+  if (
+    value === "agent" ||
+    value === "hooks" ||
+    value === "instruction" ||
+    value === "plugin" ||
+    value === "skill" ||
+    value === "workspace"
+  ) {
+    return value;
+  }
+  throw new Error("skillset: expected lookup subject skill, agent, instruction, workspace, hooks, or plugin");
+}
+
+export function readLookupTarget(value: string): TargetName {
+  if (value === "claude" || value === "codex") return value;
+  throw new Error(`skillset: unknown lookup compatibility target ${value}; expected claude or codex`);
+}
+
+export function addLookupTarget(targets: readonly TargetName[], target: TargetName): TargetName[] {
+  return [...new Set([...targets, target])];
+}
+
+export function addLookupTargets(targets: readonly TargetName[], value: string): TargetName[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .reduce((current, item) => addLookupTarget(current, readLookupTarget(item)), [...targets]);
+}
+
+export function addLookupView(views: readonly LookupView[], view: LookupView): LookupView[] {
+  return [...new Set([...views, view])];
+}
+
+export function setLookupField(current: string | undefined, value: string): string {
+  if (current !== undefined) throw new Error("skillset: pass only one --field value");
+  return value;
+}
+
+function printLookupReport(report: LookupReport): void {
+  if (report.subject === undefined) {
+    console.log("skillset lookup subjects");
+    for (const subject of report.subjects) {
+      console.log(`  ${subject.subject}: ${subject.description}`);
+      console.log(`    views: ${subject.defaultViews.join(", ")}`);
+    }
+    console.log("  flags: --frontmatter --fields --field <path> --values --events --compat [claude|codex...] --examples --schema --claude --codex --json");
+    console.log(`skillset: listed ${report.subjects.length} lookup subjects`);
+    return;
+  }
+
+  console.log(`skillset lookup ${report.subject}${report.aspects.length === 0 ? "" : ` ${report.aspects.join(" ")}`}`);
+  for (const diagnostic of report.diagnostics) {
+    console.log(`  ${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`);
+  }
+  if (report.fields.length > 0) {
+    console.log("  fields:");
+    for (const field of report.fields) {
+      const required = field.required ? " required" : "";
+      const values = field.values === undefined ? "" : ` values: ${field.values.map(formatLookupValue).join(", ")}`;
+      console.log(`    ${field.path}: ${field.type}${required}${values}`);
+    }
+  }
+  if (report.events.length > 0) {
+    console.log("  events:");
+    for (const event of report.events) {
+      const required = event.fields.filter((field) => field.required).map((field) => field.name);
+      const suffix = required.length === 0 ? "" : ` required: ${required.join(", ")}`;
+      console.log(`    [${event.target}] ${event.name}${suffix}`);
+    }
+  }
+  if (report.compatibility.length > 0) {
+    console.log("  compatibility:");
+    for (const item of report.compatibility) {
+      const reason = item.reason === undefined ? "" : ` (${item.reason})`;
+      const note = item.note === undefined ? "" : ` note: ${item.note}`;
+      console.log(`    [${item.target}] ${item.featureId}: ${item.status}${reason}${note}`);
+    }
+  }
+  if (report.examples.length > 0) {
+    console.log("  examples:");
+    for (const example of report.examples) {
+      console.log(`    ${example.path}: ${example.description}`);
+    }
+  }
+  if (report.schema !== undefined) {
+    console.log(`  schema: ${report.schema.id} (${report.schema.title})`);
+  }
+  console.log(`skillset: lookup ${report.diagnostics.some((diagnostic) => diagnostic.severity === "error") ? "reported diagnostics" : "complete"}`);
+}
+
+function formatLookupValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}

--- a/apps/skillset/src/runtime-tester-cli.ts
+++ b/apps/skillset/src/runtime-tester-cli.ts
@@ -1,0 +1,199 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import {
+  executeRuntimeTesterRun,
+  listRuntimeTesterRuns,
+  readRuntimeTesterStatus,
+  startRuntimeTesterRun,
+  tailRuntimeTesterRun,
+  type RuntimeTesterClaudeSettingSources,
+  type RuntimeTesterListEntry,
+  type RuntimeTesterRunReport,
+  type RuntimeTesterState,
+  type RuntimeTesterStatus,
+  type RuntimeTesterSubcommand,
+  type RuntimeTesterTailLine,
+} from "./runtime-tester";
+import { renderValidatedJson } from "./structured-output";
+import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, TargetName } from "./types";
+
+export interface RuntimeTesterCommandOptions {
+  readonly background: boolean;
+  readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+  readonly json: boolean;
+  readonly lines?: number;
+  readonly name?: string;
+  readonly plugins: readonly string[];
+  readonly prompt?: string;
+  readonly promptFile?: string;
+  readonly runId?: string;
+  readonly skillsetOptions: SkillsetOptions;
+  readonly subcommand?: RuntimeTesterSubcommand;
+  readonly target?: TargetName;
+  readonly timeoutMs?: number;
+}
+
+export async function runRuntimeTesterCommand(rootPath: string, options: RuntimeTesterCommandOptions): Promise<void> {
+  if (options.subcommand === "run") {
+    const report = await startRuntimeTesterRun(rootPath, {
+      ...options.skillsetOptions,
+      background: options.background,
+      ...(options.claudeSettingSources === undefined ? {} : { claudeSettingSources: options.claudeSettingSources }),
+      ...(options.name === undefined ? {} : { name: options.name }),
+      plugins: options.plugins,
+      prompt: await readRuntimeTesterPrompt(rootPath, options.prompt, options.promptFile),
+      target: requireRuntimeTesterTarget(options.target),
+      ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+    });
+    if (options.json) console.log(renderValidatedJson(report as unknown as JsonRecord, "runtime tester run"));
+    else printRuntimeTesterRun(report);
+    if (!report.ok) process.exitCode = 1;
+    return;
+  }
+  if (options.subcommand === "worker") {
+    if (options.runId === undefined) throw new Error("skillset: runtime-tester worker requires run id");
+    await executeRuntimeTesterRun(rootPath, options.runId);
+    return;
+  }
+  if (options.subcommand === "status") {
+    const status = await readRuntimeTesterStatus(rootPath, options.runId);
+    if (options.json) console.log(renderValidatedJson(status as unknown as JsonRecord, "runtime tester status"));
+    else printRuntimeTesterStatus(status);
+    if (status.state === "failed") process.exitCode = 1;
+    return;
+  }
+  if (options.subcommand === "tail") {
+    const lines = await tailRuntimeTesterRun(rootPath, options.runId, options.lines ?? 40);
+    if (options.json) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "runtime tester tail"));
+    else printRuntimeTesterTail(lines);
+    return;
+  }
+  if (options.subcommand === "list") {
+    const entries = await listRuntimeTesterRuns(rootPath);
+    if (options.json) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "runtime tester list"));
+    else printRuntimeTesterList(entries);
+    return;
+  }
+}
+
+export function isRuntimeTesterSubcommand(value: string | undefined): value is RuntimeTesterSubcommand {
+  return value === "list" || value === "run" || value === "status" || value === "tail" || value === "worker";
+}
+
+export function validateRuntimeTesterFlags(
+  command: string,
+  subcommand: RuntimeTesterSubcommand | undefined,
+  runtime: {
+    readonly background: boolean;
+    readonly buildMode?: CompileBuildMode;
+    readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+    readonly distDir?: string;
+    readonly dryRun: boolean;
+    readonly lines?: number;
+    readonly name?: string;
+    readonly plugins: readonly string[];
+    readonly prompt?: string;
+    readonly promptFile?: string;
+    readonly scopes?: readonly BuildScope[];
+    readonly target?: TargetName;
+    readonly timeoutMs?: number;
+    readonly yes: boolean;
+  }
+): void {
+  const hasRuntimeFlag = runtime.background ||
+    runtime.claudeSettingSources !== undefined ||
+    runtime.lines !== undefined ||
+    runtime.name !== undefined ||
+    runtime.plugins.length > 0 ||
+    runtime.prompt !== undefined ||
+    runtime.promptFile !== undefined ||
+    runtime.target !== undefined ||
+    runtime.timeoutMs !== undefined;
+  if (hasRuntimeFlag && command !== "runtime-tester") {
+    throw new Error("skillset: runtime tester options are only supported with runtime-tester");
+  }
+  if (command !== "runtime-tester") return;
+  if (subcommand === undefined) throw new Error("skillset: expected runtime-tester subcommand");
+  if (runtime.buildMode !== undefined || runtime.distDir !== undefined || runtime.dryRun || runtime.scopes !== undefined || runtime.yes) {
+    throw new Error("skillset: build/write options are not supported with runtime-tester; runtime tester builds an isolated projection under logical .skillset/cache/runtime-tester");
+  }
+  if (subcommand === "run") {
+    if (runtime.target === undefined) throw new Error("skillset: runtime-tester run requires --target claude or codex");
+    if ((runtime.prompt === undefined && runtime.promptFile === undefined) || (runtime.prompt !== undefined && runtime.promptFile !== undefined)) {
+      throw new Error("skillset: runtime-tester run requires exactly one of --prompt or --prompt-file");
+    }
+    return;
+  }
+  if (runtime.background || runtime.claudeSettingSources !== undefined || runtime.name !== undefined || runtime.plugins.length > 0 || runtime.prompt !== undefined || runtime.promptFile !== undefined || runtime.target !== undefined || runtime.timeoutMs !== undefined) {
+    throw new Error(`skillset: runtime tester run options are not supported with ${subcommand}`);
+  }
+  if (runtime.lines !== undefined && subcommand !== "tail") {
+    throw new Error("skillset: --lines is only supported with runtime-tester tail");
+  }
+}
+
+async function readRuntimeTesterPrompt(
+  rootPath: string,
+  prompt: string | undefined,
+  promptFile: string | undefined
+): Promise<string> {
+  if (prompt !== undefined) return prompt;
+  if (promptFile === undefined) throw new Error("skillset: runtime-tester run requires --prompt or --prompt-file");
+  return readFile(resolve(rootPath, promptFile), "utf8");
+}
+
+function requireRuntimeTesterTarget(target: TargetName | undefined): TargetName {
+  if (target === undefined) throw new Error("skillset: runtime-tester run requires --target claude or codex");
+  return target;
+}
+
+function printRuntimeTesterRun(report: RuntimeTesterRunReport): void {
+  console.log(`skillset: runtime tester ${formatRuntimeTesterState(report.state)}${report.background ? " in background" : ""}`);
+  console.log(`  run: ${report.runPath}`);
+  console.log(`  latest: ${report.latestPath}`);
+  console.log(`  status: ${report.statusPath}`);
+  console.log(`  tail: ${report.tailPath}`);
+  console.log(`  report: ${report.reportPath}`);
+}
+
+function printRuntimeTesterStatus(status: RuntimeTesterStatus): void {
+  console.log(`skillset: runtime tester ${status.runId} ${formatRuntimeTesterState(status.state)}`);
+  console.log(`  target: ${status.target}`);
+  console.log(`  name: ${status.name}`);
+  if (status.pid !== undefined) console.log(`  pid: ${status.pid}`);
+  if (status.command !== undefined) console.log(`  command: ${status.command.join(" ")}`);
+  if (status.exitCode !== undefined) console.log(`  exit: ${status.exitCode}`);
+  if (status.error !== undefined) console.log(`  error: ${status.error}`);
+  console.log(`  started: ${status.startedAt}`);
+  if (status.endedAt !== undefined) console.log(`  ended: ${status.endedAt}`);
+  console.log(`  updated: ${status.updatedAt}`);
+  console.log(`  run: ${status.runPath}`);
+  console.log(`  latest: ${status.latestRoot}`);
+  console.log(`  prompt: ${status.promptPath}`);
+  console.log(`  tail: ${status.outputPath}`);
+  console.log(`  report: ${status.reportPath}`);
+  if (status.finalMessagePath !== undefined) console.log(`  final: ${status.finalMessagePath}`);
+}
+
+function printRuntimeTesterTail(lines: readonly RuntimeTesterTailLine[]): void {
+  for (const line of lines) {
+    const prefix = line.timestamp.length === 0 ? line.stream : `${line.timestamp} ${line.stream}`;
+    process.stdout.write(`${prefix}: ${line.message.endsWith("\n") ? line.message : `${line.message}\n`}`);
+  }
+}
+
+function printRuntimeTesterList(entries: readonly RuntimeTesterListEntry[]): void {
+  if (entries.length === 0) {
+    console.log("skillset: no runtime tester runs");
+    return;
+  }
+  for (const entry of entries) {
+    const ended = entry.endedAt === undefined ? "" : ` ended ${entry.endedAt}`;
+    console.log(`${entry.runId} ${entry.target} ${formatRuntimeTesterState(entry.state)} started ${entry.startedAt}${ended} ${entry.name}`);
+  }
+}
+
+function formatRuntimeTesterState(state: RuntimeTesterState): string {
+  return state;
+}


### PR DESCRIPTION
## Context

SET-226 asked for a small command-island extraction after the lookup and runtime tester work landed, without introducing a broad CLI framework or changing runtime tester artifact behavior.

## What changed

- Moved lookup command execution, rendering, and lookup-specific parse helpers into `apps/skillset/src/lookup-cli.ts`.
- Moved runtime tester command execution, text rendering, subcommand recognition, prompt loading, target validation, and runtime-tester flag validation into `apps/skillset/src/runtime-tester-cli.ts`.
- Left the shared argv parser in `apps/skillset/src/cli-core.ts`, but reduced command-specific bulk there.
- Added a patch changeset for the package-facing refactor.

## Verification

- `bun run typecheck`
- `bun test apps/skillset/src/__tests__/lookup-cli.test.ts apps/skillset/src/__tests__/runtime-tester.test.ts`
- `bun run check`
- `bun run changeset:check`
- `bun run skillset:ci`
- Pre-push hook: repo sanity, whitespace, changesets, workflow lint, `skillset:ci`, `check`

## Review

Local review report: `.agents/goals/2026-06-29-skillset-hooks-runtime-closure/tmp/reviews/codex-set226/round1.json`

Score: 5/5, clean, no open P0-P2 findings.

## Notes

Runtime tester provider command construction remains in `apps/skillset/src/runtime-tester.ts` intentionally. This branch keeps SET-226 behavior-preserving and avoids a less mechanical split inside run lifecycle/storage.

Linear: SET-226
