### PR TITLE
docs(toolkit): harden runtime context matrix

### DIFF
--- a/.changeset/toolkit-runtime-docs-lookup.md
+++ b/.changeset/toolkit-runtime-docs-lookup.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Document and verify the toolkit runtime context support matrix through lookup output, schema examples, and adaptive hook fixtures.

--- a/apps/skillset/src/__tests__/lookup-cli.test.ts
+++ b/apps/skillset/src/__tests__/lookup-cli.test.ts
@@ -66,6 +66,30 @@ test("SET-220: lookup hooks adaptive lens shows adaptive hook fields", async () 
   expect(report.compatibility.map((item) => item.featureId)).toEqual(["adaptive-hooks"]);
 });
 
+test("SET-232: lookup hooks toolkit lens reports runtime context support", async () => {
+  const result = await runSkillsetCli("lookup", "hooks", "toolkit", "--field", "context.env", "--values", "--compat", "codex", "--json");
+
+  expect(result.exitCode).toBe(0);
+  const report = JSON.parse(result.stdout) as {
+    readonly compatibility: readonly { readonly featureId: string; readonly note?: string; readonly status: string; readonly target: string }[];
+    readonly fields: readonly { readonly path: string; readonly values?: readonly string[] }[];
+  };
+  expect(report.fields).toEqual([
+    expect.objectContaining({
+      path: "context.env",
+      values: ["hook.event", "provider", "session.id"],
+    }),
+  ]);
+  expect(report.compatibility).toEqual([
+    expect.objectContaining({
+      featureId: "runtime-context",
+      note: expect.stringContaining("raw Codex environment remains available"),
+      status: "transformed",
+      target: "codex",
+    }),
+  ]);
+});
+
 test("SET-220: lookup plugin bin compatibility reports Codex unsupported reason", async () => {
   const result = await runSkillsetCli("lookup", "plugin", "bin", "--compat", "codex", "--json");
 

--- a/docs/features/hook-guardrails.md
+++ b/docs/features/hook-guardrails.md
@@ -33,6 +33,8 @@ skillset-toolkit runtime context --event Stop --format env --fields provider,hoo
 | Agent runtime hook execution | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `implemented` / `target_specific` | Core CLI behavior called by reviewed project-local runtime config. |
 | Runtime context helper | `skillset-toolkit runtime context --event <event> --format env|json` | `skillset-toolkit runtime context --event <event> --format env|json` | `implemented` / `target_specific` | Helper used by generated adaptive hook wrappers for `context.strategy: toolkit`; the shared context model lives in `@skillset/toolkit/runtime`. |
 
+For the normalized runtime context support matrix, use `skillset lookup hooks toolkit --field context.env --values --compat claude,codex` or see [Hooks](hooks.md#runtime-context).
+
 ## Diagnostics
 
 Pre-commit guardrails are staged-aware and fast through `skillset change check --staged`, which compares the Git index against `HEAD`. Pre-push snippets run broader checks through `skillset change check --since origin/main`, `skillset check`, `skillset verify`, and `skillset doctor`.

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -98,13 +98,52 @@ Inline v1 fields are deliberately small:
 
 Omitting `context` is equivalent to `context.strategy: none`, so existing hooks keep their command text unchanged.
 
-For `context.strategy: toolkit`, generated hooks call:
+For `context.strategy: toolkit`, generated hooks call the installable helper:
 
 ```sh
 skillset-toolkit runtime context --event <event> --format env --fields <field,...>
 ```
 
-The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. JS and TS hook scripts can also import the typed package surface from `@skillset/toolkit/runtime`; shell and Python scripts can consume the same model through `skillset-toolkit runtime context --format json`.
+The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. It does not erase target-native variables such as `CLAUDE_SESSION_ID` or `CODEX_SESSION_ID`; scripts that need provider-specific data can still read the raw environment deliberately.
+
+Generated hooks and out-of-repo scripts should use the `skillset-toolkit` CLI because it is shipped by the published `skillset` package. Repo-local tools that already depend on the internal workspace package can import the typed runtime surface directly:
+
+```ts
+import { createHookRuntimeContext, renderHookRuntimeContextJson } from "@skillset/toolkit/runtime";
+
+const context = createHookRuntimeContext({
+  env: process.env,
+  event: "Stop",
+  fields: ["provider", "hook.event", "session.id"],
+});
+
+process.stdout.write(renderHookRuntimeContextJson(context));
+```
+
+Shell hooks can evaluate env output:
+
+```sh
+eval "$(skillset-toolkit runtime context --event Stop --format env --fields provider,hook.event,session.id)"
+printf '%s\n' "$SKILLSET_PROVIDER:$SKILLSET_HOOK_EVENT"
+```
+
+Python hooks can consume JSON output without shell evaluation:
+
+```python
+import json
+import subprocess
+
+context = json.loads(subprocess.check_output([
+    "skillset-toolkit",
+    "runtime",
+    "context",
+    "--event",
+    "Stop",
+    "--format",
+    "json",
+]))
+print(context["provider"])
+```
 
 ### Attachments
 
@@ -158,7 +197,7 @@ Unsupported cases include Codex skill/agent no-faithful-destination cases, Claud
 
 ### Provider Reference
 
-Use `skillset lookup hooks --events --compat <target>` for provider event and support facts. Use `skillset lookup hooks adaptive --fields --schema --examples` for the adaptive hook unit source contract.
+Use `skillset lookup hooks --events --compat <target>` for provider event and support facts. Use `skillset lookup hooks adaptive --fields --schema --examples` for the adaptive hook unit source contract. Use `skillset lookup hooks toolkit --field context.env --values --compat <target>` for the normalized runtime context field matrix.
 
 Provider details are intentionally registry-backed instead of duplicated here. Claude has the broader hook surface; Codex support is narrower and currently centers on synchronous command handlers. Skillset keeps provider-specific validation explicit so incompatible hooks fail visibly instead of being silently widened or dropped.
 
@@ -185,4 +224,4 @@ Hook definitions are generated plugin files. Plugin lock hashes include hook sou
 
 ## Tests and Fixtures
 
-Fixtures cover shared hooks, root hook rejection, target-specific hook validation, async handler rejection, excluded plugin output selection, generated manifest fields, and adaptive hook authoring in `fixtures/adaptive-hooks`.
+Fixtures cover shared hooks, root hook rejection, target-specific hook validation, async handler rejection, excluded plugin output selection, generated manifest fields, and adaptive hook authoring in `fixtures/adaptive-hooks`, including toolkit runtime context rendering.

--- a/docs/reference/examples/adaptive-hook.yaml
+++ b/docs/reference/examples/adaptive-hook.yaml
@@ -2,6 +2,12 @@ claude:
   if: Bash(git *)
 codex:
   matcher: Bash
+context:
+  env:
+    - provider
+    - hook.event
+    - session.id
+  strategy: toolkit
 description: Checks shell commands before they run.
 events:
   - PreToolUse

--- a/fixtures/adaptive-hooks/.skillset/plugins/guard/hooks/shell-policy/hook.json
+++ b/fixtures/adaptive-hooks/.skillset/plugins/guard/hooks/shell-policy/hook.json
@@ -2,6 +2,10 @@
   "name": "shell-policy",
   "description": "Checks shell commands before they run.",
   "events": ["PreToolUse"],
+  "context": {
+    "strategy": "toolkit",
+    "env": ["provider", "hook.event", "session.id"]
+  },
   "run": {
     "script": "./check.sh"
   }

--- a/fixtures/adaptive-hooks/README.md
+++ b/fixtures/adaptive-hooks/README.md
@@ -7,6 +7,7 @@ the current Skillset workspace layout and covers:
 - flat and directory adaptive hook units;
 - `hooks.auto` expansion;
 - attachment status messages and matchers;
+- `context.strategy: toolkit` runtime context rendering;
 - `{{scripts.dir}}` and hook-local `./` script references;
 - Claude skill-local and project-agent frontmatter hooks;
 - a separate native aggregate plugin using `hooks/hooks.json`.

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -55,6 +55,7 @@ const SEEDED_FEATURE_IDS = [
   "render-results",
   "resources",
   "runtime-adapters",
+  "runtime-context",
   "standalone-skills",
   "supports",
   "target-native-islands",
@@ -209,6 +210,14 @@ describe("feature registry", () => {
       status: "shimmed",
     }));
     expect(getSkillsetFeature("runtime-adapters")?.runtimeSupport?.cursor?.status).toBe("planned");
+    expect(getSkillsetFeature("runtime-context")?.targetSupport.claude).toEqual(expect.objectContaining({
+      note: expect.stringContaining("provider, hook.event, and session.id"),
+      status: "transformed",
+    }));
+    expect(getSkillsetFeature("runtime-context")?.targetSupport.codex).toEqual(expect.objectContaining({
+      note: expect.stringContaining("raw Codex environment remains available"),
+      status: "transformed",
+    }));
     expect(getSkillsetFeature("runtime-adapters")?.runtimeSupport?.devin?.status).toBe("future");
     expect(listSkillsetFeaturesByTarget("claude").map((entry) => entry.id)).not.toContain("changes");
     expect(listSkillsetFeaturesByTarget("codex").map((entry) => entry.id)).not.toContain("workflows");

--- a/packages/core/src/__tests__/lookup.test.ts
+++ b/packages/core/src/__tests__/lookup.test.ts
@@ -132,6 +132,47 @@ describe("lookupSkillsetReference", () => {
     }).compatibility.map((item) => item.featureId)).toEqual(["adaptive-hooks"]);
   });
 
+  it("reports runtime context compatibility through toolkit hook aspects", () => {
+    const report = lookupSkillsetReference({
+      aspects: ["toolkit"],
+      field: "context.env",
+      subject: "hooks",
+      targets: ["claude", "codex"],
+      views: ["fields", "values", "compat"],
+    });
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.fields).toEqual([
+      expect.objectContaining({
+        contractId: "adaptive-hook",
+        path: "context.env",
+        type: "array<enum>",
+        values: ["hook.event", "provider", "session.id"],
+      }),
+    ]);
+    expect(report.compatibility).toEqual([
+      expect.objectContaining({
+        featureId: "runtime-context",
+        note: expect.stringContaining("raw Claude environment remains available"),
+        status: "transformed",
+        target: "claude",
+      }),
+      expect.objectContaining({
+        featureId: "runtime-context",
+        note: expect.stringContaining("raw Codex environment remains available"),
+        status: "transformed",
+        target: "codex",
+      }),
+    ]);
+
+    expect(lookupSkillsetReference({
+      aspects: ["context", "runtime"],
+      subject: "hooks",
+      targets: ["codex"],
+      views: ["compat"],
+    }).compatibility.map((item) => item.featureId)).toEqual(["runtime-context"]);
+  });
+
   it("derives plugin aspect compatibility from the feature registry", () => {
     const report = lookupSkillsetReference({
       aspects: ["bin"],

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -679,6 +679,46 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     validationOwner: "packages/core/src/feature-registry.ts",
   }),
   feature({
+    docs: ["docs/features/hooks.md", "docs/features/hook-guardrails.md"],
+    evidence: [
+      docs("docs/features/hooks.md"),
+      source("packages/toolkit/src/runtime.ts"),
+      source("packages/toolkit/src/cli.ts"),
+      source("packages/core/src/render.ts"),
+      test("packages/toolkit/src/__tests__/runtime.test.ts", "runtime context normalization coverage"),
+      test("packages/toolkit/src/__tests__/cli.test.ts", "shell-friendly runtime context CLI coverage"),
+      test("packages/core/src/__tests__/adaptive-hook-attachments.test.ts", "generated toolkit hook wrapper coverage"),
+    ],
+    id: "runtime-context",
+    kind: "workflow",
+    renderOwner: "packages/core/src/render.ts",
+    sourceShape: "adaptive hook context.strategy toolkit runtime context helper",
+    status: "implemented",
+    summary: "Normalizes Claude and Codex hook runtime context into Skillset fields for hook scripts through a typed API and shell-friendly CLI.",
+    targetSupport: {
+      claude: {
+        evidence: [
+          docs("docs/features/hooks.md"),
+          source("packages/toolkit/src/runtime.ts"),
+          test("packages/toolkit/src/__tests__/runtime.test.ts", "Claude-like environment normalization"),
+        ],
+        note: "Normalized fields are provider, hook.event, and session.id; raw Claude environment remains available to the hook command.",
+        status: "transformed",
+      },
+      codex: {
+        evidence: [
+          docs("docs/features/hooks.md"),
+          source("packages/toolkit/src/runtime.ts"),
+          test("packages/toolkit/src/__tests__/runtime.test.ts", "Codex-like environment normalization"),
+        ],
+        note: "Normalized fields are provider, hook.event, and session.id; raw Codex environment remains available to the hook command.",
+        status: "transformed",
+      },
+    },
+    title: "Runtime Context",
+    validationOwner: "packages/toolkit/src/runtime.ts",
+  }),
+  feature({
     docs: ["docs/features/releases.md"],
     evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-38 release apply coverage")],
     id: "releases",

--- a/packages/core/src/lookup.ts
+++ b/packages/core/src/lookup.ts
@@ -162,9 +162,12 @@ const ASPECT_FEATURES: Partial<Record<LookupSubject, Record<string, readonly Ski
   hooks: {
     adaptive: ["adaptive-hooks"],
     attachments: ["adaptive-hooks"],
+    context: ["runtime-context"],
     aggregate: ["plugin-hooks"],
     handlers: ["plugin-hooks"],
     native: ["plugin-hooks"],
+    runtime: ["runtime-context"],
+    toolkit: ["runtime-context"],
     units: ["adaptive-hooks"],
   },
   instruction: {
@@ -301,7 +304,7 @@ function contractForLookup(subject: LookupSubject, aspects: readonly string[]): 
 }
 
 function isAdaptiveHookAspect(aspect: string): boolean {
-  return aspect === "adaptive" || aspect === "units";
+  return aspect === "adaptive" || aspect === "context" || aspect === "runtime" || aspect === "toolkit" || aspect === "units";
 }
 
 function invalidCombinationDiagnostics(

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -328,6 +328,10 @@ export const skillsetSchemaExamples = [
       codex: {
         matcher: "Bash",
       },
+      context: {
+        env: ["provider", "hook.event", "session.id"],
+        strategy: "toolkit",
+      },
       description: "Checks shell commands before they run.",
       events: ["PreToolUse"],
       match: {


### PR DESCRIPTION
## Context

This is the final hardening slice after the `@skillset/toolkit` runtime-context stack:

- SET-229 promoted the runtime helper into `@skillset/toolkit/runtime`.
- SET-230 exposed the helper through a shell-friendly CLI.
- SET-231 routed generated `context.strategy: toolkit` wrappers through the proven runtime.

SET-232 closes the loop by making the capability discoverable in lookup output, documenting the supported usage, and proving it through the adaptive-hook fixture.

## What Changed

- Added a `runtime-context` feature registry entry with Claude/Codex target support marked as transformed.
- Added `hooks toolkit`, `hooks runtime`, and `hooks context` lookup aliases that expose `context.env` field values and compatibility details.
- Updated the adaptive hook schema example and fixture to use `context.strategy: toolkit` with normalized env fields.
- Expanded hook docs and guardrails with the runtime-context support matrix plus shell/Python examples.
- Clarified that direct `@skillset/toolkit/runtime` imports are repo-local/internal while generated and out-of-repo hooks should use the `skillset-toolkit` CLI.
- Added a patch changeset for the docs/lookup/fixture hardening.

## Verification

- `bun run schema:generate && bun run schema:check`
- `bun test packages/core/src/__tests__/lookup.test.ts apps/skillset/src/__tests__/lookup-cli.test.ts packages/core/src/__tests__/feature-registry.test.ts packages/schema/src/__tests__/schema.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts`
- `bun ./apps/skillset/src/cli.ts check --root fixtures/adaptive-hooks`
- `bun ./apps/skillset/src/cli.ts diff --root fixtures/adaptive-hooks`
- Temp-copy fixture build, then inspected generated Claude/Codex commands for `skillset-toolkit runtime context`.
- `bun ./apps/skillset/src/cli.ts lookup hooks toolkit --field context.env --values --compat claude,codex`
- `bun run typecheck`
- `bun run check`
- `bun run skillset:ci`
- `bun run changeset:status`
- `git diff --check --cached`
- `bun scripts/changeset-guard.ts --changed-files <( git diff --name-only --cached )`
- `bun run hooks:pre-push`

## Local Review

- Clean 5/5 review report: `.agents/goals/2026-06-30-skillset-toolkit-runtime-context/tmp/reviews/codex-set232/round1.json`
- Open P0/P1/P2 findings: 0
- One doc-overpromise finding was fixed before this PR: public docs now point generated/out-of-repo scripts at the CLI instead of implying public package import support.

## Risk

- The typed `@skillset/toolkit/runtime` import remains private/internal for now; the stable public path is the `skillset-toolkit` CLI shipped by the `skillset` package.
- Fixture generated outputs were verified through a temp build and inspection rather than committed as golden output.
