### PR TITLE
docs: define cursor provider contract

### DIFF
--- a/.changeset/cursor-provider-contract.md
+++ b/.changeset/cursor-provider-contract.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Record the Cursor first-class provider contract and point runtime support evidence at the new provider baseline.

--- a/docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md
+++ b/docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md
@@ -1,0 +1,158 @@
+---
+slug: cursor-is-a-first-class-provider
+title: Cursor Is a First-Class Provider
+status: draft
+created: 2026-07-02
+updated: 2026-07-02
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [0, 1, feature-reference-and-schema-registry, agent-source-model, lowering-outcomes-and-loss-ledger]
+---
+
+# ADR: Cursor Is a First-Class Provider
+
+## Context
+
+Skillset has treated Cursor as a runtime candidate while Claude and Codex were the
+only compile targets. That boundary was useful while Cursor evidence was thin, but
+the current Cursor surface is now broad enough that a compatibility shim would be
+the wrong model.
+
+Cursor documents first-class project and plugin surfaces:
+
+- skills at `.cursor/skills/<skill>/SKILL.md`;
+- rules at `.cursor/rules/**/*.mdc`, with `AGENTS.md` also documented as a
+  guidance input;
+- subagents at `.cursor/agents/*.md`, including Cursor-native frontmatter such as
+  `readonly` and `is_background`;
+- plugins with `.cursor-plugin/plugin.json`, root component directories for
+  `rules/`, `skills/`, `agents/`, `commands/`, `hooks/hooks.json`, `mcp.json`,
+  `assets/`, `scripts/`, and `README.md`;
+- marketplaces at root `.cursor-plugin/marketplace.json`;
+- MCP server config under `mcpServers` in plugin-root `mcp.json`;
+- hooks using Cursor lower-camel events such as `sessionStart`,
+  `beforeShellExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `preCompact`,
+  `workspaceOpen`, and others.
+
+The local Cursor CLI also exposes non-interactive runtime machinery through
+`agent` / `cursor-agent` with `--print`, `--output-format`, `--mode plan|ask`,
+`--sandbox`, `--trust`, `--plugin-dir`, and `--workspace`. That is enough to make
+runtime smoke tests a first-class verification path once target output exists.
+
+The danger is to treat Cursor as "Claude-shaped" or "Codex-shaped" because some
+filenames look familiar. Cursor hooks share concepts with Claude and Codex, but
+their event spelling, event set, command payloads, and project/plugin activation
+surfaces are Cursor-native. Cursor subagents share Markdown and YAML with Claude,
+but `readonly` and `is_background` are Cursor capabilities, not portable facts by
+default. Cursor plugins share root component directories with the other providers,
+but `.cursor-plugin` is its own destination contract.
+
+## Decision
+
+Cursor is a first-class Skillset provider. Skillset will add `cursor` as a
+compile target only through provider-evidence, target schema, registry support,
+renderer, import, conformance, and runtime-test slices that preserve Cursor-native
+truth.
+
+This means:
+
+- `compile.targets` may include `cursor` only after `@skillset/schema`,
+  `@skillset/core`, `@skillset/registry`, Workbench, lookup, and generated schema
+  artifacts all agree that `cursor` is a valid target.
+- Cursor provider evidence belongs in `@skillset/registry` with the same offline,
+  checked-in provenance model used for Claude and Codex. Current provider target
+  unions must become extensible enough for Cursor evidence instead of growing
+  Claude/Codex-only special cases.
+- Cursor output must use Cursor-native destinations:
+  - project skills under `.cursor/skills/`;
+  - project rules under `.cursor/rules/` as `.mdc`;
+  - project subagents under `.cursor/agents/`;
+  - plugin bundles under `plugins/<plugin>/cursor/` by default, with
+    `.cursor-plugin/plugin.json` inside the generated bundle;
+  - plugin-local Cursor provider source from `.skillset/plugins/<plugin>/_cursor/**`;
+  - workspace-level Cursor provider source from `.skillset/_cursor/**`.
+- Cursor renderers must dogfood the feature registry and provider evidence before
+  claiming a feature is native, transformed, shimmed, metadata-only, degraded,
+  lossy, or unsupported.
+- Imported Cursor files remain provider-native first. Skillset may lift a Cursor
+  hook, rule, subagent, or plugin component into adaptive source only when registry
+  facts prove the event, matcher, handler, scope, runtime behavior, and output
+  destination can be preserved faithfully.
+- Cursor-specific capability keys stay explicit inside `cursor` blocks or
+  provider-native source until there is a proven portable meaning. `readonly` and
+  `is_background` are good Cursor-native facts; any future portable capability
+  vocabulary must be grounded in an intent model that records provider support,
+  realization, degradation, and unsupported diagnostics.
+- Runtime testing must use the real local Cursor CLI in isolated workspaces and
+  local plugin directories. It must not install, trust, mutate user config, or rely
+  on global provider state as a side effect of build.
+
+The provider contract is deliberately stronger than "make Cursor compile." The
+test is whether `skillset lookup`, `skillset explain`, build diagnostics,
+render results, locks, docs, fixtures, and runtime-tester output all tell the same
+truth for Cursor that they tell for Claude and Codex.
+
+## Implementation Milestones
+
+The Cursor provider parity stack should proceed in milestone order. If a later
+slice discovers missing provider facts, it must update the registry/design first
+instead of patching the renderer locally.
+
+| Milestone | Required outcome |
+| --- | --- |
+| Evidence and contract | Cursor docs and local CLI evidence are recorded; this ADR and the portable capability/permission intent model define what can be native, transformed, shimmed, degraded, lossy, or unsupported. |
+| Target and output plumbing | `cursor` is accepted by schema/core/registry/Workbench/lookup; output roots, `_cursor` source islands, locks, safety checks, and generated schema artifacts include Cursor. |
+| Native renderers | Skills, rules, subagents, plugins, marketplaces, MCP, hooks, commands, and provider-native companions render only where Cursor has a faithful destination. |
+| Import and runtime proof | Cursor imports preserve native source unless a faithful adaptive lift exists; runtime-tester dogfoods generated Cursor output with the local CLI in isolated workspaces. |
+| Parity gate | Adapter conformance, deterministic projection, fixtures, docs, generated guidance, Linear, PR checks, and local review all agree that Cursor is fully working. |
+
+## Consequences
+
+### Positive
+
+- Cursor support can be as complete as Claude/Codex support without being forced
+  through either provider's vocabulary.
+- Provider facts become more modular because the registry must support third-party
+  provider packages and future provider evidence, not just hard-coded internal
+  Claude/Codex unions.
+- Diagnostics stay honest when Cursor can represent a feature differently, cannot
+  represent it, or can only represent it through an explicit Cursor-native escape
+  hatch.
+- Runtime proof becomes reusable: the same non-interactive Cursor CLI machinery
+  can later support evals, activation checks, and fixture reviews.
+
+### Tradeoffs
+
+- Adding Cursor is broader than adding another string to `TargetName`; schema
+  artifacts, registry evidence, Workbench, lookup, docs, and conformance all need
+  to move together.
+- Some source that looks portable will remain provider-native until Cursor,
+  Claude, and Codex capability facts prove an adaptive contract.
+- The initial Cursor provider may require more fixture and runtime-test setup than
+  a pure compile-only target because the CLI has meaningful activation behavior.
+
+### What This Does NOT Decide
+
+- It does not make Cursor the default target for new workspaces. That default
+  belongs to the final parity gate after fixtures and runtime proof are green.
+- It does not install Cursor plugins, trust workspaces, mutate `~/.cursor`, or
+  change user-level Cursor configuration.
+- It does not decide a universal permission/capability vocabulary. That model must
+  be designed as portable intent plus provider declarations and provider-native
+  realizations, then adopted only where proven.
+
+## References
+
+- [Tenets](../tenets.md) - source-first, provider-native, fail-loud design principles.
+- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - registry-backed capability claims and evidence.
+- [Agent / Subagent Source Model](20260604-agent-source-model.md) - project and plugin agent boundaries.
+- [Lowering Outcomes and Loss Ledger](20260614-lowering-outcomes-and-loss-ledger.md) - vocabulary for transformed, degraded, lossy, and unsupported outcomes.
+- [Runtime Adapters](../../features/runtime-adapters.md) - current target/runtime boundary.
+- [Provider Surface Evidence Matrix](../../target-surfaces.md) - provider destination evidence and verification notes.
+- [Cursor skills docs](https://cursor.com/docs/skills) - project skill surface, checked 2026-07-02.
+- [Cursor rules docs](https://cursor.com/docs/rules) - project rules and `AGENTS.md`, checked 2026-07-02.
+- [Cursor subagents docs](https://cursor.com/docs/subagents) - project subagent frontmatter, checked 2026-07-02.
+- [Cursor plugins docs](https://cursor.com/docs/plugins) - plugin overview, checked 2026-07-02.
+- [Cursor plugins reference](https://cursor.com/docs/reference/plugins) - plugin structure, marketplaces, hooks, and MCP, checked 2026-07-02.
+- [Cursor hooks docs](https://cursor.com/docs/hooks) - hook runtime behavior and events, checked 2026-07-02.
+- [Cursor MCP docs](https://cursor.com/docs/mcp) - MCP server configuration, checked 2026-07-02.
+- [Cursor headless CLI docs](https://cursor.com/docs/cli/headless) - non-interactive CLI mode, checked 2026-07-02.

--- a/docs/adrs/drafts/README.md
+++ b/docs/adrs/drafts/README.md
@@ -55,3 +55,5 @@ Draft map: `docs/adrs/drafts/decision-map.json`; numbered map: `docs/adrs/decisi
 
 - [Source References Resolve And Rename Together](20260701-path-references-resolve-and-rename-together.md)
   - depends on [Agent / Subagent Source Model](20260604-agent-source-model.md), [First-Class Sets](20260604-first-class-sets.md), [Named Partials](20260627-named-partials.md), [Skillset Workspace Layout](20260627-skillset-workspace-layout.md)
+- [Cursor Is a First-Class Provider](20260702-cursor-is-a-first-class-provider.md)
+  - depends on [ADR-0000: Source-First Loadouts](../0000-source-first-loadouts.md), [ADR-0001: Root Compile Policy](../0001-root-compile-policy.md), [Agent / Subagent Source Model](20260604-agent-source-model.md), [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md), [Lowering Outcomes and Loss Ledger](20260614-lowering-outcomes-and-loss-ledger.md)

--- a/docs/adrs/drafts/decision-map.json
+++ b/docs/adrs/drafts/decision-map.json
@@ -8,6 +8,11 @@
           "context": "- [Agent / Subagent Source Model](20260604-agent-source-model.md) - project agents as the first close-match surface.",
           "from": "20260604",
           "fromPath": "docs/adrs/drafts/20260604-model-and-reasoning-alias-profiles.md"
+        },
+        {
+          "context": "- [Agent / Subagent Source Model](20260604-agent-source-model.md) - project and plugin agent boundaries.",
+          "from": "20260702",
+          "fromPath": "docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md"
         }
       ],
       "number": null,
@@ -91,6 +96,11 @@
           "context": "- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - static feature capability and registry evidence model.",
           "from": "20260614",
           "fromPath": "docs/adrs/drafts/20260614-lowering-outcomes-and-loss-ledger.md"
+        },
+        {
+          "context": "- [Feature Reference and Schema Registry](20260604-feature-reference-and-schema-registry.md) - registry-backed capability claims and evidence.",
+          "from": "20260702",
+          "fromPath": "docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md"
         },
         {
           "context": "See [Feature Reference and Schema Registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) for the ADR-level decision.",
@@ -510,6 +520,11 @@
           "fromPath": "docs/adrs/drafts/20260604-feature-reference-and-schema-registry.md"
         },
         {
+          "context": "- [Lowering Outcomes and Loss Ledger](20260614-lowering-outcomes-and-loss-ledger.md) - vocabulary for transformed, degraded, lossy, and unsupported outcomes.",
+          "from": "20260702",
+          "fromPath": "docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md"
+        },
+        {
           "context": "See the render-results ADR, currently filed as [Lowering Outcomes and Loss Ledger](../adrs/drafts/20260614-lowering-outcomes-and-loss-ledger.md), for the historical decision.",
           "from": "render-results",
           "fromPath": "docs/features/render-results.md"
@@ -694,6 +709,36 @@
       "superseded_by": null,
       "title": "Source References Resolve And Rename Together",
       "updated": "2026-07-01"
+    },
+    {
+      "created": "2026-07-02",
+      "depends_on": [
+        "0",
+        "1",
+        "feature-reference-and-schema-registry",
+        "agent-source-model",
+        "lowering-outcomes-and-loss-ledger"
+      ],
+      "inbound": [
+        {
+          "context": "- [Cursor provider ADR](../adrs/drafts/20260702-cursor-is-a-first-class-provider.md) - first-class Cursor provider contract.",
+          "from": "runtime-adapters",
+          "fromPath": "docs/features/runtime-adapters.md"
+        },
+        {
+          "context": "ADR](adrs/drafts/20260702-cursor-is-a-first-class-provider.md). Provider evidence",
+          "from": "target-surfaces",
+          "fromPath": "docs/target-surfaces.md"
+        }
+      ],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md",
+      "slug": "cursor-is-a-first-class-provider",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Cursor Is a First-Class Provider",
+      "updated": "2026-07-02"
     }
   ],
   "version": 1

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -8,7 +8,16 @@ Runtime adapters describe how a Skillset rendering can be used by an actual agen
 
 ## Status
 
-Runtime adapter records are `planned`. The registry can now describe runtime support, and `skillset runtime-tester` can run non-interactive Claude or Codex prompts against isolated local renderings, but Skillset still only builds the Claude and Codex target renderings. Gemini, Cursor, Devin, Droid, and OpenCode are tracked as runtime candidates, not build targets.
+Runtime adapter records are `planned`. The registry can now describe runtime
+support, and `skillset runtime-tester` can run non-interactive Claude or Codex
+prompts against isolated local renderings, but Skillset still only builds the
+Claude and Codex target renderings.
+
+Cursor is now designed as the next first-class provider target, not a runtime-only
+compatibility candidate. Until the Cursor target schema, registry evidence,
+renderers, import path, conformance fixtures, and runtime smoke tests land
+together, `cursor` remains invalid in `compile.targets` and the runtime support
+record remains `planned`.
 
 ## Authoring
 
@@ -61,7 +70,7 @@ The test: adding a runtime must not make `compile.targets` accept a new value. I
 | Claude Code | `native` for current Claude target renderings | Claude project agents, plugin agents, plugin manifests, skills, hooks, and related surfaces remain target-native Claude output. |
 | Codex CLI | `native` for current Codex target renderings, `shimmed` for some near-match behavior | Codex TOML agents are native. Claude-style agent skill metadata is approximated through deterministic developer-instruction prefaces. |
 | Codex App | `externally_managed` where app/runtime activation is involved | Build can render app definitions, but activation and trust stay outside build. |
-| Cursor | `planned` | Needs current target docs and fixture evidence before Skillset claims rendering or distribution support. |
+| Cursor | `planned` | Planned first-class provider target; see the Cursor provider ADR and provider-surface baseline. Runtime smoke should use the local `agent` / `cursor-agent` CLI with isolated workspaces and `--plugin-dir` once Cursor output exists. |
 | Gemini CLI | `planned` | Needs current extension/distribution docs and fixture evidence before Skillset claims rendering or distribution support. |
 | Devin | `future` | Tracked as a possible runtime, not a current target. |
 | Droid | `future` | Tracked as a possible runtime, not a current target. |
@@ -82,6 +91,8 @@ Runtime support records are registry evidence, not generated target files. Futur
 ## Evidence
 
 - [Feature registry](../adrs/drafts/20260604-feature-reference-and-schema-registry.md) - schema-backed support and evidence direction.
+- [Cursor provider ADR](../adrs/drafts/20260702-cursor-is-a-first-class-provider.md) - first-class Cursor provider contract.
+- [Provider Surface Evidence Matrix](../target-surfaces.md#cursor-provider-baseline) - Cursor evidence baseline and milestone boundary.
 - [Agents](agents.md) - project-agent support and Codex skill-preface shim.
 - [Tests and Evals](tests-and-evals.md) - activation/eval boundary.
 - `fixtures/external/repos.yaml` - pinned external multi-runtime fixture manifest, including Superpowers.

--- a/docs/target-surfaces.md
+++ b/docs/target-surfaces.md
@@ -56,6 +56,30 @@ Source examples use `<source-root>` as shorthand for the canonical `.skillset/` 
 
 Default behavior for unsupported or lossy build results is fail-loud. Softer modes must record visible warnings, skipped-source provenance, or force provenance before they can be treated as safe.
 
+## Cursor provider baseline
+
+Cursor provider support is planned as a first-class compile target, not a Claude
+or Codex compatibility shim. The contract is defined by the [Cursor provider
+ADR](adrs/drafts/20260702-cursor-is-a-first-class-provider.md). Provider evidence
+was live-doc checked on 2026-07-02 against the official Cursor docs.
+
+Cursor becomes implemented only when schema, registry, core, Workbench, lookup,
+generated schema artifacts, renderers, import/adopt, conformance fixtures,
+runtime-tester, docs, and generated guidance all agree on the same provider facts.
+Until then, `compile.targets: [cursor]` must remain invalid.
+
+| Cursor surface | Cursor destination | Status | Notes |
+| --- | --- | --- | --- |
+| Skills | `.cursor/skills/<skill>/SKILL.md` | Planned | Project-level Cursor skills use `SKILL.md`; plugin skills live under plugin-root `skills/`. |
+| Rules | `.cursor/rules/**/*.mdc` | Planned | Cursor also documents `AGENTS.md`; Skillset must decide project-rule rendering from Cursor intent, not from Claude/Codex filenames. |
+| Project subagents | `.cursor/agents/*.md` | Planned | Cursor frontmatter includes `name`, `description`, `model`, `readonly`, and `is_background`; Cursor-specific fields stay provider-native until portable intent is proven. |
+| Plugins | `.cursor-plugin/plugin.json` plus plugin-root components | Planned | Components include `rules/`, `skills/`, `agents/`, `commands/`, `hooks/hooks.json`, `mcp.json`, `assets/`, `scripts/`, and `README.md`. |
+| Marketplace | `.cursor-plugin/marketplace.json` | Planned | Multi-plugin repository catalog surface. External plugin references need provider evidence before marketplace update claims support. |
+| MCP | plugin-root `mcp.json` with `mcpServers` | Planned | Cursor detects plugin-root `mcp.json`; manifest `mcpServers` is needed only for custom paths or inline config. |
+| Hooks | plugin-root `hooks/hooks.json` | Planned | Cursor events are lower-camel provider-native names such as `sessionStart`, `beforeShellExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `preCompact`, and `workspaceOpen`. |
+| Provider-native source | `<source-root>/_cursor/**` and `<source-root>/plugins/<plugin>/_cursor/**` | Planned | Native source remains provider-native by default and is lifted to adaptive source only when registry facts prove a faithful mapping. |
+| Runtime smoke | local `agent` / `cursor-agent` CLI | Planned | Use isolated workspaces, `--print`, `--output-format`, `--mode`, `--plugin-dir`, and `--workspace`; build must not install, trust, or mutate user-level Cursor config. |
+
 ## Source contract
 
 | Source | Renders to | Status | Notes |

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -684,8 +684,13 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         status: "externally_managed",
       },
       cursor: {
-        evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos.yaml")],
-        reason: "Cursor support needs target documentation and adapter evidence before Skillset can lower or distribute it.",
+        evidence: [
+          docs("docs/features/runtime-adapters.md"),
+          docs("docs/target-surfaces.md#cursor-provider-baseline"),
+          docs("docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md"),
+          fixture("fixtures/external/repos.yaml"),
+        ],
+        reason: "Cursor is planned as a first-class provider target; implementation still needs target schema, registry evidence, renderers, import, conformance, and runtime smoke before Skillset can lower or distribute it.",
         status: "planned",
       },
       "gemini-cli": {


### PR DESCRIPTION
## Context

Stack 1/5 for Cursor provider parity. Defines the first-class Cursor provider contract, evidence references, and planned milestones.

## Changes

- Adds the Cursor provider ADR/contract framing.
- Records the provider evidence and compatibility boundaries used by the follow-on implementation slices.

## Verification

- M1 local review: 5/5 clean (`.agents/goals/2026-07-02-cursor-provider-parity/tmp/reviews/codex-m1/round-1.json`).
- Full stack local verification later passed through `bun run check` and pre-push gates on the stack tip.

## Stack

1. set-242-cursor-provider-evidence-contract
2. set-243-cursor-target-core
3. set-245-cursor-native-renderers
4. set-250-cursor-runtime-import-docs
5. set-253-cursor-parity-gate