### PR TITLE
fix(release): reject mixed public and private changesets

### DIFF
--- a/.changeset/change-entry-migration.md
+++ b/.changeset/change-entry-migration.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/schema": patch
 "skillset": patch
 ---
 

--- a/.changeset/cursor-default-target.md
+++ b/.changeset/cursor-default-target.md
@@ -1,6 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
 "skillset": patch
 ---
 

--- a/.changeset/cursor-native-renderers.md
+++ b/.changeset/cursor-native-renderers.md
@@ -1,6 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/registry": patch
 "skillset": patch
 ---
 

--- a/.changeset/cursor-runtime-import-docs.md
+++ b/.changeset/cursor-runtime-import-docs.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/cursor-target-core.md
+++ b/.changeset/cursor-target-core.md
@@ -1,7 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
-"@skillset/workbench": patch
 "skillset": patch
 ---
 

--- a/.changeset/hook-evidence-lift-diagnostics.md
+++ b/.changeset/hook-evidence-lift-diagnostics.md
@@ -1,6 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/registry": patch
 "skillset": patch
 ---
 

--- a/.changeset/known-skillsets-index.md
+++ b/.changeset/known-skillsets-index.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/ledger-derived-release-state.md
+++ b/.changeset/ledger-derived-release-state.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/license-outputs.md
+++ b/.changeset/license-outputs.md
@@ -1,6 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
 "skillset": patch
 ---
 

--- a/.changeset/marketplace-check.md
+++ b/.changeset/marketplace-check.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/marketplace-ref-policy.md
+++ b/.changeset/marketplace-ref-policy.md
@@ -1,6 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
 "skillset": patch
 ---
 

--- a/.changeset/marketplace-update.md
+++ b/.changeset/marketplace-update.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/native-hook-companion-files.md
+++ b/.changeset/native-hook-companion-files.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/plugin-first-output-layout.md
+++ b/.changeset/plugin-first-output-layout.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/portable-tools-policy.md
+++ b/.changeset/portable-tools-policy.md
@@ -1,7 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
-"@skillset/workbench": patch
 "skillset": patch
 ---
 

--- a/.changeset/remove-retired-plugin-roots.md
+++ b/.changeset/remove-retired-plugin-roots.md
@@ -1,5 +1,4 @@
 ---
-"@skillset/core": patch
 "skillset": patch
 ---
 

--- a/.changeset/unsupported-destination-soft-policies.md
+++ b/.changeset/unsupported-destination-soft-policies.md
@@ -1,7 +1,4 @@
 ---
-"@skillset/core": patch
-"@skillset/schema": patch
-"@skillset/workbench": patch
 "skillset": patch
 ---
 

--- a/apps/skillset/src/changeset-awareness.ts
+++ b/apps/skillset/src/changeset-awareness.ts
@@ -1,3 +1,8 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parseMarkdown } from "@skillset/core/internal/yaml";
+
 import { gitSafeEnv } from "./git-env";
 
 export type ChangedFile = {
@@ -11,6 +16,53 @@ export type ChangesetGuardResult = {
   ok: boolean;
   packageFiles: readonly ChangedFile[];
 };
+
+export type MixedChangesetReleaseEntry = {
+  readonly changesetPath: string;
+  readonly ignoredPackages: readonly string[];
+  readonly publishedPackages: readonly string[];
+};
+
+export async function findMixedChangesetReleaseEntries(
+  rootPath: string
+): Promise<readonly MixedChangesetReleaseEntry[]> {
+  const changesetConfig = await readJsonRecord(join(rootPath, ".changeset/config.json"));
+  const ignoredPackages = new Set(readStringArray(changesetConfig.ignore));
+  const privatePackages = isRecord(changesetConfig.privatePackages)
+    ? changesetConfig.privatePackages
+    : {};
+
+  for (const workspaceRoot of ["apps", "packages"]) {
+    const entries = await readDirectory(join(rootPath, workspaceRoot));
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const manifest = await readJsonRecord(join(rootPath, workspaceRoot, entry.name, "package.json"));
+      const name = typeof manifest.name === "string" ? manifest.name : undefined;
+      if (name && manifest.private === true && privatePackages.version !== true) {
+        ignoredPackages.add(name);
+      }
+    }
+  }
+
+  const mixed: MixedChangesetReleaseEntry[] = [];
+  for (const entry of (await readDirectory(join(rootPath, ".changeset")))
+    .filter((candidate) => candidate.isFile() && candidate.name.endsWith(".md"))
+    .sort((left, right) => left.name.localeCompare(right.name))) {
+    const changesetPath = `.changeset/${entry.name}`;
+    const source = await Bun.file(join(rootPath, changesetPath)).text();
+    const packageNames = Object.keys(parseMarkdown(source, changesetPath).frontmatter).sort();
+    const ignored = packageNames.filter((name) => ignoredPackages.has(name));
+    const published = packageNames.filter((name) => !ignoredPackages.has(name));
+    if (ignored.length === 0 || published.length === 0) continue;
+    mixed.push({
+      changesetPath,
+      ignoredPackages: ignored,
+      publishedPackages: published,
+    });
+  }
+
+  return mixed;
+}
 
 export function evaluateChangesetGuard(changedFiles: readonly ChangedFile[]): ChangesetGuardResult {
   const packageFiles = changedFiles.filter((file) => isPackageAffectingPath(file.path));
@@ -152,6 +204,31 @@ function summarizePaths(files: readonly ChangedFile[]) {
   const shown = paths.slice(0, 8);
   const suffix = paths.length > shown.length ? `, and ${paths.length - shown.length} more` : "";
   return shown.join(", ") + suffix;
+}
+
+async function readDirectory(path: string) {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (isRecord(error) && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function readJsonRecord(path: string): Promise<Record<string, unknown>> {
+  const parsed = await Bun.file(path).json() as unknown;
+  if (!isRecord(parsed)) throw new Error(`skillset: expected ${path} to contain a JSON object`);
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
 }
 
 async function runText(

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -34,7 +34,7 @@ Package-facing means a change that can affect the published `skillset` CLI packa
 | `packages/*/package.json` for `core`, `lint`, `registry`, `schema`, and `transforms` | Runtime dependency and package metadata for the private workspace packages that feed the CLI. |
 | `bun.lock` / `bun.lockb` | Dependency resolution that can alter the packaged CLI runtime. |
 
-`bun run changeset:check` enforces this boundary. It fails when package-facing paths change without an active `.changeset/*.md`, and it also fails when an active Changeset appears on a branch that only changes repo machinery. Deleted Changesets are ignored so cleanup branches can remove mistaken package-release entries.
+`bun run changeset:check` enforces this boundary. It fails when package-facing paths change without an active `.changeset/*.md`, when an active Changeset appears on a branch that only changes repo machinery, or when a pending Changeset mixes the published `skillset` package with ignored private `@skillset/*` packages. Deleted Changesets are ignored so cleanup branches can remove mistaken package-release entries. Private-only Changesets remain valid internal evidence; a public Changeset should list only packages that Changesets can version.
 
 Provider and schema changes usually have two evidence surfaces. The package Changeset explains the npm-facing behavior change, while the Skillset pending change entry explains any source-unit or generated-output provenance change in the local workspace. Generated schema artifacts under `docs/reference/schemas/` and `docs/reference/examples/` are reviewed with the contract change but do not replace the `.changeset/*.md` entry because they are derived from `packages/schema/src/**`.
 

--- a/scripts/__tests__/changeset-guard.test.ts
+++ b/scripts/__tests__/changeset-guard.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   evaluateChangesetGuard,
+  findMixedChangesetReleaseEntries,
   isActiveChangesetEntry,
   isPackageAffectingPath,
   parseChangedFileLine,
 } from "../../apps/skillset/src/changeset-awareness";
+import { runChangesetGuard } from "../changeset-guard";
 
 describe("changeset guard", () => {
   test("requires an active changeset for published package payload changes", () => {
@@ -26,6 +31,113 @@ describe("changeset guard", () => {
 
     expect(result.ok).toBe(true);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  test("reports changesets that mix published and ignored private packages", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-changeset-guard-"));
+    try {
+      await mkdir(join(root, "apps/skillset"), { recursive: true });
+      await mkdir(join(root, "packages/schema"), { recursive: true });
+      await mkdir(join(root, ".changeset"), { recursive: true });
+      await writeFile(join(root, "apps/skillset/package.json"), JSON.stringify({ name: "skillset" }));
+      await writeFile(
+        join(root, "packages/schema/package.json"),
+        JSON.stringify({ name: "@skillset/schema", private: true })
+      );
+      await writeFile(
+        join(root, ".changeset/config.json"),
+        JSON.stringify({ ignore: [], privatePackages: { version: false } })
+      );
+      await writeFile(
+        join(root, ".changeset/mixed.md"),
+        '---\n"@skillset/schema": patch\n"skillset": patch\n---\n\nRelease both.\n'
+      );
+
+      await expect(findMixedChangesetReleaseEntries(root)).resolves.toEqual([
+        {
+          changesetPath: ".changeset/mixed.md",
+          ignoredPackages: ["@skillset/schema"],
+          publishedPackages: ["skillset"],
+        },
+      ]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("command rejects mixed release entries with an actionable diagnostic", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-changeset-command-"));
+    try {
+      await mkdir(join(root, "apps/skillset/src"), { recursive: true });
+      await mkdir(join(root, "packages/schema"), { recursive: true });
+      await mkdir(join(root, ".changeset"), { recursive: true });
+      await writeFile(join(root, "apps/skillset/package.json"), JSON.stringify({ name: "skillset" }));
+      await writeFile(
+        join(root, "packages/schema/package.json"),
+        JSON.stringify({ name: "@skillset/schema", private: true })
+      );
+      await writeFile(
+        join(root, ".changeset/config.json"),
+        JSON.stringify({ ignore: [], privatePackages: { version: false } })
+      );
+      await writeFile(
+        join(root, ".changeset/mixed.md"),
+        '---\n"@skillset/schema": patch\n"skillset": patch\n---\n\nRelease both.\n'
+      );
+      const changedFilesPath = join(root, "changed-files.txt");
+      await writeFile(
+        changedFilesPath,
+        "M\tapps/skillset/src/cli.ts\nM\t.changeset/mixed.md\n"
+      );
+      const output: string[] = [];
+
+      const exitCode = await runChangesetGuard(
+        ["--changed-files", changedFilesPath],
+        { rootPath: root, writeLine: (line) => output.push(line) }
+      );
+
+      expect(exitCode).toBe(1);
+      expect(output.join("\n")).toContain(
+        ".changeset/mixed.md mixes ignored package(s) @skillset/schema with published package(s) skillset"
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("classifies private-only, public-only, explicit ignore, and versioned private entries", async () => {
+    const ignoredRoot = await writeReleaseBoundaryFixture({
+      changesets: {
+        "explicit-ignore.md": '---\n"@skillset/ignored": patch\n"skillset": patch\n---\n',
+        "private-only.md": '---\n"@skillset/schema": patch\n---\n',
+        "public-only.md": '---\n"skillset": patch\n---\n',
+      },
+      ignore: ["@skillset/ignored"],
+      privatePackageVersioning: false,
+    });
+    const versionedRoot = await writeReleaseBoundaryFixture({
+      changesets: {
+        "versioned-private.md": '---\n"@skillset/schema": patch\n"skillset": patch\n---\n',
+      },
+      ignore: [],
+      privatePackageVersioning: true,
+    });
+
+    try {
+      await expect(findMixedChangesetReleaseEntries(ignoredRoot)).resolves.toEqual([
+        {
+          changesetPath: ".changeset/explicit-ignore.md",
+          ignoredPackages: ["@skillset/ignored"],
+          publishedPackages: ["skillset"],
+        },
+      ]);
+      await expect(findMixedChangesetReleaseEntries(versionedRoot)).resolves.toEqual([]);
+    } finally {
+      await Promise.all([
+        rm(ignoredRoot, { force: true, recursive: true }),
+        rm(versionedRoot, { force: true, recursive: true }),
+      ]);
+    }
   });
 
   test("blocks active changesets when only repo machinery changed", () => {
@@ -108,3 +220,37 @@ describe("changeset guard", () => {
     expect(parseChangedFileLine("")).toBeUndefined();
   });
 });
+
+async function writeReleaseBoundaryFixture(options: {
+  readonly changesets: Readonly<Record<string, string>>;
+  readonly ignore: readonly string[];
+  readonly privatePackageVersioning: boolean;
+}) {
+  const root = await mkdtemp(join(tmpdir(), "skillset-changeset-boundary-"));
+  await mkdir(join(root, "apps/skillset"), { recursive: true });
+  await mkdir(join(root, "packages/ignored"), { recursive: true });
+  await mkdir(join(root, "packages/schema"), { recursive: true });
+  await mkdir(join(root, ".changeset"), { recursive: true });
+  await writeFile(join(root, "apps/skillset/package.json"), JSON.stringify({ name: "skillset" }));
+  await writeFile(
+    join(root, "packages/ignored/package.json"),
+    JSON.stringify({ name: "@skillset/ignored" })
+  );
+  await writeFile(
+    join(root, "packages/schema/package.json"),
+    JSON.stringify({ name: "@skillset/schema", private: true })
+  );
+  await writeFile(
+    join(root, ".changeset/config.json"),
+    JSON.stringify({
+      ignore: options.ignore,
+      privatePackages: { version: options.privatePackageVersioning },
+    })
+  );
+  await Promise.all(
+    Object.entries(options.changesets).map(([name, source]) =>
+      writeFile(join(root, ".changeset", name), source)
+    )
+  );
+  return root;
+}

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import {
   defaultChangesetBaseline,
   evaluateChangesetGuard,
+  findMixedChangesetReleaseEntries,
   readChangedFilesFromGit,
   readChangedFilesFromPath,
 } from "../apps/skillset/src/changeset-awareness";
@@ -12,28 +13,51 @@ const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const changedFilesOption = "--changed-files";
 const baseOption = "--base";
 
-async function main() {
-  const args = Bun.argv.slice(2);
+export type ChangesetGuardCommandOptions = {
+  readonly rootPath?: string;
+  readonly writeLine?: (line: string) => void;
+};
+
+export async function runChangesetGuard(
+  args: readonly string[],
+  options: ChangesetGuardCommandOptions = {}
+) {
+  const rootPath = options.rootPath ?? rootDir;
+  const writeLine = options.writeLine ?? ((line: string) => console.error(line));
   const changedFilesPath = valueAfter(args, changedFilesOption);
-  const base = valueAfter(args, baseOption) ?? (await defaultChangesetBaseline(rootDir));
   const changedFiles = changedFilesPath
     ? await readChangedFilesFromPath(changedFilesPath)
-    : await readChangedFilesFromGit(rootDir, base);
+    : await readChangedFilesFromGit(
+      rootPath,
+      valueAfter(args, baseOption) ?? (await defaultChangesetBaseline(rootPath))
+    );
   const result = evaluateChangesetGuard(changedFiles);
+  const mixedChangesets = await findMixedChangesetReleaseEntries(rootPath);
 
   if (result.packageFiles.length === 0 && result.changesetFiles.length === 0) {
-    console.error("skillset: changeset guard found no package-facing changes");
+    writeLine("skillset: changeset guard found no package-facing changes");
   } else {
-    console.error(
+    writeLine(
       `skillset: changeset guard found ${result.packageFiles.length} package-facing path(s) and ${result.changesetFiles.length} active changeset(s)`
     );
   }
 
   for (const diagnostic of result.diagnostics) {
-    console.error(`skillset: ${diagnostic}`);
+    writeLine(`skillset: ${diagnostic}`);
   }
 
-  if (!result.ok) process.exit(1);
+  for (const entry of mixedChangesets) {
+    writeLine(
+      `skillset: ${entry.changesetPath} mixes ignored package(s) ${entry.ignoredPackages.join(", ")} with published package(s) ${entry.publishedPackages.join(", ")}; remove ignored package entries from this public Changeset`
+    );
+  }
+
+  return result.ok && mixedChangesets.length === 0 ? 0 : 1;
+}
+
+async function main() {
+  const exitCode = await runChangesetGuard(Bun.argv.slice(2));
+  if (exitCode !== 0) process.exit(exitCode);
 }
 
 function valueAfter(args: readonly string[], option: string) {


### PR DESCRIPTION
## Context

Refs [SET-267](https://linear.app/outfitter/issue/SET-267/unblock-the-accumulated-0x-release-by-normalizing-mixed-changesets).

The accumulated 0.x release was blocked because 17 pending Changesets mixed the public `skillset` package with ignored private workspace packages. Changesets rejects that shape before it can create the generated version PR.

## What Changed

- Removed ignored private package entries from the 17 mixed public Changesets while preserving their public `skillset` patch intent.
- Added a structural guard that derives ignored packages from Changesets config and private workspace manifests.
- Made the guard command directly testable without changing its user-facing CLI.
- Added command-level and classification-matrix coverage for mixed, private-only, public-only, explicit-ignore, and versioned-private entries.
- Documented the public/private Changeset boundary.

## Verification

- `bun test scripts/__tests__/changeset-guard.test.ts` (12 pass)
- `bun run changeset:status` (plans `skillset@0.16.3`)
- `bun run publish:check` (854 tests; generated files and package dry-run pass)
- `bun run hooks:pre-push`
- Local review, standing round 2: 5/5 clean, zero open P0-P2
- Local review, release-focused round 2: 5/5 clean, zero open P0-P2

## Risk / Rollout

The guard affects repository release metadata only. Private-only Changesets remain valid internal evidence. Publication continues through the existing generated Changesets PR and protected GitHub Actions release path.