### PR TITLE
feat(toolkit): add runtime context cli

### DIFF
--- a/.changeset/toolkit-runtime-cli.md
+++ b/.changeset/toolkit-runtime-cli.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add a shell-friendly `@skillset/toolkit` runtime context CLI for JSON and env output.

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -3,8 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "skillset-toolkit": "./src/cli.ts"
+  },
   "exports": {
     ".": "./src/index.ts",
+    "./cli": "./src/cli.ts",
     "./runtime": "./src/runtime.ts"
   }
 }

--- a/packages/toolkit/src/__tests__/cli.test.ts
+++ b/packages/toolkit/src/__tests__/cli.test.ts
@@ -1,0 +1,138 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = process.cwd();
+const cliPath = join(repoRoot, "packages/toolkit/src/cli.ts");
+
+describe("@skillset/toolkit CLI", () => {
+  test("prints deterministic JSON with normalized and raw namespaces", async () => {
+    const result = await runToolkit(["runtime", "context", "--event", "Stop"], {
+      CODEX_REPO_ROOT: "/tmp/codex repo",
+      CODEX_SESSION_ID: "codex-session",
+    });
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    const report = JSON.parse(result.stdout) as {
+      readonly hook: { readonly event: string };
+      readonly provider: string;
+      readonly raw: { readonly env: Record<string, string> };
+      readonly schemaVersion: number;
+      readonly session: { readonly id?: string };
+    };
+    expect(report.schemaVersion).toBe(1);
+    expect(report.provider).toBe("codex");
+    expect(report.hook.event).toBe("Stop");
+    expect(report.session.id).toBe("codex-session");
+    expect(report.raw.env.CODEX_REPO_ROOT).toBe("/tmp/codex repo");
+    expect(result.stdout).toBe(`${JSON.stringify(report, null, 2)}\n`);
+  });
+
+  test("prints eval-safe env output for empty, spaced, quoted, and missing values", async () => {
+    const command = [
+      "eval \"$(",
+      shellQuote(process.execPath),
+      shellQuote(cliPath),
+      "runtime context --event 'Stop Event' --format env",
+      ")\"",
+      "&& printf '<%s>|<%s>|<%s>' \"$SKILLSET_PROVIDER\" \"$SKILLSET_HOOK_EVENT\" \"$SKILLSET_SESSION_ID\"",
+    ].join(" ");
+    const result = await runShell(command, {
+      CLAUDE_PROJECT_DIR: "/tmp/claude repo",
+      CLAUDE_SESSION_ID: "quote ' me",
+    });
+
+    expect(result).toEqual({ exitCode: 0, stderr: "", stdout: "<claude>|<Stop Event>|<quote ' me>" });
+
+    const missing = await runShell(command, { SKILLSET_PROVIDER: "unknown" });
+    expect(missing).toEqual({ exitCode: 0, stderr: "", stdout: "<unknown>|<Stop Event>|<>" });
+
+    const empty = await runShell(command, { SKILLSET_PROVIDER: "codex", SKILLSET_SESSION_ID: "" });
+    expect(empty).toEqual({ exitCode: 0, stderr: "", stdout: "<codex>|<Stop Event>|<>" });
+  });
+
+  test("supports Python JSON consumption without provider-specific parsing", async () => {
+    await expect(commandExists("python3")).resolves.toBe(true);
+    const python = [
+      "import json, sys",
+      "doc = json.load(sys.stdin)",
+      "print(doc['provider'] + '|' + doc['raw']['env']['CODEX_SESSION_ID'])",
+    ].join("; ");
+    const command = [
+      shellQuote(process.execPath),
+      shellQuote(cliPath),
+      "runtime context --event Stop --format json",
+      "| python3 -c",
+      shellQuote(python),
+    ].join(" ");
+    const result = await runShell(command, {
+      CODEX_SESSION_ID: "session-from-python",
+      OPENAI_WORKSPACE_ROOT: "/tmp/workspace",
+    });
+
+    expect(result).toEqual({ exitCode: 0, stderr: "", stdout: "codex|session-from-python\n" });
+  });
+
+  test("fails loudly for unknown fields", async () => {
+    const result = await runToolkit(["runtime", "context", "--event", "Stop", "--fields", "provider,nope"], {});
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("hooks context field must be provider, hook.event, or session.id");
+  });
+});
+
+async function runToolkit(
+  args: readonly string[],
+  env: Record<string, string>
+): Promise<{ readonly exitCode: number; readonly stderr: string; readonly stdout: string }> {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, cliPath, ...args],
+    cwd: repoRoot,
+    env: testEnv(env),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+async function runShell(
+  command: string,
+  env: Record<string, string>
+): Promise<{ readonly exitCode: number; readonly stderr: string; readonly stdout: string }> {
+  const proc = Bun.spawn({
+    cmd: ["/bin/sh", "-c", command],
+    cwd: repoRoot,
+    env: testEnv(env),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  const result = await runShell(`command -v ${shellQuote(command)} >/dev/null 2>&1`, {});
+  return result.exitCode === 0;
+}
+
+function testEnv(env: Record<string, string>): Record<string, string> {
+  return {
+    HOME: process.env.HOME ?? "",
+    PATH: process.env.PATH ?? "",
+    TMPDIR: process.env.TMPDIR ?? "/tmp",
+    ...env,
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}

--- a/packages/toolkit/src/cli.ts
+++ b/packages/toolkit/src/cli.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+import {
+  readRuntimeContextField,
+  readRuntimeContextFormat,
+  renderRuntimeContext,
+  type RuntimeContextField,
+  type RuntimeContextFormat,
+} from "./runtime";
+
+export interface ToolkitCliIO {
+  readonly stderr?: Pick<typeof process.stderr, "write">;
+  readonly stdout?: Pick<typeof process.stdout, "write">;
+}
+
+interface RuntimeContextCliOptions {
+  readonly event: string;
+  readonly fields?: readonly RuntimeContextField[];
+  readonly format: RuntimeContextFormat;
+}
+
+const USAGE = `Usage: skillset-toolkit runtime context --event <event> [--format json|env] [--fields provider,hook.event,session.id]
+
+Commands:
+  runtime context  Print normalized Skillset runtime context for hook scripts.
+`;
+
+export async function runToolkitCli(rawArgs: readonly string[] = process.argv.slice(2), io: ToolkitCliIO = {}): Promise<number> {
+  const stdout = io.stdout ?? process.stdout;
+  const stderr = io.stderr ?? process.stderr;
+  try {
+    if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+      stdout.write(USAGE);
+      return 0;
+    }
+    const options = parseRuntimeContextArgs(rawArgs);
+    stdout.write(await renderRuntimeContext(options));
+    return 0;
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function parseRuntimeContextArgs(args: readonly string[]): RuntimeContextCliOptions {
+  if (args[0] !== "runtime" || args[1] !== "context") {
+    throw new Error("skillset-toolkit: expected command runtime context");
+  }
+
+  let event: string | undefined;
+  let fields: readonly RuntimeContextField[] | undefined;
+  let format: RuntimeContextFormat = "json";
+
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--event") {
+      event = readFlagValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--format") {
+      format = readRuntimeContextFormat(readFlagValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+    if (arg === "--fields" || arg === "--context-fields") {
+      fields = readRuntimeContextFields(readFlagValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+    throw new Error(`skillset-toolkit: unknown runtime context option ${arg ?? ""}`);
+  }
+
+  if (event === undefined || event.trim().length === 0) {
+    throw new Error("skillset-toolkit: runtime context requires --event <event>");
+  }
+
+  return {
+    event,
+    ...(fields === undefined ? {} : { fields }),
+    format,
+  };
+}
+
+function readRuntimeContextFields(value: string): readonly RuntimeContextField[] {
+  const fields = value.split(",").map((field) => field.trim()).filter(Boolean).map(readRuntimeContextField);
+  if (fields.length === 0) throw new Error("skillset-toolkit: --fields must include at least one context field");
+  return fields;
+}
+
+function readFlagValue(args: readonly string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) throw new Error(`skillset-toolkit: ${flag} requires a value`);
+  return value;
+}
+
+if (import.meta.main) {
+  process.exitCode = await runToolkitCli();
+}


### PR DESCRIPTION
## Context

SET-229 promoted runtime context normalization into `@skillset/toolkit/runtime`. This slice exposes that same helper through a package-level command path so Bash, Python, and other non-JS hook scripts can consume the normalized context without reimplementing provider-specific env parsing.

## What changed

- Added a `skillset-toolkit` bin for the private `@skillset/toolkit` workspace package.
- Added `skillset-toolkit runtime context --event <event> [--format json|env] [--fields ...]`.
- Kept JSON as the default scripting format.
- Kept env output available for shell hook scripts using the existing deterministic shell escaping from `@skillset/toolkit/runtime`.
- Accepted `--context-fields` as an alias for compatibility with the existing `skillset hooks context` helper.
- Added subprocess tests that prove:
  - deterministic JSON output with normalized and raw namespaces;
  - shell `eval` of env output for empty, spaced, quoted, and missing values;
  - Python JSON consumption without provider-specific parsing;
  - invalid field errors fail loudly.

## Boundary

This does not add a `skillset toolkit ...` passthrough. The package CLI is intentionally owned by `@skillset/toolkit`, while the compiler app remains on its existing `skillset hooks context` helper until SET-231 owns generated hook rendering.

## Verification

- `bun test packages/toolkit/src/__tests__/runtime.test.ts packages/toolkit/src/__tests__/cli.test.ts apps/skillset/src/__tests__/runtime-hooks.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run skillset:ci`
- `bun run changeset:status`
- staged changeset guard with `bun scripts/changeset-guard.ts --changed-files`
- `git diff --check --cached && git diff --check`
- pre-push hook passed, including `skillset-ci` and full `check`

Local review: `.agents/goals/2026-06-30-skillset-toolkit-runtime-context/tmp/reviews/codex-set230/round1.json`, 5/5 with zero open P0-P2 findings. One pre-report P2 coverage mismatch was fixed by adding explicit empty-value env coverage.
