### PR TITLE
feat: add marketplace catalog source contract

### DIFF
--- a/.changeset/marketplace-catalog-contract.md
+++ b/.changeset/marketplace-catalog-contract.md
@@ -1,0 +1,6 @@
+---
+"@skillset/core": patch
+"@skillset/schema": patch
+---
+
+Add the root `marketplaces` source contract for curated provider catalogs with local and external Skillset plugin references, while reserving readiness checks and provider index rendering for follow-up commands.

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -113,6 +113,65 @@ Demo custom ordinary workspace skill.
   );
 });
 
+test("SET-133: workspace config loads marketplace catalog source", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+compile:
+  targets: [claude, codex]
+marketplaces:
+  outfitter:
+    title: Outfitter
+    description: Curated Outfitter plugins.
+    targets: [claude, codex]
+    plugins:
+      - plugin: local-tools
+      - id: trails
+        plugin: trails-review
+        repo: github:outfitter-dev/trails
+        channel: latest
+      - plugin: skillset
+        repo: https://github.com/outfitter-dev/skillset.git
+        ref: main
+        targets: [claude]
+`,
+    ".skillset/plugins/local-tools/skillset.yaml": `
+skillset:
+  name: local-tools
+`,
+  });
+
+  const graph = await loadBuildGraph(root);
+
+  expect(graph.root.marketplaces.outfitter).toEqual({
+    description: "Curated Outfitter plugins.",
+    plugins: [
+      { id: "local-tools", plugin: "local-tools" },
+      { channel: "latest", id: "trails", plugin: "trails-review", repo: "github:outfitter-dev/trails" },
+      { id: "skillset", plugin: "skillset", ref: "main", repo: "https://github.com/outfitter-dev/skillset.git", targets: ["claude"] },
+    ],
+    targets: ["claude", "codex"],
+    title: "Outfitter",
+  });
+});
+
+test("SET-133: marketplace catalog source rejects filesystem repo references", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    plugins:
+      - plugin: trails-review
+        repo: ../trails
+`,
+  });
+
+  await expect(loadBuildGraph(root)).rejects.toThrow("marketplace plugin repo must be a remote repo reference");
+});
+
 test("workspace ignores unrelated top-level directories", async () => {
   const root = await fixture({
     "skillset.yaml": `

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -23,6 +23,7 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 - [Hooks](hooks.md): native aggregate hook emission, adaptive hook units, target validation, and activation boundaries.
 - [Instructions](instructions.md): source-root `rules/` rendering to Claude rules and Codex `AGENTS.md`, preprocessing, and collision safety.
 - [LSP Servers](lsp-servers.md): Claude plugin `.lsp.json` pass-through, manifest wiring, and future validation boundaries.
+- [Marketplaces](marketplaces.md): curated provider catalogs, external plugin references, readiness states, and check/update boundaries.
 - [MCP Servers](mcp-servers.md): plugin `.mcp.json`, `mcp.source`, manifest wiring, and structured validation.
 - [Monitors](monitors.md): Claude experimental monitor pass-through, manifest wiring, and Codex unsupported boundaries.
 - [Output Safety](output-safety.md): managed output ownership, unmanaged neighbor handling, reversible backups, and restore.

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -1,0 +1,90 @@
+# Marketplaces
+
+Feature id: `marketplaces`
+
+Support vocabulary: [Feature Reference](README.md#support-vocabulary)
+
+Marketplaces describe curated provider catalog intent. A marketplace repo owns catalog membership and marketplace-level presentation, while each plugin repo owns plugin source, version authority, generated provider bundles, and release provenance.
+
+This source contract is intentionally separate from [Distributions](distributions.md). A distribution plan asks where generated files could sync after a build. A marketplace catalog asks which local or external Skillset plugins should appear in provider marketplace indexes once readiness has been proven.
+
+## Source Shape
+
+Marketplace source lives in root `skillset.yaml` under `marketplaces`:
+
+```yaml
+marketplaces:
+  outfitter:
+    title: Outfitter
+    targets:
+      - claude
+      - codex
+    plugins:
+      - plugin: outfitter-core
+      - plugin: trails-review
+        repo: github:outfitter-dev/trails
+        channel: latest
+      - plugin: skillset
+        repo: github:outfitter-dev/skillset
+        ref: main
+```
+
+Catalog ids are lowercase ids. `targets` defaults to every supported provider target. `plugins` is required and each entry requires `plugin`, the logical Skillset plugin id.
+
+Missing `repo` means the plugin is authored in the current marketplace repo under `.skillset/plugins/<plugin>/`. Present `repo` means the plugin is authored by another Skillset repo. Committed marketplace source must use a remote repo reference, not a local filesystem path such as `../trails` or `file:../trails`; local checkout discovery belongs to managed user/XDG state.
+
+Optional plugin entry fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Catalog entry id when it must differ from the plugin id. Defaults to `plugin`. |
+| `repo` | External Skillset repo reference, such as `github:org/repo` or an HTTPS git URL. |
+| `channel` | Floating policy such as `latest`; lock provenance must pin the resolved commit/version later. |
+| `ref` | Git ref requested by the catalog source. |
+| `version` | Version policy requested by the catalog source. |
+| `targets` | Provider targets for this entry, narrowing the catalog targets. |
+
+Provider output paths such as `plugins-claude`, `plugins-codex`, `.claude-plugin`, or `.codex-plugin` are not part of the marketplace source contract. Provider-native source forms are derived output details for `marketplace update`.
+
+## Resolution
+
+The planned resolver order is:
+
+1. Current marketplace repo for local entries.
+2. Managed user/XDG known-Skillsets index for local checkout convenience.
+3. Remote git or cache resolution for CI and portable verification.
+4. A structured unresolved diagnostic.
+
+The user/XDG index is managed state, not committed source truth. CI must be able to resolve from committed marketplace source and remote refs without a developer machine's local index.
+
+## Readiness
+
+Marketplace readiness is explicit:
+
+| State | Meaning |
+| --- | --- |
+| `declared` | The catalog references an entry. |
+| `resolved` | The referenced repo and plugin source were found. |
+| `renderable` | Source/config says the requested provider target can be rendered. |
+| `generated` | The expected provider plugin bundle exists at the derived output path. |
+| `verified` | Generated output matches source, lock, and build expectations. |
+| `marketplace-ready` | A provider marketplace entry can be emitted. |
+| `not-ready` | Any step failed with a structured reason. |
+
+`resolved` plus `renderable` is not enough. Provider marketplace entries require generated and verified provider output for the selected target/ref/channel.
+
+## Commands
+
+`skillset marketplace check` is planned as the read-only verifier. It should parse marketplace source, resolve local and external plugin entries, verify provider target support and generated output freshness, validate the provider-native marketplace output that would be written, and report unresolved, stale, unbuilt, target-missing, unsupported-provider, version/ref drift, and local-vs-remote differences. It must not write provider marketplace files, publish, install, trust, or activate anything.
+
+`skillset marketplace update` is planned as the explicit write command. It should run the same readiness checks, refuse not-ready entries, render provider-native marketplace indexes, and update existing `skillset.lock` provenance. It must require the usual write posture and must not mutate external plugin repos or runtime/user settings.
+
+## Provenance
+
+Marketplace provenance belongs in existing `skillset.lock` files. There is no separate marketplace lock. Lock/report records should include the marketplace id, entry id, plugin id, source repo, requested channel/ref/version policy, resolved commit SHA/ref, plugin version, provider target, provider-native marketplace source form, derived provider output path, generated output hash, and readiness status.
+
+## Evidence
+
+- [SET-133](https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references) - source contract and command boundary.
+- [Distributions](distributions.md) - related post-build sync planning surface.
+- [Runtime Adapters](runtime-adapters.md) - runtime support remains separate from compile targets and marketplace readiness.

--- a/docs/reference/examples/workspace-config.yaml
+++ b/docs/reference/examples/workspace-config.yaml
@@ -33,6 +33,23 @@ dependencies:
 distributions:
   plugins:
     path: dist/plugins
+marketplaces:
+  outfitter:
+    description: Curated Outfitter provider plugins.
+    plugins:
+      - plugin: outfitter-core
+      - channel: latest
+        plugin: trails-review
+        repo: github:outfitter-dev/trails
+      - plugin: skillset
+        ref: main
+        repo: github:outfitter-dev/skillset
+        targets:
+          - claude
+    targets:
+      - claude
+      - codex
+    title: Outfitter
 skillset:
   author:
     email: team@example.com

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -1827,6 +1827,93 @@
         "distributions": {
           "type": "object"
         },
+        "marketplaces": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "plugins": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "channel": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "id": {
+                      "pattern": "^[a-z0-9][a-z0-9-]*$",
+                      "type": "string"
+                    },
+                    "plugin": {
+                      "pattern": "^[a-z0-9][a-z0-9-]*$",
+                      "type": "string"
+                    },
+                    "ref": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "repo": {
+                      "minLength": 1,
+                      "not": {
+                        "pattern": "^(?:\\.|/|~|file:|[A-Za-z]:[\\\\/])"
+                      },
+                      "type": "string"
+                    },
+                    "targets": {
+                      "items": {
+                        "enum": [
+                          "claude",
+                          "codex"
+                        ],
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    },
+                    "version": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "plugin"
+                  ],
+                  "type": "object"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "targets": {
+                "items": {
+                  "enum": [
+                    "claude",
+                    "codex"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array",
+                "uniqueItems": true
+              },
+              "title": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "plugins"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "pattern": "^[a-z0-9][a-z0-9._-]*$"
+          },
+          "type": "object"
+        },
         "skillset": {
           "additionalProperties": false,
           "properties": {

--- a/docs/reference/schemas/0.1.0/workspace-config.schema.json
+++ b/docs/reference/schemas/0.1.0/workspace-config.schema.json
@@ -121,6 +121,93 @@
     "distributions": {
       "type": "object"
     },
+    "marketplaces": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "plugins": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "channel": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "id": {
+                  "pattern": "^[a-z0-9][a-z0-9-]*$",
+                  "type": "string"
+                },
+                "plugin": {
+                  "pattern": "^[a-z0-9][a-z0-9-]*$",
+                  "type": "string"
+                },
+                "ref": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "repo": {
+                  "minLength": 1,
+                  "not": {
+                    "pattern": "^(?:\\.|/|~|file:|[A-Za-z]:[\\\\/])"
+                  },
+                  "type": "string"
+                },
+                "targets": {
+                  "items": {
+                    "enum": [
+                      "claude",
+                      "codex"
+                    ],
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "uniqueItems": true
+                },
+                "version": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plugin"
+              ],
+              "type": "object"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "targets": {
+            "items": {
+              "enum": [
+                "claude",
+                "codex"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "title": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "plugins"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9._-]*$"
+      },
+      "type": "object"
+    },
     "skillset": {
       "additionalProperties": false,
       "properties": {

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -32,6 +32,7 @@ const SEEDED_FEATURE_IDS = [
   "distributions",
   "feature-registry",
   "future-companion-source-pointers",
+  "marketplaces",
   "output-safety",
   "plugin-agents",
   "plugin-apps",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,6 +15,8 @@ import type {
   DistributionConfig,
   JsonRecord,
   JsonValue,
+  MarketplaceCatalogConfig,
+  MarketplacePluginEntryConfig,
   OutputConfig,
   OutputSelection,
   ResolvedTarget,
@@ -29,8 +31,8 @@ export type FeatureSurface = "agents" | "instructions" | "plugins" | "skills";
 const DEFAULT_SURFACES = new Set<FeatureSurface>(["agents", "instructions", "plugins", "skills"]);
 const CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "defaults", "dependencies", "skillset", "supports"]);
 const PLUGIN_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "hooks"]);
-const ROOT_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "compile", "distributions", "workspace"]);
-const WORKSPACE_CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "compile", "defaults", "dependencies", "distributions", "workspace"]);
+const ROOT_CONFIG_TOP_LEVEL_KEYS = new Set([...CONFIG_TOP_LEVEL_KEYS, "compile", "distributions", "marketplaces", "workspace"]);
+const WORKSPACE_CONFIG_TOP_LEVEL_KEYS = new Set(["agents", "changes", "claude", "codex", "compile", "defaults", "dependencies", "distributions", "marketplaces", "workspace"]);
 const ROOT_SOURCE_MANIFEST_TOP_LEVEL_KEYS = new Set(["dependencies", "skillset", "supports"]);
 const COMPILE_BUILD_MODES = new Set<CompileBuildMode>(SCHEMA_COMPILE_BUILD_MODES as readonly CompileBuildMode[]);
 const UNSUPPORTED_DESTINATION_POLICIES = new Set<UnsupportedDestinationPolicy>([
@@ -58,6 +60,7 @@ const SOURCE_ONLY_KEYS = new Set([
   "implicit_invocation",
   "hooks",
   "mcp",
+  "marketplaces",
   "model",
   "resources",
   "schema",
@@ -262,6 +265,35 @@ export function readDistributionConfig(
       }
     }
     result[name] = readDistributionObject(value, `${label}.distributions.${name}`);
+  }
+  return result;
+}
+
+export function readMarketplaceCatalogConfig(
+  record: JsonRecord,
+  label: string
+): Readonly<Record<string, MarketplaceCatalogConfig>> {
+  const raw = record.marketplaces;
+  if (raw === undefined) return {};
+  if (!isJsonRecord(raw)) {
+    throw new Error(`skillset: expected ${label}.marketplaces to be an object`);
+  }
+
+  const result: Record<string, MarketplaceCatalogConfig> = {};
+  for (const name of Object.keys(raw).sort()) {
+    if (!/^[a-z0-9][a-z0-9._-]*$/.test(name)) {
+      throw new Error(`skillset: expected ${label}.marketplaces key ${JSON.stringify(name)} to be a lowercase id`);
+    }
+    const value = raw[name];
+    if (!isJsonRecord(value)) {
+      throw new Error(`skillset: expected ${label}.marketplaces.${name} to be an object`);
+    }
+    for (const key of Object.keys(value)) {
+      if (key !== "description" && key !== "plugins" && key !== "targets" && key !== "title") {
+        throw new Error(`skillset: unsupported marketplace key ${key} in ${label}.marketplaces.${name}`);
+      }
+    }
+    result[name] = readMarketplaceCatalogObject(value, `${label}.marketplaces.${name}`);
   }
   return result;
 }
@@ -718,6 +750,89 @@ function readDistributionObject(record: JsonRecord, label: string): Distribution
     from,
     to,
   };
+}
+
+function readMarketplaceCatalogObject(record: JsonRecord, label: string): MarketplaceCatalogConfig {
+  const title = readOptionalString(record, "title", `${label}.title`);
+  const description = readOptionalString(record, "description", `${label}.description`);
+  const targets = readOptionalTargetNames(record.targets, `${label}.targets`) ?? targetNames();
+  const rawPlugins = record.plugins;
+  if (!Array.isArray(rawPlugins) || rawPlugins.length === 0) {
+    throw new Error(`skillset: expected ${label}.plugins to be a non-empty array`);
+  }
+
+  return {
+    ...(description === undefined ? {} : { description }),
+    plugins: rawPlugins.map((entry, index) => readMarketplacePluginEntry(entry, `${label}.plugins[${index}]`)),
+    targets,
+    ...(title === undefined ? {} : { title }),
+  };
+}
+
+function readMarketplacePluginEntry(raw: JsonValue | undefined, label: string): MarketplacePluginEntryConfig {
+  if (!isJsonRecord(raw)) {
+    throw new Error(`skillset: expected ${label} to be an object`);
+  }
+  for (const key of Object.keys(raw)) {
+    if (key !== "channel" && key !== "id" && key !== "plugin" && key !== "ref" && key !== "repo" && key !== "targets" && key !== "version") {
+      throw new Error(`skillset: unsupported marketplace plugin key ${key} in ${label}`);
+    }
+  }
+
+  const plugin = readRequiredString(raw, "plugin", `${label}.plugin`);
+  const id = readOptionalString(raw, "id", `${label}.id`) ?? plugin;
+  validateMarketplaceId(id, `${label}.id`);
+  validateMarketplaceId(plugin, `${label}.plugin`);
+  const repo = readOptionalString(raw, "repo", `${label}.repo`);
+  if (repo !== undefined) validateMarketplaceRepo(repo, `${label}.repo`);
+  const targets = readOptionalTargetNames(raw.targets, `${label}.targets`);
+  const channel = readOptionalString(raw, "channel", `${label}.channel`);
+  const ref = readOptionalString(raw, "ref", `${label}.ref`);
+  const version = readOptionalString(raw, "version", `${label}.version`);
+  return {
+    ...(channel === undefined ? {} : { channel }),
+    id,
+    plugin,
+    ...(ref === undefined ? {} : { ref }),
+    ...(repo === undefined ? {} : { repo }),
+    ...(targets === undefined ? {} : { targets }),
+    ...(version === undefined ? {} : { version }),
+  };
+}
+
+function readOptionalTargetNames(raw: JsonValue | undefined, label: string): readonly TargetName[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(`skillset: expected ${label} to be a non-empty target array`);
+  }
+  const seen = new Set<TargetName>();
+  for (const target of raw) {
+    if (target !== "claude" && target !== "codex") {
+      throw new Error(`skillset: unsupported target ${JSON.stringify(target)} in ${label}; expected claude or codex`);
+    }
+    if (seen.has(target)) {
+      throw new Error(`skillset: duplicate target ${JSON.stringify(target)} in ${label}`);
+    }
+    seen.add(target);
+  }
+  return [...seen];
+}
+
+function validateMarketplaceId(value: string, label: string): void {
+  if (/^[a-z0-9][a-z0-9-]*$/.test(value)) return;
+  throw new Error(`skillset: expected ${label} to be a lowercase plugin id`);
+}
+
+function validateMarketplaceRepo(value: string, label: string): void {
+  if (
+    value.startsWith(".") ||
+    value.startsWith("/") ||
+    value.startsWith("~") ||
+    value.startsWith("file:") ||
+    /^[A-Za-z]:[\\/]/.test(value)
+  ) {
+    throw new Error(`skillset: expected ${label} to be a remote repo reference, not a filesystem path`);
+  }
 }
 
 function readDistributionFrom(raw: JsonValue | undefined, label: string): DistributionConfig["from"] {

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -206,6 +206,34 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     validationOwner: "packages/core/src/config.ts",
   }),
   feature({
+    docs: ["docs/features/marketplaces.md"],
+    evidence: [
+      docs("https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references"),
+      test("apps/skillset/src/__tests__/skillset.test.ts", "SET-133 marketplace catalog parser coverage"),
+      test("packages/schema/src/__tests__/schema.test.ts", "workspace config marketplace contract coverage"),
+    ],
+    id: "marketplaces",
+    kind: "workflow",
+    renderOwner: "future",
+    sourceShape: "workspace skillset.yaml marketplaces",
+    status: "planned",
+    summary: "Declares curated provider marketplace catalogs that can reference local or external Skillset plugins without provider output paths.",
+    targetSupport: {
+      claude: {
+        evidence: [docs("docs/features/marketplaces.md"), providerSchemaSnapshot("claude-marketplace-schema")],
+        provider: { schemaSnapshots: ["claude-marketplace-schema"] },
+        status: "planned",
+      },
+      codex: {
+        evidence: [docs("docs/features/marketplaces.md"), providerSnapshot("codex-plugin")],
+        provider: { destinationFormat: "codex-plugin" },
+        status: "planned",
+      },
+    },
+    title: "Marketplaces",
+    validationOwner: "packages/core/src/config.ts",
+  }),
+  feature({
     docs: ["docs/features/feature-registry.md"],
     evidence: [
       docs("docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"),

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -18,6 +18,7 @@ import {
   readCompileConfig,
   readCompileTargets,
   readDistributionConfig,
+  readMarketplaceCatalogConfig,
   readOutputConfig,
   readSkillsetMetadata,
   readSkillsetName,
@@ -125,6 +126,7 @@ export async function loadBuildGraph(
     options.distDir === undefined ? {} : { distDir: options.distDir }
   );
   const distributions = readDistributionConfig(rootConfig, workspace.configPath);
+  const marketplaces = readMarketplaceCatalogConfig(rootConfig, workspace.configPath);
   const workspaceConfig = readSkillsetWorkspaceConfig(rootConfig, workspace.configPath);
   const rootTargets = resolveTargets(readCompileTargets(rootConfig, workspace.configPath), rootConfig, workspace.configPath, {
     allowDefaults: true,
@@ -140,6 +142,7 @@ export async function loadBuildGraph(
   const root = {
     compile,
     distributions,
+    marketplaces,
     metadata,
     outputs,
     targets: filteredTargets,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,6 +22,7 @@ export interface ResolvedTarget {
 export interface RootConfig {
   readonly compile: CompileConfig;
   readonly distributions: Readonly<Record<string, DistributionConfig>>;
+  readonly marketplaces: Readonly<Record<string, MarketplaceCatalogConfig>>;
   readonly metadata: JsonRecord;
   readonly outputs: OutputConfig;
   readonly targets: Readonly<Record<TargetName, ResolvedTarget>>;
@@ -83,6 +84,23 @@ export interface DistributionConfig {
   readonly dryRun: boolean;
   readonly from: DistributionFromConfig;
   readonly to: DistributionToConfig;
+}
+
+export interface MarketplaceCatalogConfig {
+  readonly description?: string;
+  readonly plugins: readonly MarketplacePluginEntryConfig[];
+  readonly targets: readonly TargetName[];
+  readonly title?: string;
+}
+
+export interface MarketplacePluginEntryConfig {
+  readonly channel?: string;
+  readonly id: string;
+  readonly plugin: string;
+  readonly ref?: string;
+  readonly repo?: string;
+  readonly targets?: readonly TargetName[];
+  readonly version?: string;
 }
 
 export interface PluginConfig {

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -119,6 +119,7 @@ describe("@skillset/schema contracts", () => {
       "defaults",
       "dependencies",
       "distributions",
+      "marketplaces",
       "skillset",
       "supports",
       "workspace",
@@ -167,6 +168,11 @@ describe("@skillset/schema contracts", () => {
     ]);
 
     const supports = workspaceProperties.supports as { anyOf: Array<Record<string, unknown>> };
+    const marketplaces = workspaceProperties.marketplaces as Record<string, unknown>;
+    expect(marketplaces).toMatchObject({
+      propertyNames: { pattern: "^[a-z0-9][a-z0-9._-]*$" },
+      type: "object",
+    });
     const objectSupports = supports.anyOf.find((variant) => variant.type === "object");
     expect(objectSupports).toMatchObject({
       additionalProperties: false,

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -19,6 +19,7 @@ export const WORKSPACE_CONFIG_KEYS = [
   "defaults",
   "dependencies",
   "distributions",
+  "marketplaces",
   "skillset",
   "supports",
   "workspace",
@@ -116,6 +117,7 @@ export const workspaceConfigContract = contract("workspace-config", "Workspace C
     defaults: { type: "object" },
     dependencies: dependenciesSchema(),
     distributions: { type: "object" },
+    marketplaces: marketplaceCatalogsSchema(),
     skillset: sourceMetadataSchema(),
     supports: supportsSchema(),
     workspace: strictObjectSchema({
@@ -357,6 +359,43 @@ function sourceOriginSchema(): SchemaJsonRecord {
       repo: ["ref"],
     },
     required: ["path"],
+  };
+}
+
+function marketplaceCatalogsSchema(): SchemaJsonRecord {
+  return {
+    additionalProperties: {
+      ...strictObjectSchema({
+        description: nonEmptyStringSchema(),
+        plugins: arraySchema(marketplacePluginEntrySchema(), { minItems: 1 }),
+        targets: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
+        title: nonEmptyStringSchema(),
+      }),
+      required: ["plugins"],
+    },
+    propertyNames: { pattern: "^[a-z0-9][a-z0-9._-]*$" },
+    type: "object",
+  };
+}
+
+function marketplacePluginEntrySchema(): SchemaJsonRecord {
+  return {
+    ...strictObjectSchema({
+      channel: nonEmptyStringSchema(),
+      id: { pattern: "^[a-z0-9][a-z0-9-]*$", type: "string" },
+      plugin: { pattern: "^[a-z0-9][a-z0-9-]*$", type: "string" },
+      ref: nonEmptyStringSchema(),
+      repo: {
+        minLength: 1,
+        not: {
+          pattern: "^(?:\\.|/|~|file:|[A-Za-z]:[\\\\/])",
+        },
+        type: "string",
+      },
+      targets: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
+      version: nonEmptyStringSchema(),
+    }),
+    required: ["plugin"],
   };
 }
 

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -71,6 +71,29 @@ export const skillsetSchemaExamples = [
           path: "dist/plugins",
         },
       },
+      marketplaces: {
+        outfitter: {
+          description: "Curated Outfitter provider plugins.",
+          plugins: [
+            {
+              plugin: "outfitter-core",
+            },
+            {
+              channel: "latest",
+              plugin: "trails-review",
+              repo: "github:outfitter-dev/trails",
+            },
+            {
+              plugin: "skillset",
+              ref: "main",
+              repo: "github:outfitter-dev/skillset",
+              targets: ["claude"],
+            },
+          ],
+          targets: ["claude", "codex"],
+          title: "Outfitter",
+        },
+      },
       skillset: {
         author: {
           email: "team@example.com",

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -37,6 +37,7 @@ export function validateWorkspaceConfig(value: unknown, path = "$"): SkillsetSch
   checkTargetBlock(value.codex, `${path}.codex`, "schema/workspace-config/target", diagnostics);
   checkCompile(value.compile, `${path}.compile`, diagnostics);
   checkDependencies(value.dependencies, `${path}.dependencies`, "schema/workspace-config/dependencies", diagnostics);
+  checkMarketplaceCatalogs(value.marketplaces, `${path}.marketplaces`, diagnostics);
   checkWorkspace(value.workspace, `${path}.workspace`, diagnostics);
   checkSourceMetadata(value.skillset, `${path}.skillset`, diagnostics);
   checkSupports(value.supports, `${path}.supports`, diagnostics);
@@ -197,19 +198,88 @@ function checkCompile(value: SchemaJsonValue | undefined, path: string, diagnost
   checkBooleanRecord(value.skillset, `${path}.skillset`, new Set(["metadata"]), diagnostics);
 }
 
-function checkTargets(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+function checkTargets(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[], label = "compile.targets"): void {
   if (!Array.isArray(value) || value.length === 0) {
-    diagnostics.push(diagnostic(path, "schema/workspace-config/targets", "compile.targets must be a non-empty array"));
+    diagnostics.push(diagnostic(path, "schema/workspace-config/targets", `${label} must be a non-empty array`));
     return;
   }
   const seen = new Set<string>();
   for (const [index, item] of value.entries()) {
     if (typeof item !== "string" || !targetNames.has(item)) {
-      diagnostics.push(diagnostic(`${path}[${index}]`, "schema/workspace-config/target", "compile.targets entries must be claude or codex"));
+      diagnostics.push(diagnostic(`${path}[${index}]`, "schema/workspace-config/target", `${label} entries must be claude or codex`));
       continue;
     }
-    if (seen.has(item)) diagnostics.push(diagnostic(`${path}[${index}]`, "schema/workspace-config/target-duplicate", `duplicate compile target ${item}`));
+    if (seen.has(item)) diagnostics.push(diagnostic(`${path}[${index}]`, "schema/workspace-config/target-duplicate", `duplicate target ${item}`));
     seen.add(item);
+  }
+}
+
+function checkMarketplaceCatalogs(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplaces", "marketplaces must be an object"));
+    return;
+  }
+  for (const [name, catalog] of Object.entries(value)) {
+    if (!/^[a-z0-9][a-z0-9._-]*$/.test(name)) {
+      diagnostics.push(diagnostic(`${path}.${name}`, "schema/workspace-config/marketplace-id", "marketplace ids must be lowercase ids"));
+    }
+    checkMarketplaceCatalog(catalog, `${path}.${name}`, diagnostics);
+  }
+}
+
+function checkMarketplaceCatalog(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace", "marketplace catalog must be an object"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["description", "plugins", "targets", "title"]), path, "schema/workspace-config/marketplace-key", diagnostics);
+  checkOptionalNonEmptyString(value.title, `${path}.title`, "schema/workspace-config/marketplace-title", diagnostics);
+  checkOptionalNonEmptyString(value.description, `${path}.description`, "schema/workspace-config/marketplace-description", diagnostics);
+  if (value.targets !== undefined) checkTargets(value.targets, `${path}.targets`, diagnostics, "marketplace targets");
+  if (!Array.isArray(value.plugins) || value.plugins.length === 0) {
+    diagnostics.push(diagnostic(`${path}.plugins`, "schema/workspace-config/marketplace-plugins", "marketplace plugins must be a non-empty array"));
+    return;
+  }
+  for (const [index, entry] of value.plugins.entries()) {
+    checkMarketplacePluginEntry(entry, `${path}.plugins[${index}]`, diagnostics);
+  }
+}
+
+function checkMarketplacePluginEntry(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin", "marketplace plugin entries must be objects"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["channel", "id", "plugin", "ref", "repo", "targets", "version"]), path, "schema/workspace-config/marketplace-plugin-key", diagnostics);
+  checkOptionalMarketplaceId(value.id, `${path}.id`, diagnostics);
+  if (value.plugin === undefined) {
+    diagnostics.push(diagnostic(`${path}.plugin`, "schema/workspace-config/marketplace-plugin", "marketplace plugin entries require plugin"));
+  } else {
+    checkOptionalMarketplaceId(value.plugin, `${path}.plugin`, diagnostics);
+  }
+  checkOptionalNonEmptyString(value.channel, `${path}.channel`, "schema/workspace-config/marketplace-plugin-channel", diagnostics);
+  checkOptionalNonEmptyString(value.ref, `${path}.ref`, "schema/workspace-config/marketplace-plugin-ref", diagnostics);
+  checkOptionalNonEmptyString(value.version, `${path}.version`, "schema/workspace-config/marketplace-plugin-version", diagnostics);
+  checkMarketplaceRepo(value.repo, `${path}.repo`, diagnostics);
+  if (value.targets !== undefined) checkTargets(value.targets, `${path}.targets`, diagnostics, "marketplace plugin targets");
+}
+
+function checkOptionalMarketplaceId(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (typeof value !== "string" || !/^[a-z0-9][a-z0-9-]*$/.test(value)) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin-id", "marketplace plugin ids must be lowercase ids"));
+  }
+}
+
+function checkMarketplaceRepo(value: SchemaJsonValue | undefined, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === undefined) return;
+  if (typeof value !== "string" || value.length === 0) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin-repo", "marketplace plugin repo must be a non-empty string"));
+    return;
+  }
+  if (value.startsWith(".") || value.startsWith("/") || value.startsWith("~") || value.startsWith("file:") || /^[A-Za-z]:[\\/]/.test(value)) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin-repo", "marketplace plugin repo must be a remote repo reference, not a filesystem path"));
   }
 }
 


### PR DESCRIPTION
## Context

SET-133 is the source-contract slice for Skillset marketplace catalogs. The goal is to let marketplace repos curate local and external Skillset plugins without committing provider output paths or local filesystem paths.

Design doc: https://linear.app/outfitter/document/skillset-marketplace-catalogs-and-external-plugin-references-fb126f432637
Linear: https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references

## What Changed

- Added a root `marketplaces:` workspace config contract with local and external plugin references.
- Added core parser/types/build-graph storage for marketplace catalog config.
- Added shared `@skillset/schema` validation and regenerated reference schemas/examples.
- Added a `docs/features/marketplaces.md` feature page and feature registry row.
- Added resolver/schema/registry tests plus a package Changeset for `@skillset/core` and `@skillset/schema`.

## Boundaries

- This does not implement `skillset marketplace check` or `skillset marketplace update`.
- This does not write provider marketplace indexes.
- This does not mutate external repos, runtime settings, trust, activation, or publication surfaces.
- `channel` / `ref` / `version` policy semantics are intentionally left for SET-235.

## Verification

- `bun run schema:generate && bun run schema:check`
- `bun test packages/schema/src/__tests__/schema.test.ts`
- `bun test packages/core/src/__tests__/feature-registry.test.ts`
- `bun test apps/skillset/src/__tests__/skillset.test.ts -t SET-133`
- `bun run typecheck`
- `bun run check`
- `bun run skillset:ci`
- `bun run changeset:check`
- `git diff --check HEAD~1..HEAD`
- pre-push hook: `skillset-ci` and full `check`

## Local Review

Targeted local review: 5/5 clean, no open P0/P1/P2.

Report: `.agents/goals/2026-06-30-skillset-marketplace-catalogs/tmp/reviews/codex/set-133-round-1.json`
