### PR TITLE
feat: add marketplace lock provenance

### DIFF
--- a/.changeset/marketplace-ref-policy.md
+++ b/.changeset/marketplace-ref-policy.md
@@ -1,0 +1,7 @@
+---
+"@skillset/core": patch
+"@skillset/schema": patch
+"skillset": patch
+---
+
+Add marketplace `sha` source support, lock provenance, and stale/pinned readiness diagnostics for `skillset marketplace check`.

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1208,6 +1208,9 @@ function printMarketplaceCheck(report: MarketplaceCheckReport): void {
         `plugin ${entry.plugin} source ${source}`
     );
     console.log(`    reason: ${entry.reason}`);
+    if (entry.lock.state !== "locked") {
+      console.log(`    lock: ${entry.lock.state} ${entry.lock.policy} (${entry.lock.reason})`);
+    }
     if (entry.generatedPath !== undefined) console.log(`    generated: ${entry.generatedPath}`);
     if (entry.generatedPaths.length > 1) {
       console.log(`    generated bundle: ${entry.generatedPaths.join(", ")}`);

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -39,9 +39,10 @@ Optional plugin entry fields:
 | --- | --- |
 | `id` | Catalog entry id when it must differ from the plugin id. Defaults to `plugin`. |
 | `repo` | External Skillset repo reference, such as `github:org/repo` or an HTTPS git URL. |
-| `channel` | Floating policy such as `latest`; lock provenance must pin the resolved commit/version later. |
-| `ref` | Git ref requested by the catalog source. |
-| `version` | Version policy requested by the catalog source. |
+| `channel` | Floating policy such as `latest`; lock provenance pins the resolved commit/version. |
+| `ref` | Git ref requested by the catalog source; lock provenance records the exact resolved checkout. |
+| `sha` | Exact commit requested by the catalog source. Pinned entries fail when the resolved checkout does not match. |
+| `version` | Version policy requested by the catalog source; plugin version authority stays in the plugin repo. |
 | `targets` | Provider targets for this entry, narrowing the catalog targets. |
 
 Provider output paths such as `plugins-claude`, `plugins-codex`, `.claude-plugin`, or `.codex-plugin` are not part of the marketplace source contract. Provider-native source forms are derived output details for `marketplace update`.
@@ -81,18 +82,21 @@ Marketplace readiness is explicit:
 
 `skillset marketplace check [name] [--json]` is the read-only verifier. It parses marketplace source, resolves local entries from the current repo, resolves external entries from the managed known-Skillsets index when available, verifies provider target support and generated output freshness, and reports unresolved, stale, unbuilt, and target-missing entries. It does not write provider marketplace files, publish, install, trust, activate anything, mutate external repos, or register local paths in committed source.
 
-The check command exits successfully only when every selected target entry reaches `marketplace-ready`. Unresolved remote refs are reported as `not-ready` until remote/cache acquisition and lock provenance land in the follow-up slices.
+The check command exits successfully only when every selected target entry reaches `marketplace-ready`. Bare local and known-index entries are treated as current-checkout checks. Explicit `channel`, `ref`, `version`, and `sha` policies must also match `skillset.lock` provenance; stale or absent lock proof blocks readiness. Unresolved remote refs are reported as `not-ready` until remote/cache acquisition lands in the follow-up update slice.
 
 `skillset marketplace update` is planned as the explicit write command. It should run the same readiness checks, refuse not-ready entries, render provider-native marketplace indexes, and update existing `skillset.lock` provenance. It must require the usual write posture and must not mutate external plugin repos or runtime/user settings.
 
 ## Provenance
 
-Marketplace provenance belongs in existing `skillset.lock` files. There is no separate marketplace lock. Lock/report records should include the marketplace id, entry id, plugin id, source repo, requested channel/ref/version policy, resolved commit SHA/ref, plugin version, provider target, provider-native marketplace source form, derived provider output path, generated output hash, and readiness status.
+Marketplace provenance belongs in existing `skillset.lock` files. There is no separate marketplace lock. The root lock can carry a top-level `marketplaces.entries` section alongside generated-output `items`; `items` remains the generated-file ownership list, while marketplace entries record catalog readiness and resolved source facts without claiming ownership of external plugin repo files.
+
+Each marketplace lock/report entry records the marketplace id, entry id, plugin id, source repo when present, requested channel/ref/sha/version policy, resolved source kind/path/ref/SHA when known, plugin version, provider target, provider-native marketplace source form, derived provider output path(s), and readiness status. Explicit pinned `sha` entries fail if the resolved checkout SHA is missing or different. Floating entries fail when the current resolution differs from the lock.
 
 ## Evidence
 
 - [SET-133](https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references) - source contract and command boundary.
 - [SET-233](https://linear.app/outfitter/issue/SET-233/add-managed-known-skillsets-index-for-marketplace-repo-resolution) - managed XDG known-Skillsets index for local checkout resolution.
 - [SET-234](https://linear.app/outfitter/issue/SET-234/implement-skillset-marketplace-check-readiness-reports) - read-only marketplace readiness reports.
+- [SET-235](https://linear.app/outfitter/issue/SET-235/define-marketplace-ref-policy-and-lock-provenance-for-floating-and) - marketplace ref policy and `skillset.lock` provenance.
 - [Distributions](distributions.md) - related post-build sync planning surface.
 - [Runtime Adapters](runtime-adapters.md) - runtime support remains separate from compile targets and marketplace readiness.

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -1862,6 +1862,10 @@
                       },
                       "type": "string"
                     },
+                    "sha": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
                     "targets": {
                       "items": {
                         "enum": [

--- a/docs/reference/schemas/0.1.0/workspace-config.schema.json
+++ b/docs/reference/schemas/0.1.0/workspace-config.schema.json
@@ -156,6 +156,10 @@
                   },
                   "type": "string"
                 },
+                "sha": {
+                  "minLength": 1,
+                  "type": "string"
+                },
                 "targets": {
                   "items": {
                     "enum": [

--- a/packages/core/src/__tests__/marketplace-check.test.ts
+++ b/packages/core/src/__tests__/marketplace-check.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -28,7 +28,8 @@ describe("marketplace check", () => {
       readiness: "marketplace-ready",
       requestedTarget: "claude",
       resolvedTargetSupport: true,
-      states: ["declared", "resolved", "renderable", "generated", "verified", "marketplace-ready"],
+      lock: expect.objectContaining({ state: "locked" }),
+      states: ["declared", "resolved", "renderable", "generated", "verified", "locked", "marketplace-ready"],
     }));
     expect(report.entries).toContainEqual(expect.objectContaining({
       generatedPath: "plugins-codex/plugins/local-tools/.codex-plugin/plugin.json",
@@ -94,14 +95,14 @@ codex: false
       plugin: "missing-tools",
       reason: "missing plugin missing-tools",
       requestedTarget: "claude",
-      states: ["declared", "resolved", "not-ready"],
+      states: ["declared", "resolved", "locked", "not-ready"],
     }));
     expect(report.entries).toContainEqual(expect.objectContaining({
       entryId: "claude-only",
       plugin: "claude-only",
       reason: "codex output is not enabled for plugin claude-only",
       requestedTarget: "codex",
-      states: ["declared", "resolved", "not-ready"],
+      states: ["declared", "resolved", "locked", "not-ready"],
     }));
   });
 
@@ -147,6 +148,7 @@ skillset:
     expect(report.ok).toBe(true);
     expect(report.entries).toEqual([expect.objectContaining({
       entryId: "trails",
+      lock: expect.objectContaining({ state: "absent", policy: "local" }),
       plugin: "trails-tools",
       readiness: "marketplace-ready",
       repo: "github:outfitter-dev/trails",
@@ -157,6 +159,31 @@ skillset:
         path: external,
         repository: "git@github.com:outfitter-dev/trails.git",
       }),
+    })]);
+  });
+
+  test("keeps bare external repo entries as current-checkout policy in the marketplace lock", async () => {
+    const root = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - id: trails
+        plugin: trails-tools
+        repo: github:outfitter-dev/trails
+`,
+    });
+
+    await buildSkillsetResult(root);
+    const lock = JSON.parse(await readFile(join(root, "skillset.lock"), "utf8")) as {
+      marketplaces: { entries: Array<{ requested: { kind: string; channel?: string } }> };
+    };
+
+    expect(lock.marketplaces.entries).toEqual([expect.objectContaining({
+      requested: { kind: "local" },
     })]);
   });
 
@@ -225,6 +252,62 @@ marketplaces:
         path: invalid,
       }),
       states: ["declared", "not-ready"],
+    })]);
+  });
+
+  test("reports stale marketplace lock provenance", async () => {
+    const root = await fixture(localMarketplaceFiles());
+    await buildSkillsetResult(root);
+    const lockPath = join(root, "skillset.lock");
+    const lock = JSON.parse(await readFile(lockPath, "utf8")) as {
+      marketplaces: { entries: Array<{ generatedPaths: string[]; resolved: { generatedPaths: string[] } }> };
+    };
+    lock.marketplaces.entries[0]!.generatedPaths = ["plugins-claude/plugins/local-tools/stale.json"];
+    lock.marketplaces.entries[0]!.resolved.generatedPaths = ["plugins-claude/plugins/local-tools/stale.json"];
+    await writeFile(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+
+    const report = await checkMarketplaces(root, { name: "outfitter" });
+
+    expect(report.ok).toBe(false);
+    expect(report.entries).toContainEqual(expect.objectContaining({
+      lock: expect.objectContaining({
+        reason: "marketplace lock entry is stale for the current resolution",
+        state: "stale",
+      }),
+      readiness: "not-ready",
+      requestedTarget: "claude",
+      states: ["declared", "resolved", "renderable", "generated", "verified", "stale", "not-ready"],
+    }));
+  });
+
+  test("blocks pinned marketplace entries when the source sha cannot be verified", async () => {
+    const root = await fixture({
+      ...localMarketplaceFiles(),
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: local-tools
+        sha: deadbeef
+`,
+    });
+    await buildSkillsetResult(root);
+
+    const report = await checkMarketplaces(root, { name: "outfitter" });
+
+    expect(report.ok).toBe(false);
+    expect(report.entries).toEqual([expect.objectContaining({
+      lock: expect.objectContaining({
+        expectedSha: "deadbeef",
+        policy: "sha",
+        reason: "pinned sha deadbeef could not be verified for the resolved source",
+        state: "stale",
+      }),
+      readiness: "not-ready",
+      states: ["declared", "pinned", "resolved", "renderable", "generated", "verified", "stale", "not-ready"],
     })]);
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -774,7 +774,7 @@ function readMarketplacePluginEntry(raw: JsonValue | undefined, label: string): 
     throw new Error(`skillset: expected ${label} to be an object`);
   }
   for (const key of Object.keys(raw)) {
-    if (key !== "channel" && key !== "id" && key !== "plugin" && key !== "ref" && key !== "repo" && key !== "targets" && key !== "version") {
+    if (key !== "channel" && key !== "id" && key !== "plugin" && key !== "ref" && key !== "repo" && key !== "sha" && key !== "targets" && key !== "version") {
       throw new Error(`skillset: unsupported marketplace plugin key ${key} in ${label}`);
     }
   }
@@ -788,6 +788,7 @@ function readMarketplacePluginEntry(raw: JsonValue | undefined, label: string): 
   const targets = readOptionalTargetNames(raw.targets, `${label}.targets`);
   const channel = readOptionalString(raw, "channel", `${label}.channel`);
   const ref = readOptionalString(raw, "ref", `${label}.ref`);
+  const sha = readOptionalString(raw, "sha", `${label}.sha`);
   const version = readOptionalString(raw, "version", `${label}.version`);
   return {
     ...(channel === undefined ? {} : { channel }),
@@ -795,6 +796,7 @@ function readMarketplacePluginEntry(raw: JsonValue | undefined, label: string): 
     plugin,
     ...(ref === undefined ? {} : { ref }),
     ...(repo === undefined ? {} : { repo }),
+    ...(sha === undefined ? {} : { sha }),
     ...(targets === undefined ? {} : { targets }),
     ...(version === undefined ? {} : { version }),
   };

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -211,8 +211,10 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       docs("https://linear.app/outfitter/issue/SET-133/design-skillset-marketplace-catalogs-and-external-plugin-references"),
       docs("https://linear.app/outfitter/issue/SET-233/add-managed-known-skillsets-index-for-marketplace-repo-resolution"),
       docs("https://linear.app/outfitter/issue/SET-234/implement-skillset-marketplace-check-readiness-reports"),
+      docs("https://linear.app/outfitter/issue/SET-235/define-marketplace-ref-policy-and-lock-provenance-for-floating-and"),
       test("apps/skillset/src/__tests__/marketplace-check-cli.test.ts", "SET-234 marketplace check CLI coverage"),
       test("packages/core/src/__tests__/marketplace-check.test.ts", "SET-234 marketplace readiness report coverage"),
+      test("packages/core/src/__tests__/marketplace-check.test.ts", "SET-235 marketplace lock provenance coverage"),
       test("apps/skillset/src/__tests__/skillset.test.ts", "SET-133 marketplace catalog parser coverage"),
       test("packages/core/src/__tests__/known-skillsets.test.ts", "managed known-Skillsets XDG index coverage"),
       test("packages/schema/src/__tests__/schema.test.ts", "workspace config marketplace contract coverage"),
@@ -222,7 +224,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     renderOwner: "packages/core/src/marketplace-check.ts",
     sourceShape: "workspace skillset.yaml marketplaces",
     status: "planned",
-    summary: "Declares curated provider marketplace catalogs and verifies local or known-index plugin readiness before provider indexes are rendered.",
+    summary: "Declares curated provider marketplace catalogs and verifies local or known-index plugin readiness with lock provenance before provider indexes are rendered.",
     targetSupport: {
       claude: {
         evidence: [docs("docs/features/marketplaces.md"), providerSchemaSnapshot("claude-marketplace-schema")],

--- a/packages/core/src/marketplace-check.ts
+++ b/packages/core/src/marketplace-check.ts
@@ -1,4 +1,8 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import { isOutputSelected } from "./config";
 import { compareStrings } from "./path";
@@ -6,6 +10,7 @@ import { pluginIdForSelector } from "./source-unit-selector";
 import { loadBuildGraph } from "./resolver";
 import { verifySkillsetResult } from "./build";
 import { resolveKnownSkillsetWorkspace, type KnownSkillsetEntry } from "./known-skillsets";
+import { pluginVersion } from "./versioning";
 import type {
   BuildGraph,
   MarketplaceCatalogConfig,
@@ -16,12 +21,18 @@ import type {
 } from "./types";
 import type { SkillsetRenderResult } from "./render-result";
 
+const execFileAsync = promisify(execFile);
+
 export type MarketplaceReadinessState =
   | "declared"
+  | "floating"
+  | "locked"
+  | "pinned"
   | "resolved"
   | "renderable"
   | "generated"
   | "verified"
+  | "stale"
   | "marketplace-ready"
   | "not-ready";
 
@@ -38,6 +49,7 @@ export interface MarketplaceCheckEntryReport {
   readonly entryId: string;
   readonly generatedPath?: string;
   readonly generatedPaths: readonly string[];
+  readonly lock: MarketplaceCheckLockReport;
   readonly plugin: string;
   readonly providerSource: string;
   readonly reason: string;
@@ -49,11 +61,59 @@ export interface MarketplaceCheckEntryReport {
   readonly states: readonly MarketplaceReadinessState[];
 }
 
+export interface MarketplaceCheckLockReport {
+  readonly path: "skillset.lock";
+  readonly policy: MarketplaceRefPolicyKind;
+  readonly reason: string;
+  readonly state: "absent" | "locked" | "stale";
+  readonly expectedSha?: string;
+  readonly resolvedSha?: string;
+}
+
 export interface MarketplaceCheckSourceReport {
   readonly cacheKey?: string;
+  readonly ref?: string;
   readonly kind: MarketplaceSourceKind;
   readonly path?: string;
   readonly repository?: string;
+  readonly sha?: string;
+}
+
+export type MarketplaceRefPolicyKind = "channel" | "local" | "ref" | "sha" | "version";
+
+export interface MarketplaceLockEntry {
+  readonly catalog: string;
+  readonly entryId: string;
+  readonly generatedPath?: string;
+  readonly generatedPaths: readonly string[];
+  readonly plugin: string;
+  readonly providerSource: string;
+  readonly readiness: "marketplace-ready" | "not-ready";
+  readonly repo?: string;
+  readonly requested: MarketplaceRequestedRefPolicy;
+  readonly requestedTarget: TargetName;
+  readonly resolved: MarketplaceResolvedLockState;
+}
+
+export interface MarketplaceRequestedRefPolicy {
+  readonly channel?: string;
+  readonly kind: MarketplaceRefPolicyKind;
+  readonly ref?: string;
+  readonly sha?: string;
+  readonly version?: string;
+}
+
+export interface MarketplaceResolvedLockState {
+  readonly cacheKey?: string;
+  readonly generatedPath?: string;
+  readonly generatedPaths: readonly string[];
+  readonly pluginVersion?: string;
+  readonly providerSource: string;
+  readonly ref?: string;
+  readonly repository?: string;
+  readonly sha?: string;
+  readonly sourceKind: MarketplaceSourceKind;
+  readonly sourcePath?: string;
 }
 
 interface MarketplaceCheckOptions extends SkillsetOptions {
@@ -67,7 +127,9 @@ interface SourceInspection {
   readonly path?: string;
   readonly repository?: string;
   readonly cacheKey?: string;
+  readonly ref?: string;
   readonly renderResults: readonly SkillsetRenderResult[];
+  readonly sha?: string;
   readonly verifyFailures: readonly string[];
 }
 
@@ -77,6 +139,7 @@ export async function checkMarketplaces(
 ): Promise<MarketplaceCheckReport> {
   const rootGraph = await loadBuildGraph(rootPath, options);
   const catalogs = selectedCatalogs(rootGraph.root.marketplaces, options.name);
+  const lockEntries = await readMarketplaceLockEntries(rootPath);
   const current = await inspectSource(rootPath, "current", options);
   const inspections = new Map<string, Promise<SourceInspection | undefined>>();
   const entries: MarketplaceCheckEntryReport[] = [];
@@ -87,7 +150,7 @@ export async function checkMarketplaces(
         ? current
         : await resolveExternalInspection(entry.repo, options, inspections);
       for (const target of entry.targets ?? catalog.targets) {
-        entries.push(checkMarketplaceEntry(catalogName, entry, target, inspection));
+        entries.push(checkMarketplaceEntry(catalogName, entry, target, inspection, lockEntries));
       }
     }
   }
@@ -161,6 +224,7 @@ async function inspectSource(
     path,
     ...(metadata.cacheKey === undefined ? {} : { cacheKey: metadata.cacheKey }),
     ...(metadata.repository === undefined ? {} : { repository: metadata.repository }),
+    ...(await gitIdentity(path)),
     renderResults: verified.renderResults,
     verifyFailures: verified.data.failures,
   };
@@ -170,29 +234,45 @@ function checkMarketplaceEntry(
   catalog: string,
   entry: MarketplacePluginEntryConfig,
   target: TargetName,
-  inspection: SourceInspection | undefined
+  inspection: SourceInspection | undefined,
+  lockEntries: readonly MarketplaceLockEntry[]
 ): MarketplaceCheckEntryReport {
-  const declared = ["declared"] as const;
+  const refPolicy = requestedRefPolicy(entry);
+  const policyStates = statesForRefPolicy(refPolicy);
+  const declared = ["declared", ...policyStates] as const;
   if (inspection === undefined) {
-    return notReady(catalog, entry, target, inspection, declared, "unresolved external repo", []);
+    return notReady(catalog, entry, target, inspection, declared, "unresolved external repo", [], refPolicy, lockEntries);
   }
   if (inspection.graph === undefined) {
-    return notReady(catalog, entry, target, inspection, declared, `failed to inspect source: ${inspection.error ?? "missing build graph"}`, []);
+    return notReady(catalog, entry, target, inspection, declared, `failed to inspect source: ${inspection.error ?? "missing build graph"}`, [], refPolicy, lockEntries);
   }
 
   const source = sourceReport(inspection);
   const plugin = inspection.graph.plugins.find((candidate) => candidate.id === entry.plugin);
   if (plugin === undefined) {
-    return notReady(catalog, entry, target, inspection, [...declared, "resolved"], `missing plugin ${entry.plugin}`, []);
+    return notReady(catalog, entry, target, inspection, [...declared, "resolved"], `missing plugin ${entry.plugin}`, [], refPolicy, lockEntries);
   }
 
   const generatedPath = pluginManifestPath(inspection.graph, plugin, target);
+  const baseLockEntry = marketplaceLockEntryFor({
+    catalog,
+    entry,
+    generatedPath,
+    generatedPaths: [],
+    inspection,
+    pluginVersion: pluginVersion(inspection.graph, plugin),
+    readiness: "not-ready",
+    requested: refPolicy,
+    target,
+  });
   if (!pluginTargetRenderable(inspection.graph, plugin, target)) {
+    const lock = compareMarketplaceLock(baseLockEntry, lockEntries);
     return {
       catalog,
       entryId: entry.id,
       generatedPath,
       generatedPaths: [],
+      lock,
       plugin: entry.plugin,
       providerSource: providerSource(generatedPath),
       reason: `${target} output is not enabled for plugin ${entry.plugin}`,
@@ -201,18 +281,49 @@ function checkMarketplaceEntry(
       requestedTarget: target,
       resolvedTargetSupport: false,
       source,
-      states: ["declared", "resolved", "not-ready"],
+      states: ["declared", ...policyStates, "resolved", ...lockStates(lock), "not-ready"],
     };
   }
 
   const outputPaths = pluginOutputPaths(inspection, plugin.id, target);
   if (outputPaths.length === 0) {
-    return notReady(catalog, entry, target, inspection, ["declared", "resolved", "renderable"], "no generated provider output was planned", [], generatedPath, true);
+    return notReady(catalog, entry, target, inspection, ["declared", ...policyStates, "resolved", "renderable"], "no generated provider output was planned", [], refPolicy, lockEntries, generatedPath, true);
   }
 
   const failures = outputPaths.flatMap((path) => failuresForPath(inspection.verifyFailures, path));
   if (failures.length > 0) {
-    return notReady(catalog, entry, target, inspection, ["declared", "resolved", "renderable"], failures[0] ?? "generated provider output is stale", outputPaths, generatedPath, true);
+    return notReady(catalog, entry, target, inspection, ["declared", ...policyStates, "resolved", "renderable"], failures[0] ?? "generated provider output is stale", outputPaths, refPolicy, lockEntries, generatedPath, true);
+  }
+
+  const lockEntry = marketplaceLockEntryFor({
+    catalog,
+    entry,
+    generatedPath,
+    generatedPaths: outputPaths,
+    inspection,
+    pluginVersion: pluginVersion(inspection.graph, plugin),
+    readiness: "marketplace-ready",
+    requested: refPolicy,
+    target,
+  });
+  const lock = compareMarketplaceLock(lockEntry, lockEntries);
+  if (lockBlocksReadiness(lock, refPolicy)) {
+    return {
+      catalog,
+      entryId: entry.id,
+      generatedPath,
+      generatedPaths: outputPaths,
+      lock,
+      plugin: entry.plugin,
+      providerSource: providerSource(generatedPath),
+      reason: lock.reason,
+      readiness: "not-ready",
+      ...(entry.repo === undefined ? {} : { repo: entry.repo }),
+      requestedTarget: target,
+      resolvedTargetSupport: true,
+      source,
+      states: ["declared", ...policyStates, "resolved", "renderable", "generated", "verified", ...lockStates(lock), "not-ready"],
+    };
   }
 
   return {
@@ -220,6 +331,7 @@ function checkMarketplaceEntry(
     entryId: entry.id,
     generatedPath,
     generatedPaths: outputPaths,
+    lock,
     plugin: entry.plugin,
     providerSource: providerSource(generatedPath),
     reason: "provider output is generated and verified",
@@ -228,7 +340,7 @@ function checkMarketplaceEntry(
     requestedTarget: target,
     resolvedTargetSupport: true,
     source,
-    states: ["declared", "resolved", "renderable", "generated", "verified", "marketplace-ready"],
+    states: ["declared", ...policyStates, "resolved", "renderable", "generated", "verified", "locked", "marketplace-ready"],
   };
 }
 
@@ -240,14 +352,30 @@ function notReady(
   states: readonly MarketplaceReadinessState[],
   reason: string,
   generatedPaths: readonly string[],
+  requested: MarketplaceRequestedRefPolicy,
+  lockEntries: readonly MarketplaceLockEntry[],
   generatedPath?: string,
   resolvedTargetSupport = false
 ): MarketplaceCheckEntryReport {
+  const lockEntryInput = {
+    catalog,
+    entry,
+    generatedPaths,
+    inspection,
+    readiness: "not-ready",
+    requested,
+    target,
+  } satisfies Omit<Parameters<typeof marketplaceLockEntryFor>[0], "generatedPath">;
+  const lock = compareMarketplaceLock(marketplaceLockEntryFor({
+    ...lockEntryInput,
+    ...(generatedPath === undefined ? {} : { generatedPath }),
+  }), lockEntries);
   return {
     catalog,
     entryId: entry.id,
     ...(generatedPath === undefined ? {} : { generatedPath }),
     generatedPaths,
+    lock,
     plugin: entry.plugin,
     providerSource: generatedPath === undefined ? "" : providerSource(generatedPath),
     reason,
@@ -256,7 +384,7 @@ function notReady(
     requestedTarget: target,
     resolvedTargetSupport,
     source: inspection === undefined ? { kind: "unresolved" } : sourceReport(inspection),
-    states: [...states, "not-ready"],
+    states: [...states, ...lockStates(lock), "not-ready"],
   };
 }
 
@@ -265,8 +393,210 @@ function sourceReport(inspection: SourceInspection): MarketplaceCheckSourceRepor
     ...(inspection.cacheKey === undefined ? {} : { cacheKey: inspection.cacheKey }),
     kind: inspection.kind,
     ...(inspection.path === undefined ? {} : { path: inspection.path }),
+    ...(inspection.ref === undefined ? {} : { ref: inspection.ref }),
     ...(inspection.repository === undefined ? {} : { repository: inspection.repository }),
+    ...(inspection.sha === undefined ? {} : { sha: inspection.sha }),
   };
+}
+
+function requestedRefPolicy(entry: MarketplacePluginEntryConfig): MarketplaceRequestedRefPolicy {
+  if (entry.sha !== undefined) return { kind: "sha", sha: entry.sha };
+  if (entry.ref !== undefined) return { kind: "ref", ref: entry.ref };
+  if (entry.channel !== undefined) return { channel: entry.channel, kind: "channel" };
+  if (entry.version !== undefined) return { kind: "version", version: entry.version };
+  return { kind: "local" };
+}
+
+function statesForRefPolicy(policy: MarketplaceRequestedRefPolicy): readonly MarketplaceReadinessState[] {
+  if (policy.kind === "sha") return ["pinned"];
+  if (policy.kind === "channel" || policy.kind === "ref" || policy.kind === "version") return ["floating"];
+  return [];
+}
+
+function lockStates(lock: MarketplaceCheckLockReport): readonly MarketplaceReadinessState[] {
+  if (lock.state === "locked") return ["locked"];
+  if (lock.state === "stale") return ["stale"];
+  return [];
+}
+
+function lockBlocksReadiness(lock: MarketplaceCheckLockReport, policy: MarketplaceRequestedRefPolicy): boolean {
+  if (lock.state === "stale") return true;
+  return lock.state === "absent" && policy.kind !== "local";
+}
+
+function marketplaceLockEntryFor(args: {
+  readonly catalog: string;
+  readonly entry: MarketplacePluginEntryConfig;
+  readonly generatedPath?: string;
+  readonly generatedPaths: readonly string[];
+  readonly inspection: SourceInspection | undefined;
+  readonly pluginVersion?: string;
+  readonly readiness: "marketplace-ready" | "not-ready";
+  readonly requested: MarketplaceRequestedRefPolicy;
+  readonly target: TargetName;
+}): MarketplaceLockEntry {
+  const provider = args.generatedPath === undefined ? "" : providerSource(args.generatedPath);
+  return {
+    catalog: args.catalog,
+    entryId: args.entry.id,
+    ...(args.generatedPath === undefined ? {} : { generatedPath: args.generatedPath }),
+    generatedPaths: args.generatedPaths,
+    plugin: args.entry.plugin,
+    providerSource: provider,
+    readiness: args.readiness,
+    ...(args.entry.repo === undefined ? {} : { repo: args.entry.repo }),
+    requested: args.requested,
+    requestedTarget: args.target,
+    resolved: {
+      ...(args.inspection?.cacheKey === undefined ? {} : { cacheKey: args.inspection.cacheKey }),
+      ...(args.generatedPath === undefined ? {} : { generatedPath: args.generatedPath }),
+      generatedPaths: args.generatedPaths,
+      ...(args.pluginVersion === undefined ? {} : { pluginVersion: args.pluginVersion }),
+      providerSource: provider,
+      ...(args.inspection?.ref === undefined ? {} : { ref: args.inspection.ref }),
+      ...(args.inspection?.repository === undefined ? {} : { repository: args.inspection.repository }),
+      ...(args.inspection?.sha === undefined ? {} : { sha: args.inspection.sha }),
+      sourceKind: args.inspection?.kind ?? "unresolved",
+      ...(args.inspection?.path === undefined ? {} : { sourcePath: args.inspection.path }),
+    },
+  };
+}
+
+function compareMarketplaceLock(
+  current: MarketplaceLockEntry,
+  lockedEntries: readonly MarketplaceLockEntry[]
+): MarketplaceCheckLockReport {
+  const match = lockedEntries.find((entry) =>
+    entry.catalog === current.catalog &&
+    entry.entryId === current.entryId &&
+    entry.requestedTarget === current.requestedTarget
+  );
+  const expectedSha = current.requested.kind === "sha" ? current.requested.sha : match?.resolved.sha;
+  const resolvedSha = current.resolved.sha;
+
+  const pinnedSha = current.requested.kind === "sha" ? current.requested.sha : undefined;
+  if (pinnedSha !== undefined && resolvedSha === undefined) {
+    return {
+      expectedSha: pinnedSha,
+      path: "skillset.lock",
+      policy: current.requested.kind,
+      reason: `pinned sha ${pinnedSha} could not be verified for the resolved source`,
+      state: "stale",
+    };
+  }
+  if (pinnedSha !== undefined && resolvedSha !== undefined && pinnedSha !== resolvedSha) {
+    return {
+      expectedSha: pinnedSha,
+      path: "skillset.lock",
+      policy: current.requested.kind,
+      reason: `pinned sha mismatch: resolved ${resolvedSha}, expected ${pinnedSha}`,
+      resolvedSha,
+      state: "stale",
+    };
+  }
+
+  if (match === undefined) {
+    if (current.requested.kind === "local") {
+      return {
+        path: "skillset.lock",
+        policy: current.requested.kind,
+        reason: "no marketplace lock entry; run skillset build --yes after marketplace source changes",
+        ...(resolvedSha === undefined ? {} : { resolvedSha }),
+        state: "absent",
+      };
+    }
+    return {
+      path: "skillset.lock",
+      policy: current.requested.kind,
+      reason: `${current.requested.kind} marketplace entry is not locked; run skillset marketplace update after resolution support lands`,
+      ...(expectedSha === undefined ? {} : { expectedSha }),
+      ...(resolvedSha === undefined ? {} : { resolvedSha }),
+      state: "absent",
+    };
+  }
+
+  if (stableMarketplaceLockFingerprint(match) !== stableMarketplaceLockFingerprint(current)) {
+    return {
+      path: "skillset.lock",
+      policy: current.requested.kind,
+      reason: "marketplace lock entry is stale for the current resolution",
+      ...(expectedSha === undefined ? {} : { expectedSha }),
+      ...(resolvedSha === undefined ? {} : { resolvedSha }),
+      state: "stale",
+    };
+  }
+
+  return {
+    path: "skillset.lock",
+    policy: current.requested.kind,
+    reason: "marketplace resolution matches skillset.lock",
+    ...(expectedSha === undefined ? {} : { expectedSha }),
+    ...(resolvedSha === undefined ? {} : { resolvedSha }),
+    state: "locked",
+  };
+}
+
+function stableMarketplaceLockFingerprint(entry: MarketplaceLockEntry): string {
+  const resolved = { ...entry.resolved };
+  if (entry.requested.kind === "local") {
+    delete resolved.ref;
+    delete resolved.sha;
+    delete resolved.sourcePath;
+  }
+  return stableJson({
+    catalog: entry.catalog,
+    entryId: entry.entryId,
+    generatedPath: entry.generatedPath,
+    generatedPaths: entry.generatedPaths,
+    plugin: entry.plugin,
+    providerSource: entry.providerSource,
+    readiness: entry.readiness,
+    repo: entry.repo,
+    requested: entry.requested,
+    requestedTarget: entry.requestedTarget,
+    resolved,
+  });
+}
+
+function compareMarketplaceLockEntries(left: MarketplaceLockEntry, right: MarketplaceLockEntry): number {
+  return compareStrings(
+    `${left.catalog}\0${left.entryId}\0${left.requestedTarget}`,
+    `${right.catalog}\0${right.entryId}\0${right.requestedTarget}`
+  );
+}
+
+async function readMarketplaceLockEntries(rootPath: string): Promise<readonly MarketplaceLockEntry[]> {
+  const lockPath = join(rootPath, "skillset.lock");
+  if (!(await exists(lockPath))) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(lockPath, "utf8")) as unknown;
+  } catch {
+    return [];
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.marketplaces) || !Array.isArray(parsed.marketplaces.entries)) return [];
+  return parsed.marketplaces.entries
+    .filter(isMarketplaceLockEntry)
+    .sort(compareMarketplaceLockEntries);
+}
+
+function isMarketplaceLockEntry(value: unknown): value is MarketplaceLockEntry {
+  return isRecord(value) &&
+    typeof value.catalog === "string" &&
+    typeof value.entryId === "string" &&
+    Array.isArray(value.generatedPaths) &&
+    value.generatedPaths.every((path) => typeof path === "string") &&
+    typeof value.plugin === "string" &&
+    typeof value.providerSource === "string" &&
+    (value.readiness === "marketplace-ready" || value.readiness === "not-ready") &&
+    isRecord(value.requested) &&
+    typeof value.requested.kind === "string" &&
+    typeof value.requestedTarget === "string" &&
+    isRecord(value.resolved) &&
+    Array.isArray(value.resolved.generatedPaths) &&
+    value.resolved.generatedPaths.every((path) => typeof path === "string") &&
+    typeof value.resolved.providerSource === "string" &&
+    typeof value.resolved.sourceKind === "string";
 }
 
 function pluginTargetRenderable(graph: BuildGraph, plugin: SourcePlugin, target: TargetName): boolean {
@@ -311,5 +641,52 @@ function compareMarketplaceEntries(left: MarketplaceCheckEntryReport, right: Mar
   return compareStrings(
     `${left.catalog}\0${left.entryId}\0${left.requestedTarget}`,
     `${right.catalog}\0${right.entryId}\0${right.requestedTarget}`
+  );
+}
+
+async function gitIdentity(path: string): Promise<{ readonly ref?: string; readonly sha?: string }> {
+  const sha = await runGit(path, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  const ref = await runGit(path, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+  return {
+    ...(ref === undefined ? {} : { ref }),
+    ...(sha === undefined ? {} : { sha }),
+  };
+}
+
+async function runGit(path: string, args: readonly string[]): Promise<string | undefined> {
+  try {
+    const result = await execFileAsync("git", ["-C", path, ...args], { timeout: 5000 });
+    const stdout = String(result.stdout).trim();
+    return stdout.length === 0 ? undefined : stdout;
+  } catch {
+    return undefined;
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => compareStrings(left, right))
+      .map(([key, entry]) => [key, sortJson(entry)])
   );
 }

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -171,6 +171,9 @@ export async function renderBuildGraph(graph: BuildGraph): Promise<readonly Rend
   rendered.push(...(await renderRules(graph, lockRoots)));
   rendered.push(...(await renderProjectIslands(graph, lockRoots)));
   rendered.push(...(await renderChangelogs(graph, lockRoots)));
+  if (Object.keys(graph.root.marketplaces).length > 0) {
+    lockRootsFor(lockRoots, WORKSPACE_LOCK_ROOT, "workspace");
+  }
   rendered.push(...renderLockFiles(graph, lockRoots));
   return [...coalesceRenderedFiles(rendered)]
     .sort((left, right) => compareStrings(left.path, right.path))
@@ -2079,6 +2082,7 @@ function renderLockFiles(
       items: lock.items
         .map((item) => stripUndefinedLockItem(item))
         .sort((left, right) => compareStrings(String(left.outputPath), String(right.outputPath))),
+      ...(outputRoot === WORKSPACE_LOCK_ROOT ? marketplaceLockProvenance(graph, lockRoots) : {}),
       selectedTargets: [...graph.root.compile.targets],
       skillsetMetadata: graph.root.compile.skillset.metadata,
       outputRoot,
@@ -2090,6 +2094,92 @@ function renderLockFiles(
   }
 
   return rendered;
+}
+
+function marketplaceLockProvenance(
+  graph: BuildGraph,
+  lockRoots: ReadonlyMap<string, LockRoot>
+): JsonRecord {
+  const entries: JsonRecord[] = [];
+  for (const [catalogName, catalog] of Object.entries(graph.root.marketplaces).sort(([left], [right]) => compareStrings(left, right))) {
+    for (const entry of catalog.plugins) {
+      const plugin = graph.plugins.find((candidate) => candidate.id === entry.plugin);
+      for (const target of entry.targets ?? catalog.targets) {
+        const generatedPath = plugin === undefined ? undefined : marketplacePluginManifestPath(graph, plugin, target);
+        const renderable = plugin !== undefined && plugin.targets[target].enabled && isOutputSelected(graph.root.outputs.targetOutputs[target].plugins, plugin.id);
+        const generatedPaths = renderable ? marketplaceGeneratedPaths(lockRoots, graph.root.outputs.plugins[target], entry.plugin) : [];
+        const provider = generatedPath === undefined ? "" : marketplaceProviderSource(generatedPath);
+        entries.push(stripUndefinedJsonRecord({
+          catalog: catalogName,
+          entryId: entry.id,
+          generatedPath,
+          generatedPaths: [...generatedPaths],
+          plugin: entry.plugin,
+          providerSource: provider,
+          readiness: renderable ? "marketplace-ready" : "not-ready",
+          repo: entry.repo,
+          requested: marketplaceRequestedPolicy(entry),
+          requestedTarget: target,
+          resolved: stripUndefinedJsonRecord({
+            generatedPath,
+            generatedPaths: [...generatedPaths],
+            pluginVersion: plugin === undefined ? undefined : pluginVersion(graph, plugin),
+            providerSource: provider,
+            repository: entry.repo,
+            sourceKind: entry.repo === undefined ? "current" : "unresolved",
+            sourcePath: entry.repo === undefined ? "." : undefined,
+          }),
+        }));
+      }
+    }
+  }
+  return entries.length === 0 ? {} : { marketplaces: { entries: entries.sort((left, right) => compareStrings(`${left.catalog}\0${left.entryId}\0${left.requestedTarget}`, `${right.catalog}\0${right.entryId}\0${right.requestedTarget}`)) } };
+}
+
+function marketplaceGeneratedPaths(
+  lockRoots: ReadonlyMap<string, LockRoot>,
+  outputRoot: string,
+  pluginId: string
+): readonly string[] {
+  const lock = lockRoots.get(outputRoot);
+  if (lock === undefined) return [];
+  const paths = new Set<string>();
+  for (const item of lock.items) {
+    if (item.plugin !== pluginId && !(item.kind === "plugin" && item.name === pluginId)) continue;
+    for (const file of item.files) paths.add(join(outputRoot, file).replaceAll("\\", "/"));
+  }
+  return [...paths].sort(compareStrings);
+}
+
+function marketplaceRequestedPolicy(entry: {
+  readonly channel?: string;
+  readonly ref?: string;
+  readonly repo?: string;
+  readonly sha?: string;
+  readonly version?: string;
+}): JsonRecord {
+  if (entry.sha !== undefined) return { kind: "sha", sha: entry.sha };
+  if (entry.ref !== undefined) return { kind: "ref", ref: entry.ref };
+  if (entry.channel !== undefined) return { channel: entry.channel, kind: "channel" };
+  if (entry.version !== undefined) return { kind: "version", version: entry.version };
+  return { kind: "local" };
+}
+
+function marketplacePluginManifestPath(graph: BuildGraph, plugin: SourcePlugin, target: TargetName): string {
+  const root = graph.root.outputs.plugins[target];
+  const manifest = target === "claude" ? ".claude-plugin/plugin.json" : ".codex-plugin/plugin.json";
+  return join(root, "plugins", plugin.id, manifest).replaceAll("\\", "/");
+}
+
+function marketplaceProviderSource(path: string): string {
+  const match = path.match(/^(.*)\/plugins\/([^/]+)/);
+  if (match === null) return path;
+  const pluginId = match[2];
+  return pluginId === undefined ? path : `./plugins/${pluginId}`;
+}
+
+function stripUndefinedJsonRecord(record: Record<string, JsonValue | undefined>): JsonRecord {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined)) as JsonRecord;
 }
 
 function lockRootsFor(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -99,6 +99,7 @@ export interface MarketplacePluginEntryConfig {
   readonly plugin: string;
   readonly ref?: string;
   readonly repo?: string;
+  readonly sha?: string;
   readonly targets?: readonly TargetName[];
   readonly version?: string;
 }

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -392,6 +392,7 @@ function marketplacePluginEntrySchema(): SchemaJsonRecord {
         },
         type: "string",
       },
+      sha: nonEmptyStringSchema(),
       targets: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
       version: nonEmptyStringSchema(),
     }),

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -251,7 +251,7 @@ function checkMarketplacePluginEntry(value: SchemaJsonValue, path: string, diagn
     diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin", "marketplace plugin entries must be objects"));
     return;
   }
-  checkAllowedKeys(value, new Set(["channel", "id", "plugin", "ref", "repo", "targets", "version"]), path, "schema/workspace-config/marketplace-plugin-key", diagnostics);
+  checkAllowedKeys(value, new Set(["channel", "id", "plugin", "ref", "repo", "sha", "targets", "version"]), path, "schema/workspace-config/marketplace-plugin-key", diagnostics);
   checkOptionalMarketplaceId(value.id, `${path}.id`, diagnostics);
   if (value.plugin === undefined) {
     diagnostics.push(diagnostic(`${path}.plugin`, "schema/workspace-config/marketplace-plugin", "marketplace plugin entries require plugin"));
@@ -260,6 +260,7 @@ function checkMarketplacePluginEntry(value: SchemaJsonValue, path: string, diagn
   }
   checkOptionalNonEmptyString(value.channel, `${path}.channel`, "schema/workspace-config/marketplace-plugin-channel", diagnostics);
   checkOptionalNonEmptyString(value.ref, `${path}.ref`, "schema/workspace-config/marketplace-plugin-ref", diagnostics);
+  checkOptionalNonEmptyString(value.sha, `${path}.sha`, "schema/workspace-config/marketplace-plugin-sha", diagnostics);
   checkOptionalNonEmptyString(value.version, `${path}.version`, "schema/workspace-config/marketplace-plugin-version", diagnostics);
   checkMarketplaceRepo(value.repo, `${path}.repo`, diagnostics);
   if (value.targets !== undefined) checkTargets(value.targets, `${path}.targets`, diagnostics, "marketplace plugin targets");


### PR DESCRIPTION
## Context

SET-235 follows the marketplace catalog source contract and readiness report slices by making marketplace references auditable through the existing `skillset.lock` surface. The goal is to keep marketplace repos as curators while proving whether external plugin refs are pinned, floating, stale, or unresolved without fetching or mutating other repos.

Closes SET-235.

## What Changed

- Added `sha` as an explicit marketplace plugin reference policy alongside `repo`, `ref`, `version`, and `channel`.
- Extended root `skillset.lock` with top-level `marketplaces.entries` provenance for generated marketplace catalogs.
- Updated `skillset marketplace check` to report lock state and block readiness for stale/floating/pinned-mismatch conditions.
- Added CLI output for non-locked marketplace entries and documented the new policy/lock behavior.
- Regenerated schema artifacts and feature registry evidence.

## Verification

- `bun run schema:generate && bun run schema:check`
- `bun test packages/core/src/__tests__/marketplace-check.test.ts apps/skillset/src/__tests__/marketplace-check-cli.test.ts packages/core/src/__tests__/feature-registry.test.ts packages/schema/src/__tests__/schema.test.ts`
- `bun run typecheck`
- `bun run changeset:check`
- `git diff --check` and `git diff --check --cached`
- `bun run check`
- `bun run skillset:ci`
- pre-push hook passed before branch push

## Local Review

Local review is 5/5 clean with no open findings. Report: `.agents/goals/2026-06-30-skillset-marketplace-catalogs/tmp/reviews/codex/set-235-round-1.json`.

## Boundaries

Remote git/cache acquisition, provider marketplace writes, and any cross-repo mutation remain deferred to SET-236. This slice only records/checks provenance and keeps runtime/user config untouched.
