### PR TITLE
feat(hooks): add inline adaptive context delivery

### DIFF
--- a/.changeset/hook-context-inline.md
+++ b/.changeset/hook-context-inline.md
@@ -1,0 +1,7 @@
+---
+"skillset": patch
+"@skillset/core": patch
+"@skillset/schema": patch
+---
+
+Add inline adaptive hook runtime context delivery while reserving toolkit-backed hooks until helper provenance is ready.

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -63,6 +63,41 @@ Flat hook units such as `hooks/<name>.json` cannot use `./...` hook-local script
 
 Plugin-level adaptive hook rendering copies referenced scripts into the generated plugin root and rewrites commands to provider runtime roots: `$CLAUDE_PLUGIN_ROOT` for Claude plugin hooks and `$PLUGIN_ROOT` for Codex plugin hooks.
 
+### Runtime Context
+
+Adaptive hook units can choose how much Skillset-normalized runtime context to pass to their command:
+
+```json
+{
+  "events": ["Stop"],
+  "context": {
+    "strategy": "inline",
+    "env": ["provider", "hook.event", "session.id"]
+  },
+  "run": {
+    "command": "node ./session-summary.js"
+  }
+}
+```
+
+`context.strategy` supports:
+
+| Strategy | Behavior |
+| --- | --- |
+| `inline` | Prefixes the generated command with requested `SKILLSET_*` environment assignments. |
+| `none` | Passes no Skillset-normalized context. Provider-native environment remains available. |
+| `toolkit` | Reserved until Skillset has a proven internal/public runtime helper boundary. It produces an explicit unsupported render result today. |
+
+Inline v1 fields are deliberately small:
+
+| Field | Generated variable |
+| --- | --- |
+| `provider` | `SKILLSET_PROVIDER` (`claude` or `codex`) |
+| `hook.event` | `SKILLSET_HOOK_EVENT` |
+| `session.id` | `SKILLSET_SESSION_ID`, sourced from `${CLAUDE_SESSION_ID:-}` or `${CODEX_SESSION_ID:-}` |
+
+Omitting `context` is equivalent to `context.strategy: none`, so existing hooks keep their command text unchanged.
+
 ### Attachments
 
 Hook definitions are reusable. Source units attach named hooks through event-keyed frontmatter or config:

--- a/docs/reference/schemas/0.1.0/adaptive-hook.schema.json
+++ b/docs/reference/schemas/0.1.0/adaptive-hook.schema.json
@@ -9,6 +9,36 @@
     "codex": {
       "type": "object"
     },
+    "context": {
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "items": {
+            "enum": [
+              "hook.event",
+              "provider",
+              "session.id"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "includeRaw": {
+          "type": "boolean"
+        },
+        "strategy": {
+          "enum": [
+            "inline",
+            "none",
+            "toolkit"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "description": {
       "minLength": 1,
       "type": "string"

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -9,6 +9,36 @@
         "codex": {
           "type": "object"
         },
+        "context": {
+          "additionalProperties": false,
+          "properties": {
+            "env": {
+              "items": {
+                "enum": [
+                  "hook.event",
+                  "provider",
+                  "session.id"
+                ],
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "includeRaw": {
+              "type": "boolean"
+            },
+            "strategy": {
+              "enum": [
+                "inline",
+                "none",
+                "toolkit"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "description": {
           "minLength": 1,
           "type": "string"

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -292,6 +292,57 @@ hooks:
     ]));
   });
 
+  test("renders inline hook context for plugin-level adaptive hooks", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-context-render
+claude: true
+codex: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - session-summary
+`,
+      ".skillset/plugins/demo/hooks/session-summary.json": JSON.stringify({
+        context: {
+          env: ["provider", "hook.event", "session.id"],
+          strategy: "inline",
+        },
+        events: ["Stop"],
+        run: { command: "node ./session-summary.js" },
+      }),
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    const claudeHooks = renderedJson(rendered, "plugins-claude/plugins/demo/hooks/hooks.json");
+    const codexHooks = renderedJson(rendered, "plugins-codex/plugins/demo/hooks/hooks.json");
+
+    expect(claudeHooks).toEqual({
+      hooks: {
+        Stop: [{
+          hooks: [{
+            command: 'SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop SKILLSET_SESSION_ID="${CLAUDE_SESSION_ID:-}" node ./session-summary.js',
+            type: "command",
+          }],
+        }],
+      },
+    });
+    expect(codexHooks).toEqual({
+      hooks: {
+        Stop: [{
+          hooks: [{
+            command: 'SKILLSET_PROVIDER=codex SKILLSET_HOOK_EVENT=Stop SKILLSET_SESSION_ID="${CODEX_SESSION_ID:-}" node ./session-summary.js',
+            type: "command",
+          }],
+        }],
+      },
+    });
+  });
+
   test("renders Claude skill and project-agent adaptive hooks into frontmatter", async () => {
     const graph = await loadBuildGraph(await fixture({
       "skillset.yaml": `
@@ -349,6 +400,48 @@ Body.
       Stop: [{
         hooks: [{ command: "echo agent", type: "command" }],
         statusMessage: "Checking agent stop",
+      }],
+    });
+  });
+
+  test("renders inline hook context for Claude frontmatter adaptive hooks", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-frontmatter-context
+claude: true
+codex: false
+`,
+      ".skillset/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  Stop:
+    - local-stop
+---
+
+Body.
+`,
+      ".skillset/skills/writer/hooks/local-stop.json": JSON.stringify({
+        context: {
+          env: ["provider", "hook.event"],
+          strategy: "inline",
+        },
+        events: ["Stop"],
+        run: { command: "echo skill" },
+      }),
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    const skillFrontmatter = renderedMarkdown(rendered, ".claude/skills/writer/SKILL.md").frontmatter;
+
+    expect(skillFrontmatter.hooks).toEqual({
+      Stop: [{
+        hooks: [{
+          command: "SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop echo skill",
+          type: "command",
+        }],
       }],
     });
   });

--- a/packages/core/src/__tests__/lookup.test.ts
+++ b/packages/core/src/__tests__/lookup.test.ts
@@ -107,6 +107,7 @@ describe("lookupSkillsetReference", () => {
     expect(report.fields.map((field) => `${field.contractId}:${field.path}`)).toEqual([
       "adaptive-hook:claude",
       "adaptive-hook:codex",
+      "adaptive-hook:context",
       "adaptive-hook:description",
       "adaptive-hook:events",
       "adaptive-hook:match",

--- a/packages/core/src/__tests__/render-result-build.test.ts
+++ b/packages/core/src/__tests__/render-result-build.test.ts
@@ -807,6 +807,34 @@ hooks:
       sourceUnit: "plugin.demo.feature:hooks",
     });
 
+    const toolkitContextRoot = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-policy-toolkit-context
+claude: true
+codex: false
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - shell-policy
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        context: { strategy: "toolkit" },
+        events: ["Stop"],
+        run: { command: "echo ok" },
+      }),
+    });
+    await expectUnsupportedOutcome(toolkitContextRoot, {
+      destination: "hooks",
+      featureId: "adaptive-hooks",
+      reason: "Adaptive hook shell-policy uses context.strategy toolkit, but plugin hook rendering does not support toolkit context delivery yet.",
+      sourceUnit: "plugin.demo.feature:hooks",
+      target: "claude",
+    });
+
     const runtimePathRoot = await fixture({
       "skillset.yaml": `
 skillset:

--- a/packages/core/src/adaptive-hook-render-support.ts
+++ b/packages/core/src/adaptive-hook-render-support.ts
@@ -26,6 +26,12 @@ function adaptiveHookUnsupportedFieldReason(
     return `Adaptive hook ${item.definition.name} uses ${target} provider overrides, but ${surface} hook rendering does not support overrides yet.`;
   }
 
+  const context = readRecord(item.definition.frontmatter, "context");
+  const contextStrategy = context === undefined ? undefined : readContextStrategy(context);
+  if (contextStrategy === "toolkit") {
+    return `Adaptive hook ${item.definition.name} uses context.strategy toolkit, but ${surface} hook rendering does not support toolkit context delivery yet.`;
+  }
+
   const run = readRecord(item.definition.frontmatter, "run") ?? {};
   for (const key of ["args", "cwd", "env"] as const) {
     if (run[key] !== undefined) {
@@ -39,6 +45,11 @@ function adaptiveHookUnsupportedFieldReason(
   }
 
   return undefined;
+}
+
+function readContextStrategy(context: Record<string, unknown>): string | undefined {
+  const strategy = context.strategy;
+  return typeof strategy === "string" ? strategy : undefined;
 }
 
 function adaptiveHookUnsupportedCapabilityReason(

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1747,7 +1747,7 @@ function adaptiveHookCommand(
 ): string {
   const run = readRecord(item.definition.frontmatter, "run") ?? {};
   const command = readString(run, "command");
-  if (command !== undefined) return command;
+  if (command !== undefined) return withAdaptiveHookContextCommand(command, item, target);
 
   const script = readString(run, "script");
   if (script === undefined) {
@@ -1770,7 +1770,7 @@ function adaptiveHookCommand(
     });
   }
   const pluginRoot = target === "claude" ? "$CLAUDE_PLUGIN_ROOT" : "$PLUGIN_ROOT";
-  return `${pluginRoot}/${relativeScriptPath}`;
+  return withAdaptiveHookContextCommand(`${pluginRoot}/${relativeScriptPath}`, item, target);
 }
 
 function hasAdaptivePluginHookOutput(
@@ -1864,7 +1864,49 @@ function adaptiveFrontmatterHookCommand(item: ResolvedAdaptiveHookAttachment): s
   if (command === undefined) {
     throw new Error(`skillset: adaptive hook ${item.definition.name} must define run.command for frontmatter hook rendering`);
   }
-  return command;
+  return withAdaptiveHookContextCommand(command, item, "claude");
+}
+
+function withAdaptiveHookContextCommand(
+  command: string,
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName
+): string {
+  const context = readRecord(item.definition.frontmatter, "context");
+  if (context === undefined) return command;
+  const strategy = readString(context, "strategy") ?? "none";
+  if (strategy === "none") return command;
+  if (strategy !== "inline") {
+    throw new Error(`skillset: adaptive hook ${item.definition.name} context.strategy ${strategy} is not supported for rendering yet`);
+  }
+  const fields = readStringArray(context, "env") ?? [];
+  if (fields.length === 0) {
+    throw new Error(`skillset: adaptive hook ${item.definition.name} context.env must list fields for inline context rendering`);
+  }
+  const assignments = fields.map((field) => adaptiveHookContextAssignment(field, item, target));
+  return `${assignments.join(" ")} ${command}`;
+}
+
+function adaptiveHookContextAssignment(
+  field: string,
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName
+): string {
+  switch (field) {
+    case "provider":
+      return `SKILLSET_PROVIDER=${target}`;
+    case "hook.event":
+      return `SKILLSET_HOOK_EVENT=${shellLiteral(item.event)}`;
+    case "session.id":
+      return `SKILLSET_SESSION_ID="${target === "claude" ? "${CLAUDE_SESSION_ID:-}" : "${CODEX_SESSION_ID:-}"}"`;
+    default:
+      throw new Error(`skillset: adaptive hook ${item.definition.name} context.env field ${field} is not supported`);
+  }
+}
+
+function shellLiteral(value: string): string {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
 function adaptiveHookAttachmentsForScope(

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -214,6 +214,10 @@ describe("@skillset/schema contracts", () => {
       events: ["PreToolUse"],
       match: { tool: ["Bash"] },
       providers: ["claude", "codex"],
+      context: {
+        env: ["provider", "hook.event", "session.id"],
+        strategy: "inline",
+      },
       run: {
         args: ["--check"],
         env: { HOOK: "shell-policy" },
@@ -225,6 +229,10 @@ describe("@skillset/schema contracts", () => {
     expect(validateAdaptiveHookUnitSource({
       events: ["PreToolUse", "PreToolUse", ""],
       providers: ["claude", "bad", "claude"],
+      context: {
+        env: ["provider", "unknown", "provider"],
+        strategy: "later",
+      },
       run: {
         args: ["ok", 1],
         command: "",
@@ -237,6 +245,9 @@ describe("@skillset/schema contracts", () => {
       "schema/adaptive-hook/events-duplicate",
       "schema/adaptive-hook/providers",
       "schema/adaptive-hook/providers-duplicate",
+      "schema/adaptive-hook/context-strategy",
+      "schema/adaptive-hook/context-env",
+      "schema/adaptive-hook/context-env-duplicate",
       "schema/adaptive-hook/run-args",
       "schema/adaptive-hook/run-command",
       "schema/adaptive-hook/run-env",

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -212,6 +212,11 @@ export const hookContract = contract("hook", "Hook Definition", "Skillset hook d
 export const adaptiveHookContract = contract("adaptive-hook", "Adaptive Hook Unit", "Skillset adaptive hook unit source contract for reusable portable hooks.", {
   ...strictObjectSchema({
     claude: { type: "object" },
+    context: strictObjectSchema({
+      env: arraySchema(enumSchema(["hook.event", "provider", "session.id"]), { minItems: 1, uniqueItems: true }),
+      includeRaw: { type: "boolean" },
+      strategy: enumSchema(["inline", "none", "toolkit"]),
+    }),
     codex: { type: "object" },
     description: nonEmptyStringSchema(),
     events: arraySchema(nonEmptyStringSchema(), { minItems: 1, uniqueItems: true }),

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -138,7 +138,7 @@ export function validateAdaptiveHookUnitSource(value: unknown, path = "$"): Skil
   const diagnostics: SkillsetSchemaDiagnostic[] = [];
   if (!isSchemaRecord(value)) return result([diagnostic(path, "schema/adaptive-hook/type", "adaptive hook unit must contain an object")]);
 
-  checkAllowedKeys(value, new Set(["claude", "codex", "description", "events", "match", "name", "providers", "run", "status"]), path, "schema/adaptive-hook/key", diagnostics);
+  checkAllowedKeys(value, new Set(["claude", "codex", "context", "description", "events", "match", "name", "providers", "run", "status"]), path, "schema/adaptive-hook/key", diagnostics);
   checkOptionalNonEmptyString(value.name, `${path}.name`, "schema/adaptive-hook/name", diagnostics);
   checkOptionalNonEmptyString(value.description, `${path}.description`, "schema/adaptive-hook/description", diagnostics);
   checkOptionalNonEmptyString(value.status, `${path}.status`, "schema/adaptive-hook/status", diagnostics);
@@ -147,6 +147,7 @@ export function validateAdaptiveHookUnitSource(value: unknown, path = "$"): Skil
   checkAdaptiveHookMatch(value.match, `${path}.match`, diagnostics);
   checkOptionalObject(value.claude, `${path}.claude`, "schema/adaptive-hook/provider-override", diagnostics);
   checkOptionalObject(value.codex, `${path}.codex`, "schema/adaptive-hook/provider-override", diagnostics);
+  checkAdaptiveHookContext(value.context, `${path}.context`, diagnostics);
   checkAdaptiveHookRun(value.run, `${path}.run`, diagnostics);
   return result(diagnostics);
 }
@@ -612,6 +613,44 @@ function checkAdaptiveHookMatch(value: SchemaJsonValue | undefined, path: string
   }
   if (typeof value === "string" && value.trim().length === 0) {
     diagnostics.push(diagnostic(path, "schema/adaptive-hook/match", "adaptive hook match must be non-empty when present"));
+  }
+}
+
+const adaptiveHookContextStrategies = new Set(["inline", "none", "toolkit"]);
+const adaptiveHookContextEnvFields = new Set(["hook.event", "provider", "session.id"]);
+
+function checkAdaptiveHookContext(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/context", "adaptive hook context must be an object when present"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["env", "includeRaw", "strategy"]), path, "schema/adaptive-hook/context-key", diagnostics);
+  if (typeof value.strategy !== "string" || !adaptiveHookContextStrategies.has(value.strategy)) {
+    diagnostics.push(diagnostic(`${path}.strategy`, "schema/adaptive-hook/context-strategy", "adaptive hook context.strategy must be inline, none, or toolkit"));
+  }
+  if (value.includeRaw !== undefined && typeof value.includeRaw !== "boolean") {
+    diagnostics.push(diagnostic(`${path}.includeRaw`, "schema/adaptive-hook/context-include-raw", "adaptive hook context.includeRaw must be a boolean"));
+  }
+  if (value.env !== undefined) checkAdaptiveHookContextEnv(value.env, `${path}.env`, diagnostics);
+  if (value.strategy === "inline" && (!Array.isArray(value.env) || value.env.length === 0)) {
+    diagnostics.push(diagnostic(`${path}.env`, "schema/adaptive-hook/context-env", "adaptive hook context.env must be a non-empty array for inline strategy"));
+  }
+}
+
+function checkAdaptiveHookContextEnv(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!Array.isArray(value) || value.length === 0) {
+    diagnostics.push(diagnostic(path, "schema/adaptive-hook/context-env", "adaptive hook context.env must be a non-empty array when present"));
+    return;
+  }
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || !adaptiveHookContextEnvFields.has(item)) {
+      diagnostics.push(diagnostic(`${path}[${index}]`, "schema/adaptive-hook/context-env", "adaptive hook context.env entries must be provider, hook.event, or session.id"));
+      continue;
+    }
+    if (seen.has(item)) diagnostics.push(diagnostic(`${path}[${index}]`, "schema/adaptive-hook/context-env-duplicate", `duplicate adaptive hook context env field ${item}`));
+    seen.add(item);
   }
 }
 


### PR DESCRIPTION
## Context

SET-169 is now the narrow inline/none hook-context slice. PR #210 has landed, so this PR is based directly on `main` and no longer includes the command-island extraction.

The goal-loop audit found that:

- SET-118 and SET-127 were already satisfied by the merged adaptive hooks stack.
- SET-18 now follows ADR-0001: `error` is the only active unsupported destination policy, with soft policies reserved.
- SET-168/toolkit should stay internal/future until helper provenance is ready.
- SET-228 now owns the helper-backed/toolkit follow-up.

## What Changed

- Added adaptive hook `context` schema support:
  - `strategy: inline | none | toolkit`
  - inline fields: `provider`, `hook.event`, `session.id`
- Rendered `context.strategy: inline` into generated hook commands with explicit `SKILLSET_*` assignments:
  - plugin-level Claude and Codex hooks
  - Claude skill/project-agent frontmatter hooks
- Kept omitted context and `strategy: none` behavior-preserving.
- Kept `strategy: toolkit` schema-recognized but render-unsupported with a structured `adaptive-hooks` unsupported result.
- Updated generated schemas, lookup expectations, hooks docs, and Changesets.

## Verification

- `bun test packages/schema/src/__tests__/schema.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts packages/core/src/__tests__/render-result-build.test.ts packages/core/src/__tests__/lookup.test.ts`
- `bun run typecheck`
- `bun run check`

Local review: `.agents/goals/2026-06-29-skillset-hooks-runtime-closure/tmp/reviews/codex-set169/round1.json`

Score: 5/5, clean, open P0/P1/P2 = 0.

## Risks / Notes

- Inline context uses shell-style command prefixes because the adopted hook output contract does not expose a portable env map. This is documented and covered by generated-output tests.
- Toolkit strategy is intentionally reserved until SET-228 proves helper-backed runtime context delivery and informs SET-168.
