### PR TITLE
test: prove project agent orchestration boundary

### DIFF
--- a/.changeset/project-agent-orchestration-proof.md
+++ b/.changeset/project-agent-orchestration-proof.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Document and prove project-agent orchestration compatibility by tying Claude native agent skill metadata and Codex skill-loading prefaces to activation probe evidence.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -2041,6 +2041,72 @@ Helper body.
   expect(report.selection.primarySkills).toEqual(["helper"]);
 });
 
+test("SET-134: project-agent orchestration activation proof distinguishes Claude native skills from Codex shim", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: activation-orchestration-root
+claude: true
+codex: true
+`,
+    ".skillset/tests/orchestration.yaml": `
+select:
+  agents:
+    - reviewer
+  skills:
+    primary:
+      - helper
+targets:
+  - claude
+  - codex
+activation:
+  - name: reviewer helper delegation
+    prompt: Ask the reviewer to use the helper guidance before reviewing.
+    expect:
+      agent: reviewer
+checks:
+  projection: true
+  files:
+    - path: .claude/agents/reviewer.md
+      contains: "skills:"
+    - path: .claude/agents/reviewer.md
+      contains: "- helper"
+    - path: .codex/agents/reviewer.toml
+      contains: "Load the following skills first"
+    - path: .codex/agents/reviewer.toml
+      contains: "- helper"
+`,
+    ".skillset/agents/reviewer.md": `
+---
+name: Reviewer
+description: Reviews with helper guidance.
+skills:
+  - helper
+---
+
+Review the workspace after loading helper guidance.
+`,
+    ".skillset/skills/helper/SKILL.md": `
+---
+name: helper
+description: Helper.
+---
+
+Helper body.
+`,
+  });
+
+  const result = await runSkillsetCli("test", "orchestration", "--root", root);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("selection: agents reviewer; primary skills helper");
+  expect(result.stdout).toContain("activation probes: 1");
+  const claudeProbe = await readFile(cachePath(root, ".skillset/cache/tests/latest/activation/claude/reviewer-helper-delegation.md"), "utf8");
+  expect(claudeProbe).toContain("Manual Claude activation probe");
+  const codexProbe = await readFile(cachePath(root, ".skillset/cache/tests/latest/activation/codex/probes.json"), "utf8");
+  expect(codexProbe).toContain("manual-shimmed");
+  expect(codexProbe).toContain("reviewer-helper-delegation");
+});
+
 test("SET-112: activation probes reject empty prompts and duplicate output names", async () => {
   const emptyPromptRoot = await contractFixture({
     "skillset.yaml": `

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -1752,6 +1752,8 @@ Tree:
   expect(claudeAgent).toContain(`name: Code Reviewer`);
   expect(claudeAgent).toContain(`description: Reviews project changes.`);
   expect(claudeAgent).toContain(`color: blue`);
+  expect(claudeAgent).toContain("skills:");
+  expect(claudeAgent).toContain("- skillset-codex-development");
   expect(claudeAgent).toContain(`generated: skillset@0.1.0`);
   expect(claudeAgent).toContain("Review diffs and call out correctness risks.");
   expect(claudeAgent).toContain("- reviewer.md");

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -63,6 +63,16 @@ The Codex skills preface is a runtime compatibility shim. It is useful and inten
 
 Claude plugin agents are a separate plugin component. Codex plugin docs do not document plugin agents, so copying Claude plugin agents into Codex output would be fake portability. A Codex-enabled plugin with `agents/` fails loudly; set `codex: false` for that plugin or move project-scoped roles to `<source-root>/agents/`.
 
+## Orchestration Compatibility
+
+Project-agent skill loading is the current orchestration boundary:
+
+- Claude receives native project-agent `skills` metadata in `.claude/agents/*.md`.
+- Cursor receives native project-agent Markdown with the shared `skills` field.
+- Codex receives a deterministic developer-instruction preface that asks the agent to load the named skills first.
+
+The Codex behavior is intentionally classified as `shimmed`, not native, because it depends on instruction following rather than target-enforced metadata. `skillset test` activation probes can cover both sides of that boundary by selecting the helper skill and project agent together, asserting the generated Claude/Codex files, and retaining manual probe assets that label Codex as `manual-shimmed`.
+
 ## Diagnostics
 
 - Duplicate or invalid resolved agent names fail before writing target files.

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -708,7 +708,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     summary: "Renders portable project agents to Claude Markdown agents and Codex TOML agents.",
     runtimeSupport: {
       "claude-code": {
-        evidence: [docs("docs/features/agents.md"), providerSnapshot("claude-subagent")],
+        evidence: [
+          docs("docs/features/agents.md"),
+          providerSnapshot("claude-subagent"),
+          test("apps/skillset/src/__tests__/contract.test.ts", "SET-134 project-agent orchestration activation proof"),
+        ],
         mechanism: "Claude Code reads project-scoped Markdown subagents from .claude/agents.",
         status: "native",
       },
@@ -716,7 +720,11 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         caveats: [
           "Codex receives skill-loading intent as developer instructions; it is not target-enforced skill metadata.",
         ],
-        evidence: [docs("docs/features/agents.md"), providerSnapshot("codex-subagent")],
+        evidence: [
+          docs("docs/features/agents.md"),
+          providerSnapshot("codex-subagent"),
+          test("apps/skillset/src/__tests__/contract.test.ts", "SET-134 project-agent orchestration activation proof"),
+        ],
         mechanism: "Skillset renders Codex TOML agents and inserts a deterministic skill-loading preface when source agents declare skills.",
         status: "shimmed",
       },


### PR DESCRIPTION
## Context

Stacked after PR #244 for the runtime activation proof goal. This slice addresses SET-134 by proving the current project-agent orchestration boundary without adding runtime mutation or a second activation harness.

## What Changed

- Add a `skillset test` activation declaration that selects a helper skill plus project agent together.
- Assert Claude keeps native project-agent `skills` metadata in `.claude/agents/*.md`.
- Assert Codex receives the deterministic skill-loading preface in `.codex/agents/*.toml`.
- Retain activation probe evidence that labels Codex as `manual-shimmed`.
- Document project-agent skill loading as the current orchestration compatibility boundary.
- Attach the SET-134 proof as runtime-support evidence for `project-agents` in the feature registry.
- Add a patch changeset.

## Verification

- `bun test apps/skillset/src/__tests__/contract.test.ts -t "SET-134"`
- `bun test apps/skillset/src/__tests__/skillset.test.ts -t "portable project agents lower"`
- `bun test packages/core/src/__tests__/feature-registry.test.ts packages/core/src/__tests__/feature-registry-check.test.ts`
- `bun run changeset:check`
- `bun run check`
- pre-push hook: `skillset ci --since $(scripts/git-trunk.sh)` and full `bun run check`

## Local Review

- Goal-packet local review: `tmp/reviews/codex/round-2.json`
- Score: 5/5
- State: clean
- Open P0/P1/P2 findings: 0

## Risks / Rollout

This proves deterministic render/probe evidence. It does not claim live model/runtime delegation behavior yet; that remains future runtime-tester or eval integration.

Refs SET-134.
