### PR TITLE
feat(toolkit): promote runtime context package

### DIFF
--- a/.changeset/hook-context-inline.md
+++ b/.changeset/hook-context-inline.md
@@ -1,7 +1,5 @@
 ---
 "skillset": patch
-"@skillset/core": patch
-"@skillset/schema": patch
 ---
 
 Add inline adaptive hook runtime context delivery while reserving toolkit-backed hooks until helper provenance is ready.

--- a/.changeset/toolkit-runtime-package.md
+++ b/.changeset/toolkit-runtime-package.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Promote the runtime context helper into the private `@skillset/toolkit/runtime` workspace package so hook scripts can build against the same typed provider context model the CLI uses.

--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -36,6 +36,7 @@
     "@skillset/lint": "workspace:*",
     "@skillset/provider-formats": "workspace:*",
     "@skillset/schema": "workspace:*",
+    "@skillset/toolkit": "workspace:*",
     "@skillset/transforms": "workspace:*"
   }
 }

--- a/apps/skillset/src/__tests__/runtime-hooks.test.ts
+++ b/apps/skillset/src/__tests__/runtime-hooks.test.ts
@@ -8,8 +8,6 @@ import { gitSafeEnv } from "../git-env";
 import {
   hasHookRelevantSourceChanges,
   hookRelevantSourcePaths,
-  readHookRuntimeContext,
-  renderHookRuntimeContext,
   resolveSkillsetCommand,
   runHookEvent,
   runSkillsetCommand,
@@ -97,81 +95,6 @@ test("runtime hook command runner strips inherited Git repository environment", 
     if (previousGitDir === undefined) delete process.env.GIT_DIR;
     else process.env.GIT_DIR = previousGitDir;
   }
-});
-
-test("runtime hook context parser accepts unknown, Claude, Codex, and stdin payload shapes", async () => {
-  const unknown = await readHookRuntimeContext({
-    cwd: "/tmp/repo",
-    env: {},
-    event: "post-tool-use",
-    rootPath: "/tmp/repo",
-  });
-  expect(unknown.provider).toBe("unknown");
-  expect(unknown.repoRoot).toBe("/tmp/repo");
-
-  const claude = await readHookRuntimeContext({
-    cwd: "/tmp/repo",
-    env: { CLAUDE_PROJECT_DIR: "/tmp/claude", CLAUDE_SESSION_ID: "session-1" },
-    event: "post-tool-use",
-    stdinText: "{\"tool\":\"Write\"}",
-  });
-  expect(claude.provider).toBe("claude");
-  expect(claude.repoRoot).toBe("/tmp/claude");
-  expect(claude.payload).toEqual({ tool: "Write" });
-  expect(claude.rawEnv).toEqual({
-    CLAUDE_PROJECT_DIR: "/tmp/claude",
-    CLAUDE_SESSION_ID: "session-1",
-  });
-
-  const codex = await readHookRuntimeContext({
-    cwd: "/tmp/repo",
-    env: { CODEX_REPO_ROOT: "/tmp/codex", CODEX_SESSION_ID: "session-2" },
-    event: "stop",
-    stdinText: "{not json",
-  });
-  expect(codex.provider).toBe("codex");
-  expect(codex.repoRoot).toBe("/tmp/codex");
-  expect(codex.payload).toBeUndefined();
-  expect(codex.payloadError).toContain("JSON");
-});
-
-test("runtime hook context renderer emits env and JSON for generated wrappers", async () => {
-  const envText = await renderHookRuntimeContext({
-    env: {
-      CLAUDE_PROJECT_DIR: "/tmp/claude",
-      CLAUDE_SESSION_ID: "session 1",
-      SKILLSET_HOOK_EVENT: "Stop",
-      SKILLSET_PROVIDER: "claude",
-    },
-    event: "Stop",
-    fields: ["provider", "hook.event", "session.id"],
-    format: "env",
-    rootPath: "/tmp/repo",
-  });
-  expect(envText).toBe([
-    "export SKILLSET_PROVIDER=claude",
-    "export SKILLSET_HOOK_EVENT=Stop",
-    "export SKILLSET_SESSION_ID='session 1'",
-    "",
-  ].join("\n"));
-
-  const jsonText = await renderHookRuntimeContext({
-    env: { CODEX_REPO_ROOT: "/tmp/codex" },
-    event: "PreToolUse",
-    fields: ["provider", "hook.event", "session.id"],
-    format: "json",
-    rootPath: "/tmp/repo",
-  });
-  const report = JSON.parse(jsonText) as {
-    readonly hook: { readonly event: string };
-    readonly provider: string;
-    readonly raw: { readonly env: Record<string, string> };
-    readonly session: { readonly id?: string };
-  };
-  expect(report.provider).toBe("codex");
-  expect(report.hook.event).toBe("PreToolUse");
-  expect(report.session).toEqual({});
-  expect(report.raw.env.CODEX_REPO_ROOT).toBe("/tmp/codex");
 });
 
 test("post-tool-use is advisory and only runs status when Skillset source changed", async () => {

--- a/apps/skillset/src/changeset-awareness.ts
+++ b/apps/skillset/src/changeset-awareness.ts
@@ -50,6 +50,7 @@ export function isPackageAffectingPath(path: string) {
   if (isRuntimeSourcePath(path, "packages/lint/src")) return true;
   if (isRuntimeSourcePath(path, "packages/provider-formats/src")) return true;
   if (isRuntimeSourcePath(path, "packages/schema/src")) return true;
+  if (isRuntimeSourcePath(path, "packages/toolkit/src")) return true;
   if (isRuntimeSourcePath(path, "packages/transforms/src")) return true;
 
   return (
@@ -57,6 +58,7 @@ export function isPackageAffectingPath(path: string) {
     path === "packages/lint/package.json" ||
     path === "packages/provider-formats/package.json" ||
     path === "packages/schema/package.json" ||
+    path === "packages/toolkit/package.json" ||
     path === "packages/transforms/package.json"
   );
 }

--- a/apps/skillset/src/runtime-hooks/context.ts
+++ b/apps/skillset/src/runtime-hooks/context.ts
@@ -1,185 +1,29 @@
-import { gitSafeEnv } from "../git-env";
+import {
+  readRuntimeContext,
+  readRuntimeContextField,
+  readRuntimeContextFormat,
+  renderRuntimeContext,
+  type RuntimeContext,
+  type RuntimeContextField,
+  type RuntimeContextFormat,
+  type RuntimeContextOptions,
+  type RuntimeContextRenderOptions,
+  type RuntimeProvider,
+} from "@skillset/toolkit/runtime";
 
-export type HookRuntimeProvider = "claude" | "codex" | "unknown";
-export type HookRuntimeContextField = "hook.event" | "provider" | "session.id";
-export type HookRuntimeContextFormat = "env" | "json";
-
-export interface HookRuntimeContext {
-  readonly cwd: string;
-  readonly event: string;
-  readonly payload?: unknown;
-  readonly payloadError?: string;
-  readonly provider: HookRuntimeProvider;
-  readonly rawEnv: Readonly<Record<string, string>>;
-  readonly repoRoot?: string;
-}
-
-export interface HookRuntimeContextOptions {
-  readonly cwd?: string;
-  readonly env?: Record<string, string | undefined>;
-  readonly event: string;
-  readonly rootPath?: string;
-  readonly stdinText?: string;
-}
-
-export interface HookRuntimeContextRenderOptions extends HookRuntimeContextOptions {
-  readonly fields?: readonly HookRuntimeContextField[];
-  readonly format: HookRuntimeContextFormat;
-}
-
-const CLAUDE_ENV_KEYS = [
-  "CLAUDE_PROJECT_DIR",
-  "CLAUDE_SESSION_ID",
-  "CLAUDE_TOOL_NAME",
-  "CLAUDE_WORKING_DIRECTORY",
-] as const;
-const CODEX_ENV_KEYS = [
-  "CODEX_CWD",
-  "CODEX_REPO_ROOT",
-  "CODEX_SESSION_ID",
-  "OPENAI_WORKSPACE_ROOT",
-] as const;
-const SKILLSET_ENV_KEYS = [
-  "SKILLSET_HOOK_COMMAND",
-  "SKILLSET_HOOK_EVENT",
-  "SKILLSET_PROVIDER",
-  "SKILLSET_SESSION_ID",
-] as const;
-const KNOWN_ENV_KEYS = [...CLAUDE_ENV_KEYS, ...CODEX_ENV_KEYS, ...SKILLSET_ENV_KEYS, "PWD"] as const;
-const HOOK_RUNTIME_CONTEXT_FIELDS = ["provider", "hook.event", "session.id"] as const satisfies readonly HookRuntimeContextField[];
-
-export async function readHookRuntimeContext(
-  options: HookRuntimeContextOptions
-): Promise<HookRuntimeContext> {
-  const env = options.env ?? process.env;
-  const cwd = options.cwd ?? process.cwd();
-  const parsedPayload = parsePayload(options.stdinText);
-  const repoRoot = options.rootPath ?? env.CODEX_REPO_ROOT ?? env.OPENAI_WORKSPACE_ROOT ?? env.CLAUDE_PROJECT_DIR ?? await gitRoot(cwd);
-  return {
-    cwd,
-    event: options.event,
-    ...parsedPayload,
-    provider: detectProvider(env),
-    rawEnv: relevantEnv(env),
-    ...(repoRoot === undefined ? {} : { repoRoot }),
-  };
-}
+export const readHookRuntimeContext = readRuntimeContext;
+export const readHookRuntimeContextField = readRuntimeContextField;
+export const readHookRuntimeContextFormat = readRuntimeContextFormat;
+export const renderHookRuntimeContext = renderRuntimeContext;
+export type HookRuntimeContext = RuntimeContext;
+export type HookRuntimeContextField = RuntimeContextField;
+export type HookRuntimeContextFormat = RuntimeContextFormat;
+export type HookRuntimeContextOptions = RuntimeContextOptions;
+export type HookRuntimeContextRenderOptions = RuntimeContextRenderOptions;
+export type HookRuntimeProvider = RuntimeProvider;
 
 export async function readHookStdin(): Promise<string | undefined> {
   if (process.stdin.isTTY) return undefined;
   const text = await new Response(Bun.stdin.stream()).text();
   return text.trim().length === 0 ? undefined : text;
-}
-
-function detectProvider(env: Record<string, string | undefined>): HookRuntimeProvider {
-  if (env.SKILLSET_PROVIDER === "claude" || env.SKILLSET_PROVIDER === "codex") return env.SKILLSET_PROVIDER;
-  if (Object.keys(env).some((key) => key.startsWith("CLAUDE_"))) return "claude";
-  if (Object.keys(env).some((key) => key.startsWith("CODEX_"))) return "codex";
-  if (env.OPENAI_WORKSPACE_ROOT !== undefined) return "codex";
-  return "unknown";
-}
-
-function relevantEnv(env: Record<string, string | undefined>): Readonly<Record<string, string>> {
-  const result: Record<string, string> = {};
-  for (const key of KNOWN_ENV_KEYS) {
-    const value = env[key];
-    if (value !== undefined) result[key] = value;
-  }
-  return result;
-}
-
-function parsePayload(stdinText: string | undefined): Pick<HookRuntimeContext, "payload" | "payloadError"> {
-  if (stdinText === undefined || stdinText.trim().length === 0) return {};
-  try {
-    return { payload: JSON.parse(stdinText) as unknown };
-  } catch (error) {
-    return { payloadError: error instanceof Error ? error.message : String(error) };
-  }
-}
-
-async function gitRoot(cwd: string): Promise<string | undefined> {
-  const proc = Bun.spawn({
-    cmd: ["git", "rev-parse", "--show-toplevel"],
-    cwd,
-    env: gitSafeEnv(),
-    stderr: "ignore",
-    stdout: "pipe",
-  });
-  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-  if (exitCode !== 0) return undefined;
-  const root = stdout.trim();
-  return root.length === 0 ? undefined : root;
-}
-
-export function readHookRuntimeContextField(value: string): HookRuntimeContextField {
-  if ((HOOK_RUNTIME_CONTEXT_FIELDS as readonly string[]).includes(value)) return value as HookRuntimeContextField;
-  throw new Error("skillset: hooks context field must be provider, hook.event, or session.id");
-}
-
-export function readHookRuntimeContextFormat(value: string): HookRuntimeContextFormat {
-  if (value === "env" || value === "json") return value;
-  throw new Error("skillset: hooks context --format must be env or json");
-}
-
-export async function renderHookRuntimeContext(options: HookRuntimeContextRenderOptions): Promise<string> {
-  const context = await readHookRuntimeContext(options);
-  const fields = [...(options.fields ?? HOOK_RUNTIME_CONTEXT_FIELDS)];
-  if (options.format === "env") return renderHookRuntimeEnv(context, fields);
-  return `${JSON.stringify(hookRuntimeContextJson(context, fields), null, 2)}\n`;
-}
-
-function renderHookRuntimeEnv(
-  context: HookRuntimeContext,
-  fields: readonly HookRuntimeContextField[]
-): string {
-  return fields
-    .map((field) => `export ${envNameForField(field)}=${shellQuote(runtimeContextFieldValue(context, field) ?? "")}`)
-    .join("\n") + "\n";
-}
-
-function hookRuntimeContextJson(
-  context: HookRuntimeContext,
-  fields: readonly HookRuntimeContextField[]
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {
-    raw: { env: context.rawEnv },
-    schemaVersion: 1,
-  };
-  if (fields.includes("provider")) result.provider = runtimeContextFieldValue(context, "provider");
-  if (fields.includes("hook.event")) result.hook = { event: runtimeContextFieldValue(context, "hook.event") };
-  if (fields.includes("session.id")) {
-    const sessionId = runtimeContextFieldValue(context, "session.id");
-    result.session = sessionId === undefined ? {} : { id: sessionId };
-  }
-  return result;
-}
-
-function runtimeContextFieldValue(
-  context: HookRuntimeContext,
-  field: HookRuntimeContextField
-): string | undefined {
-  switch (field) {
-    case "provider":
-      return context.provider;
-    case "hook.event":
-      return context.rawEnv.SKILLSET_HOOK_EVENT ?? context.event;
-    case "session.id":
-      return context.rawEnv.SKILLSET_SESSION_ID ?? context.rawEnv.CLAUDE_SESSION_ID ?? context.rawEnv.CODEX_SESSION_ID;
-  }
-}
-
-function envNameForField(field: HookRuntimeContextField): string {
-  switch (field) {
-    case "provider":
-      return "SKILLSET_PROVIDER";
-    case "hook.event":
-      return "SKILLSET_HOOK_EVENT";
-    case "session.id":
-      return "SKILLSET_SESSION_ID";
-  }
-}
-
-function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_./:-]*$/.test(value)) return value.length === 0 ? "''" : value;
-  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.16.0",
+      "version": "0.16.2",
       "bin": {
         "create-skillset": "dist/create.js",
         "skillset": "dist/cli.js",
@@ -29,6 +29,7 @@
         "@skillset/lint": "workspace:*",
         "@skillset/provider-formats": "workspace:*",
         "@skillset/schema": "workspace:*",
+        "@skillset/toolkit": "workspace:*",
         "@skillset/transforms": "workspace:*",
       },
     },
@@ -53,6 +54,10 @@
     },
     "packages/schema": {
       "name": "@skillset/schema",
+      "version": "0.0.0",
+    },
+    "packages/toolkit": {
+      "name": "@skillset/toolkit",
       "version": "0.0.0",
     },
     "packages/transforms": {
@@ -205,6 +210,8 @@
     "@skillset/provider-formats": ["@skillset/provider-formats@workspace:packages/provider-formats"],
 
     "@skillset/schema": ["@skillset/schema@workspace:packages/schema"],
+
+    "@skillset/toolkit": ["@skillset/toolkit@workspace:packages/toolkit"],
 
     "@skillset/transforms": ["@skillset/transforms@workspace:packages/transforms"],
 

--- a/docs/features/hook-guardrails.md
+++ b/docs/features/hook-guardrails.md
@@ -31,7 +31,7 @@ skillset hooks context --event Stop --format env --context-fields provider,hook.
 | Git hook-runner snippet | n/a | n/a | `implemented` | Prints additive snippets for existing hook runners; does not install. |
 | Agent runtime hook suggestion | reviewed config suggestion | reviewed config suggestion | `implemented` / `target_specific` | Prints project-local suggestions; must not mutate runtime config automatically. |
 | Agent runtime hook execution | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `implemented` / `target_specific` | Core CLI behavior called by reviewed project-local runtime config. |
-| Runtime context helper | `skillset hooks context --event <event> --format env|json` | `skillset hooks context --event <event> --format env|json` | `implemented` / `target_specific` | Internal helper used by generated adaptive hook wrappers for `context.strategy: toolkit`; public package surface is tracked separately. |
+| Runtime context helper | `skillset hooks context --event <event> --format env|json` | `skillset hooks context --event <event> --format env|json` | `implemented` / `target_specific` | Internal helper used by generated adaptive hook wrappers for `context.strategy: toolkit`; the shared context model lives in `@skillset/toolkit/runtime`. |
 
 ## Diagnostics
 

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -86,7 +86,7 @@ Adaptive hook units can choose how much Skillset-normalized runtime context to p
 | --- | --- |
 | `inline` | Prefixes the generated command with requested `SKILLSET_*` environment assignments. |
 | `none` | Passes no Skillset-normalized context. Provider-native environment remains available. |
-| `toolkit` | Renders through Skillset's internal `skillset hooks context` helper. This proves the helper-backed wrapper path before the public `@skillset/toolkit/runtime` package boundary lands. |
+| `toolkit` | Renders through Skillset's internal `skillset hooks context` helper, backed by the shared `@skillset/toolkit/runtime` context model. Generated hooks still use the CLI helper until the compiler integration slice switches wrappers to the package/shell boundary. |
 
 Inline v1 fields are deliberately small:
 
@@ -104,7 +104,7 @@ For `context.strategy: toolkit`, generated hooks call:
 skillset hooks context --event <event> --format env --context-fields <field,...>
 ```
 
-The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. This is an internal proof surface for generated wrappers; public JS/TS and shell package surfaces are tracked separately under the `@skillset/toolkit` follow-up stack.
+The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. Hook scripts that run inside this repo can also import the typed package surface from `@skillset/toolkit/runtime`; generated hook output does not depend on that package until the compiler integration slice lands.
 
 ### Attachments
 

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -24,6 +24,7 @@ Package-facing means a change that can affect the published `skillset` CLI packa
 | `packages/lint/src/**` except tests | Lint implementation consumed by the CLI. |
 | `packages/provider-formats/src/**` except tests | Adopted provider destination-format snapshots, schema evidence, and migration registry consumed by the CLI and core conformance checks. |
 | `packages/schema/src/**` except tests | Source contract schemas, validators, examples, and artifact generation consumed by the CLI, Workbench, and generated editor-schema references. |
+| `packages/toolkit/src/**` except tests | Runtime helper surfaces intended for hook scripts and compiler-owned wrappers. |
 | `packages/transforms/src/**` except tests | Transform implementation consumed by the CLI. |
 | `packages/*/package.json` for `core`, `lint`, `provider-formats`, `schema`, and `transforms` | Runtime dependency and package metadata for the private workspace packages that feed the CLI. |
 | `bun.lock` / `bun.lockb` | Dependency resolution that can alter the packaged CLI runtime. |

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@skillset/toolkit",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./runtime": "./src/runtime.ts"
+  }
+}

--- a/packages/toolkit/src/__tests__/runtime.test.ts
+++ b/packages/toolkit/src/__tests__/runtime.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  readRuntimeContext,
+  renderRuntimeContext,
+  RUNTIME_CONTEXT_FIELD_DEFINITIONS,
+  runtimeContextFieldValue,
+} from "@skillset/toolkit/runtime";
+
+describe("@skillset/toolkit runtime", () => {
+  test("exports field metadata with provider availability and confidence", () => {
+    expect(RUNTIME_CONTEXT_FIELD_DEFINITIONS.map((definition) => definition.field)).toEqual([
+      "provider",
+      "hook.event",
+      "session.id",
+    ]);
+    expect(RUNTIME_CONTEXT_FIELD_DEFINITIONS.find((definition) => definition.field === "session.id")).toMatchObject({
+      availability: { claude: "available", codex: "available", unknown: "unknown" },
+      confidence: "provider",
+      envName: "SKILLSET_SESSION_ID",
+    });
+  });
+
+  test("reads unknown, Claude, Codex, missing, and conflicting provider context", async () => {
+    const unknown = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: {},
+      event: "post-tool-use",
+      rootPath: "/tmp/repo",
+    });
+    expect(unknown.provider).toBe("unknown");
+    expect(unknown.repoRoot).toBe("/tmp/repo");
+    expect(runtimeContextFieldValue(unknown, "session.id")).toBeUndefined();
+
+    const claude = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: { CLAUDE_PROJECT_DIR: "/tmp/claude", CLAUDE_SESSION_ID: "session-1" },
+      event: "post-tool-use",
+      stdinText: "{\"tool\":\"Write\"}",
+    });
+    expect(claude.provider).toBe("claude");
+    expect(claude.repoRoot).toBe("/tmp/claude");
+    expect(claude.payload).toEqual({ tool: "Write" });
+    expect(claude.rawEnv).toEqual({
+      CLAUDE_PROJECT_DIR: "/tmp/claude",
+      CLAUDE_SESSION_ID: "session-1",
+    });
+
+    const codex = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: { CODEX_REPO_ROOT: "/tmp/codex", CODEX_SESSION_ID: "session-2" },
+      event: "stop",
+      stdinText: "{not json",
+    });
+    expect(codex.provider).toBe("codex");
+    expect(codex.repoRoot).toBe("/tmp/codex");
+    expect(codex.payload).toBeUndefined();
+    expect(codex.payloadError).toContain("JSON");
+
+    const conflicting = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: {
+        CLAUDE_SESSION_ID: "claude-session",
+        CODEX_SESSION_ID: "codex-session",
+        SKILLSET_PROVIDER: "codex",
+        SKILLSET_SESSION_ID: "skillset-session",
+      },
+      event: "Stop",
+      rootPath: "/tmp/repo",
+    });
+    expect(conflicting.provider).toBe("codex");
+    expect(runtimeContextFieldValue(conflicting, "session.id")).toBe("skillset-session");
+  });
+
+  test("renders env and JSON for generated wrappers while preserving raw provider data", async () => {
+    const envText = await renderRuntimeContext({
+      env: {
+        CLAUDE_PROJECT_DIR: "/tmp/claude",
+        CLAUDE_SESSION_ID: "session 1",
+        SKILLSET_HOOK_EVENT: "Stop",
+        SKILLSET_PROVIDER: "claude",
+      },
+      event: "Stop",
+      fields: ["provider", "hook.event", "session.id"],
+      format: "env",
+      rootPath: "/tmp/repo",
+    });
+    expect(envText).toBe([
+      "export SKILLSET_PROVIDER=claude",
+      "export SKILLSET_HOOK_EVENT=Stop",
+      "export SKILLSET_SESSION_ID='session 1'",
+      "",
+    ].join("\n"));
+
+    const jsonText = await renderRuntimeContext({
+      env: { CODEX_REPO_ROOT: "/tmp/codex" },
+      event: "PreToolUse",
+      fields: ["provider", "hook.event", "session.id"],
+      format: "json",
+      rootPath: "/tmp/repo",
+    });
+    const report = JSON.parse(jsonText) as {
+      readonly fields: readonly { readonly field: string }[];
+      readonly hook: { readonly event: string };
+      readonly provider: string;
+      readonly raw: { readonly env: Record<string, string> };
+      readonly session: { readonly id?: string };
+    };
+    expect(report.provider).toBe("codex");
+    expect(report.hook.event).toBe("PreToolUse");
+    expect(report.session).toEqual({});
+    expect(report.raw.env.CODEX_REPO_ROOT).toBe("/tmp/codex");
+    expect(report.fields.map((field) => field.field)).toEqual(["provider", "hook.event", "session.id"]);
+  });
+});

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./runtime";

--- a/packages/toolkit/src/runtime.ts
+++ b/packages/toolkit/src/runtime.ts
@@ -1,0 +1,231 @@
+export type RuntimeProvider = "claude" | "codex" | "unknown";
+export type RuntimeContextField = "hook.event" | "provider" | "session.id";
+export type RuntimeContextFormat = "env" | "json";
+export type RuntimeContextFieldAvailability = "available" | "unavailable" | "unknown";
+export type RuntimeContextFieldConfidence = "skillset" | "provider" | "caller" | "unavailable";
+
+export interface RuntimeContext {
+  readonly cwd: string;
+  readonly event: string;
+  readonly payload?: unknown;
+  readonly payloadError?: string;
+  readonly provider: RuntimeProvider;
+  readonly rawEnv: Readonly<Record<string, string>>;
+  readonly repoRoot?: string;
+}
+
+export interface RuntimeContextOptions {
+  readonly cwd?: string;
+  readonly env?: Record<string, string | undefined>;
+  readonly event: string;
+  readonly rootPath?: string;
+  readonly stdinText?: string;
+}
+
+export interface RuntimeContextRenderOptions extends RuntimeContextOptions {
+  readonly fields?: readonly RuntimeContextField[];
+  readonly format: RuntimeContextFormat;
+}
+
+export interface RuntimeContextFieldDefinition {
+  readonly availability: Readonly<Record<RuntimeProvider, RuntimeContextFieldAvailability>>;
+  readonly confidence: RuntimeContextFieldConfidence;
+  readonly description: string;
+  readonly envName: string;
+  readonly field: RuntimeContextField;
+}
+
+const CLAUDE_ENV_KEYS = [
+  "CLAUDE_PROJECT_DIR",
+  "CLAUDE_SESSION_ID",
+  "CLAUDE_TOOL_NAME",
+  "CLAUDE_WORKING_DIRECTORY",
+] as const;
+const CODEX_ENV_KEYS = [
+  "CODEX_CWD",
+  "CODEX_REPO_ROOT",
+  "CODEX_SESSION_ID",
+  "OPENAI_WORKSPACE_ROOT",
+] as const;
+const SKILLSET_ENV_KEYS = [
+  "SKILLSET_HOOK_COMMAND",
+  "SKILLSET_HOOK_EVENT",
+  "SKILLSET_PROVIDER",
+  "SKILLSET_SESSION_ID",
+] as const;
+const KNOWN_ENV_KEYS = [...CLAUDE_ENV_KEYS, ...CODEX_ENV_KEYS, ...SKILLSET_ENV_KEYS, "PWD"] as const;
+
+export const RUNTIME_CONTEXT_FIELD_DEFINITIONS = [
+  {
+    availability: { claude: "available", codex: "available", unknown: "unknown" },
+    confidence: "skillset",
+    description: "Normalized provider lens selected from Skillset wrapper env or provider-specific environment.",
+    envName: "SKILLSET_PROVIDER",
+    field: "provider",
+  },
+  {
+    availability: { claude: "available", codex: "available", unknown: "available" },
+    confidence: "caller",
+    description: "Hook event name passed by the generated wrapper or caller.",
+    envName: "SKILLSET_HOOK_EVENT",
+    field: "hook.event",
+  },
+  {
+    availability: { claude: "available", codex: "available", unknown: "unknown" },
+    confidence: "provider",
+    description: "Provider session id when the runtime exposes one; absent when unavailable.",
+    envName: "SKILLSET_SESSION_ID",
+    field: "session.id",
+  },
+] as const satisfies readonly RuntimeContextFieldDefinition[];
+
+const RUNTIME_CONTEXT_FIELDS = RUNTIME_CONTEXT_FIELD_DEFINITIONS.map((definition) => definition.field);
+
+export async function readRuntimeContext(options: RuntimeContextOptions): Promise<RuntimeContext> {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const parsedPayload = parsePayload(options.stdinText);
+  const repoRoot = options.rootPath ?? env.CODEX_REPO_ROOT ?? env.OPENAI_WORKSPACE_ROOT ?? env.CLAUDE_PROJECT_DIR ?? await gitRoot(cwd);
+  return {
+    cwd,
+    event: options.event,
+    ...parsedPayload,
+    provider: detectProvider(env),
+    rawEnv: relevantEnv(env),
+    ...(repoRoot === undefined ? {} : { repoRoot }),
+  };
+}
+
+export function readRuntimeContextField(value: string): RuntimeContextField {
+  if ((RUNTIME_CONTEXT_FIELDS as readonly string[]).includes(value)) return value as RuntimeContextField;
+  throw new Error("skillset: hooks context field must be provider, hook.event, or session.id");
+}
+
+export function readRuntimeContextFormat(value: string): RuntimeContextFormat {
+  if (value === "env" || value === "json") return value;
+  throw new Error("skillset: hooks context --format must be env or json");
+}
+
+export async function renderRuntimeContext(options: RuntimeContextRenderOptions): Promise<string> {
+  const context = await readRuntimeContext(options);
+  const fields = [...(options.fields ?? RUNTIME_CONTEXT_FIELDS)];
+  if (options.format === "env") return renderRuntimeEnv(context, fields);
+  return `${JSON.stringify(runtimeContextJson(context, fields), null, 2)}\n`;
+}
+
+export function runtimeContextFieldValue(
+  context: RuntimeContext,
+  field: RuntimeContextField
+): string | undefined {
+  switch (field) {
+    case "provider":
+      return context.provider;
+    case "hook.event":
+      return context.rawEnv.SKILLSET_HOOK_EVENT ?? context.event;
+    case "session.id":
+      return context.rawEnv.SKILLSET_SESSION_ID ?? context.rawEnv.CLAUDE_SESSION_ID ?? context.rawEnv.CODEX_SESSION_ID;
+  }
+}
+
+function detectProvider(env: Record<string, string | undefined>): RuntimeProvider {
+  if (env.SKILLSET_PROVIDER === "claude" || env.SKILLSET_PROVIDER === "codex") return env.SKILLSET_PROVIDER;
+  if (Object.keys(env).some((key) => key.startsWith("CLAUDE_"))) return "claude";
+  if (Object.keys(env).some((key) => key.startsWith("CODEX_"))) return "codex";
+  if (env.OPENAI_WORKSPACE_ROOT !== undefined) return "codex";
+  return "unknown";
+}
+
+function relevantEnv(env: Record<string, string | undefined>): Readonly<Record<string, string>> {
+  const result: Record<string, string> = {};
+  for (const key of KNOWN_ENV_KEYS) {
+    const value = env[key];
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}
+
+function parsePayload(stdinText: string | undefined): Pick<RuntimeContext, "payload" | "payloadError"> {
+  if (stdinText === undefined || stdinText.trim().length === 0) return {};
+  try {
+    return { payload: JSON.parse(stdinText) as unknown };
+  } catch (error) {
+    return { payloadError: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function gitRoot(cwd: string): Promise<string | undefined> {
+  const proc = Bun.spawn({
+    cmd: ["git", "rev-parse", "--show-toplevel"],
+    cwd,
+    env: gitSafeEnv(),
+    stderr: "ignore",
+    stdout: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  if (exitCode !== 0) return undefined;
+  const root = stdout.trim();
+  return root.length === 0 ? undefined : root;
+}
+
+function renderRuntimeEnv(
+  context: RuntimeContext,
+  fields: readonly RuntimeContextField[]
+): string {
+  return fields
+    .map((field) => `export ${envNameForField(field)}=${shellQuote(runtimeContextFieldValue(context, field) ?? "")}`)
+    .join("\n") + "\n";
+}
+
+function runtimeContextJson(
+  context: RuntimeContext,
+  fields: readonly RuntimeContextField[]
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    fields: RUNTIME_CONTEXT_FIELD_DEFINITIONS.filter((definition) => fields.includes(definition.field)),
+    raw: { env: context.rawEnv },
+    schemaVersion: 1,
+  };
+  if (fields.includes("provider")) result.provider = runtimeContextFieldValue(context, "provider");
+  if (fields.includes("hook.event")) result.hook = { event: runtimeContextFieldValue(context, "hook.event") };
+  if (fields.includes("session.id")) {
+    const sessionId = runtimeContextFieldValue(context, "session.id");
+    result.session = sessionId === undefined ? {} : { id: sessionId };
+  }
+  return result;
+}
+
+function envNameForField(field: RuntimeContextField): string {
+  switch (field) {
+    case "provider":
+      return "SKILLSET_PROVIDER";
+    case "hook.event":
+      return "SKILLSET_HOOK_EVENT";
+    case "session.id":
+      return "SKILLSET_SESSION_ID";
+  }
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:-]*$/.test(value)) return value.length === 0 ? "''" : value;
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+function gitSafeEnv(sourceEnv: Record<string, string | undefined> = process.env): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(sourceEnv)) {
+    if (value === undefined) continue;
+    if (
+      key === "GIT_DIR" ||
+      key === "GIT_WORK_TREE" ||
+      key === "GIT_INDEX_FILE" ||
+      key === "GIT_OBJECT_DIRECTORY" ||
+      key === "GIT_COMMON_DIR" ||
+      key === "GIT_NAMESPACE" ||
+      key.startsWith("GIT_ALTERNATE_OBJECT")
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
+}

--- a/scripts/__tests__/changeset-guard.test.ts
+++ b/scripts/__tests__/changeset-guard.test.ts
@@ -72,6 +72,8 @@ describe("changeset guard", () => {
     expect(isPackageAffectingPath("packages/schema/src/contracts.ts")).toBe(true);
     expect(isPackageAffectingPath("packages/schema/src/validate.ts")).toBe(true);
     expect(isPackageAffectingPath("packages/schema/src/__tests__/schema.test.ts")).toBe(false);
+    expect(isPackageAffectingPath("packages/toolkit/src/runtime.ts")).toBe(true);
+    expect(isPackageAffectingPath("packages/toolkit/src/__tests__/runtime.test.ts")).toBe(false);
     expect(isPackageAffectingPath("docs/reference/schemas/0.1.0/skillset.schema.json")).toBe(false);
     expect(isPackageAffectingPath("docs/reference/examples/skill-frontmatter.yaml")).toBe(false);
   });


### PR DESCRIPTION
## Context

SET-228 proved that adaptive hook context delivery works through a generated wrapper that shells through Skillset's helper. That PR is merged. This follow-up promotes the provider/context model into a reusable internal toolkit package without yet making generated output depend on the package.

## What changed

- Added a private workspace package, `@skillset/toolkit`, with a `./runtime` export.
- Moved runtime context detection, field metadata, and env/json rendering into `@skillset/toolkit/runtime`.
- Kept `apps/skillset` hook behavior intact by re-exporting the shared helpers from the app runtime hook module.
- Preserved provider-specific raw environment keys without broad secret-shaped env capture.
- Added tests for Claude, Codex, unknown provider, missing/conflicting context, field metadata, env/json rendering, and raw pass-through.
- Updated changeset awareness and release docs so toolkit source changes count as package-facing.
- Fixed the existing active hook-context changeset metadata so `changeset:status` is healthy with ignored private packages.

## Boundary

This does not switch generated hook wrappers to import `@skillset/toolkit/runtime` directly. SET-231 owns the compiler/rendering cutover after the package API has proven stable enough.

## Verification

- `bun test packages/toolkit/src/__tests__/runtime.test.ts apps/skillset/src/__tests__/runtime-hooks.test.ts apps/skillset/src/__tests__/contract.test.ts scripts/__tests__/changeset-guard.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run skillset:ci`
- `bun run changeset:status`
- `bun run changeset:check`
- `git diff --check --cached && git diff --check`

Local review: `.agents/goals/2026-06-30-skillset-toolkit-runtime-context/tmp/reviews/codex-set229/round1.json`, 5/5 with zero open P0-P2 findings.
