### PR TITLE
feat: render cursor provider outputs

### DIFF
--- a/.changeset/cursor-native-renderers.md
+++ b/.changeset/cursor-native-renderers.md
@@ -1,0 +1,7 @@
+---
+"@skillset/core": patch
+"@skillset/registry": patch
+"skillset": patch
+---
+
+Render Cursor as a first-class provider target with native plugin, marketplace, skill, rule, agent, hook, and MCP outputs backed by provider registry evidence.

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -90,6 +90,185 @@ Demo plugin skill.
   expect(await exists(join(root, "plugins/demo/codex/skills/child/SKILL.md"))).toBe(true);
 });
 
+test("Cursor target emits native plugin, skill, rule, agent, hook, MCP, and marketplace outputs", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-root
+  title: Cursor Root
+  marketplace:
+    name: cursor-market
+compile:
+  targets: [cursor]
+cursor: true
+`,
+    ".skillset/skills/standalone/SKILL.md": `
+---
+name: standalone
+description: Standalone Cursor skill.
+---
+
+Standalone body.
+`,
+    ".skillset/rules/docs/writing.md": `
+---
+description: Write docs clearly.
+paths:
+  - docs/**/*.md
+---
+
+Write docs clearly.
+`,
+    ".skillset/agents/reviewer.md": `
+---
+description: Review Cursor changes.
+cursor:
+  readonly: true
+  model: cursor-fast
+---
+
+Review changes.
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+  title: Alpha Plugin
+  summary: Alpha Cursor plugin.
+hooks:
+  SessionStart:
+    - greet-session
+cursor:
+  manifest:
+    displayName: Alpha Cursor
+    category: productivity
+    tags: [review, docs]
+`,
+    ".skillset/plugins/alpha/skills/plugin-skill/SKILL.md": `
+---
+name: plugin-skill
+description: Plugin Cursor skill.
+---
+
+Plugin skill body.
+`,
+    ".skillset/plugins/alpha/hooks/greet-session.json": JSON.stringify({
+      events: ["SessionStart"],
+      run: { command: "echo hello" },
+    }),
+    ".skillset/plugins/alpha/.mcp.json": JSON.stringify({
+      mcpServers: {
+        alpha: {
+          command: "alpha-mcp",
+        },
+      },
+    }),
+    ".skillset/plugins/alpha/rules/plugin-quality.mdc": `
+---
+description: Keep alpha quality high.
+alwaysApply: true
+---
+
+Keep quality high.
+`,
+    ".skillset/plugins/alpha/agents/plugin-architect.md": `
+---
+name: plugin-architect
+description: Design alpha plugin changes.
+readonly: true
+---
+
+Design alpha plugin changes.
+`,
+    ".skillset/plugins/alpha/commands/check.md": `
+# Check
+
+Run alpha checks.
+`,
+  });
+
+  await buildSkillset(root);
+
+  expect(await exists(join(root, ".cursor/skills/standalone/SKILL.md"))).toBe(true);
+  expect(await exists(join(root, ".cursor/rules/docs/writing.mdc"))).toBe(true);
+  expect(await exists(join(root, ".cursor/agents/reviewer.md"))).toBe(true);
+  expect(await exists(join(root, "plugins/alpha/cursor/.cursor-plugin/plugin.json"))).toBe(true);
+  expect(await exists(join(root, "plugins/alpha/cursor/skills/plugin-skill/SKILL.md"))).toBe(true);
+  expect(await exists(join(root, "plugins/alpha/cursor/rules/plugin-quality.mdc"))).toBe(true);
+  expect(await exists(join(root, "plugins/alpha/cursor/agents/plugin-architect.md"))).toBe(true);
+  expect(await exists(join(root, "plugins/alpha/cursor/commands/check.md"))).toBe(true);
+  expect(await exists(join(root, "plugins/alpha/cursor/mcp.json"))).toBe(true);
+
+  const marketplace = JSON.parse(await readFile(join(root, ".cursor-plugin/marketplace.json"), "utf8")) as {
+    readonly plugins: readonly { readonly description: string; readonly name: string; readonly source: string }[];
+  };
+  expect(marketplace.plugins).toEqual([
+    { description: "Alpha Cursor plugin.", name: "alpha", source: "plugins/alpha/cursor" },
+  ]);
+
+  const manifest = JSON.parse(await readFile(join(root, "plugins/alpha/cursor/.cursor-plugin/plugin.json"), "utf8")) as Record<string, unknown>;
+  expect(manifest).toMatchObject({
+    agents: "./agents/",
+    commands: "./commands/",
+    displayName: "Alpha Cursor",
+    hooks: "./hooks/hooks.json",
+    mcpServers: "./mcp.json",
+    name: "alpha",
+    rules: "./rules/",
+    skills: "./skills/",
+  });
+
+  const hooks = JSON.parse(await readFile(join(root, "plugins/alpha/cursor/hooks/hooks.json"), "utf8")) as {
+    readonly hooks: Record<string, unknown>;
+  };
+  expect(Object.keys(hooks.hooks)).toEqual(["sessionStart"]);
+
+  const rule = await readFile(join(root, ".cursor/rules/docs/writing.mdc"), "utf8");
+  expect(rule).toContain("description: Write docs clearly.");
+  expect(rule).toContain("globs:");
+  expect(rule).toContain("docs/**/*.md");
+
+  const agent = await readFile(join(root, ".cursor/agents/reviewer.md"), "utf8");
+  expect(agent).toContain("readonly: true");
+  expect(agent).toContain("model: cursor-fast");
+
+  const lock = await readFile(join(root, "plugins/skillset.lock"), "utf8");
+  expect(lock).toContain(`"target": "workspace"`);
+  expect(lock).toContain(`"outputPath": "alpha/cursor/mcp.json"`);
+});
+
+test("Cursor native plugin hooks render provider-native event names", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-root
+compile:
+  targets: [cursor]
+cursor: true
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+`,
+    ".skillset/plugins/alpha/hooks/hooks.json": JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [{ command: "echo hello", type: "command" }],
+            matcher: "*",
+          },
+        ],
+      },
+    }),
+  });
+
+  await buildSkillset(root);
+
+  const hooks = JSON.parse(await readFile(join(root, "plugins/alpha/cursor/hooks/hooks.json"), "utf8")) as {
+    readonly hooks: Record<string, unknown>;
+  };
+  expect(Object.keys(hooks.hooks)).toEqual(["sessionStart"]);
+});
+
 test("rejects custom source directories after workspace layout cutover", async () => {
   const root = await fixture({
     "authoring/skillset.yaml": `

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -47,6 +47,7 @@ const SEEDED_FEATURE_IDS = [
   "plugin-monitors",
   "plugin-output-styles",
   "plugin-readme",
+  "plugin-rules",
   "plugin-scripts",
   "plugin-skills",
   "plugin-src",
@@ -87,9 +88,11 @@ describe("feature registry", () => {
       expect(feature.evidence.length).toBeGreaterThan(0);
       expect(feature.targetSupport.claude).toBeDefined();
       expect(feature.targetSupport.codex).toBeDefined();
+      expect(feature.targetSupport.cursor).toBeDefined();
       expect(feature.targetSupport.claude.evidence?.length ?? 0).toBeGreaterThan(0);
       expect(feature.targetSupport.codex.evidence?.length ?? 0).toBeGreaterThan(0);
-      for (const support of [feature.targetSupport.claude, feature.targetSupport.codex]) {
+      expect(feature.targetSupport.cursor.evidence?.length ?? 0).toBeGreaterThan(0);
+      for (const support of [feature.targetSupport.claude, feature.targetSupport.codex, feature.targetSupport.cursor]) {
         for (const evidence of support.evidence ?? []) {
           if (evidence.kind === "external-docs") expect(evidence.verifiedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
           if (evidence.kind === "provider-snapshot") {
@@ -211,7 +214,7 @@ describe("feature registry", () => {
       mechanism: expect.stringContaining("skill-loading preface"),
       status: "shimmed",
     }));
-    expect(getSkillsetFeature("runtime-adapters")?.runtimeSupport?.cursor?.status).toBe("planned");
+    expect(getSkillsetFeature("runtime-adapters")?.runtimeSupport?.cursor?.status).toBe("native");
     expect(getSkillsetFeature("runtime-context")?.targetSupport.claude).toEqual(expect.objectContaining({
       note: expect.stringContaining("provider, hook.event, and session.id"),
       status: "transformed",

--- a/packages/core/src/__tests__/hook-capabilities.test.ts
+++ b/packages/core/src/__tests__/hook-capabilities.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import {
   CODEX_HOOK_EVENTS,
+  canonicalHookEventName,
   classifyAdaptiveHookUnitPath,
   hookEventSupported,
   hookHandlerTypesForEvent,
   hookProviderCapabilities,
+  nativeHookEventName,
   validateAdaptiveHookUnitPaths,
 } from "../hook-capabilities";
 
@@ -66,6 +68,20 @@ describe("hook provider capabilities", () => {
     expect(codex.scopeSupport.agent).toBe("unsupported");
   });
 
+  test("records Cursor handler, scope, and native event-name constraints", () => {
+    const cursor = hookProviderCapabilities.cursor;
+    expect(hookEventSupported("cursor", "SessionStart")).toBe(true);
+    expect(hookEventSupported("cursor", "sessionStart")).toBe(true);
+    expect(nativeHookEventName("cursor", "SessionStart")).toBe("sessionStart");
+    expect(canonicalHookEventName("cursor", "sessionStart")).toBe("SessionStart");
+    expect([...hookHandlerTypesForEvent("cursor", "sessionStart")]).toEqual(["command"]);
+    expect(cursor.asyncCommand).toBe(false);
+    expect(cursor.scopeSupport.plugin).toBe("native");
+    expect(cursor.scopeSupport.skill).toBe("unsupported");
+    expect(cursor.scopeSupport.agent).toBe("unsupported");
+    expect(cursor.runtimeNotesByEvent.SessionStart).toContain("native-event-names-are-lower-camel");
+  });
+
   test("records Claude event-specific handler constraints", () => {
     for (const event of hookProviderCapabilities.claude.documentedEvents) {
       expect([...hookHandlerTypesForEvent("claude", event)], event).not.toEqual([]);
@@ -79,6 +95,7 @@ describe("hook provider capabilities", () => {
   test("dogfoods provider hook evidence for payload and runtime facts", () => {
     const claude = hookProviderCapabilities.claude;
     const codex = hookProviderCapabilities.codex;
+    const cursor = hookProviderCapabilities.cursor;
 
     expect(claude.providerRefByEvent.PreToolUse).toBe("claude-hooks-overlay");
     expect(claude.matcherEvaluationByEvent.PreToolUse).toBe("exact-list-or-regex");
@@ -98,6 +115,10 @@ describe("hook provider capabilities", () => {
     expect(codex.rawOutputFieldsByEvent.PreToolUse).toEqual(expect.arrayContaining(["continue", "decision", "hookSpecificOutput", "stopReason", "suppressOutput"]));
     expect(codex.unsupportedOutputFieldsByEvent.PreToolUse).toEqual(["continue", "stopReason", "suppressOutput"]);
     expect(codex.handlerSkippedFieldsByType.command).toEqual(["async"]);
+
+    expect(cursor.providerRefByEvent.BeforeSubmitPrompt).toBe("cursor-hooks-docs");
+    expect(cursor.matcherEvaluationByEvent.BeforeSubmitPrompt).toBe("ignored");
+    expect(cursor.canBlockByEvent.BeforeSubmitPrompt).toBe(true);
   });
 });
 

--- a/packages/core/src/adaptive-hook-classifier.ts
+++ b/packages/core/src/adaptive-hook-classifier.ts
@@ -1,6 +1,7 @@
 import type { ResolvedAdaptiveHookAttachment } from "./adaptive-hook-attachments";
 import { readRecord } from "./config";
-import { hookProviderCapabilities } from "./hook-capabilities";
+import { canonicalHookEventName, hookProviderCapabilities } from "./hook-capabilities";
+import { targetNames } from "./targets";
 import type { AdaptiveHookScope, TargetName } from "./types";
 
 export type AdaptiveHookRenderSurface = "frontmatter" | "plugin";
@@ -24,7 +25,7 @@ export interface AdaptiveHookIntentClassification {
   readonly target: TargetName;
 }
 
-const TARGETS = ["claude", "codex"] as const satisfies readonly TargetName[];
+const TARGETS = targetNames();
 
 export function classifyAdaptiveHookIntent(
   item: ResolvedAdaptiveHookAttachment,
@@ -32,9 +33,10 @@ export function classifyAdaptiveHookIntent(
   surface: AdaptiveHookRenderSurface
 ): AdaptiveHookIntentClassification {
   const capabilities = hookProviderCapabilities[target];
-  const providerRef = capabilities.providerRefByEvent[item.event] ?? `hook-capabilities:${target}`;
-  const matcherKind = capabilities.matcherByEvent[item.event] ?? "none";
-  const matcherEvaluation = capabilities.matcherEvaluationByEvent[item.event] ?? "provider-native";
+  const capabilityEvent = canonicalHookEventName(target, item.event);
+  const providerRef = capabilities.providerRefByEvent[capabilityEvent] ?? `hook-capabilities:${target}`;
+  const matcherKind = capabilities.matcherByEvent[capabilityEvent] ?? "none";
+  const matcherEvaluation = capabilities.matcherEvaluationByEvent[capabilityEvent] ?? "provider-native";
   const unsupportedReason = adaptiveHookUnsupportedReason(item, target, surface);
   if (unsupportedReason !== undefined) {
     const status: AdaptiveHookIntentStatus = adaptiveHookNativeOnlyReason(item.attachment.scope, target) === unsupportedReason
@@ -162,11 +164,20 @@ function adaptiveHookProviderScopeReason(
 }
 
 function adaptiveHookNativeOnlyReason(scope: AdaptiveHookScope, target: TargetName): string | undefined {
-  if (scope.kind === "skill" && target === "codex") {
-    return "Codex has no faithful skill-local hook destination for adaptive hook attachments.";
-  }
-  if (scope.kind === "agent" && target === "codex") {
-    return "Codex has no faithful project-agent hook destination for adaptive hook attachments.";
+  const support = scope.kind === "skill"
+    ? hookProviderCapabilities[target].scopeSupport.skill
+    : scope.kind === "agent"
+    ? hookProviderCapabilities[target].scopeSupport.agent
+    : scope.kind === "plugin"
+    ? hookProviderCapabilities[target].scopeSupport.plugin
+    : undefined;
+  if (support === "unsupported") {
+    const destination = scope.kind === "skill"
+      ? "skill-local"
+      : scope.kind === "agent"
+      ? "project-agent"
+      : "plugin";
+    return `${targetLabel(target)} has no faithful ${destination} hook destination for adaptive hook attachments.`;
   }
   return undefined;
 }
@@ -205,17 +216,24 @@ function adaptiveHookUnsupportedCapabilityReason(
   target: TargetName
 ): string | undefined {
   const capabilities = hookProviderCapabilities[target];
-  const targetLabel = target === "claude" ? "Claude" : "Codex";
-  if (!capabilities.documentedEvents.has(item.event)) {
-    return `${targetLabel} does not support adaptive hook event ${item.event}.`;
+  const capabilityEvent = canonicalHookEventName(target, item.event);
+  const label = targetLabel(target);
+  if (!capabilities.documentedEvents.has(capabilityEvent)) {
+    return `${label} does not support adaptive hook event ${item.event}.`;
   }
   const matcher = item.attachment.match ?? item.definition.frontmatter.match;
-  if (matcher !== undefined && capabilities.matcherByEvent[item.event] === "ignored") {
-    return `${targetLabel} ignores matchers for adaptive hook event ${item.event}, so this attachment cannot render faithfully.`;
+  if (matcher !== undefined && capabilities.matcherByEvent[capabilityEvent] === "ignored") {
+    return `${label} ignores matchers for adaptive hook event ${item.event}, so this attachment cannot render faithfully.`;
   }
   return undefined;
 }
 
 function providerListAllows(providers: readonly TargetName[] | undefined, target: TargetName): boolean {
   return providers === undefined || providers.includes(target);
+}
+
+function targetLabel(target: TargetName): string {
+  if (target === "claude") return "Claude";
+  if (target === "codex") return "Codex";
+  return "Cursor";
 }

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -253,6 +253,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         reason: "Codex plugin bundles are renderable, but Codex marketplace activation is currently a runtime config surface rather than a provider-owned generated index.",
         status: "future",
       },
+      cursor: {
+        evidence: [docs("docs/features/marketplaces.md"), providerSnapshot("cursor-plugin")],
+        provider: { destinationFormat: "cursor-plugin" },
+        status: "native",
+      },
     },
     title: "Marketplaces",
     validationOwner: "packages/core/src/config.ts",
@@ -330,9 +335,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     ], {
       claude: [providerSnapshot("claude-plugin")],
       codex: [providerSnapshot("codex-plugin")],
+      cursor: [providerSnapshot("cursor-plugin")],
     }, {
       claude: { destinationFormat: "claude-plugin" },
       codex: { destinationFormat: "codex-plugin" },
+      cursor: { destinationFormat: "cursor-plugin" },
     }),
     title: "Plugin MCP Servers",
     validationOwner: "packages/core/src/resources.ts",
@@ -385,6 +392,12 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         reason: "Codex plugins do not expose a documented plugin-local bin contract.",
         status: "unsupported",
       },
+      cursor: {
+        evidence: [docs("docs/features/executables.md"), providerSnapshot("cursor-plugin")],
+        provider: { destinationFormat: "cursor-plugin", unsupportedDestinations: ["bin"] },
+        reason: "Cursor plugins do not expose a documented plugin-local bin contract.",
+        status: "unsupported",
+      },
     },
     title: "Plugin Bin",
     validationOwner: "packages/core/src/resources.ts",
@@ -401,8 +414,29 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         status: "pass_through",
       },
       codex: { evidence: [docs("docs/features/commands.md")], status: "not_applicable" },
+      cursor: {
+        evidence: [docs("docs/features/commands.md"), providerSnapshot("cursor-plugin")],
+        provider: { destinationFormat: "cursor-plugin" },
+        status: "pass_through",
+      },
     },
     title: "Plugin Commands",
+  }),
+  pluginCompanionFeature({
+    docs: ["docs/features/instructions.md", "docs/features/plugins.md"],
+    id: "plugin-rules",
+    sourceShape: "plugin rules/",
+    summary: "Passes Cursor plugin rule companions through to Cursor plugin outputs.",
+    targetSupport: {
+      claude: { evidence: [docs("docs/features/instructions.md")], status: "not_applicable" },
+      codex: { evidence: [docs("docs/features/instructions.md")], status: "not_applicable" },
+      cursor: {
+        evidence: [docs("docs/features/instructions.md"), providerSnapshot("cursor-plugin"), providerSnapshot("cursor-rules")],
+        provider: { destinationFormat: "cursor-plugin" },
+        status: "pass_through",
+      },
+    },
+    title: "Plugin Rules",
   }),
   feature({
     docs: ["docs/features/hooks.md"],
@@ -418,9 +452,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     ], {
       claude: [providerSnapshot("claude-hooks")],
       codex: [providerSnapshot("codex-plugin")],
+      cursor: [providerSnapshot("cursor-hooks"), providerSnapshot("cursor-plugin")],
     }, {
       claude: { destinationFormat: "claude-hooks" },
       codex: { destinationFormat: "codex-plugin", schemaSnapshots: ["codex-hooks-schema", "codex-hook-event-schemas"] },
+      cursor: { destinationFormat: "cursor-hooks" },
     }),
     title: "Plugin Hooks",
     validationOwner: "packages/core/src/hooks.ts",
@@ -464,6 +500,17 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         provider: { destinationFormat: "codex-plugin", schemaSnapshots: ["codex-hooks-schema", "codex-hook-event-schemas"] },
         status: "degraded",
       },
+      cursor: {
+        evidence: [
+          docs("docs/features/hooks.md"),
+          providerSnapshot("cursor-hooks"),
+          providerSnapshot("cursor-plugin"),
+          source("packages/core/src/hook-capabilities.ts"),
+        ],
+        reason: "Cursor supports plugin-level command hooks, but has no faithful skill-local or project-agent hook destination and uses provider-native lower-camel event names.",
+        provider: { destinationFormat: "cursor-hooks" },
+        status: "degraded",
+      },
     },
     title: "Adaptive Hooks",
     validationOwner: "packages/schema/src/validate.ts",
@@ -497,9 +544,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     ], {
       claude: [providerSnapshot("claude-plugin")],
       codex: [providerSnapshot("codex-plugin")],
+      cursor: [providerSnapshot("cursor-plugin")],
     }, {
       claude: { destinationFormat: "claude-plugin", schemaSnapshots: ["claude-plugin-manifest-schema"] },
       codex: { destinationFormat: "codex-plugin", manualOverlays: ["codex-plugin-manifest-overlay"] },
+      cursor: { destinationFormat: "cursor-plugin" },
     }),
     title: "Plugin Manifests",
     validationOwner: "packages/core/src/config.ts",
@@ -562,9 +611,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     ], {
       claude: [providerSnapshot("claude-skill")],
       codex: [providerSnapshot("codex-skill")],
+      cursor: [providerSnapshot("cursor-skill")],
     }, {
       claude: { destinationFormat: "claude-skill", manualOverlays: ["claude-skill-frontmatter-overlay"] },
       codex: { destinationFormat: "codex-skill", schemaSnapshots: ["codex-skill-metadata-schema"] },
+      cursor: { destinationFormat: "cursor-skill" },
     }),
     title: "Plugin Skills",
     validationOwner: "packages/core/src/resolver.ts",
@@ -612,6 +663,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         reason: "Codex plugin documentation does not include a plugin agents component.",
         status: "unsupported",
       },
+      cursor: {
+        evidence: [docs("docs/features/agents.md"), providerSnapshot("cursor-agent"), providerSnapshot("cursor-plugin")],
+        provider: { destinationFormat: "cursor-agent" },
+        status: "pass_through",
+      },
     },
     title: "Plugin Agents",
     validationOwner: "packages/core/src/resolver.ts",
@@ -630,6 +686,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       codex: {
         evidence: [docs("docs/features/instructions.md"), providerSnapshot("codex-agents-md")],
         provider: { destinationFormat: "codex-agents-md", manualOverlays: ["codex-agents-md-overlay"] },
+        status: "transformed",
+      },
+      cursor: {
+        evidence: [docs("docs/features/instructions.md"), providerSnapshot("cursor-rules")],
+        provider: { destinationFormat: "cursor-rules" },
         status: "transformed",
       },
     },
@@ -671,6 +732,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         provider: { destinationFormat: "codex-subagent", manualOverlays: ["codex-subagent-toml-overlay"] },
         status: "transformed",
       },
+      cursor: {
+        evidence: [docs("docs/features/agents.md"), providerSnapshot("cursor-agent")],
+        provider: { destinationFormat: "cursor-agent" },
+        status: "native",
+      },
     },
     title: "Project Agents",
     validationOwner: "packages/core/src/resolver.ts",
@@ -704,8 +770,8 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
           docs("docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md"),
           fixture("fixtures/external/repos.yaml"),
         ],
-        reason: "Cursor is planned as a first-class provider target; implementation still needs target schema, registry evidence, renderers, import, conformance, and runtime smoke before Skillset can lower or distribute it.",
-        status: "planned",
+        mechanism: "Current Cursor build target projections feed Cursor plugin, project rule, project agent, hook, MCP, and skill surfaces.",
+        status: "native",
       },
       "gemini-cli": {
         evidence: [docs("docs/features/runtime-adapters.md"), fixture("fixtures/external/repos.yaml")],
@@ -771,6 +837,14 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         note: "Normalized fields are provider, hook.event, and session.id; raw Codex environment remains available to the hook command.",
         status: "transformed",
       },
+      cursor: {
+        evidence: [
+          docs("docs/features/hooks.md"),
+          source("packages/toolkit/src/runtime.ts"),
+        ],
+        note: "Normalized fields are provider, hook.event, and session.id; raw Cursor environment remains available to the hook command.",
+        status: "transformed",
+      },
     },
     title: "Runtime Context",
     validationOwner: "packages/toolkit/src/runtime.ts",
@@ -802,9 +876,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     ], {
       claude: [providerSnapshot("claude-skill")],
       codex: [providerSnapshot("codex-skill")],
+      cursor: [providerSnapshot("cursor-skill")],
     }, {
       claude: { destinationFormat: "claude-skill", manualOverlays: ["claude-skill-frontmatter-overlay"] },
       codex: { destinationFormat: "codex-skill" },
+      cursor: { destinationFormat: "cursor-skill" },
     }),
     title: "Resources",
     validationOwner: "packages/core/src/resources.ts",
@@ -823,9 +899,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     ], {
       claude: [providerSnapshot("claude-skill")],
       codex: [providerSnapshot("codex-skill")],
+      cursor: [providerSnapshot("cursor-skill")],
     }, {
       claude: { destinationFormat: "claude-skill", manualOverlays: ["claude-skill-frontmatter-overlay"] },
       codex: { destinationFormat: "codex-skill", schemaSnapshots: ["codex-skill-metadata-schema"] },
+      cursor: { destinationFormat: "cursor-skill" },
     }),
     title: "Standalone Skills",
     validationOwner: "packages/core/src/resolver.ts",
@@ -849,7 +927,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     id: "target-native-islands",
     kind: "target-native",
     renderOwner: "packages/core/src/render.ts",
-    sourceShape: ".skillset/_claude/**, .skillset/_codex/**, and plugin-local provider source subdirs",
+    sourceShape: ".skillset/_claude/**, .skillset/_codex/**, .skillset/_cursor/**, and plugin-local provider source subdirs",
     status: "implemented",
     summary: "Mirrors explicit provider-specific files only to their intended provider output.",
     targetSupport: bothTargets("pass_through"),

--- a/packages/core/src/hook-capabilities.ts
+++ b/packages/core/src/hook-capabilities.ts
@@ -69,6 +69,37 @@ export type AdaptiveHookUnitPath =
 
 const CLAUDE_HOOK_EVIDENCE = getProviderHookEvidence("claude");
 const CODEX_HOOK_EVIDENCE = getProviderHookEvidence("codex");
+const CURSOR_HOOK_EVIDENCE = getProviderHookEvidence("cursor");
+
+const CURSOR_NATIVE_EVENT_BY_CANONICAL: Readonly<Record<string, string>> = {
+  AfterAgentResponse: "afterAgentResponse",
+  AfterAgentThought: "afterAgentThought",
+  AfterFileEdit: "afterFileEdit",
+  AfterMCPExecution: "afterMCPExecution",
+  AfterShellExecution: "afterShellExecution",
+  AfterTabFileEdit: "afterTabFileEdit",
+  BeforeMCPExecution: "beforeMCPExecution",
+  BeforeReadFile: "beforeReadFile",
+  BeforeShellExecution: "beforeShellExecution",
+  BeforeSubmitPrompt: "beforeSubmitPrompt",
+  BeforeTabFileRead: "beforeTabFileRead",
+  PostCompact: "postCompact",
+  PostToolUse: "postToolUse",
+  PostToolUseFailure: "postToolUseFailure",
+  PreCompact: "preCompact",
+  PreToolUse: "preToolUse",
+  SessionEnd: "sessionEnd",
+  SessionStart: "sessionStart",
+  Stop: "stop",
+  SubagentStart: "subagentStart",
+  SubagentStop: "subagentStop",
+  UserPromptSubmit: "userPromptSubmit",
+  WorkspaceOpen: "workspaceOpen",
+};
+
+const CURSOR_CANONICAL_EVENT_BY_NATIVE: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(CURSOR_NATIVE_EVENT_BY_CANONICAL).map(([canonical, native]) => [native, canonical])
+);
 
 export const CLAUDE_HOOK_EVENTS: ReadonlySet<string> = eventSet(CLAUDE_HOOK_EVIDENCE);
 export const CODEX_HOOK_EVENTS: ReadonlySet<string> = eventSet(CODEX_HOOK_EVIDENCE);
@@ -97,7 +128,17 @@ export const hookProviderCapabilities: Readonly<Record<HookCapabilityProvider, H
     },
     statusMessage: true,
   }),
-  cursor: unsupportedCapability("cursor"),
+  cursor: capabilityFromEvidence(CURSOR_HOOK_EVIDENCE, {
+    asyncCommand: false,
+    scopeSupport: {
+      agent: "unsupported",
+      plugin: "native",
+      project: "native",
+      skill: "unsupported",
+      user: "native",
+    },
+    statusMessage: false,
+  }),
 };
 
 function eventSet(evidence: ProviderHookEvidence): ReadonlySet<string> {
@@ -106,41 +147,6 @@ function eventSet(evidence: ProviderHookEvidence): ReadonlySet<string> {
 
 function handlerTypeSet(evidence: ProviderHookEvidence): ReadonlySet<string> {
   return new Set(evidence.handlerTypes.map((handler) => handler.type));
-}
-
-function unsupportedCapability(provider: HookCapabilityProvider): HookProviderCapability {
-  return {
-    asyncCommand: false,
-    canBlockByEvent: {},
-    configFields: {
-      groupFields: [],
-      handlerCommonFields: [],
-      rootFields: [],
-    },
-    documentedEvents: new Set(),
-    handlerFieldsByType: {},
-    handlerSkippedFieldsByType: {},
-    handlerTypes: new Set(),
-    handlerTypesByEvent: {},
-    inputFieldsByEvent: {},
-    matcherByEvent: {},
-    matcherEvaluationByEvent: {},
-    matcherValuesByEvent: {},
-    outputFieldsByEvent: {},
-    provider,
-    providerRefByEvent: {},
-    rawOutputFieldsByEvent: {},
-    runtimeNotesByEvent: {},
-    scopeSupport: {
-      agent: "unsupported",
-      plugin: "unsupported",
-      project: "unsupported",
-      skill: "unsupported",
-      user: "unsupported",
-    },
-    statusMessage: false,
-    unsupportedOutputFieldsByEvent: {},
-  };
 }
 
 function capabilityFromEvidence(
@@ -176,11 +182,21 @@ function capabilityFromEvidence(
 }
 
 export function hookHandlerTypesForEvent(provider: HookCapabilityProvider, event: string): ReadonlySet<string> {
-  return hookProviderCapabilities[provider].handlerTypesByEvent[event] ?? new Set();
+  return hookProviderCapabilities[provider].handlerTypesByEvent[canonicalHookEventName(provider, event)] ?? new Set();
 }
 
 export function hookEventSupported(provider: HookCapabilityProvider, event: string): boolean {
-  return hookProviderCapabilities[provider].documentedEvents.has(event);
+  return hookProviderCapabilities[provider].documentedEvents.has(canonicalHookEventName(provider, event));
+}
+
+export function canonicalHookEventName(provider: HookCapabilityProvider, event: string): string {
+  if (provider !== "cursor") return event;
+  return CURSOR_CANONICAL_EVENT_BY_NATIVE[event] ?? event;
+}
+
+export function nativeHookEventName(provider: HookCapabilityProvider, event: string): string {
+  if (provider !== "cursor") return event;
+  return CURSOR_NATIVE_EVENT_BY_CANONICAL[event] ?? event;
 }
 
 export function classifyAdaptiveHookUnitPath(path: string): AdaptiveHookUnitPath {

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,7 +1,9 @@
 import type { JsonRecord, JsonValue, TargetName } from "./types";
 import { isJsonRecord } from "./yaml";
 import {
+  canonicalHookEventName,
   hookHandlerTypesForEvent,
+  hookEventSupported,
   hookProviderCapabilities,
 } from "./hook-capabilities";
 export {
@@ -20,7 +22,7 @@ export function validateHookDefinition(
   parsed: JsonValue,
   context: { readonly sourcePath: string; readonly target: TargetName }
 ): void {
-  const targetLabel = context.target === "claude" ? "Claude" : "Codex";
+  const targetLabel = labelForTarget(context.target);
   if (!isJsonRecord(parsed)) {
     throw new Error(
       `skillset: ${targetLabel} hook file ${context.sourcePath} must contain a JSON object`
@@ -34,12 +36,13 @@ function validateProviderHooks(
   context: { readonly sourcePath: string; readonly target: TargetName }
 ): void {
   const capabilities = hookProviderCapabilities[context.target];
-  const targetLabel = context.target === "claude" ? "Claude" : "Codex";
+  const targetLabel = labelForTarget(context.target);
   const events = isJsonRecord(parsed.hooks) ? parsed.hooks : parsed;
 
   for (const [event, groups] of Object.entries(events)) {
     if (events === parsed && event === "hooks") continue;
-    if (!capabilities.documentedEvents.has(event)) {
+    const capabilityEvent = canonicalHookEventName(context.target, event);
+    if (!hookEventSupported(context.target, event)) {
       throw new Error(
         `skillset: ${targetLabel} hook file ${context.sourcePath} uses the ${event} event, which ${targetLabel} does not support. ` +
           `${targetLabel} hook events are: ${[...capabilities.documentedEvents].join(", ")}.`
@@ -64,7 +67,7 @@ function validateProviderHooks(
         }
         if (type === "command" && handler.async === true && !capabilities.asyncCommand) {
           throw new Error(
-            `skillset: ${targetLabel} hook file ${context.sourcePath} uses async: true for ${event}, ` +
+            `skillset: ${targetLabel} hook file ${context.sourcePath} uses async: true for ${capabilityEvent}, ` +
               `but ${targetLabel} parses async command hooks and skips them. ` +
               `Remove async: true or set ${context.target}: false for this plugin.`
           );
@@ -76,4 +79,10 @@ function validateProviderHooks(
 
 function formatHandlerTypes(types: ReadonlySet<string>): string {
   return [...types].sort().map((type) => `type: ${type}`).join(", ");
+}
+
+function labelForTarget(target: TargetName): string {
+  if (target === "claude") return "Claude";
+  if (target === "codex") return "Codex";
+  return "Cursor";
 }

--- a/packages/core/src/render-result-collector.ts
+++ b/packages/core/src/render-result-collector.ts
@@ -8,6 +8,7 @@ import {
 import { adaptiveHookUnsupportedRenderReason, type AdaptiveHookRenderSurface } from "./adaptive-hook-render-support";
 import { readString, isOutputSelected } from "./config";
 import { getSkillsetFeature } from "./feature-registry";
+import { hookProviderCapabilities } from "./hook-capabilities";
 import {
   defineRenderResult,
   type SkillsetRenderResult,
@@ -339,11 +340,20 @@ function unsupportedAdaptiveHookDestination(scope: AdaptiveHookScope): string | 
 
 function unsupportedAdaptiveHookReason(item: ResolvedAdaptiveHookAttachment, target: TargetName): string | undefined {
   const scope = item.attachment.scope;
-  if (scope.kind === "skill" && target === "codex") {
-    return "Codex has no faithful skill-local hook destination for adaptive hook attachments.";
-  }
-  if (scope.kind === "agent" && target === "codex") {
-    return "Codex has no faithful project-agent hook destination for adaptive hook attachments.";
+  const support = scope.kind === "skill"
+    ? hookProviderCapabilities[target].scopeSupport.skill
+    : scope.kind === "agent"
+    ? hookProviderCapabilities[target].scopeSupport.agent
+    : scope.kind === "plugin"
+    ? hookProviderCapabilities[target].scopeSupport.plugin
+    : undefined;
+  if (support === "unsupported") {
+    const destination = scope.kind === "skill"
+      ? "skill-local"
+      : scope.kind === "agent"
+      ? "project-agent"
+      : "plugin";
+    return `${targetLabel(target)} has no faithful ${destination} hook destination for adaptive hook attachments.`;
   }
   const surface = adaptiveHookRenderSurfaceForScope(scope);
   if (surface !== undefined) return adaptiveHookUnsupportedRenderReason(item, target, surface);
@@ -445,28 +455,31 @@ function unsupportedPluginFeatureOutcomes(
   if (scopes !== undefined && !scopes.includes("plugins")) return [];
   const outcomes: SkillsetRenderResult[] = [];
   for (const plugin of graph.plugins) {
-    if (!pluginTargetSelected(graph, plugin.id, "codex")) continue;
     const pluginPath = normalizePath(relative(graph.rootPath, plugin.path));
 
-    for (const feature of plugin.features) {
-      if (feature.key !== "bin") continue;
-      const featureId = "plugin-bin";
-      const evidence = evidenceFor(featureId, "codex");
-      outcomes.push(
-        defineRenderResult({
-          destination: "bin",
-          ...(evidence === undefined ? {} : { evidence }),
-          featureId,
-          policy: "unsupported:error",
-          reason: requiredReasonForStatus(featureId, "codex", "unsupported"),
-          sourcePath: normalizePath(relative(graph.rootPath, feature.sourcePath)),
-          sourceUnit: selectorForPluginFeature(plugin.id, feature.key),
-          status: "unsupported",
-          target: "codex",
-        })
-      );
+    for (const target of TARGETS.filter((candidate) => candidate !== "claude")) {
+      if (!pluginTargetSelected(graph, plugin.id, target)) continue;
+      for (const feature of plugin.features) {
+        if (feature.key !== "bin") continue;
+        const featureId = "plugin-bin";
+        const evidence = evidenceFor(featureId, target);
+        outcomes.push(
+          defineRenderResult({
+            destination: "bin",
+            ...(evidence === undefined ? {} : { evidence }),
+            featureId,
+            policy: "unsupported:error",
+            reason: requiredReasonForStatus(featureId, target, "unsupported"),
+            sourcePath: normalizePath(relative(graph.rootPath, feature.sourcePath)),
+            sourceUnit: selectorForPluginFeature(plugin.id, feature.key),
+            status: "unsupported",
+            target,
+          })
+        );
+      }
     }
 
+    if (!pluginTargetSelected(graph, plugin.id, "codex")) continue;
     const agentsPath = join(plugin.path, "agents");
     if (!hasMeaningfulFiles(agentsPath)) continue;
     const featureId = "plugin-agents";
@@ -566,7 +579,7 @@ function sourceUnitForLockItem(item: RenderedLockItem, target: TargetName | unde
 
 function sourceUnitForIsland(item: RenderedLockItem, target: TargetName | undefined): string {
   const [nameTarget, owner, ...relativeParts] = item.name.split(":");
-  const islandTarget = target ?? (nameTarget === "claude" || nameTarget === "codex" ? nameTarget : undefined);
+  const islandTarget = target ?? (isTargetName(nameTarget) ? nameTarget : undefined);
   if (islandTarget === undefined) return item.sourcePath;
   const relativePath = relativeParts.join(":") || item.outputPath;
   if (owner !== undefined && owner !== "project") {
@@ -638,14 +651,17 @@ function companionForPath(
     if (target === "claude" && pluginPath === ".lsp.json") {
       return { featureId: "plugin-lsp-servers", featureKey: "lsp-servers", pluginId, sourceRelativePath: ".lsp.json", target };
     }
-    if (target === "claude" && isCompanionPath(pluginPath, "commands")) {
+    if ((target === "claude" || target === "cursor") && isCompanionPath(pluginPath, "commands")) {
       return { featureId: "plugin-commands", featureKey: "commands", pluginId, sourceRelativePath: pluginPath, target };
     }
     if (pluginPath === "hooks/hooks.json" || pluginPath.startsWith("hooks/")) {
       return { featureId: "plugin-hooks", featureKey: "hooks", pluginId, sourceRelativePath: pluginPath, target };
     }
-    if (target === "claude" && isCompanionPath(pluginPath, "agents")) {
+    if ((target === "claude" || target === "cursor") && isCompanionPath(pluginPath, "agents")) {
       return { featureId: "plugin-agents", featureKey: "agents", pluginId, sourceRelativePath: pluginPath, target };
+    }
+    if (target === "cursor" && isCompanionPath(pluginPath, "rules")) {
+      return { featureId: "plugin-rules", featureKey: "rules", pluginId, sourceRelativePath: pluginPath, target };
     }
     if (target === "claude" && isCompanionPath(pluginPath, "output-styles")) {
       return { featureId: "plugin-output-styles", featureKey: "output-styles", pluginId, sourceRelativePath: pluginPath, target };
@@ -674,7 +690,14 @@ function isCompanionPath(path: string, topLevelPath: string): boolean {
 }
 
 function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
-  return readString(graph.root.targets[target].options, "projectRoot") ?? (target === "claude" ? ".claude" : ".codex");
+  return readString(graph.root.targets[target].options, "projectRoot") ??
+    (target === "claude" ? ".claude" : target === "codex" ? ".codex" : ".cursor");
+}
+
+function targetLabel(target: TargetName): string {
+  if (target === "claude") return "Claude";
+  if (target === "codex") return "Codex";
+  return "Cursor";
 }
 
 function pluginTargetSelected(graph: BuildGraph, pluginId: string, target: TargetName): boolean {

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -25,6 +25,7 @@ import {
   renderClaudePluginDependencies,
   renderCodexDependencyNotice,
 } from "./dependencies";
+import { nativeHookEventName } from "./hook-capabilities";
 import { validateHookDefinition } from "./hooks";
 import { resolveLicense, type ResolvedLicense } from "./licenses";
 import { compareStrings, validateSlug } from "./path";
@@ -72,6 +73,7 @@ import type {
   StandaloneSkill,
   TargetName,
 } from "./types";
+import { targetNames } from "./targets";
 import { pluginVersion, rootVersion, skillVersion, skillVersionLabel } from "./versioning";
 import { isJsonRecord, parseMarkdown, parseYamlRecord, stringifyJson } from "./yaml";
 
@@ -164,15 +166,18 @@ export async function renderBuildGraph(graph: BuildGraph): Promise<readonly Rend
   const lockRoots = new Map<string, LockRoot>();
   rendered.push(...renderRepositoryReadmes(graph));
   rendered.push(...(await renderClaudeMarketplace(graph)));
+  rendered.push(...(await renderCursorMarketplace(graph)));
 
   for (const plugin of graph.plugins) {
-    rendered.push(...(await renderPluginTarget(graph, plugin, "claude", lockRoots)));
-    rendered.push(...(await renderPluginTarget(graph, plugin, "codex", lockRoots)));
+    for (const target of targetNames()) {
+      rendered.push(...(await renderPluginTarget(graph, plugin, target, lockRoots)));
+    }
   }
 
   for (const skill of graph.standaloneSkills) {
-    rendered.push(...(await renderStandaloneSkill(graph, skill, "claude", lockRoots)));
-    rendered.push(...(await renderStandaloneSkill(graph, skill, "codex", lockRoots)));
+    for (const target of targetNames()) {
+      rendered.push(...(await renderStandaloneSkill(graph, skill, target, lockRoots)));
+    }
   }
 
   rendered.push(...(await renderProjectAgents(graph, lockRoots)));
@@ -225,57 +230,44 @@ function shouldRenderStandaloneSkill(
 
 function renderRepositoryReadmes(graph: BuildGraph): readonly RenderedFile[] {
   const rendered: RenderedFile[] = [];
-  const claudeActive = graph.plugins.some((plugin) => shouldRenderPlugin(graph, plugin, "claude"));
-  const codexActive = graph.plugins.some((plugin) => shouldRenderPlugin(graph, plugin, "codex"));
-  if (
-    graph.root.outputs.plugins.claude === graph.root.outputs.plugins.codex &&
-    isDefaultPluginOutputRoot(graph.root.outputs.plugins.claude) &&
-    (claudeActive || codexActive)
-  ) {
-    rendered.push(
-      textFile(
-        `${graph.root.outputs.plugins.claude}/README.md`,
-        [
-          "# Skillset Plugins",
-          "",
-          "Generated Skillset plugin repository.",
-          "",
-          "- `<plugin-id>/claude/` contains each Claude plugin bundle.",
-          "- `<plugin-id>/codex/` contains each Codex plugin bundle.",
-          "- `skillset.lock` records deterministic generated-state provenance.",
-          "",
-        ].join("\n")
-      )
-    );
-    return rendered;
+  const activeTargets = targetNames().filter((target) =>
+    graph.plugins.some((plugin) => shouldRenderPlugin(graph, plugin, target))
+  );
+  const outputRoots = new Set(activeTargets.map((target) => graph.root.outputs.plugins[target]));
+  if (outputRoots.size === 1 && activeTargets.length > 0) {
+    const [outputRoot] = outputRoots;
+    if (outputRoot !== undefined && isDefaultPluginOutputRoot(outputRoot)) {
+      const bundleLines = activeTargets.map((target) =>
+        `- \`<plugin-id>/${target}/\` contains each ${targetLabel(target)} plugin bundle.`
+      );
+      rendered.push(
+        textFile(
+          `${outputRoot}/README.md`,
+          [
+            "# Skillset Plugins",
+            "",
+            "Generated Skillset plugin repository.",
+            "",
+            ...bundleLines,
+            "- `skillset.lock` records deterministic generated-state provenance.",
+            "",
+          ].join("\n")
+        )
+      );
+      return rendered;
+    }
   }
-  if (claudeActive) {
+  for (const target of activeTargets) {
+    const outputRoot = graph.root.outputs.plugins[target];
     rendered.push(
       textFile(
-        `${graph.root.outputs.plugins.claude}/README.md`,
+        `${outputRoot}/README.md`,
         [
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.claude) ? "# Skillset Plugins" : "# Claude Plugins",
+          isDefaultPluginOutputRoot(outputRoot) ? "# Skillset Plugins" : `# ${targetLabel(target)} Plugins`,
           "",
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.claude) ? "Generated Skillset plugin repository." : "Generated Claude plugin repository.",
+          isDefaultPluginOutputRoot(outputRoot) ? "Generated Skillset plugin repository." : `Generated ${targetLabel(target)} plugin repository.`,
           "",
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.claude) ? "- `../.claude-plugin/marketplace.json` indexes generated Claude plugins." : "- `.claude-plugin/marketplace.json` indexes the generated plugins.",
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.claude) ? "- `<plugin-id>/claude/` contains each Claude plugin bundle." : "- `plugins/<plugin-id>/` contains each Claude plugin bundle.",
-          "- `skillset.lock` records deterministic generated-state provenance.",
-          "",
-        ].join("\n")
-      )
-    );
-  }
-  if (codexActive) {
-    rendered.push(
-      textFile(
-        `${graph.root.outputs.plugins.codex}/README.md`,
-        [
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.codex) ? "# Skillset Plugins" : "# Codex Plugins",
-          "",
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.codex) ? "Generated Skillset plugin repository." : "Generated Codex plugin repository.",
-          "",
-          isDefaultPluginOutputRoot(graph.root.outputs.plugins.codex) ? "- `<plugin-id>/codex/` contains each Codex plugin bundle." : "- `plugins/<plugin-id>/` contains each Codex plugin bundle.",
+          ...marketplaceReadmeLines(outputRoot, target),
           "- `skillset.lock` records deterministic generated-state provenance.",
           "",
         ].join("\n")
@@ -283,6 +275,30 @@ function renderRepositoryReadmes(graph: BuildGraph): readonly RenderedFile[] {
     );
   }
   return rendered;
+}
+
+function targetLabel(target: TargetName): string {
+  if (target === "claude") return "Claude";
+  if (target === "codex") return "Codex";
+  return "Cursor";
+}
+
+function marketplaceReadmeLines(outputRoot: string, target: TargetName): readonly string[] {
+  if (target === "claude") {
+    return [
+      isDefaultPluginOutputRoot(outputRoot) ? "- `../.claude-plugin/marketplace.json` indexes generated Claude plugins." : "- `.claude-plugin/marketplace.json` indexes the generated plugins.",
+      isDefaultPluginOutputRoot(outputRoot) ? "- `<plugin-id>/claude/` contains each Claude plugin bundle." : "- `plugins/<plugin-id>/` contains each Claude plugin bundle.",
+    ];
+  }
+  if (target === "cursor") {
+    return [
+      isDefaultPluginOutputRoot(outputRoot) ? "- `../.cursor-plugin/marketplace.json` indexes generated Cursor plugins." : "- `.cursor-plugin/marketplace.json` indexes the generated plugins.",
+      isDefaultPluginOutputRoot(outputRoot) ? "- `<plugin-id>/cursor/` contains each Cursor plugin bundle." : "- `plugins/<plugin-id>/` contains each Cursor plugin bundle.",
+    ];
+  }
+  return [
+    isDefaultPluginOutputRoot(outputRoot) ? "- `<plugin-id>/codex/` contains each Codex plugin bundle." : "- `plugins/<plugin-id>/` contains each Codex plugin bundle.",
+  ];
 }
 
 async function renderClaudeMarketplace(graph: BuildGraph): Promise<readonly RenderedFile[]> {
@@ -341,6 +357,56 @@ async function renderClaudeMarketplace(graph: BuildGraph): Promise<readonly Rend
   ];
 }
 
+async function renderCursorMarketplace(graph: BuildGraph): Promise<readonly RenderedFile[]> {
+  const plugins = [];
+  for (const plugin of graph.plugins.filter((candidate) => shouldRenderPlugin(graph, candidate, "cursor"))) {
+    const metadata = plugin.metadata;
+    plugins.push(
+      mergeRecords(
+        {
+          name: plugin.id,
+          source: providerSourceForPlugin(graph.root.outputs.plugins.cursor, "cursor", plugin.id).replace(/^\.\//, ""),
+          description: readString(metadata, "summary") ?? readString(metadata, "description") ?? plugin.id,
+        },
+        readRecord(plugin.targets.cursor.options, "marketplace") ?? {}
+      )
+    );
+  }
+
+  if (plugins.length === 0) return [];
+
+  const root = graph.root.metadata;
+  const owner = readRecord(root, "owner") ?? readRecord(root, "author") ?? {};
+  const portableMarketplace = readRecord(root, "marketplace") ?? {};
+  const marketplace = mergeRecords(
+    {
+      name: readString(portableMarketplace, "name") ?? readString(root, "name") ?? readString(root, "id") ?? "skillset",
+      owner,
+      metadata: {
+        description:
+          readString(root, "summary") ??
+          readString(root, "description") ??
+          "Source-first Skillset plugins",
+      },
+      plugins,
+    },
+    readRecord(graph.root.targets.cursor.options, "marketplace") ?? {}
+  );
+
+  return [
+    textFile(
+      cursorMarketplacePath(graph.root.outputs.plugins.cursor),
+      renderValidatedJson(marketplace, "Cursor marketplace")
+    ),
+  ];
+}
+
+function cursorMarketplacePath(outputRoot: string): string {
+  return isDefaultPluginOutputRoot(outputRoot)
+    ? ".cursor-plugin/marketplace.json"
+    : join(outputRoot, ".cursor-plugin", "marketplace.json").replaceAll("\\", "/");
+}
+
 async function renderPluginTarget(
   graph: BuildGraph,
   plugin: SourcePlugin,
@@ -363,9 +429,7 @@ async function renderPluginTarget(
   const rootLicense = await resolveRootLicense(graph);
   const pluginLicense = await resolvePluginLicense(graph, plugin, rootLicense);
   const manifestFile = textFile(
-    target === "claude"
-      ? `${basePath}/.claude-plugin/plugin.json`
-      : `${basePath}/.codex-plugin/plugin.json`,
+    pluginManifestPath(outputRoot, target, plugin.id),
     renderValidatedJson(
       renderPluginManifest(graph, plugin, target, enabledSkills, pluginLicense),
       `${plugin.id} ${target} plugin manifest`
@@ -448,14 +512,35 @@ function renderPluginManifest(
   const targetBase =
     target === "claude"
       ? withOptionalSurfacePaths(graph, mergeRecords(base, dependencies === undefined ? {} : { dependencies }), plugin, enabledSkills, target)
-      : mergeRecords(withOptionalSurfacePaths(graph, base, plugin, enabledSkills, target), {
+      : target === "codex"
+      ? mergeRecords(withOptionalSurfacePaths(graph, base, plugin, enabledSkills, target), {
           interface: renderCodexInterface(graph, plugin),
-        });
+        })
+      : withOptionalSurfacePaths(
+          graph,
+          mergeRecords(base, renderCursorPluginDisplayFields(metadata, portableManifest)),
+          plugin,
+          enabledSkills,
+          target
+        );
   const withOverrides = mergeRecords(targetBase, manifestOverrides);
 
   return mergeRecords(withOverrides, {
     version: pluginVersion(graph, plugin),
   });
+}
+
+function renderCursorPluginDisplayFields(
+  metadata: JsonRecord,
+  portableManifest: JsonRecord
+): JsonRecord {
+  const tags = readStringArray(portableManifest, "tags");
+  return {
+    displayName: readString(portableManifest, "displayName") ?? readString(metadata, "title"),
+    category: readString(portableManifest, "category"),
+    logo: readString(portableManifest, "logo") ?? readString(metadata, "logo"),
+    ...(tags === undefined ? {} : { tags: [...tags] }),
+  };
 }
 
 function renderCodexInterface(graph: BuildGraph, plugin: SourcePlugin): JsonRecord {
@@ -550,12 +635,20 @@ function withOptionalSurfacePaths(
       experimental.monitors = "./monitors/monitors.json";
     }
     if (Object.keys(experimental).length > 0) withPaths.experimental = experimental;
-  } else {
+  } else if (target === "codex") {
     if (pluginHasPath(plugin, "hooks/hooks.json") || hasAdaptivePluginHookOutput(graph, plugin, target)) {
       withPaths.hooks = "./hooks/hooks.json";
     }
     if (pluginHasFeature(plugin, "mcp")) withPaths.mcpServers = "./.mcp.json";
     if (pluginHasPath(plugin, ".app.json")) withPaths.apps = "./.app.json";
+  } else {
+    if (pluginHasPath(plugin, "rules")) withPaths.rules = "./rules/";
+    if (pluginHasPath(plugin, "commands")) withPaths.commands = "./commands/";
+    if (pluginHasPath(plugin, "agents")) withPaths.agents = "./agents/";
+    if (pluginHasPath(plugin, "hooks/hooks.json") || hasAdaptivePluginHookOutput(graph, plugin, target)) {
+      withPaths.hooks = "./hooks/hooks.json";
+    }
+    if (pluginHasFeature(plugin, "mcp")) withPaths.mcpServers = "./mcp.json";
   }
 
   return withPaths;
@@ -693,6 +786,9 @@ async function renderProjectAgents(
     if (agent.targets.codex.enabled) {
       results.push(await renderCodexProjectAgent(graph, agent));
     }
+    if (agent.targets.cursor.enabled) {
+      results.push(await renderCursorProjectAgent(graph, agent));
+    }
     if (results.length === 0) continue;
     const files = results.map((result) => result.file);
     rendered.push(...files);
@@ -704,6 +800,47 @@ async function renderProjectAgents(
     }
   }
   return rendered;
+}
+
+async function renderCursorProjectAgent(
+  graph: BuildGraph,
+  agent: SourceProjectAgent
+): Promise<RenderedProjectAgentFile> {
+  const targetOptions = agent.targets.cursor.options;
+  const initialPrompt = readString(targetOptions, "initialPrompt") ?? readString(agent.frontmatter, "initialPrompt");
+  const skills = readStringArray(targetOptions, "skills") ?? readStringArray(agent.frontmatter, "skills");
+  const frontmatter = mergeRecords(
+    mergeRecords(
+      stripAgentTargetOptions(stripSourceFrontmatter(agent.frontmatter, agent.sourcePath)),
+      stripAgentTargetOptions(targetOptions)
+    ),
+    {
+      name: readString(targetOptions, "name") ?? agent.name,
+      description: readString(targetOptions, "description") ?? readString(agent.frontmatter, "description") ?? agent.name,
+      ...(skills === undefined ? {} : { skills: [...skills] }),
+      ...(initialPrompt === undefined ? {} : { initialPrompt }),
+      ...(graph.root.compile.skillset.metadata
+        ? { metadata: { skillset: { generated: GENERATED_BY } } }
+        : {}),
+    }
+  );
+  const preprocessDependencies = new Set<string>();
+  const body = await preprocessText(agent.body, {
+    frontmatter: agent.frontmatter,
+    preprocessDependencies,
+    rootPath: graph.rootPath,
+    sourcePath: agent.sourcePath,
+    sourceRoot: graph.sourceRoot,
+  });
+  const targetPath = join(targetProjectRoot(graph, "cursor"), "agents", `${agent.outputName}.md`);
+  return {
+    file: textFile(
+      targetPath,
+      renderValidatedMarkdown(frontmatter, body, `${relative(graph.rootPath, agent.sourcePath)} -> ${targetPath}`),
+      relative(graph.rootPath, agent.sourcePath)
+    ),
+    preprocessDependencies: projectAgentPreprocessDependencies(graph, preprocessDependencies),
+  };
 }
 
 async function renderClaudeProjectAgent(
@@ -1389,6 +1526,7 @@ async function renderRules(
   const rendered: RenderedFile[] = [];
   rendered.push(...(await renderClaudeRules(graph, lockRoots)));
   rendered.push(...(await renderCodexAgentsFiles(graph, lockRoots)));
+  rendered.push(...(await renderCursorRules(graph, lockRoots)));
   return rendered;
 }
 
@@ -1466,6 +1604,44 @@ async function renderCodexAgentsFiles(
   return rendered;
 }
 
+async function renderCursorRules(
+  graph: BuildGraph,
+  lockRoots: Map<string, LockRoot>
+): Promise<readonly RenderedFile[]> {
+  const rendered: RenderedFile[] = [];
+  const outputRoot = join(targetProjectRoot(graph, "cursor"), "rules");
+
+  for (const rule of graph.rules.filter((sourceRule) => sourceRule.targets.cursor.enabled)) {
+    const targetFile = join(outputRoot, cursorRuleRelativePath(rule.relativePath));
+    const markdown = await renderCursorRuleMarkdown(graph, rule, targetFile);
+    const file = textFile(
+      targetFile,
+      markdown.content,
+      relative(graph.rootPath, rule.sourcePath)
+    );
+    rendered.push(file);
+    lockRootsFor(lockRoots, WORKSPACE_LOCK_ROOT, "workspace").items.push(
+      lockItemForRule({
+        files: [file],
+        graph,
+        name: rule.id,
+        outputRoot: WORKSPACE_LOCK_ROOT,
+        outputPath: targetFile,
+        preprocessDependencies: markdown.preprocessDependencies,
+        sourceHash: hashTextRule(rule, markdown.preprocessDependencies, graph.rootPath),
+        ...(rule.sourceOrigin === undefined ? {} : { sourceOrigin: rule.sourceOrigin }),
+        sourcePath: relative(graph.rootPath, rule.sourcePath),
+      })
+    );
+  }
+
+  return rendered;
+}
+
+function cursorRuleRelativePath(path: string): string {
+  return path.replace(/\.md$/u, ".mdc");
+}
+
 async function renderClaudeRuleMarkdown(
   graph: BuildGraph,
   rule: SourceRule,
@@ -1477,6 +1653,30 @@ async function renderClaudeRuleMarkdown(
   const body = await renderRuleBody(graph, rule, outputPath, preprocessDependencies);
   return {
     content: stringifyOptionalMarkdown(frontmatter, body),
+    preprocessDependencies: formattedPreprocessDependencies(graph, preprocessDependencies),
+  };
+}
+
+async function renderCursorRuleMarkdown(
+  graph: BuildGraph,
+  rule: SourceRule,
+  outputPath: string
+): Promise<RenderedRuleMarkdown> {
+  const paths = readRulePaths(rule);
+  const description =
+    readString(rule.frontmatter, "description") ??
+    readString(rule.frontmatter, "summary") ??
+    readString(rule.frontmatter, "title") ??
+    rule.id;
+  const frontmatter: JsonRecord = {
+    description,
+    alwaysApply: paths.length === 0,
+    ...(paths.length === 0 ? {} : { globs: [...paths] }),
+  };
+  const preprocessDependencies = new Set<string>();
+  const body = await renderRuleBody(graph, rule, outputPath, preprocessDependencies);
+  return {
+    content: renderValidatedMarkdown(frontmatter, normalizeRuleBody(body), `${relative(graph.rootPath, rule.sourcePath)} -> ${outputPath}`),
     preprocessDependencies: formattedPreprocessDependencies(graph, preprocessDependencies),
   };
 }
@@ -1724,11 +1924,13 @@ async function copyPluginCompanionFiles(
           "scripts",
           "src",
         ]
-      : ["README.md", ".app.json", "assets", "scripts", "src"];
+      : target === "codex"
+      ? ["README.md", ".app.json", "assets", "scripts", "src"]
+      : ["README.md", "rules", "commands", "agents", "hooks", "assets", "scripts", "src"];
 
-  if (target === "codex") {
-    const codexHook = await renderCodexHookFile(graph, plugin, basePath);
-    if (codexHook !== undefined) rendered.push(codexHook);
+  if (target === "codex" || target === "cursor") {
+    const hook = await renderNormalizedPluginHookFile(graph, plugin, target, basePath);
+    if (hook !== undefined) rendered.push(hook);
   }
 
   for (const candidate of candidates) {
@@ -1746,6 +1948,7 @@ async function copyPluginCompanionFiles(
       }
       await validateHookJson(graph, join(sourcePath, "hooks.json"), "claude");
     }
+    if ((target === "codex" || target === "cursor") && candidate === "hooks") continue;
 
     rendered.push(...(await copyPath(sourcePath, join(basePath, candidate))));
   }
@@ -1771,9 +1974,10 @@ async function renderAdaptivePluginHookFiles(
   const hooks: Record<string, JsonValue[]> = {};
   const scriptFiles = new Map<string, RenderedFile>();
   for (const item of resolved) {
-    const eventGroups = hooks[item.event] ?? [];
+    const event = nativeHookEventName(target, item.event);
+    const eventGroups = hooks[event] ?? [];
     eventGroups.push(renderAdaptiveHookGroup(graph, plugin, target, item, basePath, scriptFiles));
-    hooks[item.event] = eventGroups;
+    hooks[event] = eventGroups;
   }
 
   const normalized = { hooks };
@@ -1909,9 +2113,10 @@ function renderAdaptiveFrontmatterHooks(
 
   const hooks: Record<string, JsonValue[]> = {};
   for (const item of resolved) {
-    const eventGroups = hooks[item.event] ?? [];
+    const event = nativeHookEventName(target, item.event);
+    const eventGroups = hooks[event] ?? [];
     eventGroups.push(renderAdaptiveFrontmatterHookGroup(item, target));
-    hooks[item.event] = eventGroups;
+    hooks[event] = eventGroups;
   }
 
   validateHookDefinition({ hooks }, { sourcePath: `${sourceLabel} adaptive hooks`, target });
@@ -2021,10 +2226,16 @@ function adaptiveHookContextAssignment(
     case "hook.event":
       return `SKILLSET_HOOK_EVENT=${shellLiteral(item.event)}`;
     case "session.id":
-      return `SKILLSET_SESSION_ID="${target === "claude" ? "${CLAUDE_SESSION_ID:-}" : "${CODEX_SESSION_ID:-}"}"`;
+      return `SKILLSET_SESSION_ID="${targetSessionIdExpression(target)}"`;
     default:
       throw new Error(`skillset: adaptive hook ${item.definition.name} context.env field ${field} is not supported`);
   }
+}
+
+function targetSessionIdExpression(target: TargetName): string {
+  if (target === "claude") return "${CLAUDE_SESSION_ID:-}";
+  if (target === "codex") return "${CODEX_SESSION_ID:-}";
+  return "${CURSOR_SESSION_ID:-}";
 }
 
 function shellLiteral(value: string): string {
@@ -2075,7 +2286,8 @@ async function renderPluginFeatureFiles(
   const rendered: RenderedFile[] = [];
   for (const feature of plugin.features) {
     if (!pluginFeatureSupportsTarget(feature, target)) continue;
-    const files = (await copyPath(feature.sourcePath, join(basePath, feature.targetPath)))
+    const targetPath = pluginFeatureTargetPath(feature, target);
+    const files = (await copyPath(feature.sourcePath, join(basePath, targetPath)))
       .filter((file) => !file.path.endsWith(".gitkeep"))
       .map((file) =>
         feature.key === "mcp"
@@ -2103,34 +2315,63 @@ function pluginFeatureSupportsTarget(feature: SourcePluginFeature, target: Targe
   return true;
 }
 
+function pluginFeatureTargetPath(feature: SourcePluginFeature, target: TargetName): string {
+  if (feature.key === "mcp" && target === "cursor") return "mcp.json";
+  return feature.targetPath;
+}
+
 function pluginHasFeature(plugin: SourcePlugin, key: SourcePluginFeature["key"]): boolean {
   return plugin.features.some((feature) => feature.key === key);
 }
 
 /**
- * Render the Codex plugin hook file at the documented default path
+ * Render Codex and Cursor plugin hook files at the documented default path
  * `hooks/hooks.json` with a top-level `hooks` object.
  *
  * Source resolution: `hooks/hooks.json` is the canonical hook source for both
  * plugin targets. Flat event maps are normalized into the canonical
  * `{ "hooks": { ... } }` shape.
  */
-async function renderCodexHookFile(
+async function renderNormalizedPluginHookFile(
   graph: BuildGraph,
   plugin: SourcePlugin,
+  target: TargetName,
   basePath: string
 ): Promise<RenderedFile | undefined> {
   const canonicalSource = join(plugin.path, "hooks", "hooks.json");
   if (!(await exists(canonicalSource))) return undefined;
 
-  await validateHookJson(graph, canonicalSource, "codex");
+  await validateHookJson(graph, canonicalSource, target);
   const parsed = JSON.parse(await readFile(canonicalSource, "utf8")) as JsonValue;
   const normalized = isJsonRecord(parsed) && isJsonRecord(parsed.hooks) ? parsed : { hooks: parsed };
+  const providerNative = normalizePluginHookEventNames(normalized, target, relative(graph.rootPath, canonicalSource));
   return textFile(
     join(basePath, "hooks", "hooks.json"),
-    renderValidatedJson(normalized, `${relative(graph.rootPath, canonicalSource)} -> ${join(basePath, "hooks", "hooks.json")}`),
+    renderValidatedJson(providerNative, `${relative(graph.rootPath, canonicalSource)} -> ${join(basePath, "hooks", "hooks.json")}`),
     relative(graph.rootPath, canonicalSource)
   );
+}
+
+function normalizePluginHookEventNames(
+  normalized: JsonRecord,
+  target: TargetName,
+  sourceLabel: string
+): JsonRecord {
+  if (target !== "cursor" || !isJsonRecord(normalized.hooks)) return normalized;
+
+  const hooks: Record<string, JsonValue> = {};
+  for (const [event, groups] of Object.entries(normalized.hooks)) {
+    if (groups === undefined) continue;
+    const nativeEvent = nativeHookEventName(target, event);
+    if (Object.hasOwn(hooks, nativeEvent)) {
+      throw new Error(
+        `skillset: Cursor hook file ${sourceLabel} maps multiple events to ${nativeEvent}; keep only one canonical or native spelling.`
+      );
+    }
+    hooks[nativeEvent] = groups;
+  }
+
+  return { ...normalized, hooks };
 }
 
 async function validateHookJson(
@@ -2140,17 +2381,17 @@ async function validateHookJson(
 ): Promise<void> {
   if (!(await exists(sourcePath))) return;
 
-  const label = relative(graph.rootPath, sourcePath);
+  const sourceLabel = relative(graph.rootPath, sourcePath);
   let parsed: JsonValue;
   try {
     parsed = JSON.parse(await readFile(sourcePath, "utf8")) as JsonValue;
   } catch (error) {
-    const targetLabel = target === "claude" ? "Claude" : "Codex";
+    const provider = targetLabel(target);
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`skillset: ${targetLabel} hook file ${label} is not valid JSON: ${message}`);
+    throw new Error(`skillset: ${provider} hook file ${sourceLabel} is not valid JSON: ${message}`);
   }
 
-  validateHookDefinition(parsed, { sourcePath: label, target });
+  validateHookDefinition(parsed, { sourcePath: sourceLabel, target });
 }
 
 async function copyPath(sourcePath: string, targetPath: string): Promise<readonly RenderedFile[]> {
@@ -2277,7 +2518,7 @@ function marketplacePluginManifestPath(graph: BuildGraph, plugin: SourcePlugin, 
 }
 
 function marketplaceProviderSource(path: string): string {
-  const defaultMatch = path.match(/^plugins\/([^/]+)\/(claude|codex)\//);
+  const defaultMatch = path.match(/^plugins\/([^/]+)\/(claude|codex|cursor)\//);
   if (defaultMatch !== null) return `./plugins/${defaultMatch[1]}/${defaultMatch[2]}`;
   const overrideMatch = path.match(/^(.*)\/plugins\/([^/]+)/);
   if (overrideMatch === null) return path;
@@ -2307,7 +2548,9 @@ function lockRootsFor(
 }
 
 function pluginLockTarget(graph: BuildGraph, target: TargetName): TargetName | "workspace" {
-  return graph.root.outputs.plugins.claude === graph.root.outputs.plugins.codex
+  return targetNames().some((candidate) =>
+    candidate !== target && graph.root.outputs.plugins[candidate] === graph.root.outputs.plugins[target]
+  )
     ? "workspace"
     : target;
 }
@@ -2416,6 +2659,7 @@ async function lockItemForPluginFeature(args: {
   readonly plugin: SourcePlugin;
   readonly target: TargetName;
 }): Promise<LockItem> {
+  const targetPath = pluginFeatureTargetPath(args.feature, args.target);
   return {
     feature: args.feature.key,
     files: args.files.map((file) => relative(args.outputRoot, file.path)).sort(),
@@ -2423,7 +2667,7 @@ async function lockItemForPluginFeature(args: {
     name: `${args.plugin.id}:${args.feature.key}`,
     origin: args.feature.origin,
     outputHash: hashRenderedFiles(args.outputRoot, args.files),
-    outputPath: relative(args.outputRoot, join(pluginTargetRoot(args.outputRoot, args.target, args.plugin.id), args.feature.targetPath)),
+    outputPath: relative(args.outputRoot, join(pluginTargetRoot(args.outputRoot, args.target, args.plugin.id), targetPath)),
     plugin: args.plugin.id,
     sourceHash: await hashPluginFeatureSource(args.feature),
     sourcePath: relative(args.graph.rootPath, args.feature.sourcePath),

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -22,6 +22,7 @@ import {
   readOutputConfig,
   readSkillsetMetadata,
   readSkillsetName,
+  isTargetName,
   readString,
   readStringArray,
   resolveFeatureTargets,
@@ -803,7 +804,7 @@ function validateAdaptiveHookAttachments(
 
 function readTargetArray(value: JsonValue | undefined): readonly TargetName[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const targets = value.filter((item): item is TargetName => item === "claude" || item === "codex");
+  const targets = value.filter(isTargetName);
   return targets.length === 0 ? undefined : targets;
 }
 

--- a/packages/registry/src/__tests__/snapshots.test.ts
+++ b/packages/registry/src/__tests__/snapshots.test.ts
@@ -31,6 +31,11 @@ describe("@skillset/registry snapshots", () => {
       "codex-plugin",
       "codex-skill",
       "codex-subagent",
+      "cursor-agent",
+      "cursor-hooks",
+      "cursor-plugin",
+      "cursor-rules",
+      "cursor-skill",
     ]);
     expect(providerDestinationFormatSnapshots.map((snapshot) => `${snapshot.target}:${snapshot.destination}`)).toEqual([
       "claude:hooks",
@@ -41,6 +46,11 @@ describe("@skillset/registry snapshots", () => {
       "codex:plugin",
       "codex:skill",
       "codex:agent",
+      "cursor:agent",
+      "cursor:hooks",
+      "cursor:plugin",
+      "cursor:instructions",
+      "cursor:skill",
     ]);
 
     for (const snapshot of providerDestinationFormatSnapshots) {
@@ -152,19 +162,23 @@ describe("@skillset/registry schema snapshots", () => {
 });
 
 describe("@skillset/registry hook evidence", () => {
-  it("exports provider hook evidence for Claude overlays and Codex schemas", () => {
+  it("exports provider hook evidence for Claude overlays, Codex schemas, and Cursor docs", () => {
     expect(listProviderHookEvidence().map((evidence) => `${evidence.target}:${evidence.evidenceKind}:${evidence.providerRef}`)).toEqual([
       "claude:docs-backed-overlay:claude-hooks-overlay",
       "codex:schema-backed:codex-hooks-schema",
+      "cursor:docs-backed-overlay:cursor-hooks-docs",
     ]);
 
     const claude = getProviderHookEvidence("claude");
     const codex = getProviderHookEvidence("codex");
+    const cursor = getProviderHookEvidence("cursor");
     const claudePreToolUse = claude.events.find((event) => event.name === "PreToolUse");
     const claudeStopFailure = claude.events.find((event) => event.name === "StopFailure");
     const codexPreCompact = codex.events.find((event) => event.name === "PreCompact");
     const codexSessionStart = codex.events.find((event) => event.name === "SessionStart");
     const codexPreToolUse = codex.events.find((event) => event.name === "PreToolUse");
+    const cursorBeforeSubmitPrompt = cursor.events.find((event) => event.name === "BeforeSubmitPrompt");
+    const cursorSessionStart = cursor.events.find((event) => event.name === "SessionStart");
 
     expect(claudePreToolUse).toMatchObject({
       canBlock: true,
@@ -197,5 +211,13 @@ describe("@skillset/registry hook evidence", () => {
     expect(codexPreToolUse?.unsupportedOutputFields).toEqual(["continue", "stopReason", "suppressOutput"]);
     expect(codexPreCompact?.matcherValues).toEqual(["manual", "auto"]);
     expect(codexSessionStart?.matcherValues).toEqual(["startup", "resume", "clear", "compact"]);
+    expect(cursorBeforeSubmitPrompt).toMatchObject({
+      canBlock: true,
+      evidenceKind: "docs-backed-overlay",
+      matcherKind: "ignored",
+      providerRef: "cursor-hooks-docs",
+    });
+    expect(cursorSessionStart?.matcherValues).toEqual(["startup", "resume", "clear", "compact"]);
+    expect(cursorSessionStart?.runtimeNotes).toContain("native-event-names-are-lower-camel");
   });
 });

--- a/packages/registry/src/hook-evidence.ts
+++ b/packages/registry/src/hook-evidence.ts
@@ -189,6 +189,32 @@ const CODEX_SUPPORTED_OUTPUT_FIELDS_BY_EVENT: Readonly<Record<string, readonly s
 const CODEX_HOOK_EVENT_SNAPSHOT = getProviderSchemaSnapshot("codex-hook-event-schemas");
 const CODEX_HOOK_EVENT_ENTRIES = readProviderSchemaSetEntries(CODEX_HOOK_EVENT_SNAPSHOT?.summary);
 
+const CURSOR_HOOK_EVENT_FACTS = [
+  cursorFact("AfterAgentResponse", "ignored", false),
+  cursorFact("AfterAgentThought", "ignored", false),
+  cursorFact("AfterFileEdit", "file-name", false),
+  cursorFact("AfterMCPExecution", "mcp-server", false),
+  cursorFact("AfterShellExecution", "ignored", false),
+  cursorFact("AfterTabFileEdit", "file-name", false),
+  cursorFact("BeforeMCPExecution", "mcp-server", true),
+  cursorFact("BeforeReadFile", "file-name", true),
+  cursorFact("BeforeShellExecution", "ignored", true),
+  cursorFact("BeforeSubmitPrompt", "ignored", true),
+  cursorFact("BeforeTabFileRead", "file-name", true),
+  cursorFact("PostCompact", "compact-trigger", false, { matcherValues: ["manual", "auto"] }),
+  cursorFact("PostToolUse", "tool", false),
+  cursorFact("PostToolUseFailure", "tool", false),
+  cursorFact("PreCompact", "compact-trigger", true, { matcherValues: ["manual", "auto"] }),
+  cursorFact("PreToolUse", "tool", true),
+  cursorFact("SessionEnd", "session-end-reason", false),
+  cursorFact("SessionStart", "session-source", false, { matcherValues: ["startup", "resume", "clear", "compact"] }),
+  cursorFact("Stop", "ignored", true),
+  cursorFact("SubagentStart", "agent-type", false),
+  cursorFact("SubagentStop", "agent-type", true),
+  cursorFact("UserPromptSubmit", "ignored", true),
+  cursorFact("WorkspaceOpen", "ignored", false),
+] as const;
+
 const codexHookEvidence = defineProviderHookEvidence({
   config: {
     groupFields: ["matcher", "hooks", "statusMessage"],
@@ -209,13 +235,30 @@ const codexHookEvidence = defineProviderHookEvidence({
   target: "codex",
 });
 
+const cursorHookEvidence = defineProviderHookEvidence({
+  config: {
+    groupFields: ["matcher", "hooks"],
+    handlerCommonFields: ["type", "command", "timeout"],
+    rootFields: ["hooks"],
+  },
+  events: CURSOR_HOOK_EVENT_FACTS.map(cursorEvent),
+  evidenceKind: "docs-backed-overlay",
+  handlerTypes: [
+    { type: "command", fields: ["type", "command", "timeout"] },
+  ],
+  providerRef: "cursor-hooks-docs",
+  sources: ["https://cursor.com/docs/hooks"],
+  target: "cursor",
+});
+
 const providerHookEvidence = {
   claude: claudeHookEvidence,
   codex: codexHookEvidence,
+  cursor: cursorHookEvidence,
 } as const satisfies Readonly<Record<ProviderHookEvidenceTarget, ProviderHookEvidence>>;
 
 export function listProviderHookEvidence(): readonly ProviderHookEvidence[] {
-  return [providerHookEvidence.claude, providerHookEvidence.codex];
+  return [providerHookEvidence.claude, providerHookEvidence.codex, providerHookEvidence.cursor];
 }
 
 export function getProviderHookEvidence(target: ProviderHookEvidenceTarget): ProviderHookEvidence {
@@ -334,6 +377,53 @@ function supportedCodexOutputFields(event: string, rawOutputFields: readonly str
 
 function codexSchemaEntry(title: string): ProviderSchemaSetEntry | undefined {
   return CODEX_HOOK_EVENT_ENTRIES.find((entry) => entry.title === title);
+}
+
+function cursorFact(
+  name: string,
+  matcherKind: ProviderHookMatcherKind,
+  canBlock: boolean,
+  options: {
+    readonly matcherValues?: readonly string[];
+    readonly runtimeNotes?: readonly string[];
+  } = {}
+): {
+  readonly canBlock: boolean;
+  readonly matcherKind: ProviderHookMatcherKind;
+  readonly matcherValues: readonly string[];
+  readonly name: string;
+  readonly runtimeNotes: readonly string[];
+} {
+  return {
+    canBlock,
+    matcherKind,
+    matcherValues: options.matcherValues ?? [],
+    name,
+    runtimeNotes: options.runtimeNotes ?? [],
+  };
+}
+
+function cursorEvent(fact: (typeof CURSOR_HOOK_EVENT_FACTS)[number]): ProviderHookEventEvidence {
+  const matcherEvaluation = fact.matcherKind === "ignored" ? "ignored" : fact.matcherValues.length > 0 ? "exact-values" : "provider-native";
+  return {
+    canBlock: fact.canBlock,
+    evidenceKind: "docs-backed-overlay",
+    handlerTypes: ["command"],
+    inputFields: [],
+    matcherEvaluation,
+    matcherKind: fact.matcherKind,
+    matcherValues: fact.matcherValues,
+    name: fact.name,
+    outputFields: [],
+    providerRef: "cursor-hooks-docs",
+    rawOutputFields: [],
+    runtimeNotes: [
+      ...fact.runtimeNotes,
+      "native-event-names-are-lower-camel",
+      ...(matcherEvaluation === "provider-native" ? ["matcher-values-provider-native"] : []),
+    ],
+    unsupportedOutputFields: [],
+  };
 }
 
 function fields(names: readonly string[], required: readonly string[]): readonly ProviderHookFieldEvidence[] {

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -6,7 +6,7 @@ export * from "./schema-snapshots";
 
 export const PROVIDER_DESTINATION_FORMAT_SNAPSHOT_SCHEMA = "skillset-provider-destination-format@1";
 
-export const PROVIDER_DESTINATION_FORMAT_TARGETS = ["claude", "codex"] as const;
+export const PROVIDER_DESTINATION_FORMAT_TARGETS = ["claude", "codex", "cursor"] as const;
 
 export type ProviderDestinationFormatTarget = (typeof PROVIDER_DESTINATION_FORMAT_TARGETS)[number];
 
@@ -18,7 +18,12 @@ export type ProviderDestinationFormatSnapshotId =
   | "codex-agents-md"
   | "codex-plugin"
   | "codex-skill"
-  | "codex-subagent";
+  | "codex-subagent"
+  | "cursor-agent"
+  | "cursor-hooks"
+  | "cursor-plugin"
+  | "cursor-rules"
+  | "cursor-skill";
 
 export type ProviderDestinationFormatJsonValue =
   | boolean
@@ -294,6 +299,138 @@ const snapshots = [
     },
     target: "codex",
     title: "Codex Project Instructions Destination Format",
+  }),
+  snapshot({
+    destination: "plugin",
+    format: {
+      components: [
+        { defaultPath: "skills/", kind: "skills", manifestField: "skills", status: "native" },
+        { defaultPath: "rules/", kind: "rules", manifestField: "rules", status: "native" },
+        { defaultPath: "agents/", kind: "agents", manifestField: "agents", status: "native" },
+        { defaultPath: "commands/", kind: "commands", manifestField: "commands", status: "native" },
+        { defaultPath: "hooks/hooks.json", kind: "hooks", manifestField: "hooks", status: "native" },
+        { defaultPath: "mcp.json", kind: "mcp", manifestField: "mcpServers", status: "native" },
+        { defaultPath: "assets/", kind: "assets", manifestField: null, status: "native" },
+        { defaultPath: "scripts/", kind: "scripts", manifestField: null, status: "native" },
+        { defaultPath: "bin/", kind: "bin", manifestField: null, status: "unsupported" },
+      ],
+      manifest: {
+        path: ".cursor-plugin/plugin.json",
+        requiredFields: ["name", "description"],
+        optionalFields: [
+          "agents",
+          "category",
+          "commands",
+          "displayName",
+          "hooks",
+          "logo",
+          "mcpServers",
+          "rules",
+          "skills",
+          "tags",
+          "version",
+        ],
+      },
+      pathRules: {
+        componentDirectoriesAtPluginRoot: true,
+        metadataDirectory: ".cursor-plugin/",
+      },
+    },
+    id: "cursor-plugin",
+    provenance: {
+      contentHash: "sha256:1d87b97a074afb49078bda9fa1e399a653229001c134b8fe0a5a2937ccbde5f9",
+      fetchedAt: FETCHED_AT,
+      sources: [
+        { url: "https://cursor.com/docs/plugins" },
+        { url: "https://github.com/cursor/plugins" },
+      ],
+    },
+    target: "cursor",
+    title: "Cursor Plugin Destination Format",
+  }),
+  snapshot({
+    destination: "skill",
+    format: {
+      directoryPattern: ".cursor/skills/<skill-name>/",
+      frontmatter: {
+        requiredFields: ["name", "description"],
+      },
+      requiredFiles: ["SKILL.md"],
+      serialization: "markdown-with-yaml-frontmatter",
+      supportingDirectories: ["assets/", "references/", "scripts/"],
+    },
+    id: "cursor-skill",
+    provenance: {
+      contentHash: "sha256:70eb2f6bac761f362c4895d71da72e9e5c047b9525f40214844e79122f569201",
+      fetchedAt: FETCHED_AT,
+      sources: [
+        { url: "https://cursor.com/docs/plugins" },
+        { url: "https://github.com/cursor/plugins" },
+      ],
+    },
+    target: "cursor",
+    title: "Cursor Skill Destination Format",
+  }),
+  snapshot({
+    destination: "agent",
+    format: {
+      filePattern: ".cursor/agents/*.md",
+      frontmatter: {
+        optionalFields: ["is_background", "model", "readonly", "skills"],
+        requiredFields: ["name", "description"],
+      },
+      serialization: "markdown-with-yaml-frontmatter",
+    },
+    id: "cursor-agent",
+    provenance: {
+      contentHash: "sha256:eb6d9afc41c0bb38724157466cab2a9a81809d5df477b85231df4ee7e190a5c0",
+      fetchedAt: FETCHED_AT,
+      sources: [
+        { url: "https://cursor.com/docs/plugins" },
+        { url: "https://github.com/cursor/plugins" },
+      ],
+    },
+    target: "cursor",
+    title: "Cursor Agent Destination Format",
+  }),
+  snapshot({
+    destination: "instructions",
+    format: {
+      filePattern: ".cursor/rules/*.mdc",
+      frontmatter: {
+        optionalFields: ["alwaysApply", "globs"],
+        requiredFields: ["description"],
+      },
+      serialization: "markdown-with-yaml-frontmatter",
+    },
+    id: "cursor-rules",
+    provenance: {
+      contentHash: "sha256:b02aeab7b95d881cd961dfb8c34a5f1e32d2368f234c27d6d2eb65d74e995bd3",
+      fetchedAt: FETCHED_AT,
+      sources: [{ url: "https://cursor.com/docs/rules" }],
+    },
+    target: "cursor",
+    title: "Cursor Rules Destination Format",
+  }),
+  snapshot({
+    destination: "hooks",
+    format: {
+      canonicalEventNames: "skillset-pascal-case",
+      nativeEventNames: "cursor-lower-camel",
+      filePattern: "hooks/hooks.json",
+      handlerFields: ["type", "command", "timeout"],
+      rootFields: ["hooks"],
+      shape: "event-map",
+      supportedHandlerTypes: ["command"],
+    },
+    id: "cursor-hooks",
+    provenance: {
+      contentHash: "sha256:9bc3b608cc0ebc7ce09e52754c69ac1148290d8165d778e488abb138654cda19",
+      fetchedAt: FETCHED_AT,
+      sources: [{ url: "https://cursor.com/docs/hooks" }],
+    },
+    target: "cursor",
+    title: "Cursor Hook Destination Format",
   }),
 ] as const satisfies readonly ProviderDestinationFormatSnapshot[];
 

--- a/packages/registry/src/migrations.ts
+++ b/packages/registry/src/migrations.ts
@@ -65,6 +65,11 @@ const PROVIDER_FORMAT_MIGRATION_SNAPSHOTS: Record<
   "codex-plugin": { provider: "codex", surface: "plugin" },
   "codex-skill": { provider: "codex", surface: "skill" },
   "codex-subagent": { provider: "codex", surface: "agent" },
+  "cursor-agent": { provider: "cursor", surface: "agent" },
+  "cursor-hooks": { provider: "cursor", surface: "hooks" },
+  "cursor-plugin": { provider: "cursor", surface: "plugin" },
+  "cursor-rules": { provider: "cursor", surface: "instructions" },
+  "cursor-skill": { provider: "cursor", surface: "skill" },
 };
 
 const PROVIDER_FORMAT_MIGRATION_TARGETS = new Set<ProviderDestinationFormatTarget>(

--- a/packages/registry/src/schema-snapshots.ts
+++ b/packages/registry/src/schema-snapshots.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 export const PROVIDER_SCHEMA_SNAPSHOT_SCHEMA = "skillset-provider-schema@1";
 
-export const PROVIDER_SCHEMA_TARGETS = ["claude", "codex"] as const;
+export const PROVIDER_SCHEMA_TARGETS = ["claude", "codex", "cursor"] as const;
 
 export type ProviderSchemaTarget = (typeof PROVIDER_SCHEMA_TARGETS)[number];
 


### PR DESCRIPTION
## Context

Stack 3/5 for Cursor provider parity. Implements Cursor-native generated output after the target vocabulary exists.

## Changes

- Emits Cursor plugin manifests, skills, rules, agents, commands, hooks, MCP, marketplace output, locks, and render-result metadata.
- Adds Cursor provider-format snapshots, hook evidence, feature registry claims, and conformance coverage.
- Regenerates self-hosted Cursor output.

## Verification

- M3 local review: 5/5 clean (`.agents/goals/2026-07-02-cursor-provider-parity/tmp/reviews/codex-m3/round-1.json`).
- `bun run check` passed during M3 and again on the final stack tip.
- Pre-push gates passed before publishing the stack.

## Stack

1. #236
2. #237
3. set-245-cursor-native-renderers
4. set-250-cursor-runtime-import-docs
5. set-253-cursor-parity-gate