### PR TITLE
feat: add cursor activation probe selection

### DIFF
--- a/.changeset/cursor-activation-probes.md
+++ b/.changeset/cursor-activation-probes.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Fix `skillset test` activation probes for Cursor by treating Cursor project agents as native Markdown outputs, and add `select.agents` for project-agent test selection.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1978,6 +1978,69 @@ Demo body.
   expect(codexProbe).toContain("fixture-guidance");
 });
 
+test("SET-132: activation probes handle Cursor as native project-agent output", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: activation-cursor-root
+cursor: true
+`,
+    ".skillset/tests/activation.yaml": `
+select:
+  agents:
+    - reviewer
+  skills:
+    primary:
+      - helper
+targets:
+  - cursor
+activation:
+  - name: cursor helper skill
+    prompt: Help me inspect this Skillset helper.
+    expect:
+      skill: helper
+  - name: cursor project agent
+    prompt: Ask the reviewer to inspect this workspace.
+    expect:
+      agent: reviewer
+checks:
+  projection: true
+`,
+    ".skillset/agents/reviewer.md": `
+---
+name: Reviewer
+description: Reviews Cursor workspaces.
+---
+
+Review the workspace.
+`,
+    ".skillset/skills/helper/SKILL.md": `
+---
+name: helper
+description: Helper.
+---
+
+Helper body.
+`,
+  });
+
+  const result = await runSkillsetCli("test", "activation", "--root", root);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("selection: agents reviewer; primary skills helper");
+  expect(await fileExists(cachePath(root, ".skillset/cache/tests/latest/activation/cursor/cursor-helper-skill.md"))).toBe(true);
+  expect(await fileExists(cachePath(root, ".skillset/cache/tests/latest/activation/cursor/cursor-project-agent.md"))).toBe(true);
+  const probes = await readFile(cachePath(root, ".skillset/cache/tests/latest/activation/cursor/probes.json"), "utf8");
+  expect(probes).toContain("manual-native");
+  expect(probes).toContain("Manual Cursor activation probe");
+  expect(probes).not.toContain("Manual Codex activation probe");
+  expect(probes).not.toContain("manual-shimmed");
+  const report = JSON.parse(await readFile(cachePath(root, ".skillset/cache/tests/latest/report.json"), "utf8")) as {
+    selection: { agents: string[]; primarySkills: string[] };
+  };
+  expect(report.selection.agents).toEqual(["reviewer"]);
+  expect(report.selection.primarySkills).toEqual(["helper"]);
+});
+
 test("SET-112: activation probes reject empty prompts and duplicate output names", async () => {
   const emptyPromptRoot = await contractFixture({
     "skillset.yaml": `

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1461,6 +1461,7 @@ function printSkillsetTest(report: SkillsetTestReport): void {
 
 function formatTestSelection(selection: SkillsetTestReport["selection"]): string {
   const parts = [
+    selection.agents.length === 0 ? undefined : `agents ${selection.agents.join(", ")}`,
     selection.plugins.length === 0 ? undefined : `plugins ${selection.plugins.join(", ")}`,
     selection.primarySkills.length === 0 ? undefined : `primary skills ${selection.primarySkills.join(", ")}`,
     selection.pluginSkills.length === 0 ? undefined : `plugin skills ${selection.pluginSkills.join(", ")}`,

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -47,6 +47,7 @@ export interface SkillsetTestCheckResult {
 }
 
 export interface SkillsetTestSelectionReport extends JsonRecord {
+  readonly agents: string[];
   readonly filterSource: boolean;
   readonly pluginSkills: string[];
   readonly plugins: string[];
@@ -73,7 +74,13 @@ interface PluginSkillSelection {
   readonly skillId: string;
 }
 
+interface ProjectAgentSelection {
+  readonly filename: string;
+  readonly outputName: string;
+}
+
 interface TestSelection {
+  readonly agents: readonly ProjectAgentSelection[];
   readonly filterSource: boolean;
   readonly pluginSkills: readonly PluginSkillSelection[];
   readonly plugins: readonly string[];
@@ -375,14 +382,15 @@ function readEffectiveTargets(record: JsonRecord, label: string): readonly Targe
 }
 
 function readSelection(graph: BuildGraph, value: JsonValue | undefined, label: string): TestSelection {
-  if (value === undefined) return { filterSource: false, pluginSkills: [], plugins: [], primarySkills: [] };
+  if (value === undefined) return { agents: [], filterSource: false, pluginSkills: [], plugins: [], primarySkills: [] };
   if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
   for (const key of Object.keys(value)) {
-    if (key !== "plugins" && key !== "skills") {
+    if (key !== "agents" && key !== "plugins" && key !== "skills") {
       throw new Error(`skillset: unsupported selector key ${key} in ${label}`);
     }
   }
 
+  const agents = readAgentSelection(graph, value.agents, `${label}.agents`);
   const pluginIds = new Set<string>();
   const primarySkillIds = new Set<string>();
   const pluginSkillKeys = new Set<string>();
@@ -399,15 +407,35 @@ function readSelection(graph: BuildGraph, value: JsonValue | undefined, label: s
   readSkillSelection(graph, value.skills, `${label}.skills`, primarySkillIds, addPluginSkill);
 
   const selection = {
+    agents,
     filterSource: true,
     pluginSkills: pluginSkills.sort((left, right) => compareStrings(`${left.pluginId}/${left.skillId}`, `${right.pluginId}/${right.skillId}`)),
     plugins: [...pluginIds].sort(compareStrings),
     primarySkills: [...primarySkillIds].sort(compareStrings),
   };
-  if (selection.plugins.length === 0 && selection.primarySkills.length === 0 && selection.pluginSkills.length === 0) {
+  if (selection.agents.length === 0 && selection.plugins.length === 0 && selection.primarySkills.length === 0 && selection.pluginSkills.length === 0) {
     throw new Error(`skillset: ${label} must select at least one source unit`);
   }
   return selection;
+}
+
+function readAgentSelection(
+  graph: BuildGraph,
+  value: JsonValue | undefined,
+  label: string
+): readonly ProjectAgentSelection[] {
+  if (value === undefined) return [];
+  if (value === true) {
+    return graph.projectAgents
+      .map((agent) => ({ filename: agent.filename, outputName: agent.outputName }))
+      .sort((left, right) => compareStrings(left.outputName, right.outputName));
+  }
+  const outputNames = graph.projectAgents.map((agent) => agent.outputName);
+  return readSelectorNames(outputNames, value, label, "project agent").map((outputName) => {
+    const agent = graph.projectAgents.find((candidate) => candidate.outputName === outputName);
+    if (agent === undefined) throw new Error(`skillset: unknown project agent ${JSON.stringify(outputName)} in ${label}`);
+    return { filename: agent.filename, outputName: agent.outputName };
+  });
 }
 
 function readPluginSelection(
@@ -828,6 +856,7 @@ function outputIncludes(selection: boolean | readonly string[], id: string): boo
 
 function selectionRecord(selection: TestSelection): SkillsetTestSelectionReport {
   return {
+    agents: selection.agents.map((agent) => agent.outputName),
     filterSource: selection.filterSource,
     pluginSkills: selection.pluginSkills.map((skill) => `${skill.pluginId}/${skill.skillId}`),
     plugins: [...selection.plugins],
@@ -865,7 +894,7 @@ function activationExpectationCandidatePaths(
     const projectRoot = targetProjectRoot(graph, target);
     return graph.projectAgents
       .filter((agent) => agent.name === expect.name || agent.outputName === expect.name)
-      .map((agent) => join(projectRoot, "agents", `${agent.outputName}.${target === "claude" ? "md" : "toml"}`));
+      .map((agent) => join(projectRoot, "agents", `${agent.outputName}.${target === "codex" ? "toml" : "md"}`));
   }
 
   return [
@@ -881,7 +910,8 @@ function activationExpectationCandidatePaths(
 }
 
 function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
-  return readString(graph.root.targets[target].options, "projectRoot") ?? (target === "claude" ? ".claude" : ".codex");
+  return readString(graph.root.targets[target].options, "projectRoot") ??
+    (target === "claude" ? ".claude" : target === "codex" ? ".codex" : ".cursor");
 }
 
 async function writeActivationProbes(
@@ -917,7 +947,7 @@ function activationProbeRecord(probe: ActivationProbe, target: TargetName): Json
     harness: activationHarness(target),
     name: slugifyProbeName(probe.name),
     prompt: probe.prompt,
-    status: target === "claude" ? "manual-native" : "manual-shimmed",
+    status: target === "codex" ? "manual-shimmed" : "manual-native",
     target,
   };
 }
@@ -925,6 +955,9 @@ function activationProbeRecord(probe: ActivationProbe, target: TargetName): Json
 function activationHarness(target: TargetName): string {
   if (target === "claude") {
     return "Manual Claude activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.";
+  }
+  if (target === "cursor") {
+    return "Manual Cursor activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.";
   }
   return "Manual Codex activation probe. Use generated Codex output or plugin-eval tooling when available; compatibility shims should be reported explicitly.";
 }
@@ -1008,10 +1041,12 @@ function renderMarkdownReport(report: JsonRecord): string {
 
 function selectionMarkdownLines(value: JsonValue | undefined): readonly string[] {
   if (!isJsonRecord(value)) return ["Selection: none"];
+  const agents = readSelectionList(value.agents);
   const plugins = readSelectionList(value.plugins);
   const primarySkills = readSelectionList(value.primarySkills);
   const pluginSkills = readSelectionList(value.pluginSkills);
   const parts = [
+    agents.length === 0 ? undefined : `agents ${agents.join(", ")}`,
     plugins.length === 0 ? undefined : `plugins ${plugins.join(", ")}`,
     primarySkills.length === 0 ? undefined : `primary skills ${primarySkills.join(", ")}`,
     pluginSkills.length === 0 ? undefined : `plugin skills ${pluginSkills.join(", ")}`,
@@ -1063,6 +1098,7 @@ async function applySourceSelection(
   if (!selection.filterSource) return;
 
   const sourceRootPath = resolveInside(stagingWorkspacePath, graph.sourceRoot);
+  await pruneSelectedChildren(join(sourceRootPath, "agents"), selection.agents.map((agent) => agent.filename));
   await pruneSelectedChildren(join(sourceRootPath, "skills"), selection.primarySkills);
 
   const selectedPluginIds = new Set([
@@ -1083,7 +1119,6 @@ async function applySourceSelection(
     await prunePluginToSelectedSkills(join(pluginsPath, pluginId), skillIds);
   }
 
-  await removeIfExists(join(sourceRootPath, "agents"));
   await removeIfExists(join(sourceRootPath, "rules"));
   await removeIfExists(join(sourceRootPath, "_claude"));
   await removeIfExists(join(sourceRootPath, "_codex"));

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -68,6 +68,17 @@ primary-skills:
     projection: true
 ```
 
+Project agents can be selected by their resolved output name:
+
+```yaml
+project-agent:
+  select:
+    agents:
+      - reviewer
+  checks:
+    projection: true
+```
+
 `select.skills.plugin` is available for plugin-bound skills, but `select.plugins.skills` is the clearer spelling when the test starts from plugins. `targets` filters provider renderings; `select` filters source units. `--scope` continues to mean generated-destination filtering, not source selection, and `skillset test` rejects build/write flags such as `--scope`, `--yes`, `--dry-run`, `--updated`, `--all`, and `--dist`.
 
 The test runner copies only source-relevant files into an isolated run workspace: root `skillset.yaml`, `.skillset/`, and source-adjacent state such as `.skillset/changes/`. It then prunes unselected source units before building. It does not stage operational `.skillset/cache/` or `.skillset/snapshots/` contents. If the repo has an existing workspace `skillset.lock`, the test stages that lock too so source-adjacent generated files such as entity `CHANGELOG.md` files remain recognized as managed inside the run.
@@ -135,7 +146,7 @@ Each probe requires `prompt` and `expect`. The v1 `expect` object must name exac
   <probe-name>.md
 ```
 
-`latest/` receives the same activation directory when the run refreshes. Claude probes are rendered as manual native harness prompts. Codex probes are rendered as manual shim-aware prompts because Codex can follow generated loading instructions, but Skillset should not pretend that every Claude-style activation signal is target-enforced in Codex. Future Codex plugin-eval integration can consume the same `probes.json` shape once that runner boundary is proven.
+`latest/` receives the same activation directory when the run refreshes. Claude and Cursor probes are rendered as manual native harness prompts. Codex probes are rendered as manual shim-aware prompts because Codex can follow generated loading instructions, but Skillset should not pretend that every Claude-style activation signal is target-enforced in Codex. Future Codex plugin-eval integration can consume the same `probes.json` shape once that runner boundary is proven.
 
 Edge cases stay explicit: multiple matching skills should be disambiguated in the expected selector, provider source may need target-specific probes, missing plugin dependencies should appear as activation setup failures rather than build successes, and compatibility shims should be reported as shims in the generated probe material.
 


### PR DESCRIPTION
## Context

Part of the runtime activation proof goal stack for SET-213 and SET-132. The existing SET-112 activation probe path was mostly in place, but Cursor had drifted after becoming a first-class provider: non-Claude targets were treated as Codex shimmed, and project-agent activation expectations looked under `.codex/agents`.

## What Changed

- Add `select.agents` to `skillset test` declarations so project-agent activation probes can scope source directly by resolved output name.
- Treat Cursor activation probes as native Markdown project-agent outputs under `.cursor/agents/*.md`.
- Keep Codex activation probes explicitly shim-aware while Claude and Cursor report `manual-native`.
- Document project-agent selection and the Claude/Cursor native vs Codex shimmed probe boundary.
- Add a patch changeset for the package-facing CLI/test-runner behavior.

## Verification

- `bun test apps/skillset/src/__tests__/contract.test.ts -t "activation probes"`
- `bun test apps/skillset/src/__tests__/contract.test.ts -t "skillset test"`
- `bun test apps/skillset/src/__tests__/contract.test.ts`
- `bun run typecheck`
- `bun run changeset:check`
- `bun run skillset:verify`
- `bun run check`
- pre-push hook: `skillset ci --since $(scripts/git-trunk.sh)` and full `bun run check`

## Local Review

- Goal-packet local review: `tmp/reviews/codex/round-1.json`
- Score: 5/5
- State: clean
- Open P0/P1/P2 findings: 0

## Risks / Rollout

This slice proves retained manual activation assets and source selection behavior. Live runtime orchestration proof remains in the next SET-134 milestone.

Refs SET-213, SET-132.
