### PR TITLE
feat: add marketplace readiness check

### DIFF
--- a/.changeset/marketplace-check.md
+++ b/.changeset/marketplace-check.md
@@ -1,0 +1,6 @@
+---
+"@skillset/core": patch
+"skillset": patch
+---
+
+Add read-only `skillset marketplace check` readiness reports for local and known-index external marketplace entries, including generated-output freshness, target support, JSON output, and not-ready diagnostics.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -6677,7 +6677,7 @@ Audit body.
 
   const misplacedJson = await runSkillsetCli("list", "--json");
   expect(misplacedJson.exitCode).toBe(1);
-  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, lookup, or runtime-tester");
+  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, lookup, marketplace, or runtime-tester");
 });
 
 test("SET-78: feature capability inspection surfaces registry ids in explain, doctor, and features", async () => {

--- a/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
+++ b/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
+import { buildSkillsetResult } from "@skillset/core";
+
+test("SET-234: marketplace check reports readiness and supports JSON output", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: local-tools
+`,
+    ".skillset/plugins/local-tools/skillset.yaml": `
+skillset:
+  name: local-tools
+`,
+    ".skillset/plugins/local-tools/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+---
+
+Use this demo skill.
+`,
+  });
+  await buildSkillsetResult(root);
+
+  const checked = await runSkillsetCli("marketplace", "check", "outfitter", "--root", root);
+
+  expect(checked).toMatchObject({ exitCode: 0, stderr: "" });
+  expect(checked.stdout).toContain("skillset: marketplace check passed");
+  expect(checked.stdout).toContain("marketplace-ready: outfitter/local-tools claude plugin local-tools");
+
+  const json = await runSkillsetCli("marketplace", "check", "outfitter", "--json", "--root", root);
+  const report = JSON.parse(json.stdout) as {
+    readonly ok: boolean;
+    readonly entries: readonly { readonly readiness: string; readonly generatedPath?: string }[];
+  };
+
+  expect(json).toMatchObject({ exitCode: 0, stderr: "" });
+  expect(report.ok).toBe(true);
+  expect(report.entries).toEqual([expect.objectContaining({
+    generatedPath: "plugins-claude/plugins/local-tools/.claude-plugin/plugin.json",
+    readiness: "marketplace-ready",
+  })]);
+});
+
+test("SET-234: marketplace check is read-only and fails when provider output is unbuilt", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: local-tools
+`,
+    ".skillset/plugins/local-tools/skillset.yaml": `
+skillset:
+  name: local-tools
+`,
+  });
+  const before = await readdir(root);
+
+  const checked = await runSkillsetCli("marketplace", "check", "--root", root);
+
+  expect(checked.exitCode).toBe(1);
+  expect(checked.stderr).toBe("");
+  expect(checked.stdout).toContain("skillset: marketplace check failed");
+  expect(checked.stdout).toContain("missing generated file: plugins-claude/plugins/local-tools/.claude-plugin/plugin.json");
+  await expect(readdir(root)).resolves.toEqual(before);
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-marketplace-cli-"));
+  for (const [path, content] of Object.entries(normalizeSkillsetFixtureFiles(files))) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}
+
+async function runSkillsetCli(
+  ...args: readonly string[]
+): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    env: { ...process.env, XDG_CONFIG_HOME: join(tmpdir(), "skillset-marketplace-cli-xdg") },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -4,6 +4,7 @@ import { basename, dirname, resolve } from "node:path";
 import {
   auditVersions,
   buildSkillsetResult,
+  checkMarketplaces,
   createOperationalPathContext,
   diffSkillsetResult,
   isRepoOperationalCachePath,
@@ -15,6 +16,7 @@ import {
   type DistributionPlanReport,
   type LookupSubject,
   type LookupView,
+  type MarketplaceCheckReport,
   type OutputBackupRestoreReport,
   type VersionAuditReport,
 } from "@skillset/core";
@@ -106,8 +108,9 @@ import { renderValidatedJson } from "./structured-output";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
 import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, SourceOrigin, TargetName } from "./types";
 
-type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "new" | "providers" | "release" | "restore" | "runtime-tester" | "suggest-source" | "test" | "update" | "verify";
+type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "marketplace" | "new" | "providers" | "release" | "restore" | "runtime-tester" | "suggest-source" | "test" | "update" | "verify";
 type DistributionSubcommand = "plan";
+type MarketplaceSubcommand = "check";
 
 const USAGE = [
   "usage: skillset build [--yes|--dry-run] [--updated|--all] [--isolated] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
@@ -134,6 +137,7 @@ const USAGE = [
   "       skillset restore <backup-id> [--yes|--dry-run] [--root <path>]",
   "       skillset suggest-source <generated-path> [--write --yes] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset distribute plan [name] [--root <path>] [--source <dir>] [--dist <dir>]",
+  "       skillset marketplace check [name] [--json] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset providers <check|diff|update> [--yes|--dry-run] [--root <path>]",
   "       skillset update [--yes|--dry-run] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset features [feature-id] [--json]",
@@ -201,6 +205,8 @@ export async function runCli(
     lookupSubject,
     lookupTargets,
     lookupViews,
+    marketplaceName,
+    marketplaceSubcommand,
     newContainer,
     newId,
     newKind,
@@ -446,6 +452,23 @@ export async function runCli(
       return;
     }
     throw new Error("skillset: expected distribute subcommand plan");
+  }
+
+  if (command === "marketplace") {
+    if (marketplaceSubcommand === "check") {
+      const report = await checkMarketplaces(rootPath, {
+        ...options,
+        ...(marketplaceName === undefined ? {} : { name: marketplaceName }),
+      });
+      if (jsonOutput) {
+        process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset marketplace check"));
+      } else {
+        printMarketplaceCheck(report);
+      }
+      if (!report.ok) process.exitCode = 1;
+      return;
+    }
+    throw new Error("skillset: expected marketplace subcommand check");
   }
 
   if (command === "hooks") {
@@ -846,6 +869,8 @@ interface ParsedArgs {
   readonly lookupSubject?: LookupSubject;
   readonly lookupTargets: readonly TargetName[];
   readonly lookupViews: readonly LookupView[];
+  readonly marketplaceName?: string;
+  readonly marketplaceSubcommand?: MarketplaceSubcommand;
   readonly newContainer?: string;
   readonly newId?: string;
   readonly newKind?: NewSourceKind;
@@ -1167,6 +1192,29 @@ function printDistributionPlan(report: DistributionPlanReport): void {
   }
 }
 
+function printMarketplaceCheck(report: MarketplaceCheckReport): void {
+  if (report.marketplaces.length === 0) {
+    console.log("skillset: no marketplaces configured");
+    return;
+  }
+  console.log(
+    `skillset: marketplace check ${report.ok ? "passed" : "failed"} ` +
+      `(${report.entries.length} target entr${report.entries.length === 1 ? "y" : "ies"})`
+  );
+  for (const entry of report.entries) {
+    const source = entry.source.path ?? entry.repo ?? entry.source.kind;
+    console.log(
+      `  ${entry.readiness}: ${entry.catalog}/${entry.entryId} ${entry.requestedTarget} ` +
+        `plugin ${entry.plugin} source ${source}`
+    );
+    console.log(`    reason: ${entry.reason}`);
+    if (entry.generatedPath !== undefined) console.log(`    generated: ${entry.generatedPath}`);
+    if (entry.generatedPaths.length > 1) {
+      console.log(`    generated bundle: ${entry.generatedPaths.join(", ")}`);
+    }
+  }
+}
+
 function formatDistributionNoOp(noOp: boolean | "unknown"): string {
   if (noOp === "unknown") return "destination state unknown";
   return noOp ? "no-op" : "would change";
@@ -1403,6 +1451,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "lint" &&
     command !== "list" &&
     command !== "lookup" &&
+    command !== "marketplace" &&
     command !== "new" &&
     command !== "providers" &&
     command !== "release" &&
@@ -1414,7 +1463,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "verify"
   ) {
     throw new Error(
-        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, new, providers, release, restore, runtime-tester, suggest-source, test, update, or verify\n" +
+        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, marketplace, new, providers, release, restore, runtime-tester, suggest-source, test, update, or verify\n" +
         USAGE
     );
   }
@@ -1467,6 +1516,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let lookupSubject: LookupSubject | undefined;
   let lookupTargets: TargetName[] = [];
   let lookupViews: LookupView[] = [];
+  let marketplaceName: string | undefined;
+  let marketplaceSubcommand: MarketplaceSubcommand | undefined;
   let newContainer: string | undefined;
   let newId: string | undefined;
   let newKind: NewSourceKind | undefined;
@@ -1529,6 +1580,20 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     const rawName = args[index];
     if (rawName !== undefined && !rawName.startsWith("--")) {
       distributionName = rawName;
+      index += 1;
+    }
+  }
+
+  if (command === "marketplace") {
+    const subcommand = args[index];
+    if (subcommand !== "check") {
+      throw new Error("skillset: expected marketplace subcommand check");
+    }
+    marketplaceSubcommand = subcommand;
+    index += 1;
+    const rawName = args[index];
+    if (rawName !== undefined && !rawName.startsWith("--")) {
+      marketplaceName = rawName;
       index += 1;
     }
   }
@@ -1989,6 +2054,14 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(scopes === undefined ? {} : { scopes }),
     yes,
   });
+  validateMarketplaceFlags(command, {
+    ...(buildMode === undefined ? {} : { buildMode }),
+    dryRun,
+    ...(marketplaceName === undefined ? {} : { name: marketplaceName }),
+    ...(scopes === undefined ? {} : { scopes }),
+    ...(marketplaceSubcommand === undefined ? {} : { subcommand: marketplaceSubcommand }),
+    yes,
+  });
 
   if (command === "release" && scopes !== undefined) {
     throw new Error("skillset: --scope is not supported with release commands yet");
@@ -2089,6 +2162,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(lookupSubject === undefined ? {} : { lookupSubject }),
     lookupTargets,
     lookupViews,
+    ...(marketplaceName === undefined ? {} : { marketplaceName }),
+    ...(marketplaceSubcommand === undefined ? {} : { marketplaceSubcommand }),
     ...(newContainer === undefined ? {} : { newContainer }),
     ...(newId === undefined ? {} : { newId }),
     ...(newKind === undefined ? {} : { newKind }),
@@ -2333,6 +2408,32 @@ function validateDistributionFlags(
     distribution.yes
   ) {
     throw new Error("skillset: build/write options are not supported with distribute plan; it is always read-only");
+  }
+}
+
+function validateMarketplaceFlags(
+  command: Command,
+  marketplace: {
+    readonly buildMode?: CompileBuildMode;
+    readonly dryRun: boolean;
+    readonly name?: string;
+    readonly scopes?: readonly BuildScope[];
+    readonly subcommand?: MarketplaceSubcommand;
+    readonly yes: boolean;
+  }
+): void {
+  if (command !== "marketplace") return;
+  if (marketplace.subcommand !== "check") throw new Error("skillset: expected marketplace subcommand check");
+  if (marketplace.name !== undefined && !/^[a-z0-9][a-z0-9._-]*$/.test(marketplace.name)) {
+    throw new Error("skillset: expected marketplace name to be a lowercase id");
+  }
+  if (
+    marketplace.buildMode !== undefined ||
+    marketplace.dryRun ||
+    marketplace.scopes !== undefined ||
+    marketplace.yes
+  ) {
+    throw new Error("skillset: build/write options are not supported with marketplace check; it is always read-only");
   }
 }
 
@@ -2686,8 +2787,8 @@ function validateAdoptFlags(
 
 function validateJsonFlags(command: Command, jsonOutput: boolean): void {
   if (!jsonOutput) return;
-  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup" || command === "runtime-tester") return;
-  throw new Error("skillset: --json is only supported with doctor, explain, features, lookup, or runtime-tester");
+  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup" || command === "marketplace" || command === "runtime-tester") return;
+  throw new Error("skillset: --json is only supported with doctor, explain, features, lookup, marketplace, or runtime-tester");
 }
 
 function validateLookupFlags(

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -48,11 +48,11 @@ Provider output paths such as `plugins-claude`, `plugins-codex`, `.claude-plugin
 
 ## Resolution
 
-The planned resolver order is:
+The resolver order is:
 
 1. Current marketplace repo for local entries.
 2. Managed user/XDG known-Skillsets index for local checkout convenience.
-3. Remote git or cache resolution for CI and portable verification.
+3. Remote git or cache resolution for CI and portable verification. This is reserved for the update/provenance follow-up work.
 4. A structured unresolved diagnostic.
 
 The user/XDG index is managed state, not committed source truth. CI must be able to resolve from committed marketplace source and remote refs without a developer machine's local index.
@@ -79,7 +79,9 @@ Marketplace readiness is explicit:
 
 ## Commands
 
-`skillset marketplace check` is planned as the read-only verifier. It should parse marketplace source, resolve local and external plugin entries, verify provider target support and generated output freshness, validate the provider-native marketplace output that would be written, and report unresolved, stale, unbuilt, target-missing, unsupported-provider, version/ref drift, and local-vs-remote differences. It must not write provider marketplace files, publish, install, trust, or activate anything.
+`skillset marketplace check [name] [--json]` is the read-only verifier. It parses marketplace source, resolves local entries from the current repo, resolves external entries from the managed known-Skillsets index when available, verifies provider target support and generated output freshness, and reports unresolved, stale, unbuilt, and target-missing entries. It does not write provider marketplace files, publish, install, trust, activate anything, mutate external repos, or register local paths in committed source.
+
+The check command exits successfully only when every selected target entry reaches `marketplace-ready`. Unresolved remote refs are reported as `not-ready` until remote/cache acquisition and lock provenance land in the follow-up slices.
 
 `skillset marketplace update` is planned as the explicit write command. It should run the same readiness checks, refuse not-ready entries, render provider-native marketplace indexes, and update existing `skillset.lock` provenance. It must require the usual write posture and must not mutate external plugin repos or runtime/user settings.
 
@@ -91,5 +93,6 @@ Marketplace provenance belongs in existing `skillset.lock` files. There is no se
 
 - [SET-133](https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references) - source contract and command boundary.
 - [SET-233](https://linear.app/outfitter/issue/SET-233/add-managed-known-skillsets-index-for-marketplace-repo-resolution) - managed XDG known-Skillsets index for local checkout resolution.
+- [SET-234](https://linear.app/outfitter/issue/SET-234/implement-skillset-marketplace-check-readiness-reports) - read-only marketplace readiness reports.
 - [Distributions](distributions.md) - related post-build sync planning surface.
 - [Runtime Adapters](runtime-adapters.md) - runtime support remains separate from compile targets and marketplace readiness.

--- a/packages/core/src/__tests__/marketplace-check.test.ts
+++ b/packages/core/src/__tests__/marketplace-check.test.ts
@@ -1,0 +1,275 @@
+import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
+import { buildSkillsetResult } from "../build";
+import { checkMarketplaces } from "../marketplace-check";
+import { writeKnownSkillsetsIndex } from "../known-skillsets";
+
+describe("marketplace check", () => {
+  test("reports local generated and verified plugin targets as marketplace-ready", async () => {
+    const root = await fixture(localMarketplaceFiles());
+    await buildSkillsetResult(root);
+
+    const report = await checkMarketplaces(root);
+
+    expect(report.ok).toBe(true);
+    expect(report.marketplaces).toEqual(["outfitter"]);
+    expect(report.entries).toHaveLength(2);
+    expect(report.entries).toContainEqual(expect.objectContaining({
+      catalog: "outfitter",
+      entryId: "local-tools",
+      generatedPath: "plugins-claude/plugins/local-tools/.claude-plugin/plugin.json",
+      plugin: "local-tools",
+      providerSource: "./plugins/local-tools",
+      readiness: "marketplace-ready",
+      requestedTarget: "claude",
+      resolvedTargetSupport: true,
+      states: ["declared", "resolved", "renderable", "generated", "verified", "marketplace-ready"],
+    }));
+    expect(report.entries).toContainEqual(expect.objectContaining({
+      generatedPath: "plugins-codex/plugins/local-tools/.codex-plugin/plugin.json",
+      requestedTarget: "codex",
+    }));
+  });
+
+  test("blocks unbuilt and stale provider output", async () => {
+    const unbuilt = await fixture(localMarketplaceFiles());
+
+    const unbuiltReport = await checkMarketplaces(unbuilt, { name: "outfitter" });
+
+    expect(unbuiltReport.ok).toBe(false);
+    expect(unbuiltReport.entries[0]).toEqual(expect.objectContaining({
+      readiness: "not-ready",
+      reason: "missing generated file: plugins-claude/plugins/local-tools/.claude-plugin/plugin.json",
+      resolvedTargetSupport: true,
+    }));
+
+    const stale = await fixture(localMarketplaceFiles());
+    await buildSkillsetResult(stale);
+    await writeFile(
+      join(stale, "plugins-claude/plugins/local-tools/.claude-plugin/plugin.json"),
+      "{ \"stale\": true }\n"
+    );
+
+    const staleReport = await checkMarketplaces(stale, { name: "outfitter" });
+
+    expect(staleReport.ok).toBe(false);
+    expect(staleReport.entries[0]).toEqual(expect.objectContaining({
+      readiness: "not-ready",
+      reason: "version drift: plugins-claude/plugins/local-tools/.claude-plugin/plugin.json version is missing, expected 0.1.0",
+      resolvedTargetSupport: true,
+    }));
+  });
+
+  test("blocks missing plugins and target-missing entries", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude, codex]
+    plugins:
+      - plugin: missing-tools
+      - plugin: claude-only
+        targets: [codex]
+`,
+      ".skillset/plugins/claude-only/skillset.yaml": `
+skillset:
+  name: claude-only
+codex: false
+`,
+    });
+    await buildSkillsetResult(root);
+
+    const report = await checkMarketplaces(root);
+
+    expect(report.ok).toBe(false);
+    expect(report.entries).toContainEqual(expect.objectContaining({
+      entryId: "missing-tools",
+      plugin: "missing-tools",
+      reason: "missing plugin missing-tools",
+      requestedTarget: "claude",
+      states: ["declared", "resolved", "not-ready"],
+    }));
+    expect(report.entries).toContainEqual(expect.objectContaining({
+      entryId: "claude-only",
+      plugin: "claude-only",
+      reason: "codex output is not enabled for plugin claude-only",
+      requestedTarget: "codex",
+      states: ["declared", "resolved", "not-ready"],
+    }));
+  });
+
+  test("resolves external plugin refs from the managed known-Skillsets index", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-marketplace-known-"));
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - id: trails
+        plugin: trails-tools
+        repo: github:outfitter-dev/trails
+`,
+    }, root);
+    const external = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: trails
+`,
+      ".skillset/plugins/trails-tools/skillset.yaml": `
+skillset:
+  name: trails-tools
+`,
+    }, root);
+    await buildSkillsetResult(external);
+    const xdg = xdgOptions(root);
+    await writeKnownSkillsetsIndex({
+      schemaVersion: 1,
+      skillsets: [{
+        cacheKey: "trails",
+        identities: ["github:outfitter-dev/trails"],
+        path: external,
+        repository: "git@github.com:outfitter-dev/trails.git",
+      }],
+    }, xdg);
+
+    const report = await checkMarketplaces(marketplace, { xdg });
+
+    expect(report.ok).toBe(true);
+    expect(report.entries).toEqual([expect.objectContaining({
+      entryId: "trails",
+      plugin: "trails-tools",
+      readiness: "marketplace-ready",
+      repo: "github:outfitter-dev/trails",
+      requestedTarget: "claude",
+      source: expect.objectContaining({
+        cacheKey: "trails",
+        kind: "known-index",
+        path: external,
+        repository: "git@github.com:outfitter-dev/trails.git",
+      }),
+    })]);
+  });
+
+  test("reports unresolved external plugin refs without remote writes", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: trails-tools
+        repo: github:outfitter-dev/trails
+`,
+    });
+    const before = await readdir(root);
+
+    const report = await checkMarketplaces(root, { xdg: xdgOptions(root) });
+
+    expect(report.ok).toBe(false);
+    expect(report.entries).toEqual([expect.objectContaining({
+      readiness: "not-ready",
+      reason: "unresolved external repo",
+      repo: "github:outfitter-dev/trails",
+      source: { kind: "unresolved" },
+      states: ["declared", "not-ready"],
+    })]);
+    await expect(readdir(root)).resolves.toEqual(before);
+  });
+
+  test("reports invalid known-index checkouts as not-ready entries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-marketplace-invalid-known-"));
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: trails-tools
+        repo: github:outfitter-dev/trails
+`,
+    }, root);
+    const invalid = await mkdtemp(join(root, "invalid-skillset-"));
+    const xdg = xdgOptions(root);
+    await writeKnownSkillsetsIndex({
+      schemaVersion: 1,
+      skillsets: [{
+        cacheKey: "trails",
+        identities: ["github:outfitter-dev/trails"],
+        path: invalid,
+      }],
+    }, xdg);
+
+    const report = await checkMarketplaces(marketplace, { xdg });
+
+    expect(report.ok).toBe(false);
+    expect(report.entries).toEqual([expect.objectContaining({
+      readiness: "not-ready",
+      reason: expect.stringContaining("failed to inspect source:"),
+      source: expect.objectContaining({
+        cacheKey: "trails",
+        kind: "known-index",
+        path: invalid,
+      }),
+      states: ["declared", "not-ready"],
+    })]);
+  });
+});
+
+function localMarketplaceFiles(): Record<string, string> {
+  return {
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+compile:
+  targets: [claude, codex]
+marketplaces:
+  outfitter:
+    targets: [claude, codex]
+    plugins:
+      - plugin: local-tools
+`,
+    ".skillset/plugins/local-tools/skillset.yaml": `
+skillset:
+  name: local-tools
+`,
+    ".skillset/plugins/local-tools/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+---
+
+Use this demo skill.
+`,
+  };
+}
+
+async function fixture(files: Record<string, string>, parent?: string): Promise<string> {
+  const root = await mkdtemp(join(parent ?? tmpdir(), "skillset-marketplace-check-"));
+  for (const [path, content] of Object.entries(normalizeSkillsetFixtureFiles(files))) {
+    await Bun.write(join(root, path), `${content.trim()}\n`);
+  }
+  return root;
+}
+
+function xdgOptions(root: string): { env: Record<string, string>; homeDir: string } {
+  return {
+    env: {
+      XDG_CONFIG_HOME: join(root, "config"),
+    },
+    homeDir: join(root, "home"),
+  };
+}

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -210,16 +210,19 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     evidence: [
       docs("https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references"),
       docs("https://linear.app/outfitter/issue/SET-233/add-managed-known-skillsets-index-for-marketplace-repo-resolution"),
+      docs("https://linear.app/outfitter/issue/SET-234/implement-skillset-marketplace-check-readiness-reports"),
+      test("apps/skillset/src/__tests__/marketplace-check-cli.test.ts", "SET-234 marketplace check CLI coverage"),
+      test("packages/core/src/__tests__/marketplace-check.test.ts", "SET-234 marketplace readiness report coverage"),
       test("apps/skillset/src/__tests__/skillset.test.ts", "SET-133 marketplace catalog parser coverage"),
       test("packages/core/src/__tests__/known-skillsets.test.ts", "managed known-Skillsets XDG index coverage"),
       test("packages/schema/src/__tests__/schema.test.ts", "workspace config marketplace contract coverage"),
     ],
     id: "marketplaces",
     kind: "workflow",
-    renderOwner: "future",
+    renderOwner: "packages/core/src/marketplace-check.ts",
     sourceShape: "workspace skillset.yaml marketplaces",
     status: "planned",
-    summary: "Declares curated provider marketplace catalogs that can reference local or external Skillset plugins without provider output paths.",
+    summary: "Declares curated provider marketplace catalogs and verifies local or known-index plugin readiness before provider indexes are rendered.",
     targetSupport: {
       claude: {
         evidence: [docs("docs/features/marketplaces.md"), providerSchemaSnapshot("claude-marketplace-schema")],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,14 @@ export {
   type DistributionSelectorKind,
 } from "./distribution";
 export {
+  checkMarketplaces,
+  type MarketplaceCheckEntryReport,
+  type MarketplaceCheckReport,
+  type MarketplaceCheckSourceReport,
+  type MarketplaceReadinessState,
+  type MarketplaceSourceKind,
+} from "./marketplace-check";
+export {
   FEATURE_STATUS_VALUES,
   RUNTIME_SUPPORT_STATUS_VALUES,
   SKILLSET_RUNTIME_IDS,

--- a/packages/core/src/marketplace-check.ts
+++ b/packages/core/src/marketplace-check.ts
@@ -1,0 +1,315 @@
+import { join } from "node:path";
+
+import { isOutputSelected } from "./config";
+import { compareStrings } from "./path";
+import { pluginIdForSelector } from "./source-unit-selector";
+import { loadBuildGraph } from "./resolver";
+import { verifySkillsetResult } from "./build";
+import { resolveKnownSkillsetWorkspace, type KnownSkillsetEntry } from "./known-skillsets";
+import type {
+  BuildGraph,
+  MarketplaceCatalogConfig,
+  MarketplacePluginEntryConfig,
+  SkillsetOptions,
+  SourcePlugin,
+  TargetName,
+} from "./types";
+import type { SkillsetRenderResult } from "./render-result";
+
+export type MarketplaceReadinessState =
+  | "declared"
+  | "resolved"
+  | "renderable"
+  | "generated"
+  | "verified"
+  | "marketplace-ready"
+  | "not-ready";
+
+export type MarketplaceSourceKind = "current" | "known-index" | "unresolved";
+
+export interface MarketplaceCheckReport {
+  readonly entries: readonly MarketplaceCheckEntryReport[];
+  readonly marketplaces: readonly string[];
+  readonly ok: boolean;
+}
+
+export interface MarketplaceCheckEntryReport {
+  readonly catalog: string;
+  readonly entryId: string;
+  readonly generatedPath?: string;
+  readonly generatedPaths: readonly string[];
+  readonly plugin: string;
+  readonly providerSource: string;
+  readonly reason: string;
+  readonly readiness: "marketplace-ready" | "not-ready";
+  readonly repo?: string;
+  readonly requestedTarget: TargetName;
+  readonly resolvedTargetSupport: boolean;
+  readonly source: MarketplaceCheckSourceReport;
+  readonly states: readonly MarketplaceReadinessState[];
+}
+
+export interface MarketplaceCheckSourceReport {
+  readonly cacheKey?: string;
+  readonly kind: MarketplaceSourceKind;
+  readonly path?: string;
+  readonly repository?: string;
+}
+
+interface MarketplaceCheckOptions extends SkillsetOptions {
+  readonly name?: string;
+}
+
+interface SourceInspection {
+  readonly error?: string;
+  readonly graph?: BuildGraph;
+  readonly kind: MarketplaceSourceKind;
+  readonly path?: string;
+  readonly repository?: string;
+  readonly cacheKey?: string;
+  readonly renderResults: readonly SkillsetRenderResult[];
+  readonly verifyFailures: readonly string[];
+}
+
+export async function checkMarketplaces(
+  rootPath: string,
+  options: MarketplaceCheckOptions = {}
+): Promise<MarketplaceCheckReport> {
+  const rootGraph = await loadBuildGraph(rootPath, options);
+  const catalogs = selectedCatalogs(rootGraph.root.marketplaces, options.name);
+  const current = await inspectSource(rootPath, "current", options);
+  const inspections = new Map<string, Promise<SourceInspection | undefined>>();
+  const entries: MarketplaceCheckEntryReport[] = [];
+
+  for (const [catalogName, catalog] of catalogs) {
+    for (const entry of catalog.plugins) {
+      const inspection = entry.repo === undefined
+        ? current
+        : await resolveExternalInspection(entry.repo, options, inspections);
+      for (const target of entry.targets ?? catalog.targets) {
+        entries.push(checkMarketplaceEntry(catalogName, entry, target, inspection));
+      }
+    }
+  }
+
+  return {
+    entries: entries.sort(compareMarketplaceEntries),
+    marketplaces: catalogs.map(([name]) => name),
+    ok: entries.every((entry) => entry.readiness === "marketplace-ready"),
+  };
+}
+
+function selectedCatalogs(
+  catalogs: Readonly<Record<string, MarketplaceCatalogConfig>>,
+  name: string | undefined
+): readonly (readonly [string, MarketplaceCatalogConfig])[] {
+  if (name !== undefined) {
+    const catalog = catalogs[name];
+    if (catalog === undefined) throw new Error(`skillset: unknown marketplace ${name}`);
+    return [[name, catalog]];
+  }
+  return Object.entries(catalogs).sort(([left], [right]) => compareStrings(left, right));
+}
+
+async function resolveExternalInspection(
+  repo: string,
+  options: SkillsetOptions,
+  inspections: Map<string, Promise<SourceInspection | undefined>>
+): Promise<SourceInspection | undefined> {
+  const existing = inspections.get(repo);
+  if (existing !== undefined) return existing;
+  const pending = resolveKnownSkillsetWorkspace(repo, options.xdg).then((entry) =>
+    entry === undefined ? undefined : inspectKnownSource(entry, options).catch((error: unknown) => failedKnownSourceInspection(entry, error))
+  );
+  inspections.set(repo, pending);
+  return pending;
+}
+
+function failedKnownSourceInspection(entry: KnownSkillsetEntry, error: unknown): SourceInspection {
+  return {
+    cacheKey: entry.cacheKey,
+    error: error instanceof Error ? error.message : String(error),
+    kind: "known-index",
+    path: entry.path,
+    ...(entry.repository === undefined ? {} : { repository: entry.repository }),
+    renderResults: [],
+    verifyFailures: [],
+  };
+}
+
+async function inspectKnownSource(
+  entry: KnownSkillsetEntry,
+  options: SkillsetOptions
+): Promise<SourceInspection> {
+  return inspectSource(entry.path, "known-index", options, {
+    cacheKey: entry.cacheKey,
+    ...(entry.repository === undefined ? {} : { repository: entry.repository }),
+  });
+}
+
+async function inspectSource(
+  path: string,
+  kind: MarketplaceSourceKind,
+  options: SkillsetOptions,
+  metadata: { readonly cacheKey?: string; readonly repository?: string } = {}
+): Promise<SourceInspection> {
+  const graph = await loadBuildGraph(path, options);
+  const verified = await verifySkillsetResult(path, options);
+  return {
+    graph,
+    kind,
+    path,
+    ...(metadata.cacheKey === undefined ? {} : { cacheKey: metadata.cacheKey }),
+    ...(metadata.repository === undefined ? {} : { repository: metadata.repository }),
+    renderResults: verified.renderResults,
+    verifyFailures: verified.data.failures,
+  };
+}
+
+function checkMarketplaceEntry(
+  catalog: string,
+  entry: MarketplacePluginEntryConfig,
+  target: TargetName,
+  inspection: SourceInspection | undefined
+): MarketplaceCheckEntryReport {
+  const declared = ["declared"] as const;
+  if (inspection === undefined) {
+    return notReady(catalog, entry, target, inspection, declared, "unresolved external repo", []);
+  }
+  if (inspection.graph === undefined) {
+    return notReady(catalog, entry, target, inspection, declared, `failed to inspect source: ${inspection.error ?? "missing build graph"}`, []);
+  }
+
+  const source = sourceReport(inspection);
+  const plugin = inspection.graph.plugins.find((candidate) => candidate.id === entry.plugin);
+  if (plugin === undefined) {
+    return notReady(catalog, entry, target, inspection, [...declared, "resolved"], `missing plugin ${entry.plugin}`, []);
+  }
+
+  const generatedPath = pluginManifestPath(inspection.graph, plugin, target);
+  if (!pluginTargetRenderable(inspection.graph, plugin, target)) {
+    return {
+      catalog,
+      entryId: entry.id,
+      generatedPath,
+      generatedPaths: [],
+      plugin: entry.plugin,
+      providerSource: providerSource(generatedPath),
+      reason: `${target} output is not enabled for plugin ${entry.plugin}`,
+      readiness: "not-ready",
+      ...(entry.repo === undefined ? {} : { repo: entry.repo }),
+      requestedTarget: target,
+      resolvedTargetSupport: false,
+      source,
+      states: ["declared", "resolved", "not-ready"],
+    };
+  }
+
+  const outputPaths = pluginOutputPaths(inspection, plugin.id, target);
+  if (outputPaths.length === 0) {
+    return notReady(catalog, entry, target, inspection, ["declared", "resolved", "renderable"], "no generated provider output was planned", [], generatedPath, true);
+  }
+
+  const failures = outputPaths.flatMap((path) => failuresForPath(inspection.verifyFailures, path));
+  if (failures.length > 0) {
+    return notReady(catalog, entry, target, inspection, ["declared", "resolved", "renderable"], failures[0] ?? "generated provider output is stale", outputPaths, generatedPath, true);
+  }
+
+  return {
+    catalog,
+    entryId: entry.id,
+    generatedPath,
+    generatedPaths: outputPaths,
+    plugin: entry.plugin,
+    providerSource: providerSource(generatedPath),
+    reason: "provider output is generated and verified",
+    readiness: "marketplace-ready",
+    ...(entry.repo === undefined ? {} : { repo: entry.repo }),
+    requestedTarget: target,
+    resolvedTargetSupport: true,
+    source,
+    states: ["declared", "resolved", "renderable", "generated", "verified", "marketplace-ready"],
+  };
+}
+
+function notReady(
+  catalog: string,
+  entry: MarketplacePluginEntryConfig,
+  target: TargetName,
+  inspection: SourceInspection | undefined,
+  states: readonly MarketplaceReadinessState[],
+  reason: string,
+  generatedPaths: readonly string[],
+  generatedPath?: string,
+  resolvedTargetSupport = false
+): MarketplaceCheckEntryReport {
+  return {
+    catalog,
+    entryId: entry.id,
+    ...(generatedPath === undefined ? {} : { generatedPath }),
+    generatedPaths,
+    plugin: entry.plugin,
+    providerSource: generatedPath === undefined ? "" : providerSource(generatedPath),
+    reason,
+    readiness: "not-ready",
+    ...(entry.repo === undefined ? {} : { repo: entry.repo }),
+    requestedTarget: target,
+    resolvedTargetSupport,
+    source: inspection === undefined ? { kind: "unresolved" } : sourceReport(inspection),
+    states: [...states, "not-ready"],
+  };
+}
+
+function sourceReport(inspection: SourceInspection): MarketplaceCheckSourceReport {
+  return {
+    ...(inspection.cacheKey === undefined ? {} : { cacheKey: inspection.cacheKey }),
+    kind: inspection.kind,
+    ...(inspection.path === undefined ? {} : { path: inspection.path }),
+    ...(inspection.repository === undefined ? {} : { repository: inspection.repository }),
+  };
+}
+
+function pluginTargetRenderable(graph: BuildGraph, plugin: SourcePlugin, target: TargetName): boolean {
+  return plugin.targets[target].enabled && isOutputSelected(graph.root.outputs.targetOutputs[target].plugins, plugin.id);
+}
+
+function pluginManifestPath(graph: BuildGraph, plugin: SourcePlugin, target: TargetName): string {
+  const root = graph.root.outputs.plugins[target];
+  const manifest = target === "claude" ? ".claude-plugin/plugin.json" : ".codex-plugin/plugin.json";
+  return join(root, "plugins", plugin.id, manifest).replaceAll("\\", "/");
+}
+
+function pluginOutputPaths(
+  inspection: SourceInspection,
+  pluginId: string,
+  target: TargetName
+): readonly string[] {
+  const paths = new Set<string>();
+  for (const result of inspection.renderResults) {
+    if (result.target !== target) continue;
+    if (pluginIdForSelector(result.sourceUnit) !== pluginId) continue;
+    if (result.outputs === undefined) continue;
+    for (const output of result.outputs) paths.add(output.path);
+  }
+  return [...paths].sort(compareStrings);
+}
+
+function failuresForPath(failures: readonly string[], path: string): readonly string[] {
+  return failures.filter((failure) => failure.includes(path));
+}
+
+function providerSource(path: string): string {
+  const match = path.match(/^(.*)\/plugins\/([^/]+)/);
+  if (match === null) return path;
+  const outputRoot = match[1];
+  const pluginId = match[2];
+  if (outputRoot === undefined || pluginId === undefined) return path;
+  return `./plugins/${pluginId}`;
+}
+
+function compareMarketplaceEntries(left: MarketplaceCheckEntryReport, right: MarketplaceCheckEntryReport): number {
+  return compareStrings(
+    `${left.catalog}\0${left.entryId}\0${left.requestedTarget}`,
+    `${right.catalog}\0${right.entryId}\0${right.requestedTarget}`
+  );
+}

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -183,7 +183,7 @@ export async function loadBuildGraph(
   ];
   validateAdaptiveHookAttachments(adaptiveHooks, hookAttachments);
 
-  if (plugins.length === 0 && standaloneSkills.length === 0 && rules.length === 0 && projectAgents.length === 0 && projectIslands.length === 0) {
+  if (plugins.length === 0 && standaloneSkills.length === 0 && rules.length === 0 && projectAgents.length === 0 && projectIslands.length === 0 && Object.keys(marketplaces).length === 0) {
     throw new Error(`skillset: no source plugins, skills, rules, project agents, or provider source found under ${sourceRoot}/`);
   }
 


### PR DESCRIPTION
## Context

Implements SET-234 in the marketplace catalog stack. SET-133 added the marketplace source contract and SET-233 added the managed known-Skillsets index; this slice adds the read-only readiness command that can prove whether marketplace catalog entries are locally renderable and generated before provider marketplace writes land.

## What changed

- Added `skillset marketplace check [name] [--json]` as a read-only CLI command.
- Added core readiness reports for local/current and managed known-Skillsets external plugin entries.
- Reports declared, resolved, renderable, generated, verified, marketplace-ready/not-ready state with plugin, target, source, generated path, and reason details.
- Allows marketplace-only workspace graphs so curator repos can be checked before local plugin source exists.
- Blocks unbuilt/stale/missing/target-missing entries and reports unresolved remote refs as `not-ready` without fetching or writing.
- Added docs, feature-registry evidence, tests, and a patch Changeset.

## Verification

- `bun test packages/core/src/__tests__/marketplace-check.test.ts apps/skillset/src/__tests__/marketplace-check-cli.test.ts packages/core/src/__tests__/feature-registry.test.ts`
- `bun test apps/skillset/src/__tests__/contract.test.ts -t "SET-83"`
- `bun run typecheck`
- `bun run skillset:ci`
- `bun run changeset:check`
- `git diff --check`
- `git diff --check --cached`
- `bun run check`
- pre-push hook: repo sanity, whitespace, Changesets, workflow lint, `skillset-ci`, `check`

## Local review

- Targeted local-review: 5/5 clean, 0 open P0-P2 findings.
- Report: `.agents/goals/2026-06-30-skillset-marketplace-catalogs/tmp/reviews/codex/set-234-round-1.json`

## Boundary / follow-up

Remote git/cache acquisition, ref policy, lock provenance, and provider marketplace writes remain deferred to SET-235/SET-236. This command intentionally reports unresolved external refs as not-ready instead of crossing the no-fetch/no-write boundary.

Closes SET-234