### PR TITLE
feat(hooks): prove toolkit context helper path

### DIFF
--- a/.changeset/toolkit-context-proof.md
+++ b/.changeset/toolkit-context-proof.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Render adaptive hooks with `context.strategy: toolkit` through an internal `skillset hooks context` runtime helper, proving helper-backed context delivery before the public toolkit package boundary lands.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1520,6 +1520,60 @@ test("SET-41: hooks print emits target runtime suggestions without installing", 
   expect(importKind.stderr).toContain("non-hook options are not supported");
 });
 
+test("SET-228: hooks context emits helper-backed runtime context", async () => {
+  const env = await runSkillsetCliWithEnv(
+    { CODEX_SESSION_ID: "session-1", SKILLSET_PROVIDER: "codex" },
+    "hooks",
+    "context",
+    "--event",
+    "Stop",
+    "--format",
+    "env",
+    "--context-fields",
+    "provider,hook.event,session.id"
+  );
+  expect(env.exitCode).toBe(0);
+  expect(env.stderr).toBe("");
+  expect(env.stdout).toBe([
+    "export SKILLSET_PROVIDER=codex",
+    "export SKILLSET_HOOK_EVENT=Stop",
+    "export SKILLSET_SESSION_ID=session-1",
+    "",
+  ].join("\n"));
+
+  const json = await runSkillsetCliWithEnv(
+    { CLAUDE_SESSION_ID: "session-2", SKILLSET_PROVIDER: "claude" },
+    "hooks",
+    "context",
+    "--event",
+    "PreToolUse",
+    "--format",
+    "json",
+    "--context-fields",
+    "provider,hook.event"
+  );
+  expect(json.exitCode).toBe(0);
+  expect(json.stderr).toBe("");
+  expect(JSON.parse(json.stdout)).toEqual(expect.objectContaining({
+    hook: { event: "PreToolUse" },
+    provider: "claude",
+    schemaVersion: 1,
+  }));
+
+  const missingEvent = await runSkillsetCli("hooks", "context", "--format", "env");
+  expect(missingEvent.exitCode).toBe(1);
+  expect(missingEvent.stderr).toContain("hooks context requires --event");
+
+  const printWithContextFlag = await runSkillsetCli("hooks", "print", "--runner", "git", "--context-fields", "provider");
+  expect(printWithContextFlag.exitCode).toBe(1);
+  expect(printWithContextFlag.stderr).toContain("hook context options are only supported with hooks context");
+
+  const cliPath = shellQuote(join(import.meta.dir, "..", "cli.ts"));
+  const stdinPreserved = await runShell(`printf payload | (eval "$(bun ${cliPath} hooks context --event Stop --format env --context-fields provider)" && cat)`);
+  expect(stdinPreserved.exitCode).toBe(0);
+  expect(stdinPreserved.stdout).toBe("payload");
+});
+
 test("SET-55: hooks run is a CLI-owned runtime entrypoint", async () => {
   const cleanRoot = await contractFixture({ "README.md": "clean\n" });
   await commitFixture(cleanRoot);
@@ -7173,6 +7227,47 @@ async function runSkillsetCliIn(cwd: string, ...args: readonly string[]): Promis
     proc.exited,
   ]);
   return { exitCode, stderr, stdout };
+}
+
+async function runSkillsetCliWithEnv(env: Record<string, string>, ...args: readonly string[]): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    env: { ...process.env, ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+async function runShell(command: string): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["sh", "-c", command],
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
 async function runSkillsetCliWithInput(input: string, ...args: readonly string[]): Promise<{

--- a/apps/skillset/src/__tests__/runtime-hooks.test.ts
+++ b/apps/skillset/src/__tests__/runtime-hooks.test.ts
@@ -9,6 +9,7 @@ import {
   hasHookRelevantSourceChanges,
   hookRelevantSourcePaths,
   readHookRuntimeContext,
+  renderHookRuntimeContext,
   resolveSkillsetCommand,
   runHookEvent,
   runSkillsetCommand,
@@ -132,6 +133,45 @@ test("runtime hook context parser accepts unknown, Claude, Codex, and stdin payl
   expect(codex.repoRoot).toBe("/tmp/codex");
   expect(codex.payload).toBeUndefined();
   expect(codex.payloadError).toContain("JSON");
+});
+
+test("runtime hook context renderer emits env and JSON for generated wrappers", async () => {
+  const envText = await renderHookRuntimeContext({
+    env: {
+      CLAUDE_PROJECT_DIR: "/tmp/claude",
+      CLAUDE_SESSION_ID: "session 1",
+      SKILLSET_HOOK_EVENT: "Stop",
+      SKILLSET_PROVIDER: "claude",
+    },
+    event: "Stop",
+    fields: ["provider", "hook.event", "session.id"],
+    format: "env",
+    rootPath: "/tmp/repo",
+  });
+  expect(envText).toBe([
+    "export SKILLSET_PROVIDER=claude",
+    "export SKILLSET_HOOK_EVENT=Stop",
+    "export SKILLSET_SESSION_ID='session 1'",
+    "",
+  ].join("\n"));
+
+  const jsonText = await renderHookRuntimeContext({
+    env: { CODEX_REPO_ROOT: "/tmp/codex" },
+    event: "PreToolUse",
+    fields: ["provider", "hook.event", "session.id"],
+    format: "json",
+    rootPath: "/tmp/repo",
+  });
+  const report = JSON.parse(jsonText) as {
+    readonly hook: { readonly event: string };
+    readonly provider: string;
+    readonly raw: { readonly env: Record<string, string> };
+    readonly session: { readonly id?: string };
+  };
+  expect(report.provider).toBe("codex");
+  expect(report.hook.event).toBe("PreToolUse");
+  expect(report.session).toEqual({});
+  expect(report.raw.env.CODEX_REPO_ROOT).toBe("/tmp/codex");
 });
 
 test("post-tool-use is advisory and only runs status when Skillset source changed", async () => {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -47,9 +47,14 @@ import { printDiagnostics, printDiffPlan, printGeneratedChangelogDriftHint, prin
 import { runDevWatch } from "./dev-watch";
 import {
   dispatchHookRun,
+  readHookRuntimeContextField,
+  readHookRuntimeContextFormat,
   readHookRunEvent,
   readHookStdin,
   renderHookPrint,
+  renderHookRuntimeContext,
+  type HookRuntimeContextField,
+  type HookRuntimeContextFormat,
   type HookRunEvent,
   type HookRunner,
   type HookSubcommand,
@@ -139,6 +144,7 @@ const USAGE = [
   "       skillset hooks print --runner <lefthook|husky|pre-commit|git> [--pre-commit] [--pre-push]",
   "       skillset hooks print --target <claude|codex> --agent-runtime",
   "       skillset hooks run <post-tool-use|stop> [--root <path>]",
+  "       skillset hooks context --event <event> [--format env|json] [--context-fields <field,...>] [--root <path>]",
   "       skillset adopt <path> [--yes|--dry-run] [--targets claude,codex] [--root <path>]",
   "       skillset init [path] [--yes|--dry-run] [--targets claude,codex] [--include ci] [--layout root|nested] [--name <name>] [--root <path>]",
   "       skillset create [path|--global] [--yes|--dry-run] [--targets claude,codex] [--include ci] [--name <name>] [--root <path>]",
@@ -175,6 +181,9 @@ export async function runCli(
     distributionName,
     distributionSubcommand,
     hookAgentRuntime,
+    hookContextEvent,
+    hookContextFields,
+    hookContextFormat,
     hookPreCommit,
     hookPrePush,
     hookRunner,
@@ -457,7 +466,17 @@ export async function runCli(
       if (result.exitCode !== 0) process.exitCode = result.exitCode;
       return;
     }
-    throw new Error("skillset: expected hooks subcommand print or run");
+    if (hookSubcommand === "context") {
+      if (hookContextEvent === undefined) throw new Error("skillset: hooks context requires --event");
+      process.stdout.write(await renderHookRuntimeContext({
+        event: hookContextEvent,
+        ...(hookContextFields === undefined ? {} : { fields: hookContextFields }),
+        format: hookContextFormat ?? "json",
+        rootPath,
+      }));
+      return;
+    }
+    throw new Error("skillset: expected hooks subcommand context, print, or run");
   }
 
   if (command === "test") {
@@ -792,6 +811,9 @@ interface ParsedArgs {
   readonly distributionSubcommand?: DistributionSubcommand;
   readonly dryRun: boolean;
   readonly hookAgentRuntime: boolean;
+  readonly hookContextEvent?: string;
+  readonly hookContextFields?: readonly HookRuntimeContextField[];
+  readonly hookContextFormat?: HookRuntimeContextFormat;
   readonly hookPreCommit: boolean;
   readonly hookPrePush: boolean;
   readonly hookRunner?: HookRunner;
@@ -1410,6 +1432,9 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let ciReportPath: string | undefined;
   let devWatch = false;
   let hookAgentRuntime = false;
+  let hookContextEvent: string | undefined;
+  let hookContextFields: readonly HookRuntimeContextField[] | undefined;
+  let hookContextFormat: HookRuntimeContextFormat | undefined;
   let hookPreCommit = false;
   let hookPrePush = false;
   let hookRunner: HookRunner | undefined;
@@ -1494,8 +1519,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
 
   if (command === "hooks") {
     const subcommand = args[index];
-    if (subcommand !== "print" && subcommand !== "run") {
-      throw new Error("skillset: expected hooks subcommand print or run");
+    if (subcommand !== "context" && subcommand !== "print" && subcommand !== "run") {
+      throw new Error("skillset: expected hooks subcommand context, print, or run");
     }
     hookSubcommand = subcommand;
     index += 1;
@@ -1678,7 +1703,10 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag !== "--claude-setting-sources" &&
       flag !== "--timeout-ms" &&
       flag !== "--lines" &&
-      flag !== "--background"
+      flag !== "--background" &&
+      flag !== "--event" &&
+      flag !== "--format" &&
+      flag !== "--context-fields"
     ) {
       throw new Error(`skillset: unknown option ${arg}`);
     }
@@ -1797,6 +1825,9 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--report") ciReportPath = value;
     if (flag === "--field") lookupField = setLookupField(lookupField, value);
     if (flag === "--runner") hookRunner = readHookRunner(value);
+    if (flag === "--event") hookContextEvent = value;
+    if (flag === "--format") hookContextFormat = readHookRuntimeContextFormat(value);
+    if (flag === "--context-fields") hookContextFields = readHookRuntimeContextFields(value);
     if (flag === "--target") {
       if (command === "runtime-tester") runtimeTesterTarget = readHookTarget(value);
       else hookTarget = readHookTarget(value);
@@ -1853,6 +1884,9 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(changeSince === undefined ? {} : { changeSince }),
     ...(distDir === undefined ? {} : { distDir }),
     dryRun,
+    ...(hookContextEvent === undefined ? {} : { contextEvent: hookContextEvent }),
+    ...(hookContextFields === undefined ? {} : { contextFields: hookContextFields }),
+    ...(hookContextFormat === undefined ? {} : { contextFormat: hookContextFormat }),
     ...(importKind === undefined ? {} : { importKind }),
     ...(importName === undefined ? {} : { importName }),
     ...(importProvider === undefined ? {} : { importProvider }),
@@ -2020,6 +2054,9 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
     dryRun,
     hookAgentRuntime,
+    ...(hookContextEvent === undefined ? {} : { hookContextEvent }),
+    ...(hookContextFields === undefined ? {} : { hookContextFields }),
+    ...(hookContextFormat === undefined ? {} : { hookContextFormat }),
     hookPreCommit,
     hookPrePush,
     ...(hookRunner === undefined ? {} : { hookRunner }),
@@ -2102,6 +2139,12 @@ function readChangeScopes(value: string): readonly string[] {
   const scopes = value.split(",").map((scope) => scope.trim()).filter((scope) => scope.length > 0);
   if (scopes.length === 0) throw new Error("skillset: --scope requires at least one source unit scope");
   return scopes.map(sourceUnitSelector);
+}
+
+function readHookRuntimeContextFields(value: string): readonly HookRuntimeContextField[] {
+  const fields = value.split(",").map((field) => field.trim()).filter((field) => field.length > 0);
+  if (fields.length === 0) throw new Error("skillset: --context-fields requires at least one field");
+  return fields.map(readHookRuntimeContextField);
 }
 
 function readChangeBump(value: string): ChangeBump {
@@ -2194,6 +2237,9 @@ function validateHookFlags(
     readonly agentRuntime: boolean;
     readonly buildMode?: CompileBuildMode;
     readonly changeSince?: string;
+    readonly contextEvent?: string;
+    readonly contextFields?: readonly HookRuntimeContextField[];
+    readonly contextFormat?: HookRuntimeContextFormat;
     readonly distDir?: string;
     readonly dryRun: boolean;
     readonly importKind?: ImportKind;
@@ -2215,12 +2261,22 @@ function validateHookFlags(
     hooks.prePush ||
     hooks.runner !== undefined ||
     hooks.target !== undefined;
+  const hasHookContextFlag =
+    hooks.contextEvent !== undefined ||
+    hooks.contextFields !== undefined ||
+    hooks.contextFormat !== undefined;
   if (hasHookPrintFlag && (command !== "hooks" || hooks.subcommand !== "print")) {
     throw new Error("skillset: hook options are only supported with hooks print");
   }
+  if (hasHookContextFlag && (command !== "hooks" || hooks.subcommand !== "context")) {
+    throw new Error("skillset: hook context options are only supported with hooks context");
+  }
   if (command !== "hooks") return;
-  if (hooks.subcommand !== "print" && hooks.subcommand !== "run") {
-    throw new Error("skillset: expected hooks subcommand print or run");
+  if (hooks.subcommand !== "context" && hooks.subcommand !== "print" && hooks.subcommand !== "run") {
+    throw new Error("skillset: expected hooks subcommand context, print, or run");
+  }
+  if (hooks.subcommand === "context" && hooks.contextEvent === undefined) {
+    throw new Error("skillset: hooks context requires --event");
   }
   if (
     hooks.buildMode !== undefined ||

--- a/apps/skillset/src/runtime-hooks/context.ts
+++ b/apps/skillset/src/runtime-hooks/context.ts
@@ -1,11 +1,12 @@
 import { gitSafeEnv } from "../git-env";
-import type { HookRunEvent } from "./events";
 
 export type HookRuntimeProvider = "claude" | "codex" | "unknown";
+export type HookRuntimeContextField = "hook.event" | "provider" | "session.id";
+export type HookRuntimeContextFormat = "env" | "json";
 
 export interface HookRuntimeContext {
   readonly cwd: string;
-  readonly event: HookRunEvent;
+  readonly event: string;
   readonly payload?: unknown;
   readonly payloadError?: string;
   readonly provider: HookRuntimeProvider;
@@ -16,9 +17,14 @@ export interface HookRuntimeContext {
 export interface HookRuntimeContextOptions {
   readonly cwd?: string;
   readonly env?: Record<string, string | undefined>;
-  readonly event: HookRunEvent;
+  readonly event: string;
   readonly rootPath?: string;
   readonly stdinText?: string;
+}
+
+export interface HookRuntimeContextRenderOptions extends HookRuntimeContextOptions {
+  readonly fields?: readonly HookRuntimeContextField[];
+  readonly format: HookRuntimeContextFormat;
 }
 
 const CLAUDE_ENV_KEYS = [
@@ -33,7 +39,14 @@ const CODEX_ENV_KEYS = [
   "CODEX_SESSION_ID",
   "OPENAI_WORKSPACE_ROOT",
 ] as const;
-const KNOWN_ENV_KEYS = [...CLAUDE_ENV_KEYS, ...CODEX_ENV_KEYS, "PWD", "SKILLSET_HOOK_COMMAND"] as const;
+const SKILLSET_ENV_KEYS = [
+  "SKILLSET_HOOK_COMMAND",
+  "SKILLSET_HOOK_EVENT",
+  "SKILLSET_PROVIDER",
+  "SKILLSET_SESSION_ID",
+] as const;
+const KNOWN_ENV_KEYS = [...CLAUDE_ENV_KEYS, ...CODEX_ENV_KEYS, ...SKILLSET_ENV_KEYS, "PWD"] as const;
+const HOOK_RUNTIME_CONTEXT_FIELDS = ["provider", "hook.event", "session.id"] as const satisfies readonly HookRuntimeContextField[];
 
 export async function readHookRuntimeContext(
   options: HookRuntimeContextOptions
@@ -59,6 +72,7 @@ export async function readHookStdin(): Promise<string | undefined> {
 }
 
 function detectProvider(env: Record<string, string | undefined>): HookRuntimeProvider {
+  if (env.SKILLSET_PROVIDER === "claude" || env.SKILLSET_PROVIDER === "codex") return env.SKILLSET_PROVIDER;
   if (Object.keys(env).some((key) => key.startsWith("CLAUDE_"))) return "claude";
   if (Object.keys(env).some((key) => key.startsWith("CODEX_"))) return "codex";
   if (env.OPENAI_WORKSPACE_ROOT !== undefined) return "codex";
@@ -95,4 +109,77 @@ async function gitRoot(cwd: string): Promise<string | undefined> {
   if (exitCode !== 0) return undefined;
   const root = stdout.trim();
   return root.length === 0 ? undefined : root;
+}
+
+export function readHookRuntimeContextField(value: string): HookRuntimeContextField {
+  if ((HOOK_RUNTIME_CONTEXT_FIELDS as readonly string[]).includes(value)) return value as HookRuntimeContextField;
+  throw new Error("skillset: hooks context field must be provider, hook.event, or session.id");
+}
+
+export function readHookRuntimeContextFormat(value: string): HookRuntimeContextFormat {
+  if (value === "env" || value === "json") return value;
+  throw new Error("skillset: hooks context --format must be env or json");
+}
+
+export async function renderHookRuntimeContext(options: HookRuntimeContextRenderOptions): Promise<string> {
+  const context = await readHookRuntimeContext(options);
+  const fields = [...(options.fields ?? HOOK_RUNTIME_CONTEXT_FIELDS)];
+  if (options.format === "env") return renderHookRuntimeEnv(context, fields);
+  return `${JSON.stringify(hookRuntimeContextJson(context, fields), null, 2)}\n`;
+}
+
+function renderHookRuntimeEnv(
+  context: HookRuntimeContext,
+  fields: readonly HookRuntimeContextField[]
+): string {
+  return fields
+    .map((field) => `export ${envNameForField(field)}=${shellQuote(runtimeContextFieldValue(context, field) ?? "")}`)
+    .join("\n") + "\n";
+}
+
+function hookRuntimeContextJson(
+  context: HookRuntimeContext,
+  fields: readonly HookRuntimeContextField[]
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    raw: { env: context.rawEnv },
+    schemaVersion: 1,
+  };
+  if (fields.includes("provider")) result.provider = runtimeContextFieldValue(context, "provider");
+  if (fields.includes("hook.event")) result.hook = { event: runtimeContextFieldValue(context, "hook.event") };
+  if (fields.includes("session.id")) {
+    const sessionId = runtimeContextFieldValue(context, "session.id");
+    result.session = sessionId === undefined ? {} : { id: sessionId };
+  }
+  return result;
+}
+
+function runtimeContextFieldValue(
+  context: HookRuntimeContext,
+  field: HookRuntimeContextField
+): string | undefined {
+  switch (field) {
+    case "provider":
+      return context.provider;
+    case "hook.event":
+      return context.rawEnv.SKILLSET_HOOK_EVENT ?? context.event;
+    case "session.id":
+      return context.rawEnv.SKILLSET_SESSION_ID ?? context.rawEnv.CLAUDE_SESSION_ID ?? context.rawEnv.CODEX_SESSION_ID;
+  }
+}
+
+function envNameForField(field: HookRuntimeContextField): string {
+  switch (field) {
+    case "provider":
+      return "SKILLSET_PROVIDER";
+    case "hook.event":
+      return "SKILLSET_HOOK_EVENT";
+    case "session.id":
+      return "SKILLSET_SESSION_ID";
+  }
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:-]*$/.test(value)) return value.length === 0 ? "''" : value;
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }

--- a/apps/skillset/src/runtime-hooks/events.ts
+++ b/apps/skillset/src/runtime-hooks/events.ts
@@ -1,7 +1,7 @@
 export const HOOK_RUN_EVENTS = ["post-tool-use", "stop"] as const;
 
 export type HookRunEvent = (typeof HOOK_RUN_EVENTS)[number];
-export type HookSubcommand = "print" | "run";
+export type HookSubcommand = "context" | "print" | "run";
 
 export function isHookRunEvent(value: string | undefined): value is HookRunEvent {
   return value === "post-tool-use" || value === "stop";

--- a/apps/skillset/src/runtime-hooks/index.ts
+++ b/apps/skillset/src/runtime-hooks/index.ts
@@ -7,9 +7,15 @@ export {
 } from "./commands";
 export {
   readHookRuntimeContext,
+  readHookRuntimeContextField,
+  readHookRuntimeContextFormat,
   readHookStdin,
+  renderHookRuntimeContext,
   type HookRuntimeContext,
+  type HookRuntimeContextField,
+  type HookRuntimeContextFormat,
   type HookRuntimeContextOptions,
+  type HookRuntimeContextRenderOptions,
   type HookRuntimeProvider,
 } from "./context";
 export {

--- a/docs/features/hook-guardrails.md
+++ b/docs/features/hook-guardrails.md
@@ -21,6 +21,7 @@ skillset hooks print --target claude --agent-runtime
 skillset hooks print --target codex --agent-runtime
 skillset hooks run post-tool-use
 skillset hooks run stop
+skillset hooks context --event Stop --format env --context-fields provider,hook.event,session.id
 ```
 
 ## Target Rendering
@@ -30,6 +31,7 @@ skillset hooks run stop
 | Git hook-runner snippet | n/a | n/a | `implemented` | Prints additive snippets for existing hook runners; does not install. |
 | Agent runtime hook suggestion | reviewed config suggestion | reviewed config suggestion | `implemented` / `target_specific` | Prints project-local suggestions; must not mutate runtime config automatically. |
 | Agent runtime hook execution | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `implemented` / `target_specific` | Core CLI behavior called by reviewed project-local runtime config. |
+| Runtime context helper | `skillset hooks context --event <event> --format env|json` | `skillset hooks context --event <event> --format env|json` | `implemented` / `target_specific` | Internal helper used by generated adaptive hook wrappers for `context.strategy: toolkit`; public package surface is tracked separately. |
 
 ## Diagnostics
 

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -86,7 +86,7 @@ Adaptive hook units can choose how much Skillset-normalized runtime context to p
 | --- | --- |
 | `inline` | Prefixes the generated command with requested `SKILLSET_*` environment assignments. |
 | `none` | Passes no Skillset-normalized context. Provider-native environment remains available. |
-| `toolkit` | Reserved until Skillset has a proven internal/public runtime helper boundary. It produces an explicit unsupported render result today. |
+| `toolkit` | Renders through Skillset's internal `skillset hooks context` helper. This proves the helper-backed wrapper path before the public `@skillset/toolkit/runtime` package boundary lands. |
 
 Inline v1 fields are deliberately small:
 
@@ -97,6 +97,14 @@ Inline v1 fields are deliberately small:
 | `session.id` | `SKILLSET_SESSION_ID`, sourced from `${CLAUDE_SESSION_ID:-}` or `${CODEX_SESSION_ID:-}` |
 
 Omitting `context` is equivalent to `context.strategy: none`, so existing hooks keep their command text unchanged.
+
+For `context.strategy: toolkit`, generated hooks call:
+
+```sh
+skillset hooks context --event <event> --format env --context-fields <field,...>
+```
+
+The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. This is an internal proof surface for generated wrappers; public JS/TS and shell package surfaces are tracked separately under the `@skillset/toolkit` follow-up stack.
 
 ### Attachments
 

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -343,6 +343,57 @@ hooks:
     });
   });
 
+  test("renders toolkit hook context for plugin-level adaptive hooks", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-toolkit-context-render
+claude: true
+codex: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - session-summary
+`,
+      ".skillset/plugins/demo/hooks/session-summary.json": JSON.stringify({
+        context: {
+          env: ["provider", "hook.event", "session.id"],
+          strategy: "toolkit",
+        },
+        events: ["Stop"],
+        run: { command: "node ./session-summary.js" },
+      }),
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    const claudeHooks = renderedJson(rendered, "plugins-claude/plugins/demo/hooks/hooks.json");
+    const codexHooks = renderedJson(rendered, "plugins-codex/plugins/demo/hooks/hooks.json");
+
+    expect(claudeHooks).toEqual({
+      hooks: {
+        Stop: [{
+          hooks: [{
+            command: 'eval "$(SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop skillset hooks context --event Stop --format env --context-fields \'provider,hook.event,session.id\')" && node ./session-summary.js',
+            type: "command",
+          }],
+        }],
+      },
+    });
+    expect(codexHooks).toEqual({
+      hooks: {
+        Stop: [{
+          hooks: [{
+            command: 'eval "$(SKILLSET_PROVIDER=codex SKILLSET_HOOK_EVENT=Stop skillset hooks context --event Stop --format env --context-fields \'provider,hook.event,session.id\')" && node ./session-summary.js',
+            type: "command",
+          }],
+        }],
+      },
+    });
+  });
+
   test("renders Claude skill and project-agent adaptive hooks into frontmatter", async () => {
     const graph = await loadBuildGraph(await fixture({
       "skillset.yaml": `
@@ -440,6 +491,48 @@ Body.
       Stop: [{
         hooks: [{
           command: "SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop echo skill",
+          type: "command",
+        }],
+      }],
+    });
+  });
+
+  test("renders toolkit hook context for Claude frontmatter adaptive hooks", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-frontmatter-toolkit-context
+claude: true
+codex: false
+`,
+      ".skillset/skills/writer/SKILL.md": `
+---
+name: writer
+description: Demo writer.
+hooks:
+  Stop:
+    - local-stop
+---
+
+Body.
+`,
+      ".skillset/skills/writer/hooks/local-stop.json": JSON.stringify({
+        context: {
+          env: ["provider", "hook.event"],
+          strategy: "toolkit",
+        },
+        events: ["Stop"],
+        run: { command: "echo skill" },
+      }),
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    const skillFrontmatter = renderedMarkdown(rendered, ".claude/skills/writer/SKILL.md").frontmatter;
+
+    expect(skillFrontmatter.hooks).toEqual({
+      Stop: [{
+        hooks: [{
+          command: 'eval "$(SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop skillset hooks context --event Stop --format env --context-fields \'provider,hook.event\')" && echo skill',
           type: "command",
         }],
       }],

--- a/packages/core/src/__tests__/render-result-build.test.ts
+++ b/packages/core/src/__tests__/render-result-build.test.ts
@@ -807,34 +807,6 @@ hooks:
       sourceUnit: "plugin.demo.feature:hooks",
     });
 
-    const toolkitContextRoot = await fixture({
-      "skillset.yaml": `
-skillset:
-  name: adaptive-hook-policy-toolkit-context
-claude: true
-codex: false
-`,
-      ".skillset/plugins/demo/skillset.yaml": `
-skillset:
-  name: demo
-hooks:
-  Stop:
-    - shell-policy
-`,
-      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
-        context: { strategy: "toolkit" },
-        events: ["Stop"],
-        run: { command: "echo ok" },
-      }),
-    });
-    await expectUnsupportedOutcome(toolkitContextRoot, {
-      destination: "hooks",
-      featureId: "adaptive-hooks",
-      reason: "Adaptive hook shell-policy uses context.strategy toolkit, but plugin hook rendering does not support toolkit context delivery yet.",
-      sourceUnit: "plugin.demo.feature:hooks",
-      target: "claude",
-    });
-
     const runtimePathRoot = await fixture({
       "skillset.yaml": `
 skillset:

--- a/packages/core/src/adaptive-hook-render-support.ts
+++ b/packages/core/src/adaptive-hook-render-support.ts
@@ -26,12 +26,6 @@ function adaptiveHookUnsupportedFieldReason(
     return `Adaptive hook ${item.definition.name} uses ${target} provider overrides, but ${surface} hook rendering does not support overrides yet.`;
   }
 
-  const context = readRecord(item.definition.frontmatter, "context");
-  const contextStrategy = context === undefined ? undefined : readContextStrategy(context);
-  if (contextStrategy === "toolkit") {
-    return `Adaptive hook ${item.definition.name} uses context.strategy toolkit, but ${surface} hook rendering does not support toolkit context delivery yet.`;
-  }
-
   const run = readRecord(item.definition.frontmatter, "run") ?? {};
   for (const key of ["args", "cwd", "env"] as const) {
     if (run[key] !== undefined) {
@@ -45,11 +39,6 @@ function adaptiveHookUnsupportedFieldReason(
   }
 
   return undefined;
-}
-
-function readContextStrategy(context: Record<string, unknown>): string | undefined {
-  const strategy = context.strategy;
-  return typeof strategy === "string" ? strategy : undefined;
 }
 
 function adaptiveHookUnsupportedCapabilityReason(

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1876,6 +1876,9 @@ function withAdaptiveHookContextCommand(
   if (context === undefined) return command;
   const strategy = readString(context, "strategy") ?? "none";
   if (strategy === "none") return command;
+  if (strategy === "toolkit") {
+    return withAdaptiveHookToolkitContextCommand(command, item, target, readStringArray(context, "env") ?? []);
+  }
   if (strategy !== "inline") {
     throw new Error(`skillset: adaptive hook ${item.definition.name} context.strategy ${strategy} is not supported for rendering yet`);
   }
@@ -1885,6 +1888,20 @@ function withAdaptiveHookContextCommand(
   }
   const assignments = fields.map((field) => adaptiveHookContextAssignment(field, item, target));
   return `${assignments.join(" ")} ${command}`;
+}
+
+function withAdaptiveHookToolkitContextCommand(
+  command: string,
+  item: ResolvedAdaptiveHookAttachment,
+  target: TargetName,
+  fields: readonly string[]
+): string {
+  const event = shellLiteral(item.event);
+  const provider = `SKILLSET_PROVIDER=${target}`;
+  const hookEvent = `SKILLSET_HOOK_EVENT=${event}`;
+  const fieldArgs = fields.length === 0 ? "" : ` --context-fields ${shellLiteral(fields.join(","))}`;
+  const helper = `${provider} ${hookEvent} skillset hooks context --event ${event} --format env${fieldArgs}`;
+  return `eval "$(${helper})" && ${command}`;
 }
 
 function adaptiveHookContextAssignment(


### PR DESCRIPTION
## Context

SET-228 is the proof gate before the public `@skillset/toolkit/runtime` work. SET-169 left `context.strategy: toolkit` schema-recognized but render-unsupported; this PR proves an internal helper-backed wrapper path without publishing or promising the package boundary.

## What Changed

- Added `skillset hooks context --event <event> --format env|json --context-fields <field,...>`.
- Reused the runtime hook context parser to emit normalized `SKILLSET_PROVIDER`, `SKILLSET_HOOK_EVENT`, and `SKILLSET_SESSION_ID` plus JSON/raw env output.
- Rendered adaptive hooks with `context.strategy: toolkit` through the internal helper for plugin hooks and Claude frontmatter hooks.
- Preserved `inline` and `none` behavior.
- Documented the internal helper-backed strategy and kept public `@skillset/toolkit/runtime` package work in SET-229+.
- Added a regression test proving `hooks context` does not consume hook stdin before the user hook command.

## Verification

- `bun test apps/skillset/src/__tests__/runtime-hooks.test.ts apps/skillset/src/__tests__/contract.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts packages/core/src/__tests__/render-result-build.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run changeset:check`
- `bun run skillset:ci`
- pre-push hook: changesets, workflow lint, `skillset ci --since trunk`, and full `bun run check`
- `bun ./apps/skillset/src/cli.ts lookup hooks adaptive --field context.strategy --values`
- `SKILLSET_PROVIDER=codex CODEX_SESSION_ID=session-123 bun ./apps/skillset/src/cli.ts hooks context --event Stop --format env --context-fields provider,hook.event,session.id`
- `printf 'payload' | (eval "$(SKILLSET_PROVIDER=claude bun ./apps/skillset/src/cli.ts hooks context --event Stop --format env --context-fields provider,hook.event)" && cat)`

Local review: `.agents/goals/2026-06-30-skillset-toolkit-runtime-context/tmp/reviews/codex-set228/round1.json`

Score: 5/5, clean, open P0/P1/P2 = 0.

## Risks / Notes

- Runtime tester does not currently invoke provider hooks; proof is through generated wrapper tests and direct helper CLI execution. SET-231/SET-232 can decide whether to add live hook invocation fixtures.
- This intentionally does not create or publish `@skillset/toolkit`; SET-229 owns that package boundary.
