### PR TITLE
feat: add known Skillsets index

### DIFF
--- a/.changeset/known-skillsets-index.md
+++ b/.changeset/known-skillsets-index.md
@@ -1,0 +1,6 @@
+---
+"@skillset/core": patch
+"skillset": patch
+---
+
+Add the managed XDG known-Skillsets index used to remember local checkout identities for future marketplace repository resolution without committing local filesystem paths.

--- a/apps/skillset/src/__tests__/known-skillsets-cli.test.ts
+++ b/apps/skillset/src/__tests__/known-skillsets-cli.test.ts
@@ -1,0 +1,93 @@
+import { mkdir, mkdtemp, readdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "bun:test";
+
+test("SET-233: check records the workspace in the managed known-Skillsets index", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-known-cli-"));
+  const xdgConfigHome = join(root, "xdg-config");
+  const workspace = join(root, "workspace");
+  await writeWorkspace(workspace);
+  await runGit(workspace, "init", "-q");
+  await runGit(workspace, "remote", "add", "origin", "git@github.com:Acme/docs-cli.git");
+  const before = await readdir(workspace);
+
+  const checked = await runSkillsetCli(
+    { XDG_CONFIG_HOME: xdgConfigHome },
+    "check",
+    "--root",
+    workspace
+  );
+
+  expect(checked).toMatchObject({ exitCode: 0 });
+  await expect(readdir(workspace)).resolves.toEqual(before);
+  const index = JSON.parse(await readFile(join(xdgConfigHome, "skillset", "skillsets.json"), "utf8")) as {
+    readonly skillsets: readonly {
+      readonly cacheKey: string;
+      readonly identities: readonly string[];
+      readonly path: string;
+      readonly repository?: string;
+    }[];
+  };
+  expect(index.skillsets).toEqual([{
+    cacheKey: "docs-cli",
+    identities: ["github:acme/docs-cli"],
+    path: await realpath(workspace),
+    repository: "git@github.com:Acme/docs-cli.git",
+  }]);
+});
+
+async function writeWorkspace(root: string): Promise<void> {
+  await mkdir(join(root, ".skillset/skills/demo"), { recursive: true });
+  await writeFile(join(root, "skillset.yaml"), `
+skillset:
+  name: docs-cli
+workspace:
+  cacheKey: docs-cli
+`);
+  await writeFile(join(root, ".skillset/skills/demo/SKILL.md"), `
+---
+name: demo
+description: Demo skill.
+---
+
+Use this demo skill.
+`);
+}
+
+async function runSkillsetCli(
+  env: Record<string, string>,
+  ...args: readonly string[]
+): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    env: { ...process.env, ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+async function runGit(root: string, ...args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn({
+    cmd: ["git", ...args],
+    cwd: root,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+}

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -8,6 +8,7 @@ import {
   diffSkillsetResult,
   isRepoOperationalCachePath,
   planDistributions,
+  recordKnownSkillsetWorkspace,
   resolveOperationalPath,
   restoreOutputBackup,
   verifySkillsetResult,
@@ -240,6 +241,7 @@ export async function runCli(
       const { data: diff } = result;
       printDiffPlan(diff, dryRun ? "dry run" : "write confirmation required");
       if (!dryRun) console.log("skillset: rerun with --yes to write generated files");
+      await rememberKnownSkillsetWorkspace(rootPath, options);
       return;
     }
     const result = await buildSkillsetResult(rootPath, options);
@@ -254,6 +256,7 @@ export async function runCli(
           `${result.writes.backupRecords?.length === 1 ? "" : "s"} to ${result.writes.backupManifestPath}`
       );
     }
+    await rememberKnownSkillsetWorkspace(rootPath, options);
     return;
   }
 
@@ -513,6 +516,7 @@ export async function runCli(
       process.stdout.write(renderProviderFormatUpdateReport(providerUpdates));
     }
     if (ciFix && (!providerUpdates.ok || providerUpdates.blocked)) process.exitCode = 1;
+    else await rememberKnownSkillsetWorkspace(rootPath, options);
     return;
   }
 
@@ -529,6 +533,7 @@ export async function runCli(
     printAdoptReport(report, dryRun ? "dry run" : writeMode ? "written" : "write confirmation required");
     if (!writeMode) console.log("skillset: rerun with --yes to adopt");
     if (writeMode && !report.ok) process.exitCode = 1;
+    if (writeMode && report.ok) await rememberKnownSkillsetWorkspace(report.rootPath, options);
     return;
   }
 
@@ -555,6 +560,7 @@ export async function runCli(
         });
     printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
     if (!yes || dryRun) console.log(`skillset: rerun ${command} with --yes to write setup files`);
+    if (yes && !dryRun) await rememberKnownSkillsetWorkspace(setup.rootPath, options);
     return;
   }
 
@@ -791,6 +797,16 @@ export function reportCliError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
   process.exitCode = 1;
+}
+
+async function rememberKnownSkillsetWorkspace(rootPath: string, options: SkillsetOptions): Promise<void> {
+  if (process.env.NODE_ENV === "test" && process.env.XDG_CONFIG_HOME === undefined) return;
+  try {
+    await recordKnownSkillsetWorkspace(rootPath, options.xdg);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`  warning: could not update known Skillsets index: ${message}`);
+  }
 }
 
 interface ParsedArgs {

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -57,6 +57,10 @@ The planned resolver order is:
 
 The user/XDG index is managed state, not committed source truth. CI must be able to resolve from committed marketplace source and remote refs without a developer machine's local index.
 
+The known-Skillsets index lives at `$XDG_CONFIG_HOME/skillset/skillsets.json`, falling back to `~/.config/skillset/skillsets.json` when `XDG_CONFIG_HOME` is unset. Skillset updates this managed file opportunistically after successful local workspace commands such as `skillset build --yes`, build previews, `skillset check`, `skillset init --yes`, `skillset create --yes`, and successful `skillset adopt --yes`. Entries record the canonical local checkout path, the effective repo cache key, and normalized repository identities such as `github:outfitter-dev/trails`.
+
+The index never records local filesystem paths in committed marketplace source, never mutates external plugin repos, and never writes Claude or Codex runtime settings. Stale paths are ignored during resolution so a moved or deleted checkout falls through to remote/git resolution instead of poisoning CI or marketplace checks.
+
 ## Readiness
 
 Marketplace readiness is explicit:
@@ -86,5 +90,6 @@ Marketplace provenance belongs in existing `skillset.lock` files. There is no se
 ## Evidence
 
 - [SET-133](https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references) - source contract and command boundary.
+- [SET-233](https://linear.app/outfitter/issue/SET-233/add-managed-known-skillsets-index-for-marketplace-repo-resolution) - managed XDG known-Skillsets index for local checkout resolution.
 - [Distributions](distributions.md) - related post-build sync planning surface.
 - [Runtime Adapters](runtime-adapters.md) - runtime support remains separate from compile targets and marketplace readiness.

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -119,6 +119,8 @@ Global Skillset state uses Skillset-owned XDG directories, never provider runtim
 | State | `XDG_STATE_HOME` | `~/.local/state` | `$XDG_STATE_HOME/skillset` |
 | Data | `XDG_DATA_HOME` | `~/.local/share` | `$XDG_DATA_HOME/skillset` |
 
+The managed known-Skillsets index lives at `$XDG_CONFIG_HOME/skillset/skillsets.json`. It records local checkout paths and normalized repo identities, such as `github:owner/repo`, for marketplace repo resolution convenience. It is machine-local config state, not committed source truth; CI and portable marketplace verification must still resolve from committed marketplace source and remote refs.
+
 Per-repo global cache buckets live directly under `$XDG_CACHE_HOME/skillset/<repo-key>/`; Skillset does not add a default `repos/` layer. Repo keys resolve in this order:
 
 1. `workspace.cacheKey` from the workspace manifest, when a repo intentionally needs a stable override.

--- a/packages/core/src/__tests__/known-skillsets.test.ts
+++ b/packages/core/src/__tests__/known-skillsets.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, readdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  knownSkillsetsIndexPath,
+  normalizeKnownSkillsetIdentity,
+  readKnownSkillsetsIndex,
+  recordKnownSkillsetWorkspace,
+  resolveKnownSkillsetWorkspace,
+  writeKnownSkillsetsIndex,
+} from "../known-skillsets";
+
+describe("known Skillsets index", () => {
+  test("reads and writes the managed index under the XDG config location", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-known-index-"));
+    const options = xdgOptions(root);
+    const workspacePath = join(root, "workspace");
+    await mkdir(workspacePath);
+
+    await writeKnownSkillsetsIndex({
+      schemaVersion: 1,
+      skillsets: [{
+        cacheKey: "docs-cli--local-abc123def456",
+        identities: ["github:acme/docs-cli"],
+        path: workspacePath,
+        repository: "https://github.com/acme/docs-cli.git",
+      }],
+    }, options);
+
+    expect(knownSkillsetsIndexPath(options)).toBe(join(root, "config", "skillset", "skillsets.json"));
+    await expect(readKnownSkillsetsIndex(options)).resolves.toEqual({
+      schemaVersion: 1,
+      skillsets: [{
+        cacheKey: "docs-cli--local-abc123def456",
+        identities: ["github:acme/docs-cli"],
+        path: workspacePath,
+        repository: "https://github.com/acme/docs-cli.git",
+      }],
+    });
+  });
+
+  test("records a workspace without writing repo-local files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-known-record-"));
+    const options = xdgOptions(root);
+    const workspacePath = join(root, "workspace");
+    await mkdir(workspacePath);
+    await writeFile(join(workspacePath, "skillset.yaml"), "workspace:\n  cacheKey: docs-cli\n");
+    const before = await readdir(workspacePath);
+    const canonicalWorkspacePath = await realpath(workspacePath);
+
+    const entry = await recordKnownSkillsetWorkspace(workspacePath, {
+      ...options,
+      repository: "git@github.com:Acme/docs-cli.git",
+    });
+
+    expect(entry).toEqual({
+      cacheKey: "docs-cli",
+      identities: ["github:acme/docs-cli"],
+      path: canonicalWorkspacePath,
+      repository: "git@github.com:Acme/docs-cli.git",
+    });
+    await expect(readdir(workspacePath)).resolves.toEqual(before);
+    await expect(readFile(knownSkillsetsIndexPath(options), "utf8")).resolves.toContain("github:acme/docs-cli");
+  });
+
+  test("resolves known GitHub identities and skips stale paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-known-resolve-"));
+    const options = xdgOptions(root);
+    const livePath = join(root, "live");
+    await mkdir(livePath);
+
+    await writeKnownSkillsetsIndex({
+      schemaVersion: 1,
+      skillsets: [
+        {
+          cacheKey: "stale",
+          identities: ["github:acme/docs-cli"],
+          path: join(root, "missing"),
+        },
+        {
+          cacheKey: "live",
+          identities: ["github:acme/docs-cli"],
+          path: livePath,
+        },
+      ],
+    }, options);
+
+    await expect(resolveKnownSkillsetWorkspace("https://github.com/Acme/docs-cli.git", options)).resolves.toEqual({
+      cacheKey: "live",
+      identities: ["github:acme/docs-cli"],
+      path: livePath,
+    });
+    await expect(resolveKnownSkillsetWorkspace("github:acme/unknown", options)).resolves.toBeUndefined();
+  });
+
+  test("normalizes supported repository identity spellings", () => {
+    expect(normalizeKnownSkillsetIdentity("github:Acme/docs-cli")).toBe("github:acme/docs-cli");
+    expect(normalizeKnownSkillsetIdentity("github.com/Acme/docs-cli.git")).toBe("github:acme/docs-cli");
+    expect(normalizeKnownSkillsetIdentity("https://github.com/Acme/docs-cli.git")).toBe("github:acme/docs-cli");
+    expect(normalizeKnownSkillsetIdentity("ssh://git@github.com/Acme/docs-cli.git")).toBe("github:acme/docs-cli");
+    expect(normalizeKnownSkillsetIdentity("git@github.com:Acme/docs-cli.git")).toBe("github:acme/docs-cli");
+  });
+});
+
+function xdgOptions(root: string): { env: Record<string, string>; homeDir: string } {
+  return {
+    env: {
+      XDG_CONFIG_HOME: join(root, "config"),
+    },
+    homeDir: join(root, "home"),
+  };
+}

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -209,7 +209,9 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     docs: ["docs/features/marketplaces.md"],
     evidence: [
       docs("https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references"),
+      docs("https://linear.app/outfitter/issue/SET-233/add-managed-known-skillsets-index-for-marketplace-repo-resolution"),
       test("apps/skillset/src/__tests__/skillset.test.ts", "SET-133 marketplace catalog parser coverage"),
+      test("packages/core/src/__tests__/known-skillsets.test.ts", "managed known-Skillsets XDG index coverage"),
       test("packages/schema/src/__tests__/schema.test.ts", "workspace config marketplace contract coverage"),
     ],
     id: "marketplaces",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,18 @@ export {
   type SkillsetXdgPaths,
 } from "./xdg";
 export {
+  knownSkillsetsIndexPath,
+  normalizeKnownSkillsetIdentity,
+  readKnownSkillsetsIndex,
+  recordKnownSkillsetWorkspace,
+  resolveKnownSkillsetWorkspace,
+  writeKnownSkillsetsIndex,
+  type KnownSkillsetEntry,
+  type KnownSkillsetsIndex,
+  type RecordKnownSkillsetOptions,
+  type ResolveKnownSkillsetOptions,
+} from "./known-skillsets";
+export {
   createOperationalPathContext,
   isRepoOperationalCachePath,
   logicalOperationalPath,

--- a/packages/core/src/known-skillsets.ts
+++ b/packages/core/src/known-skillsets.ts
@@ -1,0 +1,257 @@
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  readSkillsetWorkspaceConfig,
+  resolveSkillsetXdgPaths,
+  resolveRepoCacheKey,
+  type SkillsetXdgOptions,
+} from "./xdg";
+import { isJsonRecord, parseYamlRecord, stringifyJson } from "./yaml";
+import type { JsonRecord, JsonValue } from "./types";
+
+const KNOWN_SKILLSETS_SCHEMA_VERSION = 1;
+const KNOWN_SKILLSETS_FILE = "skillsets.json";
+
+export interface KnownSkillsetEntry {
+  readonly cacheKey: string;
+  readonly identities: readonly string[];
+  readonly path: string;
+  readonly repository?: string;
+}
+
+export interface KnownSkillsetsIndex {
+  readonly schemaVersion: 1;
+  readonly skillsets: readonly KnownSkillsetEntry[];
+}
+
+export interface RecordKnownSkillsetOptions extends SkillsetXdgOptions {
+  readonly cacheKey?: string;
+  readonly repository?: string;
+}
+
+export interface ResolveKnownSkillsetOptions extends SkillsetXdgOptions {}
+
+export function knownSkillsetsIndexPath(options: SkillsetXdgOptions = {}): string {
+  return join(resolveSkillsetXdgPaths(options).config, KNOWN_SKILLSETS_FILE);
+}
+
+export async function readKnownSkillsetsIndex(options: SkillsetXdgOptions = {}): Promise<KnownSkillsetsIndex> {
+  const path = knownSkillsetsIndexPath(options);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if (isNotFoundError(error)) return emptyKnownSkillsetsIndex();
+    throw error;
+  }
+
+  const parsed = JSON.parse(raw) as unknown;
+  return parseKnownSkillsetsIndex(parsed, path);
+}
+
+export async function writeKnownSkillsetsIndex(
+  index: KnownSkillsetsIndex,
+  options: SkillsetXdgOptions = {}
+): Promise<void> {
+  const path = knownSkillsetsIndexPath(options);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, stringifyKnownSkillsetsIndex(index), "utf8");
+}
+
+export async function recordKnownSkillsetWorkspace(
+  rootPath: string,
+  options: RecordKnownSkillsetOptions = {}
+): Promise<KnownSkillsetEntry> {
+  const resolvedPath = await realpath(rootPath).catch(() => resolve(rootPath));
+  const cacheKey = options.cacheKey ?? await readWorkspaceCacheKey(resolvedPath) ?? resolveRepoCacheKey({ rootPath: resolvedPath }).key;
+  const repository = options.repository ?? await readGitRemoteUrl(resolvedPath);
+  const identities = normalizeKnownSkillsetIdentities(repository);
+  const entry: KnownSkillsetEntry = {
+    cacheKey,
+    identities,
+    path: resolvedPath,
+    ...(repository === undefined ? {} : { repository }),
+  };
+
+  const index = await readKnownSkillsetsIndex(options);
+  await writeKnownSkillsetsIndex(upsertKnownSkillsetEntry(index, entry), options);
+  return entry;
+}
+
+export async function resolveKnownSkillsetWorkspace(
+  identity: string,
+  options: ResolveKnownSkillsetOptions = {}
+): Promise<KnownSkillsetEntry | undefined> {
+  const normalized = normalizeKnownSkillsetIdentity(identity);
+  if (normalized === undefined) return undefined;
+
+  const index = await readKnownSkillsetsIndex(options);
+  for (const entry of index.skillsets) {
+    if (!entry.identities.includes(normalized)) continue;
+    if (await isExistingDirectory(entry.path)) return entry;
+  }
+  return undefined;
+}
+
+export function normalizeKnownSkillsetIdentity(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+
+  const github = normalizeGithubIdentity(trimmed);
+  if (github !== undefined) return github;
+
+  return trimmed.replace(/\.git$/i, "").toLowerCase();
+}
+
+function normalizeKnownSkillsetIdentities(repository: string | undefined): readonly string[] {
+  const normalized = repository === undefined ? undefined : normalizeKnownSkillsetIdentity(repository);
+  return normalized === undefined ? [] : [normalized];
+}
+
+function upsertKnownSkillsetEntry(index: KnownSkillsetsIndex, entry: KnownSkillsetEntry): KnownSkillsetsIndex {
+  const entries = index.skillsets.filter((candidate) =>
+    candidate.path !== entry.path &&
+    candidate.cacheKey !== entry.cacheKey &&
+    !candidate.identities.some((identity) => entry.identities.includes(identity))
+  );
+  return {
+    schemaVersion: KNOWN_SKILLSETS_SCHEMA_VERSION,
+    skillsets: [...entries, entry].sort(compareKnownSkillsetEntries),
+  };
+}
+
+function parseKnownSkillsetsIndex(value: unknown, label: string): KnownSkillsetsIndex {
+  if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to contain a JSON object`);
+  if (value.schemaVersion !== KNOWN_SKILLSETS_SCHEMA_VERSION) {
+    throw new Error(`skillset: expected ${label}.schemaVersion to be ${KNOWN_SKILLSETS_SCHEMA_VERSION}`);
+  }
+  if (!Array.isArray(value.skillsets)) {
+    throw new Error(`skillset: expected ${label}.skillsets to be an array`);
+  }
+  return {
+    schemaVersion: KNOWN_SKILLSETS_SCHEMA_VERSION,
+    skillsets: value.skillsets.map((item, index) => readKnownSkillsetEntry(item, `${label}.skillsets[${index}]`)),
+  };
+}
+
+function readKnownSkillsetEntry(value: JsonValue | undefined, label: string): KnownSkillsetEntry {
+  if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
+  const path = readRequiredString(value.path, `${label}.path`);
+  const cacheKey = readRequiredString(value.cacheKey, `${label}.cacheKey`);
+  if (!Array.isArray(value.identities) || !value.identities.every((identity) => typeof identity === "string")) {
+    throw new Error(`skillset: expected ${label}.identities to be a string array`);
+  }
+  const identities = value.identities.map((identity) => {
+    const normalized = normalizeKnownSkillsetIdentity(identity);
+    if (normalized === undefined) throw new Error(`skillset: expected ${label}.identities to contain non-empty strings`);
+    return normalized;
+  });
+  const repository = value.repository === undefined ? undefined : readRequiredString(value.repository, `${label}.repository`);
+  return {
+    cacheKey,
+    identities: [...new Set(identities)].sort(),
+    path,
+    ...(repository === undefined ? {} : { repository }),
+  };
+}
+
+function stringifyKnownSkillsetsIndex(index: KnownSkillsetsIndex): string {
+  return stringifyJson(index as unknown as JsonRecord);
+}
+
+function emptyKnownSkillsetsIndex(): KnownSkillsetsIndex {
+  return {
+    schemaVersion: KNOWN_SKILLSETS_SCHEMA_VERSION,
+    skillsets: [],
+  };
+}
+
+function readRequiredString(value: JsonValue | undefined, label: string): string {
+  if (typeof value !== "string" || value.trim() !== value || value.length === 0) {
+    throw new Error(`skillset: expected ${label} to be a non-empty string`);
+  }
+  return value;
+}
+
+function normalizeGithubIdentity(value: string): string | undefined {
+  const githubPrefix = value.match(/^github:([^/]+)\/([^/]+)$/i);
+  if (githubPrefix !== null) return githubIdentity(githubPrefix[1], githubPrefix[2]);
+
+  const scpLike = value.match(/^git@github\.com:([^/]+)\/(.+)$/i);
+  if (scpLike !== null) return githubIdentity(scpLike[1], scpLike[2]);
+
+  let url: URL;
+  try {
+    url = new URL(value.includes("://") ? value : `https://${value}`);
+  } catch {
+    return undefined;
+  }
+
+  if (url.hostname.toLowerCase() !== "github.com") return undefined;
+  const [owner, repo] = url.pathname.replace(/^\/+/, "").split("/");
+  return githubIdentity(owner, repo);
+}
+
+function githubIdentity(owner: string | undefined, repo: string | undefined): string | undefined {
+  if (owner === undefined || repo === undefined) return undefined;
+  const normalizedOwner = owner.trim().toLowerCase();
+  const normalizedRepo = repo.trim().replace(/\.git$/i, "").toLowerCase();
+  if (normalizedOwner.length === 0 || normalizedRepo.length === 0 || normalizedRepo.includes("/")) return undefined;
+  return `github:${normalizedOwner}/${normalizedRepo}`;
+}
+
+async function readGitRemoteUrl(rootPath: string): Promise<string | undefined> {
+  const proc = Bun.spawn({
+    cmd: ["git", "-C", rootPath, "remote", "get-url", "origin"],
+    env: gitCommandEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) return undefined;
+  const remote = stdout.trim();
+  return remote.length === 0 ? undefined : remote;
+}
+
+async function readWorkspaceCacheKey(rootPath: string): Promise<string | undefined> {
+  const configPath = join(rootPath, "skillset.yaml");
+  let content: string;
+  try {
+    content = await readFile(configPath, "utf8");
+  } catch (error) {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  }
+  return readSkillsetWorkspaceConfig(parseYamlRecord(content, configPath), configPath).cacheKey;
+}
+
+function gitCommandEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined || key === "GIT_DIR" || key === "GIT_WORK_TREE") continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+async function isExistingDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if (isNotFoundError(error)) return false;
+    throw error;
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function compareKnownSkillsetEntries(left: KnownSkillsetEntry, right: KnownSkillsetEntry): number {
+  return left.path.localeCompare(right.path);
+}


### PR DESCRIPTION
## Context

SET-233 follows the marketplace catalog source contract from SET-133. Marketplace repos need a local-machine way to resolve a committed repo identity like `github:owner/repo` to an existing checkout without committing filesystem paths or depending on local state in CI.

This replaces the auto-closed stacked draft PR #218 after SET-133 merged and its base branch was deleted.

## What changed

- Added a managed XDG config index at `$XDG_CONFIG_HOME/skillset/skillsets.json`.
- Added core helpers to read/write/record/resolve known Skillset checkouts and normalize GitHub identities.
- Dogfooded the index from safe CLI workspace commands: build previews/writes, check, init/create writes, and successful adopt writes.
- Documented the index in marketplace and layout docs, and added feature-registry evidence.
- Added core and CLI tests for read/write, identity normalization, stale path fallback, and no repo-local writes.

## Verification

- `bun test apps/skillset/src/__tests__/known-skillsets-cli.test.ts packages/core/src/__tests__/known-skillsets.test.ts packages/core/src/__tests__/feature-registry.test.ts packages/core/src/__tests__/xdg.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run skillset:ci`
- `bun run changeset:check`
- `git diff --check`
- pre-push full gate before rebase: repo sanity, whitespace, changesets, workflow lint, `skillset-ci`, full `check` (769 tests)

## Local review

- 5/5 clean: `.agents/goals/2026-06-30-skillset-marketplace-catalogs/tmp/reviews/codex/set-233-round-1.json`

## Risks / rollout

- This intentionally does not implement remote acquisition, marketplace readiness checks, lock provenance, or provider marketplace rendering. Those remain stacked follow-ups.
- CLI index updates warn instead of failing the source/build command if local user config cannot be updated.
