### PR TITLE
fix: remove retired plugin output adoption paths

### DIFF
--- a/.changeset/remove-retired-plugin-roots.md
+++ b/.changeset/remove-retired-plugin-roots.md
@@ -1,0 +1,6 @@
+---
+"@skillset/core": patch
+"skillset": patch
+---
+
+Stop treating retired provider-first plugin output roots as importable or conformance-relevant paths now that generated plugin output uses the plugin-first `plugins/<plugin>/<provider>` layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ For source/config/frontmatter fields, follow [docs/schema-contracts.md](docs/sch
 ## Responsibilities
 
 - Read adaptive source from a repo's `.skillset/` directory with workspace/source config in root `skillset.yaml`.
-- Emit target-native plugin repositories under configured output roots, defaulting to `plugins-claude/` and `plugins-codex/`.
+- Emit target-native plugin bundles under `plugins/<plugin>/<provider>/` by default, with shared generated provenance in `plugins/skillset.lock`.
 - Emit standalone skills under configured target skill roots, defaulting to `.claude/skills` and `.agents/skills`.
 - Emit source instructions from `<source-root>/rules/**/*.md` to Claude `.claude/rules/**/*.md` and Codex directory-local `AGENTS.md` files without overwriting unmanaged guidance.
 - Preserve plugin boundaries across Claude and Codex outputs.
@@ -83,5 +83,5 @@ bun ./apps/skillset/src/cli.ts doctor --root .
 - Do not publish this package or add a remote unless the maintainer explicitly asks.
 - Do not mutate user-level Claude or Codex config.
 - Do not install, trust, or symlink generated plugins or skills into global runtime locations.
-- Do not hand-edit `.claude/skills`, `.agents/skills`, `plugins-claude`, or `plugins-codex` as source truth; in this repo, edit `skillset/` for source or `skillset.yaml` for workspace config, then rebuild.
+- Do not hand-edit `.claude/skills`, `.agents/skills`, or `plugins/` as source truth; in this repo, edit `.skillset/` for source or `skillset.yaml` for workspace config, then rebuild.
 - Keep this package focused on compilation, validation, import, and checks.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -6124,6 +6124,18 @@ test("SET-62: init detects nested plugins without a marketplace manifest", async
   ]);
 });
 
+test("SET-256: init ignores retired provider-first generated plugin roots", async () => {
+  const root = await contractFixture({
+    "plugins-claude/plugins/alpha/.claude-plugin/plugin.json": JSON.stringify({ name: "alpha" }),
+    "plugins-codex/plugins/beta/.codex-plugin/plugin.json": JSON.stringify({ name: "beta" }),
+    "plugins/authored/.claude-plugin/plugin.json": JSON.stringify({ name: "authored" }),
+  });
+
+  const report = await initSkillset({ cwd: root, useGitRoot: false, write: false });
+
+  expect(report.importCandidates).toEqual([{ kind: "plugin", path: "plugins/authored" }]);
+});
+
 test("SET-255: shared plugin lock does not hide authored plugin import candidates", async () => {
   const root = await contractFixture({
     ".claude-plugin/marketplace.json": JSON.stringify({
@@ -6611,7 +6623,7 @@ Body.
   const preview = await runSkillsetCli("init", "--root", root);
   expect(preview.exitCode).toBe(0);
   expect(preview.stdout).not.toContain("? import candidate skills .agents/skills");
-  expect(preview.stdout).not.toContain("? import candidate plugins plugins-codex/plugins");
+  expect(preview.stdout).not.toContain("? import candidate plugins plugins/");
 });
 
 test("SET-43: init rejects version conflicts with existing release state", async () => {

--- a/apps/skillset/src/setup.ts
+++ b/apps/skillset/src/setup.ts
@@ -269,8 +269,6 @@ async function detectImportCandidates(
   await maybeCandidate(candidates, rootPath, ".claude/skills", "skills");
   await maybeCandidate(candidates, rootPath, ".codex/skills", "skills");
   await maybeCandidate(candidates, rootPath, ".agents/skills", "skills");
-  await maybeCandidate(candidates, rootPath, "plugins-claude/plugins", "plugins");
-  await maybeCandidate(candidates, rootPath, "plugins-codex/plugins", "plugins");
   if (await pathExists(join(rootPath, ".claude-plugin/plugin.json")) || await pathExists(join(rootPath, ".codex-plugin/plugin.json"))) {
     candidates.push({ kind: "plugin", path: "." });
   }

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -45,7 +45,7 @@ Optional plugin entry fields:
 | `version` | Version policy requested by the catalog source; plugin version authority stays in the plugin repo. |
 | `targets` | Provider targets for this entry, narrowing the catalog targets. |
 
-Provider output paths such as `plugins-claude`, `plugins-codex`, `.claude-plugin`, or `.codex-plugin` are not part of the marketplace source contract. Provider-native source forms are derived output details for `marketplace update`.
+Provider output paths such as `plugins/<plugin>/<provider>`, `.claude-plugin`, or `.codex-plugin` are not part of the marketplace source contract. Provider-native source forms are derived output details for `marketplace update`.
 
 For Claude, local entries render as relative plugin roots such as `./plugins/outfitter-core`. External entries render as provider-native git subdirectory sources that point at the referenced repo and the derived generated Claude plugin bundle path, such as:
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,7 @@ pre-commit:
     - name: skillset
       env:
         GIT_PAGER: cat
-      glob: "{.skillset/**,.claude/skills/**,.agents/skills/**,plugins-claude/**,plugins-codex/**,AGENTS.md}"
+      glob: "{.skillset/**,.claude/skills/**,.agents/skills/**,plugins/**,AGENTS.md}"
       run: bun run skillset:verify
     - name: workflows
       env:

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -11,8 +11,7 @@ export default defineConfig({
     ".scratch/**",
     ".agents/skills/**",
     ".claude/skills/**",
-    "plugins-claude/**",
-    "plugins-codex/**",
+    "plugins/**",
   ],
   proseWrap: "never",
 });

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     ".scratch/**",
     ".agents/skills/**",
     ".claude/skills/**",
-    "plugins-claude/**",
-    "plugins-codex/**",
+    "plugins/**",
   ],
 });

--- a/packages/core/src/provider-format-conformance.ts
+++ b/packages/core/src/provider-format-conformance.ts
@@ -584,7 +584,7 @@ function readStringArray(record: JsonRecord, key: string): readonly string[] {
 }
 
 function isClaudeHookPath(path: string): boolean {
-  return (hasSegment(path, "plugins-claude") || hasPluginTargetSegment(path, "claude")) && path.endsWith("/hooks/hooks.json");
+  return hasPluginTargetSegment(path, "claude") && path.endsWith("/hooks/hooks.json");
 }
 
 function isClaudeHookFile(file: ProviderFormatConformanceFile): boolean {
@@ -592,7 +592,7 @@ function isClaudeHookFile(file: ProviderFormatConformanceFile): boolean {
 }
 
 function isCodexHookPath(path: string): boolean {
-  return (hasSegment(path, "plugins-codex") || hasPluginTargetSegment(path, "codex")) && path.endsWith("/hooks/hooks.json");
+  return hasPluginTargetSegment(path, "codex") && path.endsWith("/hooks/hooks.json");
 }
 
 function isCodexHookFile(file: ProviderFormatConformanceFile): boolean {
@@ -602,7 +602,7 @@ function isCodexHookFile(file: ProviderFormatConformanceFile): boolean {
 function isClaudeSubagentPath(path: string): boolean {
   return path.endsWith(".md") && (
     hasSegmentSequence(path, ".claude", "agents") ||
-    ((hasSegment(path, "plugins-claude") || hasPluginTargetSegment(path, "claude")) && hasSegment(path, "agents"))
+    (hasPluginTargetSegment(path, "claude") && hasSegment(path, "agents"))
   );
 }
 
@@ -623,8 +623,8 @@ function isCodexSubagentFile(file: ProviderFormatConformanceFile): boolean {
 
 function skillTarget(path: string): TargetName | undefined {
   if (!path.endsWith("/SKILL.md")) return undefined;
-  if (hasSegmentSequence(path, ".agents", "skills") || hasSegment(path, "plugins-codex") || hasPluginTargetSegment(path, "codex")) return "codex";
-  if (hasSegmentSequence(path, ".claude", "skills") || hasSegment(path, "plugins-claude") || hasPluginTargetSegment(path, "claude")) return "claude";
+  if (hasSegmentSequence(path, ".agents", "skills") || hasPluginTargetSegment(path, "codex")) return "codex";
+  if (hasSegmentSequence(path, ".claude", "skills") || hasPluginTargetSegment(path, "claude")) return "claude";
   return undefined;
 }
 

--- a/scripts/terminology-guard.ts
+++ b/scripts/terminology-guard.ts
@@ -55,8 +55,7 @@ export const ALLOWLIST_PATHS: readonly string[] = [
   // Generated output trees are validated against `.skillset/` source by skillset:verify.
   ".agents/skills/",
   ".claude/",
-  "plugins-claude/",
-  "plugins-codex/",
+  "plugins/",
   ".skillset/cache/",
   ".skillset/snapshots/",
   // Changesets and change-provenance notes describe the cutover / prior changes.


### PR DESCRIPTION
## Context

SET-256 is now a hard cutover away from the retired provider-first generated plugin roots. Since Skillset is still pre-release, we do not need an adoption/migration path for `plugins-claude/plugins` or `plugins-codex/plugins`.

## What changed

- Removed setup import-candidate detection for retired provider-first plugin output roots.
- Added a SET-256 regression proving those old roots are ignored while authored `plugins/<plugin>` remains importable.
- Updated active repo guidance and local tooling globs/ignores to use the current `plugins/<plugin>/<provider>` output layout.
- Tightened provider-format conformance path classification so it dogfoods plugin-first target segments only.
- Added a patch changeset for `skillset` and `@skillset/core`.

## Verification

- `bun test apps/skillset/src/__tests__/contract.test.ts --timeout 20000`
- `bun test packages/core/src/__tests__/provider-format-conformance.test.ts packages/core/src/__tests__/adapter-conformance.test.ts packages/core/src/__tests__/adapter-conformance-coverage.test.ts --timeout 20000`
- `bun run skillset:ci`
- `bun run changeset:check`
- `bun run check`
- Pre-push hook: changesets, workflow lint, `skillset ci`, and full `bun run check`

## Notes

Historical ADR references to `plugins-claude` / `plugins-codex` remain untouched. Active code/guidance/tooling now points at the current plugin-first layout.
