### PR TITLE
feat(marketplace): resolve remote sources in XDG cache

### DIFF
--- a/.changeset/remote-marketplace-cache.md
+++ b/.changeset/remote-marketplace-cache.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Resolve external marketplace repositories into a deterministic XDG Git cache with portable lock provenance, strict revision validation, and clean-CI check/update support.

--- a/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
+++ b/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 
 import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
-import { buildSkillsetResult, writeKnownSkillsetsIndex } from "@skillset/core";
+import { createTestGitRemote } from "../../../../scripts/test-helpers/git-remote";
+import { buildSkillsetResult } from "@skillset/core";
 
 test("SET-234: marketplace check reports readiness and supports JSON output", async () => {
   const root = await fixture({
@@ -117,18 +118,13 @@ Use this demo skill.
 `,
   }, parent);
   await buildSkillsetResult(external);
-  const xdg = xdgOptions(parent);
-  await writeKnownSkillsetsIndex({
-    schemaVersion: 1,
-    skillsets: [{
-      cacheKey: "trails",
-      identities: ["github:outfitter-dev/trails"],
-      path: external,
-      repository: "git@github.com:outfitter-dev/trails.git",
-    }],
-  }, xdg);
+  const gitRoot = await mkdtemp(join(parent, "git-"));
+  const remote = await createTestGitRemote(external, {
+    repository: "https://github.com/outfitter-dev/trails.git",
+    rootPath: gitRoot,
+  });
 
-  const preview = await runSkillsetCliWithEnv(xdg.env, "marketplace", "update", "outfitter", "--root", marketplace);
+  const preview = await runSkillsetCliWithEnv(remote.env, "marketplace", "update", "outfitter", "--root", marketplace);
 
   expect(preview).toMatchObject({ exitCode: 0, stderr: "" });
   expect(preview.stdout).toContain("skillset: marketplace update passed");
@@ -138,7 +134,7 @@ Use this demo skill.
 
   const updated = await runSkillsetCliWithEnv(
     {
-      ...xdg.env,
+      ...remote.env,
       GIT_DIR: ".git",
       GIT_WORK_TREE: process.cwd(),
     },
@@ -158,11 +154,12 @@ Use this demo skill.
   };
   expect(marketplaceJson.plugins).toEqual([expect.objectContaining({
     name: "trails-tools",
-    source: {
+    source: expect.objectContaining({
       path: "plugins/trails-tools/claude",
+      sha: remote.sha,
       source: "git-subdir",
       url: "outfitter-dev/trails",
-    },
+    }),
   })]);
   const lock = JSON.parse(await readFile(join(marketplace, "skillset.lock"), "utf8")) as {
     readonly marketplaces: { readonly entries: readonly { readonly catalog: string; readonly repo?: string }[] };
@@ -171,6 +168,36 @@ Use this demo skill.
     catalog: "outfitter",
     repo: "github:outfitter-dev/trails",
   })]);
+
+  const checkedJson = await runSkillsetCliWithEnv(
+    remote.env,
+    "marketplace",
+    "check",
+    "outfitter",
+    "--json",
+    "--root",
+    marketplace
+  );
+  const updateJson = await runSkillsetCliWithEnv(
+    remote.env,
+    "marketplace",
+    "update",
+    "outfitter",
+    "--json",
+    "--root",
+    marketplace
+  );
+  expect(checkedJson).toMatchObject({ exitCode: 0, stderr: "" });
+  expect(updateJson).toMatchObject({ exitCode: 0, stderr: "" });
+  const checkedReport = JSON.parse(checkedJson.stdout) as {
+    readonly entries: readonly { readonly provenance: unknown }[];
+  };
+  const updateReport = JSON.parse(updateJson.stdout) as {
+    readonly check: { readonly entries: readonly { readonly provenance: unknown }[] };
+  };
+  expect(checkedReport.entries[0]?.provenance).toEqual(updateReport.check.entries[0]?.provenance);
+  expect(checkedJson.stdout).not.toContain(parent);
+  expect(updateJson.stdout).not.toContain(parent);
 });
 
 test("SET-236: marketplace update renders mixed local and external Claude entries", async () => {
@@ -223,17 +250,13 @@ Use this demo skill.
   }, parent);
   await buildSkillsetResult(marketplace);
   await buildSkillsetResult(external);
-  const xdg = xdgOptions(parent);
-  await writeKnownSkillsetsIndex({
-    schemaVersion: 1,
-    skillsets: [{
-      cacheKey: "trails",
-      identities: ["github:outfitter-dev/trails"],
-      path: external,
-    }],
-  }, xdg);
+  const gitRoot = await mkdtemp(join(parent, "git-"));
+  const remote = await createTestGitRemote(external, {
+    repository: "https://github.com/outfitter-dev/trails.git",
+    rootPath: gitRoot,
+  });
 
-  const updated = await runSkillsetCliWithEnv(xdg.env, "marketplace", "update", "outfitter", "--yes", "--root", marketplace);
+  const updated = await runSkillsetCliWithEnv(remote.env, "marketplace", "update", "outfitter", "--yes", "--root", marketplace);
 
   expect(updated).toMatchObject({ exitCode: 0, stderr: "" });
   const marketplaceJson = JSON.parse(await readFile(join(marketplace, ".claude-plugin/marketplace.json"), "utf8")) as {
@@ -250,9 +273,19 @@ Use this demo skill.
       }),
     }),
   ]);
-});
+  const verified = await runSkillsetCliWithEnv(
+    {
+      ...remote.env,
+      GIT_CONFIG_VALUE_0: "file:///definitely-unavailable/",
+    },
+    "verify",
+    "--root",
+    marketplace
+  );
+  expect(verified).toMatchObject({ exitCode: 0, stderr: "" });
+}, 15_000);
 
-test("SET-236: marketplace update requires resolved sha proof for floating external refs", async () => {
+test("SET-268: marketplace update does not treat a warm floating cache as current while offline", async () => {
   const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-floating-"));
   const marketplace = await fixture({
     "skillset.yaml": `
@@ -287,24 +320,40 @@ Use this demo skill.
 `,
   }, parent);
   await buildSkillsetResult(external);
-  const xdg = xdgOptions(parent);
-  await writeKnownSkillsetsIndex({
-    schemaVersion: 1,
-    skillsets: [{
-      cacheKey: "trails",
-      identities: ["github:outfitter-dev/trails"],
-      path: external,
-    }],
-  }, xdg);
+  const gitRoot = await mkdtemp(join(parent, "git-"));
+  const remote = await createTestGitRemote(external, {
+    repository: "https://github.com/outfitter-dev/trails.git",
+    rootPath: gitRoot,
+  });
+  const warm = await runSkillsetCliWithEnv(
+    remote.env,
+    "marketplace",
+    "update",
+    "outfitter",
+    "--root",
+    marketplace
+  );
+  expect(warm.exitCode).toBe(0);
 
-  const updated = await runSkillsetCliWithEnv(xdg.env, "marketplace", "update", "outfitter", "--yes", "--root", marketplace);
+  const updated = await runSkillsetCliWithEnv(
+    {
+      ...remote.env,
+      GIT_CONFIG_VALUE_0: "file:///definitely-unavailable/",
+    },
+    "marketplace",
+    "update",
+    "outfitter",
+    "--yes",
+    "--root",
+    marketplace
+  );
 
   expect(updated.exitCode).toBe(1);
   expect(updated.stderr).toBe("");
   expect(updated.stdout).toContain("skillset: marketplace update failed");
-  expect(updated.stdout).toContain("channel marketplace entry is not locked");
+  expect(updated.stdout).toContain("remote repository could not be reached");
   await expect(readdir(marketplace)).resolves.not.toContain("plugins-claude");
-});
+}, 15_000);
 
 async function fixture(files: Record<string, string>, parent?: string): Promise<string> {
   const root = await mkdtemp(join(parent ?? tmpdir(), "skillset-marketplace-cli-"));
@@ -344,13 +393,4 @@ async function runSkillsetCliWithEnv(
     proc.exited,
   ]);
   return { exitCode, stderr, stdout };
-}
-
-function xdgOptions(root: string): { env: Record<string, string>; homeDir: string } {
-  return {
-    env: {
-      XDG_CONFIG_HOME: join(root, "config"),
-    },
-    homeDir: join(root, "home"),
-  };
 }

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -351,6 +351,51 @@ marketplaces:
   await expect(loadBuildGraph(root)).rejects.toThrow("marketplace plugin repo must be a remote repo reference");
 });
 
+test("SET-268: marketplace source rejects ambiguous or unsafe remote revisions", async () => {
+  const conflicting = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    plugins:
+      - plugin: trails-review
+        repo: github:outfitter-dev/trails
+        ref: main
+        sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`,
+  });
+  await expect(loadBuildGraph(conflicting)).rejects.toThrow("at most one of channel, ref, sha, or version");
+
+  const credentialed = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    plugins:
+      - plugin: trails-review
+        repo: https://token@github.com/outfitter-dev/trails.git
+        ref: main
+`,
+  });
+  await expect(loadBuildGraph(credentialed)).rejects.toThrow("credential-free");
+
+  const shortSha = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    plugins:
+      - plugin: trails-review
+        repo: github:outfitter-dev/trails
+        sha: deadbeef
+`,
+  });
+  await expect(loadBuildGraph(shortSha)).rejects.toThrow("full lowercase 40-character commit");
+});
+
 test("workspace ignores unrelated top-level directories", async () => {
   const root = await fixture({
     "skillset.yaml": `

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -497,7 +497,7 @@ export async function runCli(
       } else {
         printMarketplaceUpdate(report);
       }
-      if (!yes || dryRun) console.log("skillset: marketplace update preview wrote no files");
+      if (!jsonOutput && (!yes || dryRun)) console.log("skillset: marketplace update preview wrote no files");
       if (!report.ok) process.exitCode = 1;
       return;
     }
@@ -1268,7 +1268,7 @@ function printMarketplaceCheck(report: MarketplaceCheckReport): void {
       `(${report.entries.length} target entr${report.entries.length === 1 ? "y" : "ies"})`
   );
   for (const entry of report.entries) {
-    const source = entry.source.path ?? entry.repo ?? entry.source.kind;
+    const source = entry.repo ?? entry.source.repository ?? entry.source.kind;
     console.log(
       `  ${entry.readiness}: ${entry.catalog}/${entry.entryId} ${entry.requestedTarget} ` +
         `plugin ${entry.plugin} source ${source}`

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -33,6 +33,8 @@ Catalog ids are lowercase ids. `targets` defaults to every supported provider ta
 
 Missing `repo` means the plugin is authored in the current marketplace repo under `.skillset/plugins/<plugin>/`. Present `repo` means the plugin is authored by another Skillset repo. Committed marketplace source must use a remote repo reference, not a local filesystem path such as `../trails` or `file:../trails`; local checkout discovery belongs to managed user/XDG state.
 
+External repository references use credential-free `github:org/repo`, HTTPS, SSH URL, or SCP-style Git syntax. Credentials remain in ordinary read-only Git/CI credential configuration and are never embedded in marketplace source. An external entry may set at most one of `channel`, `ref`, `sha`, or `version`. Omitting all four defaults to `channel: latest`; `latest` is the only channel currently defined. `sha` requires a full lowercase 40-character commit, `version` requires semantic version syntax, and unsafe or option-shaped refs are rejected before Git runs.
+
 Optional plugin entry fields:
 
 | Field | Meaning |
@@ -65,15 +67,17 @@ The authored Skillset source stays repo-shaped (`repo`, `ref`, `sha`, `channel`,
 The resolver order is:
 
 1. Current marketplace repo for local entries.
-2. Managed user/XDG known-Skillsets index for local checkout convenience.
-3. Remote git or cache resolution for CI and portable verification. This is reserved for the update/provenance follow-up work.
+2. A managed user/XDG known-Skillsets checkout when it has the declared origin and exact requested pinned SHA.
+3. Deterministic remote Git acquisition under `$XDG_CACHE_HOME/skillset/remotes/`, falling back to `~/.cache/skillset/remotes/`.
 4. A structured unresolved diagnostic.
 
-The user/XDG index is managed state, not committed source truth. CI must be able to resolve from committed marketplace source and remote refs without a developer machine's local index.
+The user/XDG index is managed state, not committed source truth. Floating `latest`, `ref`, and `version` policies resolve from the declared remote so a stale local checkout cannot masquerade as current. Pinned SHA checks may reuse a matching clean known checkout or a verified remote-cache checkout without network access; dirty known checkouts fall through to the remote cache. Known-checkout inspection disables optional Git locks, fsmonitor, and untracked-cache updates so the read-only command does not refresh the external repository's index. Floating checks contact the remote on every run; a warm cache is not proof that a floating ref is still current.
+
+Remote cache identity is derived from the canonical repository plus normalized revision policy, so two refs or SHAs from the same repository cannot share an inspection accidentally. New entries are prepared out of place, published atomically, and serialized by cache key. Existing entries must retain the declared origin, remain inside their XDG cache boundary, use an internal Git directory, and resolve the requested full commit before forced checkout or cleanup. Checkout runs with hooks and inherited filter configuration disabled. A mismatched, symlinked, corrupt, or escaping cache entry fails as `not-ready`; Skillset does not repair it by touching another cache entry or source repository.
 
 The known-Skillsets index lives at `$XDG_CONFIG_HOME/skillset/skillsets.json`, falling back to `~/.config/skillset/skillsets.json` when `XDG_CONFIG_HOME` is unset. Skillset updates this managed file opportunistically after successful local workspace commands such as `skillset build --yes`, build previews, `skillset check`, `skillset init --yes`, `skillset create --yes`, and successful `skillset adopt --yes`. Entries record the canonical local checkout path, the effective repo cache key, and normalized repository identities such as `github:outfitter-dev/trails`.
 
-The index never records local filesystem paths in committed marketplace source, never mutates external plugin repos, and never writes Claude or Codex runtime settings. Stale paths are ignored during resolution so a moved or deleted checkout falls through to remote/git resolution instead of poisoning CI or marketplace checks.
+The index never records local filesystem paths in committed marketplace source, never mutates external plugin repos, and never writes Claude, Codex, or Cursor runtime settings. Stale, origin-mismatched, or commit-mismatched paths fall through to remote resolution instead of poisoning CI or marketplace checks.
 
 ## Readiness
 
@@ -93,9 +97,9 @@ Marketplace readiness is explicit:
 
 ## Commands
 
-`skillset marketplace check [name] [--json]` is the read-only verifier. It parses marketplace source, resolves local entries from the current repo, resolves external entries from the managed known-Skillsets index when available, verifies provider target support and generated output freshness, and reports unresolved, stale, unbuilt, and target-missing entries. It does not write provider marketplace files, publish, install, trust, activate anything, mutate external repos, or register local paths in committed source.
+`skillset marketplace check [name] [--json]` is the read-only marketplace verifier. It parses marketplace source, resolves local entries from the current repo, resolves external entries from an exact known checkout or deterministic XDG remote cache, verifies provider target support and generated output freshness, and reports unresolved, stale, unbuilt, and target-missing entries. Remote acquisition may populate or refresh only the XDG cache; it does not write the marketplace repo, provider marketplace files, external repos, runtime config, installs, trust, or activation state.
 
-The check command exits successfully only when every selected target entry reaches `marketplace-ready`. Bare local and known-index entries are treated as current-checkout checks. Explicit `channel`, `ref`, `version`, and `sha` policies must also match `skillset.lock` provenance; stale or absent lock proof blocks readiness. Unresolved remote refs are reported as `not-ready` until remote/cache acquisition lands in the follow-up update slice.
+The check command exits successfully only when every selected target entry reaches `marketplace-ready`. Local entries use current-checkout policy. External `channel`, `ref`, `version`, and `sha` policies must match portable `skillset.lock` provenance; stale or absent lock proof blocks readiness. Acquisition, origin, ref, schema, generated-output, and cache failures remain structured `not-ready` entries and do not partially update marketplace output.
 
 `skillset marketplace update [name] [--yes|--dry-run] [--json]` is the explicit write command. It runs the same source resolution, generated-output verification, and target support checks as `marketplace check`, refuses unresolved/unbuilt/stale generated output, renders provider-supported marketplace indexes, and updates existing `skillset.lock` provenance. Without `--yes`, it previews the files it would write and writes nothing.
 
@@ -105,7 +109,9 @@ The check command exits successfully only when every selected target entry reach
 
 Marketplace provenance belongs in existing `skillset.lock` files. There is no separate marketplace lock. The root lock can carry a top-level `marketplaces.entries` section alongside generated-output `items`; `items` remains the generated-file ownership list, while marketplace entries record catalog readiness and resolved source facts without claiming ownership of external plugin repo files.
 
-Each marketplace lock/report entry records the marketplace id, entry id, plugin id, source repo when present, requested channel/ref/sha/version policy, resolved source kind/path/ref/SHA when known, plugin version, provider target, provider-native marketplace source form, derived provider output path(s), and readiness status. Explicit pinned `sha` entries fail if the resolved checkout SHA is missing or different. Floating entries fail when the current resolution differs from the lock.
+Each marketplace lock/report entry records the marketplace id, entry id, plugin id, source repo when present, requested channel/ref/sha/version policy, resolved portable repository/ref/SHA facts, plugin version, provider target, provider-native marketplace source form, derived provider output path(s), and readiness status. For provider indexes that can contain external entries, the lock also stores the validated provider-native entry needed for offline re-rendering and records which named catalog currently owns each provider marketplace output. Missing or mismatched provider-entry proof invalidates the external lock entry instead of silently omitting the plugin. Reports may identify whether runtime resolution used `current`, `known-index`, or `remote-cache`; committed lock provenance normalizes external resolution to `external`. Neither surface serializes checkout roots, XDG paths, cache keys, credentials, or local Git URLs. Explicit pinned `sha` entries fail if the resolved checkout SHA is missing or different. Floating entries fail when the current resolution differs from the lock.
+
+Ordinary build and verify paths remain network-free. Once `marketplace update` records a ready external resolution, normal lock rendering preserves that portable entry while its committed repo/plugin/policy/target declaration is unchanged. Changing the declaration invalidates the preserved resolution and requires another marketplace update. This allows `skillset verify` and `skillset ci` to pass after an update without silently re-resolving the network.
 
 ## Evidence
 
@@ -114,5 +120,6 @@ Each marketplace lock/report entry records the marketplace id, entry id, plugin 
 - [SET-234](https://linear.app/outfitter/issue/SET-234/implement-skillset-marketplace-check-readiness-reports) - read-only marketplace readiness reports.
 - [SET-235](https://linear.app/outfitter/issue/SET-235/define-marketplace-ref-policy-and-lock-provenance-for-floating-and) - marketplace ref policy and `skillset.lock` provenance.
 - [SET-236](https://linear.app/outfitter/issue/SET-236/implement-skillset-marketplace-update-provider-index-rendering) - `marketplace update` provider index rendering.
+- [SET-268](https://linear.app/outfitter/issue/SET-268/resolve-external-marketplace-repositories-into-deterministic-xdg-cache) - deterministic remote XDG acquisition and portable provenance.
 - [Distributions](distributions.md) - related post-build sync planning surface.
 - [Runtime Adapters](runtime-adapters.md) - runtime support remains separate from compile targets and marketplace readiness.

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -1955,9 +1955,59 @@
               "plugins": {
                 "items": {
                   "additionalProperties": false,
+                  "allOf": [
+                    {
+                      "not": {
+                        "required": [
+                          "channel",
+                          "ref"
+                        ]
+                      }
+                    },
+                    {
+                      "not": {
+                        "required": [
+                          "channel",
+                          "sha"
+                        ]
+                      }
+                    },
+                    {
+                      "not": {
+                        "required": [
+                          "channel",
+                          "version"
+                        ]
+                      }
+                    },
+                    {
+                      "not": {
+                        "required": [
+                          "ref",
+                          "sha"
+                        ]
+                      }
+                    },
+                    {
+                      "not": {
+                        "required": [
+                          "ref",
+                          "version"
+                        ]
+                      }
+                    },
+                    {
+                      "not": {
+                        "required": [
+                          "sha",
+                          "version"
+                        ]
+                      }
+                    }
+                  ],
                   "properties": {
                     "channel": {
-                      "minLength": 1,
+                      "const": "latest",
                       "type": "string"
                     },
                     "id": {
@@ -1969,18 +2019,15 @@
                       "type": "string"
                     },
                     "ref": {
-                      "minLength": 1,
+                      "pattern": "^(?!.*(?:\\.\\.|//|@\\{|\\.lock$))[A-Za-z0-9][A-Za-z0-9._/-]*(?<![./])$",
                       "type": "string"
                     },
                     "repo": {
-                      "minLength": 1,
-                      "not": {
-                        "pattern": "^(?:\\.|/|~|file:|[A-Za-z]:[\\\\/])"
-                      },
+                      "pattern": "^(?:github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\\.git)?|[^:@/\\s]+@[^:\\s/]+:[^\\s]+|https://(?![^/]*@)[^\\s/?#]+/[^\\s?#]+|ssh://(?:[^:@\\s]+@)?[^\\s/?#]+/[^\\s?#]+)$",
                       "type": "string"
                     },
                     "sha": {
-                      "minLength": 1,
+                      "pattern": "^[0-9a-f]{40}$",
                       "type": "string"
                     },
                     "targets": {
@@ -1997,7 +2044,7 @@
                       "uniqueItems": true
                     },
                     "version": {
-                      "minLength": 1,
+                      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
                       "type": "string"
                     }
                   },

--- a/docs/reference/schemas/0.1.0/workspace-config.schema.json
+++ b/docs/reference/schemas/0.1.0/workspace-config.schema.json
@@ -146,9 +146,59 @@
           "plugins": {
             "items": {
               "additionalProperties": false,
+              "allOf": [
+                {
+                  "not": {
+                    "required": [
+                      "channel",
+                      "ref"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "channel",
+                      "sha"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "channel",
+                      "version"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "ref",
+                      "sha"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "ref",
+                      "version"
+                    ]
+                  }
+                },
+                {
+                  "not": {
+                    "required": [
+                      "sha",
+                      "version"
+                    ]
+                  }
+                }
+              ],
               "properties": {
                 "channel": {
-                  "minLength": 1,
+                  "const": "latest",
                   "type": "string"
                 },
                 "id": {
@@ -160,18 +210,15 @@
                   "type": "string"
                 },
                 "ref": {
-                  "minLength": 1,
+                  "pattern": "^(?!.*(?:\\.\\.|//|@\\{|\\.lock$))[A-Za-z0-9][A-Za-z0-9._/-]*(?<![./])$",
                   "type": "string"
                 },
                 "repo": {
-                  "minLength": 1,
-                  "not": {
-                    "pattern": "^(?:\\.|/|~|file:|[A-Za-z]:[\\\\/])"
-                  },
+                  "pattern": "^(?:github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\\.git)?|[^:@/\\s]+@[^:\\s/]+:[^\\s]+|https://(?![^/]*@)[^\\s/?#]+/[^\\s?#]+|ssh://(?:[^:@\\s]+@)?[^\\s/?#]+/[^\\s?#]+)$",
                   "type": "string"
                 },
                 "sha": {
-                  "minLength": 1,
+                  "pattern": "^[0-9a-f]{40}$",
                   "type": "string"
                 },
                 "targets": {
@@ -188,7 +235,7 @@
                   "uniqueItems": true
                 },
                 "version": {
-                  "minLength": 1,
+                  "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
                   "type": "string"
                 }
               },

--- a/packages/core/src/__tests__/atomic-file-set.test.ts
+++ b/packages/core/src/__tests__/atomic-file-set.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { writeAtomicFileSet } from "../atomic-file-set";
+
+test("marketplace file transactions roll back every installed file after a late failure", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-atomic-file-set-"));
+  const providerPath = join(root, ".claude-plugin", "marketplace.json");
+  const lockPath = join(root, "skillset.lock");
+  await Bun.write(providerPath, "provider-before\n");
+  await writeFile(lockPath, "lock-before\n");
+
+  await expect(writeAtomicFileSet([
+    { content: "provider-after\n", path: providerPath },
+    { content: "lock-after\n", path: lockPath },
+  ], {
+    beforeInstall: (_path, index) => {
+      if (index === 1) throw new Error("injected late lock failure");
+    },
+  })).rejects.toThrow("injected late lock failure");
+
+  expect(await readFile(providerPath, "utf8")).toBe("provider-before\n");
+  expect(await readFile(lockPath, "utf8")).toBe("lock-before\n");
+  expect((await readdir(root)).filter((name) => name.startsWith(".skillset-marketplace-"))).toEqual([]);
+  expect((await readdir(join(root, ".claude-plugin"))).filter((name) => name.startsWith(".skillset-marketplace-"))).toEqual([]);
+});

--- a/packages/core/src/__tests__/marketplace-check.test.ts
+++ b/packages/core/src/__tests__/marketplace-check.test.ts
@@ -1,13 +1,19 @@
-import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, readdir, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
 import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
-import { buildSkillsetResult } from "../build";
+import { createTestGitRemote, runTestGit } from "../../../../scripts/test-helpers/git-remote";
+import { buildSkillsetResult, verifySkillsetResult } from "../build";
+import { storedClaudeMarketplaceProviderEntry } from "../claude-marketplace";
+import { detectHostLeaks } from "../host-leak";
 import { checkMarketplaces } from "../marketplace-check";
+import { updateMarketplaces } from "../marketplace-update";
 import { writeKnownSkillsetsIndex } from "../known-skillsets";
+import { resolveRemoteRepositoryCache } from "../remote-repository-cache";
+import type { JsonRecord } from "../types";
 
 describe("marketplace check", () => {
   test("reports local generated and verified plugin targets as marketplace-ready", async () => {
@@ -108,19 +114,6 @@ codex: false
 
   test("resolves external plugin refs from the managed known-Skillsets index", async () => {
     const root = await mkdtemp(join(tmpdir(), "skillset-marketplace-known-"));
-    const marketplace = await fixture({
-      "skillset.yaml": `
-skillset:
-  name: marketplace-root
-marketplaces:
-  outfitter:
-    targets: [claude]
-    plugins:
-      - id: trails
-        plugin: trails-tools
-        repo: github:outfitter-dev/trails
-`,
-    }, root);
     const external = await fixture({
       "skillset.yaml": `
 skillset:
@@ -132,37 +125,85 @@ skillset:
 `,
     }, root);
     await buildSkillsetResult(external);
-    const xdg = xdgOptions(root);
+    const gitRoot = await mkdtemp(join(root, "git-"));
+    const remote = await createTestGitRemote(external, {
+      repository: "https://github.com/outfitter-dev/trails.git",
+      rootPath: gitRoot,
+    });
+    await runTestGit(external, "remote", "add", "origin", remote.repository);
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - id: trails
+        plugin: trails-tools
+        repo: github:outfitter-dev/trails
+        sha: ${remote.sha}
+`,
+    }, root);
     await writeKnownSkillsetsIndex({
       schemaVersion: 1,
       skillsets: [{
         cacheKey: "trails",
         identities: ["github:outfitter-dev/trails"],
         path: external,
-        repository: "git@github.com:outfitter-dev/trails.git",
+        repository: remote.repository,
       }],
-    }, xdg);
+    }, remote.xdg);
+    const trackedPath = join(external, ".skillset/plugins/trails-tools/skillset.yaml");
+    const trackedStat = await stat(trackedPath);
+    await utimes(trackedPath, trackedStat.atime, new Date(trackedStat.mtimeMs + 10_000));
+    const indexPath = join(external, ".git/index");
+    const indexBefore = await readFile(indexPath);
 
-    const report = await checkMarketplaces(marketplace, { xdg });
+    const updated = await updateMarketplaces(marketplace, { name: "outfitter", write: true, xdg: remote.xdg });
+    const report = await checkMarketplaces(marketplace, { xdg: remote.xdg });
 
+    expect(updated.ok).toBe(true);
     expect(report.ok).toBe(true);
+    expect((await readFile(indexPath)).equals(indexBefore)).toBe(true);
     expect(report.entries).toEqual([expect.objectContaining({
       entryId: "trails",
-      lock: expect.objectContaining({ state: "absent", policy: "local" }),
+      lock: expect.objectContaining({ state: "locked", policy: "sha" }),
       plugin: "trails-tools",
       readiness: "marketplace-ready",
       repo: "github:outfitter-dev/trails",
       requestedTarget: "claude",
       source: expect.objectContaining({
-        cacheKey: "trails",
         kind: "known-index",
-        path: external,
-        repository: "git@github.com:outfitter-dev/trails.git",
+        repository: "github:outfitter-dev/trails",
+        sha: remote.sha,
       }),
     })]);
+    const remoteOnlyXdg = {
+      ...remote.xdg,
+      env: {
+        ...remote.xdg.env,
+        XDG_CONFIG_HOME: join(root, "clean-config"),
+      },
+    };
+    const remoteReport = await checkMarketplaces(marketplace, { xdg: remoteOnlyXdg });
+    expect(remoteReport.ok).toBe(true);
+    expect(remoteReport.entries[0]?.source.kind).toBe("remote-cache");
+    expect(remoteReport.entries[0]?.provenance).toEqual(report.entries[0]?.provenance);
+
+    await writeFile(join(external, ".skillset/plugins/trails-tools/skillset.yaml"), `
+skillset:
+  name: trails-tools
+  version: 2.0.0
+`.trimStart());
+    await buildSkillsetResult(external);
+    const dirtyReport = await checkMarketplaces(marketplace, { xdg: remote.xdg });
+    expect(dirtyReport.ok).toBe(true);
+    expect(dirtyReport.entries[0]?.source.kind).toBe("remote-cache");
+    expect(dirtyReport.entries[0]?.provenance.resolved.pluginVersion).not.toBe("2.0.0");
   });
 
-  test("keeps bare external repo entries as current-checkout policy in the marketplace lock", async () => {
+  test("defaults bare external repo entries to the latest channel policy", async () => {
     const root = await fixture({
       "skillset.yaml": `
 skillset:
@@ -183,11 +224,12 @@ marketplaces:
     };
 
     expect(lock.marketplaces.entries).toEqual([expect.objectContaining({
-      requested: { kind: "local" },
+      requested: { channel: "latest", kind: "channel" },
     })]);
   });
 
-  test("reports unresolved external plugin refs without remote writes", async () => {
+  test("reports unavailable external plugin refs without marketplace writes", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-unavailable-"));
     const root = await fixture({
       "skillset.yaml": `
 skillset:
@@ -197,25 +239,27 @@ marketplaces:
     targets: [claude]
     plugins:
       - plugin: trails-tools
-        repo: github:outfitter-dev/trails
+        repo: https://git.invalid/outfitter-dev/trails.git
+        ref: main
 `,
-    });
+    }, parent);
+    const xdg = unavailableXdg(parent, "https://git.invalid/outfitter-dev/trails.git");
     const before = await readdir(root);
 
-    const report = await checkMarketplaces(root, { xdg: xdgOptions(root) });
+    const report = await checkMarketplaces(root, { xdg });
 
     expect(report.ok).toBe(false);
     expect(report.entries).toEqual([expect.objectContaining({
       readiness: "not-ready",
-      reason: "unresolved external repo",
-      repo: "github:outfitter-dev/trails",
-      source: { kind: "unresolved" },
-      states: ["declared", "not-ready"],
+      reason: "failed to inspect source: skillset: remote repository could not be reached",
+      repo: "https://git.invalid/outfitter-dev/trails.git",
+      source: { kind: "remote-cache", repository: "https://git.invalid/outfitter-dev/trails" },
+      states: ["declared", "floating", "not-ready"],
     })]);
     await expect(readdir(root)).resolves.toEqual(before);
   });
 
-  test("reports invalid known-index checkouts as not-ready entries", async () => {
+  test("ignores invalid known-index checkouts and falls through to remote resolution", async () => {
     const root = await mkdtemp(join(tmpdir(), "skillset-marketplace-invalid-known-"));
     const marketplace = await fixture({
       "skillset.yaml": `
@@ -226,16 +270,17 @@ marketplaces:
     targets: [claude]
     plugins:
       - plugin: trails-tools
-        repo: github:outfitter-dev/trails
+        repo: https://git.invalid/outfitter-dev/trails.git
+        sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `,
     }, root);
     const invalid = await mkdtemp(join(root, "invalid-skillset-"));
-    const xdg = xdgOptions(root);
+    const xdg = unavailableXdg(root, "https://git.invalid/outfitter-dev/trails.git");
     await writeKnownSkillsetsIndex({
       schemaVersion: 1,
       skillsets: [{
         cacheKey: "trails",
-        identities: ["github:outfitter-dev/trails"],
+        identities: ["https://git.invalid/outfitter-dev/trails.git"],
         path: invalid,
       }],
     }, xdg);
@@ -245,13 +290,12 @@ marketplaces:
     expect(report.ok).toBe(false);
     expect(report.entries).toEqual([expect.objectContaining({
       readiness: "not-ready",
-      reason: expect.stringContaining("failed to inspect source:"),
-      source: expect.objectContaining({
-        cacheKey: "trails",
-        kind: "known-index",
-        path: invalid,
-      }),
-      states: ["declared", "not-ready"],
+      reason: "failed to inspect source: skillset: remote acquisition failed for https://git.invalid/outfitter-dev/trails during fetch",
+      source: {
+        kind: "remote-cache",
+        repository: "https://git.invalid/outfitter-dev/trails",
+      },
+      states: ["declared", "pinned", "stale", "not-ready"],
     })]);
   });
 
@@ -291,7 +335,7 @@ marketplaces:
     targets: [claude]
     plugins:
       - plugin: local-tools
-        sha: deadbeef
+        sha: dddddddddddddddddddddddddddddddddddddddd
 `,
     });
     await buildSkillsetResult(root);
@@ -301,14 +345,432 @@ marketplaces:
     expect(report.ok).toBe(false);
     expect(report.entries).toEqual([expect.objectContaining({
       lock: expect.objectContaining({
-        expectedSha: "deadbeef",
+        expectedSha: "dddddddddddddddddddddddddddddddddddddddd",
         policy: "sha",
-        reason: "pinned sha deadbeef could not be verified for the resolved source",
+        reason: "pinned sha dddddddddddddddddddddddddddddddddddddddd could not be verified for the resolved source",
         state: "stale",
       }),
       readiness: "not-ready",
       states: ["declared", "pinned", "resolved", "renderable", "generated", "verified", "stale", "not-ready"],
     })]);
+  });
+
+  test("SET-268: resolves remote refs through XDG with portable check, update, and lock provenance", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-remote-"));
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - id: trails
+        plugin: trails-tools
+        repo: https://git.example/acme/trails.git
+        ref: main
+`,
+    }, parent);
+    const external = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: trails
+`,
+      ".skillset/plugins/trails-tools/skillset.yaml": `
+skillset:
+  name: trails-tools
+  version: 1.2.3
+`,
+      ".skillset/plugins/trails-tools/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+---
+
+Use this demo skill.
+`,
+    }, parent);
+    await buildSkillsetResult(external);
+    const gitRoot = await mkdtemp(join(parent, "git-"));
+    const remote = await createTestGitRemote(external, {
+      repository: "https://git.example/acme/trails.git",
+      rootPath: gitRoot,
+    });
+
+    const updated = await updateMarketplaces(marketplace, {
+      name: "outfitter",
+      write: true,
+      xdg: remote.xdg,
+    });
+
+    expect(updated.ok).toBe(true);
+    expect(updated.writtenPaths).toEqual([".claude-plugin/marketplace.json", "skillset.lock"]);
+    expect(updated.check.entries).toEqual([expect.objectContaining({
+      readiness: "marketplace-ready",
+      source: {
+        kind: "remote-cache",
+        ref: "main",
+        repository: "https://git.example/acme/trails",
+        sha: remote.sha,
+      },
+      provenance: expect.objectContaining({
+        resolved: expect.objectContaining({
+          repository: "https://git.example/acme/trails",
+          sha: remote.sha,
+          sourceKind: "external",
+        }),
+      }),
+    })]);
+
+    const lockText = await readFile(join(marketplace, "skillset.lock"), "utf8");
+    const indexText = await readFile(join(marketplace, ".claude-plugin/marketplace.json"), "utf8");
+    const reportText = JSON.stringify(updated.check);
+    for (const [path, content] of [
+      ["skillset.lock", lockText],
+      [".claude-plugin/marketplace.json", indexText],
+      ["marketplace-report.json", reportText],
+    ] as const) {
+      expect(detectHostLeaks(path, content, {
+        forbiddenSubstrings: [parent, external, remote.remotePath, remote.xdg.homeDir],
+      })).toEqual([]);
+      expect(content).not.toContain("sourcePath");
+      expect(content).not.toContain("cacheKey");
+    }
+    expect(JSON.parse(indexText)).toEqual(expect.objectContaining({
+      plugins: [expect.objectContaining({
+        source: expect.objectContaining({ ref: "main", sha: remote.sha }),
+      })],
+    }));
+
+    const checked = await checkMarketplaces(marketplace, { name: "outfitter", xdg: remote.xdg });
+    const verified = await verifySkillsetResult(marketplace, { xdg: remote.xdg });
+    expect(checked.ok).toBe(true);
+    expect(checked.entries[0]?.provenance).toEqual(updated.check.entries[0]?.provenance);
+    expect(verified.data.failures).toEqual([]);
+    await chmod(join(marketplace, "skillset.lock"), 0o444);
+    expect((await updateMarketplaces(marketplace, {
+      name: "outfitter",
+      write: true,
+      xdg: remote.xdg,
+    })).ok).toBe(true);
+    expect((await verifySkillsetResult(marketplace, { xdg: remote.xdg })).data.failures).toEqual([]);
+
+    const tamperedLock = JSON.parse(lockText) as {
+      marketplaces: { entries: Array<JsonRecord & { providerEntry?: JsonRecord }> };
+    };
+    const storedEntry = tamperedLock.marketplaces.entries[0];
+    expect(storedEntry).toBeDefined();
+    expect(storedClaudeMarketplaceProviderEntry(storedEntry ?? {})).toBeDefined();
+    const malformedEntry = structuredClone(storedEntry ?? {});
+    if (
+      malformedEntry.providerEntry !== undefined &&
+      typeof malformedEntry.providerEntry.source === "object" &&
+      malformedEntry.providerEntry.source !== null &&
+      !Array.isArray(malformedEntry.providerEntry.source)
+    ) {
+      malformedEntry.providerEntry = {
+        ...malformedEntry.providerEntry,
+        source: {
+          ...(malformedEntry.providerEntry.source as JsonRecord),
+          sha: "b".repeat(40),
+        },
+      };
+    }
+    expect(storedClaudeMarketplaceProviderEntry(malformedEntry)).toBeUndefined();
+    if (storedEntry !== undefined) delete storedEntry.providerEntry;
+    const tamperedIndex = JSON.parse(indexText) as { plugins: unknown[] };
+    tamperedIndex.plugins = [];
+    await writeFile(join(marketplace, "skillset.lock"), `${JSON.stringify(tamperedLock, null, 2)}\n`);
+    await writeFile(
+      join(marketplace, ".claude-plugin/marketplace.json"),
+      `${JSON.stringify(tamperedIndex, null, 2)}\n`
+    );
+
+    const tamperedCheck = await checkMarketplaces(marketplace, { name: "outfitter", xdg: remote.xdg });
+    const tamperedVerify = await verifySkillsetResult(marketplace, { xdg: remote.xdg });
+    expect(tamperedCheck.ok).toBe(false);
+    expect(tamperedCheck.entries[0]?.lock.state).toBe("absent");
+    expect(tamperedVerify.data.failures).toContain("stale generated file: skillset.lock");
+  });
+
+  test("SET-268: sequential named catalog updates preserve the active offline marketplace", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-catalog-selection-"));
+    const repository = "https://git.example/acme/catalog-plugins.git";
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  alpha:
+    targets: [claude]
+    plugins:
+      - plugin: local-a
+      - plugin: remote-a
+        repo: ${repository}
+        ref: main
+  beta:
+    targets: [claude]
+    plugins:
+      - plugin: local-b
+      - plugin: remote-b
+        repo: ${repository}
+        ref: main
+`,
+      ".skillset/plugins/local-a/skillset.yaml": "skillset:\n  name: local-a\n",
+      ".skillset/plugins/local-b/skillset.yaml": "skillset:\n  name: local-b\n",
+    }, parent);
+    const external = await fixture({
+      "skillset.yaml": "skillset:\n  name: catalog-plugins\n",
+      ".skillset/plugins/remote-a/skillset.yaml": "skillset:\n  name: remote-a\n",
+      ".skillset/plugins/remote-b/skillset.yaml": "skillset:\n  name: remote-b\n",
+    }, parent);
+    await buildSkillsetResult(marketplace);
+    await buildSkillsetResult(external);
+    const gitRoot = await mkdtemp(join(parent, "git-"));
+    const remote = await createTestGitRemote(external, { repository, rootPath: gitRoot });
+
+    expect((await updateMarketplaces(marketplace, {
+      name: "alpha",
+      write: true,
+      xdg: remote.xdg,
+    })).ok).toBe(true);
+    expect((await verifySkillsetResult(marketplace, { xdg: remote.xdg })).data.failures).toEqual([]);
+
+    expect((await updateMarketplaces(marketplace, {
+      name: "beta",
+      write: true,
+      xdg: remote.xdg,
+    })).ok).toBe(true);
+    expect((await verifySkillsetResult(marketplace, { xdg: remote.xdg })).data.failures).toEqual([]);
+    const index = JSON.parse(
+      await readFile(join(marketplace, ".claude-plugin/marketplace.json"), "utf8")
+    ) as { plugins: Array<{ name: string }> };
+    const lock = JSON.parse(await readFile(join(marketplace, "skillset.lock"), "utf8")) as {
+      marketplaces: { activeCatalogs: { claude: string } };
+    };
+    expect(index.plugins.map(({ name }) => name)).toEqual(["local-b", "remote-b"]);
+    expect(lock.marketplaces.activeCatalogs).toEqual({ claude: "beta" });
+  }, 15_000);
+
+  test("SET-268: acquisition failure leaves every marketplace output untouched", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-remote-failure-"));
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - id: valid
+        plugin: trails-tools
+        repo: https://git.example/acme/trails.git
+        ref: main
+      - id: missing
+        plugin: missing-tools
+        repo: https://git.invalid/acme/missing.git
+        ref: main
+`,
+    }, parent);
+    const external = await fixture({
+      "skillset.yaml": "skillset:\n  name: trails\n",
+      ".skillset/plugins/trails-tools/skillset.yaml": "skillset:\n  name: trails-tools\n",
+    }, parent);
+    await buildSkillsetResult(external);
+    const gitRoot = await mkdtemp(join(parent, "git-"));
+    const remote = await createTestGitRemote(external, {
+      repository: "https://git.example/acme/trails.git",
+      rootPath: gitRoot,
+    });
+    const before = await readdir(marketplace);
+
+    const updated = await updateMarketplaces(marketplace, {
+      name: "outfitter",
+      write: true,
+      xdg: remote.xdg,
+    });
+
+    expect(updated.ok).toBe(false);
+    expect(updated.files).toEqual([]);
+    expect(updated.writtenPaths).toEqual([]);
+    expect(updated.check.entries).toContainEqual(expect.objectContaining({
+      entryId: "missing",
+      readiness: "not-ready",
+      reason: "failed to inspect source: skillset: remote repository could not be reached",
+      source: {
+        kind: "remote-cache",
+        repository: "https://git.invalid/acme/missing",
+      },
+    }));
+    await expect(readdir(marketplace)).resolves.toEqual(before);
+  });
+
+  test("SET-268: resolves two revisions from the same repository independently", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-revisions-"));
+    const external = await fixture({
+      "skillset.yaml": "skillset:\n  name: revisions\n",
+      ".skillset/plugins/revision-tools/skillset.yaml": `
+skillset:
+  name: revision-tools
+  version: 1.0.0
+`,
+      ".skillset/plugins/revision-tools/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo skill.
+---
+
+First revision.
+`,
+    }, parent);
+    await buildSkillsetResult(external);
+    const gitRoot = await mkdtemp(join(parent, "git-"));
+    const remote = await createTestGitRemote(external, {
+      repository: "https://git.example/acme/revisions.git",
+      rootPath: gitRoot,
+    });
+    const firstSha = remote.sha;
+
+    await writeFile(join(external, ".skillset/plugins/revision-tools/skillset.yaml"), `
+skillset:
+  name: revision-tools
+  version: 2.0.0
+`.trimStart());
+    await buildSkillsetResult(external);
+    await runTestGit(external, "add", "--all");
+    await runTestGit(external, "commit", "-m", "second fixture revision");
+    const secondSha = await runTestGit(external, "rev-parse", "HEAD");
+    await runTestGit(external, "push", remote.remotePath, "main");
+
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - id: revision-one
+        plugin: revision-tools
+        repo: ${remote.repository}
+        sha: ${firstSha}
+      - id: revision-two
+        plugin: revision-tools
+        repo: ${remote.repository}
+        sha: ${secondSha}
+`,
+    }, parent);
+
+    const report = await checkMarketplaces(marketplace, {
+      lockMode: "refresh",
+      name: "outfitter",
+      xdg: remote.xdg,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.entries.map((entry) => [entry.entryId, entry.source.sha, entry.provenance.resolved.pluginVersion])).toEqual([
+      ["revision-one", firstSha, "1.0.0"],
+      ["revision-two", secondSha, "2.0.0"],
+    ]);
+  });
+
+  test("SET-268: blocks stale generated output acquired from a remote ref", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-stale-remote-"));
+    const external = await fixture({
+      "skillset.yaml": "skillset:\n  name: stale-remote\n",
+      ".skillset/plugins/stale-tools/skillset.yaml": `
+skillset:
+  name: stale-tools
+  version: 1.0.0
+`,
+    }, parent);
+    await buildSkillsetResult(external);
+    const gitRoot = await mkdtemp(join(parent, "git-"));
+    const remote = await createTestGitRemote(external, {
+      repository: "https://git.example/acme/stale.git",
+      rootPath: gitRoot,
+    });
+    await writeFile(join(external, ".skillset/plugins/stale-tools/skillset.yaml"), `
+skillset:
+  name: stale-tools
+  version: 2.0.0
+`.trimStart());
+    await runTestGit(external, "add", "--all");
+    await runTestGit(external, "commit", "-m", "stale source without generated output");
+    await runTestGit(external, "push", remote.remotePath, "main");
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: stale-tools
+        repo: ${remote.repository}
+        ref: main
+`,
+    }, parent);
+
+    const updated = await updateMarketplaces(marketplace, {
+      name: "outfitter",
+      write: true,
+      xdg: remote.xdg,
+    });
+
+    expect(updated.ok).toBe(false);
+    expect(updated.writtenPaths).toEqual([]);
+    expect(updated.check.entries[0]).toEqual(expect.objectContaining({
+      readiness: "not-ready",
+      reason: "version drift: plugins/stale-tools/claude/.claude-plugin/plugin.json version is 1.0.0, expected 2.0.0",
+    }));
+  });
+
+  test("SET-268: reports a wrong-origin cache without repairing or exposing its path", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "skillset-marketplace-wrong-origin-"));
+    const external = await fixture({
+      "skillset.yaml": "skillset:\n  name: wrong-origin\n",
+      ".skillset/plugins/origin-tools/skillset.yaml": "skillset:\n  name: origin-tools\n",
+    }, parent);
+    await buildSkillsetResult(external);
+    const gitRoot = await mkdtemp(join(parent, "git-"));
+    const remote = await createTestGitRemote(external, {
+      repository: "https://git.example/acme/origin.git",
+      rootPath: gitRoot,
+    });
+    const marketplace = await fixture({
+      "skillset.yaml": `
+skillset:
+  name: marketplace-root
+marketplaces:
+  outfitter:
+    targets: [claude]
+    plugins:
+      - plugin: origin-tools
+        repo: ${remote.repository}
+        ref: main
+`,
+    }, parent);
+    expect((await updateMarketplaces(marketplace, { name: "outfitter", xdg: remote.xdg })).ok).toBe(true);
+    const cache = resolveRemoteRepositoryCache(remote.repository, { kind: "ref", ref: "main" }, remote.xdg);
+    await runTestGit(cache.path, "remote", "set-url", "origin", "https://git.example/other/repo.git");
+
+    const updated = await updateMarketplaces(marketplace, {
+      name: "outfitter",
+      write: true,
+      xdg: remote.xdg,
+    });
+
+    expect(updated.ok).toBe(false);
+    expect(updated.writtenPaths).toEqual([]);
+    expect(updated.check.entries[0]?.reason).toBe(
+      "failed to inspect source: skillset: remote cache origin does not match the requested repository"
+    );
+    expect(JSON.stringify(updated.check)).not.toContain(cache.path);
+    expect(JSON.stringify(updated.check)).not.toContain(cache.cacheKey);
+    expect(await runTestGit(cache.path, "config", "--get", "remote.origin.url")).toBe(
+      "https://git.example/other/repo.git"
+    );
   });
 });
 
@@ -351,6 +813,23 @@ async function fixture(files: Record<string, string>, parent?: string): Promise<
 function xdgOptions(root: string): { env: Record<string, string>; homeDir: string } {
   return {
     env: {
+      XDG_CONFIG_HOME: join(root, "config"),
+    },
+    homeDir: join(root, "home"),
+  };
+}
+
+function unavailableXdg(
+  root: string,
+  repository: string
+): { env: Record<string, string>; homeDir: string } {
+  return {
+    env: {
+      GIT_ALLOW_PROTOCOL: "file",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: `url.file://${join(root, "missing.git")}/.insteadOf`,
+      GIT_CONFIG_VALUE_0: repository,
+      XDG_CACHE_HOME: join(root, "cache"),
       XDG_CONFIG_HOME: join(root, "config"),
     },
     homeDir: join(root, "home"),

--- a/packages/core/src/__tests__/remote-repository-cache.test.ts
+++ b/packages/core/src/__tests__/remote-repository-cache.test.ts
@@ -1,0 +1,281 @@
+import { mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  acquireRemoteRepository,
+  parseRemoteRepositoryReference,
+  resolveRemoteRepositoryCache,
+} from "../remote-repository-cache";
+
+describe("remote repository cache", () => {
+  test("normalizes supported references and derives deterministic XDG paths", () => {
+    expect(parseRemoteRepositoryReference("github:Outfitter-Dev/Skillset")).toEqual({
+      canonical: "github:outfitter-dev/skillset",
+      fetchUrl: "https://github.com/Outfitter-Dev/Skillset.git",
+    });
+    expect(parseRemoteRepositoryReference("git@github.com:Outfitter-Dev/Skillset.git")).toEqual({
+      canonical: "github:outfitter-dev/skillset",
+      fetchUrl: "git@github.com:Outfitter-Dev/Skillset.git",
+    });
+    expect(() => parseRemoteRepositoryReference("https://token@github.com/outfitter-dev/skillset.git")).toThrow(
+      "must not contain credentials"
+    );
+    expect(() => parseRemoteRepositoryReference("https://user:SENTINEL@git.example:443/acme/plugin.git")).toThrow(
+      "must not contain credentials"
+    );
+    expect(() => parseRemoteRepositoryReference("file:///tmp/skillset.git")).toThrow("unsupported remote repository protocol");
+    expect(parseRemoteRepositoryReference("https://git.example:8443/acme/plugin.git").canonical).toBe(
+      "https://git.example:8443/acme/plugin"
+    );
+    const relativeScp = parseRemoteRepositoryReference("git@git.example:acme/plugin.git");
+    const absoluteScp = parseRemoteRepositoryReference("git@git.example:/acme/plugin.git");
+    expect(relativeScp.canonical).not.toBe(absoluteScp.canonical);
+    expect(resolveRemoteRepositoryCache(relativeScp.fetchUrl, { kind: "ref", ref: "main" }, {
+      env: { XDG_CACHE_HOME: "/xdg/cache" },
+      homeDir: "/home/matt",
+    }).path).not.toBe(resolveRemoteRepositoryCache(absoluteScp.fetchUrl, { kind: "ref", ref: "main" }, {
+      env: { XDG_CACHE_HOME: "/xdg/cache" },
+      homeDir: "/home/matt",
+    }).path);
+
+    const first = resolveRemoteRepositoryCache(
+      "github:Outfitter-Dev/Skillset",
+      { kind: "ref", ref: "main" },
+      { env: { XDG_CACHE_HOME: "/xdg/cache" }, homeDir: "/home/matt" }
+    );
+    const second = resolveRemoteRepositoryCache(
+      "https://github.com/outfitter-dev/skillset.git",
+      { kind: "ref", ref: "main" },
+      { env: { XDG_CACHE_HOME: "/xdg/cache" }, homeDir: "/home/matt" }
+    );
+    const pinned = resolveRemoteRepositoryCache(
+      "github:outfitter-dev/skillset",
+      { kind: "sha", sha: "a".repeat(40) },
+      { env: { XDG_CACHE_HOME: "/xdg/cache" }, homeDir: "/home/matt" }
+    );
+
+    expect(first).toEqual(second);
+    expect(first.path).toStartWith("/xdg/cache/skillset/remotes/");
+    expect(first.cacheKey).toMatch(/^github-outfitter-dev-skillset--[0-9a-f]{24}\/ref-main--[0-9a-f]{16}$/);
+    expect(pinned.path).not.toBe(first.path);
+  });
+
+  test("acquires exact commits, reuses a verified cache offline, and never writes the remote", async () => {
+    const fixture = await gitRemoteFixture();
+    const before = await git(fixture.remote, "show-ref");
+
+    const first = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: fixture.firstSha },
+      xdg: fixture.xdg,
+    });
+    const second = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: fixture.firstSha },
+      xdg: {
+        ...fixture.xdg,
+        env: {
+          ...fixture.xdg.env,
+          GIT_CONFIG_VALUE_0: "file:///definitely-unavailable/",
+        },
+      },
+    });
+
+    expect(first).toMatchObject({
+      cacheHit: false,
+      repository: "https://git.example/acme/plugin",
+      sha: fixture.firstSha,
+    });
+    expect(second).toMatchObject({ cacheHit: true, sha: fixture.firstSha });
+    expect(second.rootPath).toBe(first.rootPath);
+    expect(await git(first.rootPath, "status", "--porcelain")).toBe("");
+    expect(await git(fixture.remote, "show-ref")).toBe(before);
+  });
+
+  test("refreshes floating refs in place and resolves version tags", async () => {
+    const fixture = await gitRemoteFixture();
+    const refFirst = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "ref", ref: "main" },
+      xdg: fixture.xdg,
+    });
+
+    await writeFile(join(fixture.work, "README.md"), "second\n");
+    await git(fixture.work, "add", "README.md");
+    await git(fixture.work, "commit", "-m", "second");
+    const secondSha = await git(fixture.work, "rev-parse", "HEAD");
+    await git(fixture.work, "tag", "v1.2.3");
+    await git(fixture.work, "push", "--tags", fixture.remote, "main");
+
+    const refSecond = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "ref", ref: "main" },
+      xdg: fixture.xdg,
+    });
+    const version = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "version", version: "1.2.3" },
+      xdg: fixture.xdg,
+    });
+
+    expect(refFirst).toMatchObject({ cacheHit: false, ref: "main", sha: fixture.firstSha });
+    expect(refSecond).toMatchObject({ cacheHit: true, ref: "main", sha: secondSha });
+    expect(refSecond.rootPath).toBe(refFirst.rootPath);
+    expect(version).toMatchObject({ cacheHit: false, ref: "refs/tags/v1.2.3", sha: secondSha });
+  });
+
+  test("serializes concurrent acquisition for the same cache entry", async () => {
+    const fixture = await gitRemoteFixture();
+
+    const [first, second] = await Promise.all([
+      acquireRemoteRepository({
+        repository: fixture.repository,
+        revision: { kind: "ref", ref: "main" },
+        xdg: fixture.xdg,
+      }),
+      acquireRemoteRepository({
+        repository: fixture.repository,
+        revision: { kind: "ref", ref: "main" },
+        xdg: fixture.xdg,
+      }),
+    ]);
+
+    expect(first.rootPath).toBe(second.rootPath);
+    expect(first.sha).toBe(fixture.firstSha);
+    expect(second.sha).toBe(fixture.firstSha);
+    expect([first.cacheHit, second.cacheHit].sort()).toEqual([false, true]);
+  });
+
+  test("fails loudly for unavailable refs, wrong origins, and corrupt cache entries", async () => {
+    const fixture = await gitRemoteFixture();
+    await expect(acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "ref", ref: "missing" },
+      xdg: fixture.xdg,
+    })).rejects.toThrow("could not resolve ref missing");
+
+    const acquired = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "ref", ref: "main" },
+      xdg: fixture.xdg,
+    });
+    await git(acquired.rootPath, "remote", "set-url", "origin", "https://example.invalid/wrong/repo.git");
+    await expect(acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "ref", ref: "main" },
+      xdg: fixture.xdg,
+    })).rejects.toThrow(`origin mismatch in remote cache ${acquired.cacheKey}`);
+
+    const corrupt = resolveRemoteRepositoryCache(
+      fixture.repository,
+      { kind: "sha", sha: "f".repeat(40) },
+      fixture.xdg
+    );
+    await Bun.write(corrupt.path, "not a repository\n");
+    await expect(acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: "f".repeat(40) },
+      xdg: fixture.xdg,
+    })).rejects.toThrow(`corrupt remote cache ${corrupt.cacheKey}`);
+  });
+
+  test("rejects symlinked cache entries and Git directories before checkout cleanup", async () => {
+    const fixture = await gitRemoteFixture();
+    const pinned = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: fixture.firstSha },
+      xdg: fixture.xdg,
+    });
+    const outside = join(dirname(fixture.remote), "outside");
+    await mkdir(outside);
+    await writeFile(join(outside, "keep.txt"), "keep\n");
+    await rm(pinned.rootPath, { force: true, recursive: true });
+    await symlink(outside, pinned.rootPath);
+
+    await expect(acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: fixture.firstSha },
+      xdg: fixture.xdg,
+    })).rejects.toThrow(`corrupt remote cache ${pinned.cacheKey}`);
+    await expect(readFile(join(outside, "keep.txt"), "utf8")).resolves.toBe("keep\n");
+
+    await rm(pinned.rootPath);
+    const safe = await acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: fixture.firstSha },
+      xdg: fixture.xdg,
+    });
+    const externalGit = join(dirname(fixture.remote), "external.git");
+    await rename(join(safe.rootPath, ".git"), externalGit);
+    await writeFile(join(safe.rootPath, ".git"), `gitdir: ${externalGit}\n`);
+
+    await expect(acquireRemoteRepository({
+      repository: fixture.repository,
+      revision: { kind: "sha", sha: fixture.firstSha },
+      xdg: fixture.xdg,
+    })).rejects.toThrow(`corrupt remote cache ${safe.cacheKey}`);
+    await expect(readFile(join(safe.rootPath, "README.md"), "utf8")).resolves.toBe("first\n");
+  });
+});
+
+interface GitRemoteFixture {
+  readonly firstSha: string;
+  readonly remote: string;
+  readonly repository: string;
+  readonly work: string;
+  readonly xdg: {
+    readonly env: Record<string, string>;
+    readonly homeDir: string;
+  };
+}
+
+async function gitRemoteFixture(): Promise<GitRemoteFixture> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-remote-cache-"));
+  const work = join(root, "work");
+  const remote = join(root, "origin.git");
+  const repository = "https://git.example/acme/plugin.git";
+  await git(root, "init", "--initial-branch=main", work);
+  await git(work, "config", "user.email", "skillset@example.test");
+  await git(work, "config", "user.name", "Skillset Tests");
+  await writeFile(join(work, "README.md"), "first\n");
+  await git(work, "add", "README.md");
+  await git(work, "commit", "-m", "first");
+  const firstSha = await git(work, "rev-parse", "HEAD");
+  await git(root, "clone", "--bare", work, remote);
+
+  return {
+    firstSha,
+    remote,
+    repository,
+    work,
+    xdg: {
+      env: {
+        GIT_ALLOW_PROTOCOL: "file",
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: `url.file://${remote}/.insteadOf`,
+        GIT_CONFIG_VALUE_0: repository,
+        XDG_CACHE_HOME: join(root, "cache"),
+      },
+      homeDir: join(root, "home"),
+    },
+  };
+}
+
+async function git(cwd: string, ...args: readonly string[]): Promise<string> {
+  const proc = Bun.spawn({
+    cmd: ["git", "-C", cwd, ...args],
+    env: process.env,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`${stdout}${stderr}`.trim());
+  return stdout.trim();
+}

--- a/packages/core/src/atomic-file-set.ts
+++ b/packages/core/src/atomic-file-set.ts
@@ -1,0 +1,118 @@
+import { lstat, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+export interface AtomicFileWrite {
+  readonly content: Uint8Array | string;
+  readonly path: string;
+}
+
+interface AtomicFileSetOptions {
+  readonly beforeInstall?: (path: string, index: number) => Promise<void> | void;
+}
+
+interface StagedFile {
+  readonly backupPath: string;
+  backupMoved: boolean;
+  installed: boolean;
+  readonly nextPath: string;
+  readonly path: string;
+  readonly stagingPath: string;
+}
+
+export async function writeAtomicFileSet(
+  writes: readonly AtomicFileWrite[],
+  options: AtomicFileSetOptions = {}
+): Promise<void> {
+  assertUniquePaths(writes);
+  const staged: StagedFile[] = [];
+  try {
+    for (const write of writes) staged.push(await stageFile(write));
+  } catch (error) {
+    await cleanupStaging(staged);
+    throw error;
+  }
+
+  try {
+    for (const [index, file] of staged.entries()) {
+      await options.beforeInstall?.(file.path, index);
+      const existing = await lstat(file.path).catch((error: unknown) => {
+        if (isMissing(error)) return undefined;
+        throw error;
+      });
+      if (existing !== undefined) {
+        if (!existing.isFile()) throw new Error(`skillset: marketplace output is not a regular file: ${file.path}`);
+        await rename(file.path, file.backupPath);
+        file.backupMoved = true;
+      }
+      await rename(file.nextPath, file.path);
+      file.installed = true;
+    }
+  } catch (error) {
+    const rollbackErrors = await rollback(staged);
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `skillset: marketplace update failed and rollback failed for ${rollbackErrors.join(", ")}: ${errorMessage(error)}`
+      );
+    }
+    await cleanupStaging(staged);
+    throw error;
+  }
+
+  await cleanupStaging(staged);
+}
+
+function assertUniquePaths(writes: readonly AtomicFileWrite[]): void {
+  const paths = new Set<string>();
+  for (const write of writes) {
+    if (paths.has(write.path)) throw new Error(`skillset: duplicate marketplace transaction path ${write.path}`);
+    paths.add(write.path);
+  }
+}
+
+async function stageFile(write: AtomicFileWrite): Promise<StagedFile> {
+  const parent = dirname(write.path);
+  await mkdir(parent, { recursive: true });
+  const stagingPath = await mkdtemp(join(parent, ".skillset-marketplace-"));
+  const nextPath = join(stagingPath, `${basename(write.path)}.next`);
+  try {
+    await writeFile(nextPath, write.content);
+    return {
+      backupMoved: false,
+      backupPath: join(stagingPath, `${basename(write.path)}.previous`),
+      installed: false,
+      nextPath,
+      path: write.path,
+      stagingPath,
+    };
+  } catch (error) {
+    await rm(stagingPath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+async function rollback(staged: readonly StagedFile[]): Promise<readonly string[]> {
+  const failures: string[] = [];
+  for (const file of [...staged].reverse()) {
+    try {
+      if (file.installed) await rm(file.path, { force: true });
+      if (file.backupMoved) await rename(file.backupPath, file.path);
+    } catch {
+      failures.push(file.path);
+    }
+  }
+  return failures;
+}
+
+async function cleanupStaging(staged: readonly StagedFile[]): Promise<void> {
+  await Promise.all(staged.map(({ stagingPath }) =>
+    rm(stagingPath, { force: true, recursive: true }).catch(() => undefined)
+  ));
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/src/claude-marketplace.ts
+++ b/packages/core/src/claude-marketplace.ts
@@ -1,0 +1,54 @@
+import type { JsonRecord } from "./types";
+import { isJsonRecord } from "./yaml";
+
+export function storedClaudeMarketplaceProviderEntry(entry: JsonRecord): JsonRecord | undefined {
+  if (
+    entry.requestedTarget !== "claude" ||
+    typeof entry.repo !== "string" ||
+    typeof entry.plugin !== "string" ||
+    typeof entry.generatedPath !== "string" ||
+    !isPortableMarketplacePath(entry.generatedPath) ||
+    !isJsonRecord(entry.requested) ||
+    !isJsonRecord(entry.resolved) ||
+    !isJsonRecord(entry.providerEntry)
+  ) {
+    return undefined;
+  }
+
+  const providerEntry = entry.providerEntry;
+  if (!isJsonRecord(providerEntry.source)) return undefined;
+  const source = providerEntry.source;
+  const resolvedSha = entry.resolved.sha;
+  if (
+    providerEntry.name !== entry.plugin ||
+    typeof resolvedSha !== "string" ||
+    !/^[0-9a-f]{40}$/u.test(resolvedSha) ||
+    source.source !== "git-subdir" ||
+    source.url !== claudeMarketplaceRepoSource(entry.repo) ||
+    source.path !== claudeMarketplacePluginRoot(entry.generatedPath) ||
+    source.sha !== resolvedSha
+  ) {
+    return undefined;
+  }
+  if (entry.requested.kind === "ref" && source.ref !== entry.requested.ref) return undefined;
+  if (entry.requested.kind !== "ref" && source.ref !== undefined) return undefined;
+  return providerEntry;
+}
+
+export function claudeMarketplaceRepoSource(repo: string): string {
+  const github = repo.match(/^github:([^/]+\/[^/]+)$/u);
+  return github?.[1] ?? repo;
+}
+
+export function claudeMarketplacePluginRoot(generatedPath: string): string {
+  const suffix = "/.claude-plugin/plugin.json";
+  if (!generatedPath.endsWith(suffix)) return generatedPath.slice(0, generatedPath.lastIndexOf("/"));
+  return generatedPath.slice(0, -suffix.length);
+}
+
+function isPortableMarketplacePath(value: string): boolean {
+  return !value.startsWith("/") &&
+    !value.startsWith("~") &&
+    !/^[A-Za-z]:[\\/]/u.test(value) &&
+    !value.split(/[\\/]+/u).includes("..");
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,6 +24,10 @@ import type {
 import { SKILLSET_RUNTIME_IDS, type SkillsetRuntimeId } from "./feature-registry";
 import { DEFAULT_PLUGIN_OUTPUT_ROOT } from "./plugin-output";
 import {
+  parseRemoteRepositoryReference,
+  validateRemoteRepositoryRevision,
+} from "./remote-repository-reference";
+import {
   DEFAULT_TARGET_NAME_SET,
   DEFAULT_TARGET_NAMES,
   TARGET_LIST_TEXT,
@@ -796,6 +800,16 @@ function readMarketplacePluginEntry(raw: JsonValue | undefined, label: string): 
   const ref = readOptionalString(raw, "ref", `${label}.ref`);
   const sha = readOptionalString(raw, "sha", `${label}.sha`);
   const version = readOptionalString(raw, "version", `${label}.version`);
+  const policies = [channel, ref, sha, version].filter((value) => value !== undefined);
+  if (policies.length > 1) {
+    throw new Error(`skillset: expected ${label} to set at most one of channel, ref, sha, or version`);
+  }
+  if (channel !== undefined && channel !== "latest") {
+    throw new Error(`skillset: expected ${label}.channel to be latest`);
+  }
+  if (ref !== undefined) validateRemoteRepositoryRevision({ kind: "ref", ref });
+  if (sha !== undefined) validateRemoteRepositoryRevision({ kind: "sha", sha });
+  if (version !== undefined) validateRemoteRepositoryRevision({ kind: "version", version });
   return {
     ...(channel === undefined ? {} : { channel }),
     id,
@@ -840,6 +854,12 @@ function validateMarketplaceRepo(value: string, label: string): void {
     /^[A-Za-z]:[\\/]/.test(value)
   ) {
     throw new Error(`skillset: expected ${label} to be a remote repo reference, not a filesystem path`);
+  }
+  try {
+    parseRemoteRepositoryReference(value);
+  } catch (error) {
+    const message = error instanceof Error ? error.message.replace(/^skillset:\s*/u, "") : String(error);
+    throw new Error(`skillset: invalid ${label}: ${message}`);
   }
 }
 

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -227,10 +227,13 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
       docs("https://linear.app/outfitter/issue/SET-234/implement-skillset-marketplace-check-readiness-reports"),
       docs("https://linear.app/outfitter/issue/SET-235/define-marketplace-ref-policy-and-lock-provenance-for-floating-and"),
       docs("https://linear.app/outfitter/issue/SET-236/implement-skillset-marketplace-update-provider-index-rendering"),
+      docs("https://linear.app/outfitter/issue/SET-268/resolve-external-marketplace-repositories-into-deterministic-xdg-cache"),
       test("apps/skillset/src/__tests__/marketplace-check-cli.test.ts", "SET-234 marketplace check CLI coverage"),
       test("apps/skillset/src/__tests__/marketplace-check-cli.test.ts", "SET-236 marketplace update CLI coverage"),
       test("packages/core/src/__tests__/marketplace-check.test.ts", "SET-234 marketplace readiness report coverage"),
       test("packages/core/src/__tests__/marketplace-check.test.ts", "SET-235 marketplace lock provenance coverage"),
+      test("packages/core/src/__tests__/marketplace-check.test.ts", "SET-268 remote marketplace resolution coverage"),
+      test("packages/core/src/__tests__/remote-repository-cache.test.ts", "SET-268 deterministic XDG Git cache coverage"),
       test("apps/skillset/src/__tests__/skillset.test.ts", "SET-133 marketplace catalog parser coverage"),
       test("packages/core/src/__tests__/known-skillsets.test.ts", "managed known-Skillsets XDG index coverage"),
       test("packages/schema/src/__tests__/schema.test.ts", "workspace config marketplace contract coverage"),
@@ -240,7 +243,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     renderOwner: "packages/core/src/marketplace-update.ts",
     sourceShape: "workspace skillset.yaml marketplaces",
     status: "implemented",
-    summary: "Declares curated provider marketplace catalogs, verifies local or known-index plugin readiness with lock provenance, and renders provider-supported marketplace indexes.",
+    summary: "Declares curated provider marketplace catalogs, resolves local or remote-cached plugin readiness with portable lock provenance, and renders provider-supported marketplace indexes.",
     targetSupport: {
       claude: {
         evidence: [docs("docs/features/marketplaces.md"), providerSchemaSnapshot("claude-marketplace-schema")],

--- a/packages/core/src/marketplace-check.ts
+++ b/packages/core/src/marketplace-check.ts
@@ -5,8 +5,19 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 
 import { isOutputSelected } from "./config";
+import { storedClaudeMarketplaceProviderEntry } from "./claude-marketplace";
+import {
+  marketplaceRequestedRefPolicy,
+  type MarketplaceRefPolicyKind,
+  type MarketplaceRequestedRefPolicy,
+} from "./marketplace-ref-policy";
 import { compareStrings } from "./path";
 import { pluginManifestPath as pluginManifestOutputPath } from "./plugin-output";
+import {
+  acquireRemoteRepository,
+  parseRemoteRepositoryReference,
+  type RemoteRepositoryRevision,
+} from "./remote-repository-cache";
 import { pluginIdForSelector } from "./source-unit-selector";
 import { loadBuildGraph } from "./resolver";
 import { verifySkillsetResult } from "./build";
@@ -16,11 +27,14 @@ import type {
   BuildGraph,
   MarketplaceCatalogConfig,
   MarketplacePluginEntryConfig,
+  JsonRecord,
   SkillsetOptions,
   SourcePlugin,
   TargetName,
 } from "./types";
 import type { SkillsetRenderResult } from "./render-result";
+
+export type { MarketplaceRefPolicyKind, MarketplaceRequestedRefPolicy } from "./marketplace-ref-policy";
 
 const execFileAsync = promisify(execFile);
 
@@ -37,7 +51,8 @@ export type MarketplaceReadinessState =
   | "marketplace-ready"
   | "not-ready";
 
-export type MarketplaceSourceKind = "current" | "known-index" | "unresolved";
+export type MarketplaceSourceKind = "current" | "known-index" | "remote-cache" | "unresolved";
+export type MarketplaceLockSourceKind = "current" | "external" | "unresolved";
 
 export interface MarketplaceCheckReport {
   readonly entries: readonly MarketplaceCheckEntryReport[];
@@ -73,15 +88,11 @@ export interface MarketplaceCheckLockReport {
 }
 
 export interface MarketplaceCheckSourceReport {
-  readonly cacheKey?: string;
   readonly ref?: string;
   readonly kind: MarketplaceSourceKind;
-  readonly path?: string;
   readonly repository?: string;
   readonly sha?: string;
 }
-
-export type MarketplaceRefPolicyKind = "channel" | "local" | "ref" | "sha" | "version";
 
 export interface MarketplaceLockEntry {
   readonly catalog: string;
@@ -89,6 +100,7 @@ export interface MarketplaceLockEntry {
   readonly generatedPath?: string;
   readonly generatedPaths: readonly string[];
   readonly plugin: string;
+  readonly providerEntry?: JsonRecord;
   readonly providerSource: string;
   readonly readiness: "marketplace-ready" | "not-ready";
   readonly repo?: string;
@@ -97,16 +109,7 @@ export interface MarketplaceLockEntry {
   readonly resolved: MarketplaceResolvedLockState;
 }
 
-export interface MarketplaceRequestedRefPolicy {
-  readonly channel?: string;
-  readonly kind: MarketplaceRefPolicyKind;
-  readonly ref?: string;
-  readonly sha?: string;
-  readonly version?: string;
-}
-
 export interface MarketplaceResolvedLockState {
-  readonly cacheKey?: string;
   readonly generatedPath?: string;
   readonly generatedPaths: readonly string[];
   readonly pluginVersion?: string;
@@ -114,8 +117,7 @@ export interface MarketplaceResolvedLockState {
   readonly ref?: string;
   readonly repository?: string;
   readonly sha?: string;
-  readonly sourceKind: MarketplaceSourceKind;
-  readonly sourcePath?: string;
+  readonly sourceKind: MarketplaceLockSourceKind;
 }
 
 interface MarketplaceCheckOptions extends SkillsetOptions {
@@ -136,33 +138,64 @@ interface SourceInspection {
   readonly verifyFailures: readonly string[];
 }
 
+export interface MarketplaceCheckResolution {
+  readonly report: MarketplaceCheckReport;
+  readonly sourceRoots: ReadonlyMap<string, string>;
+}
+
 export async function checkMarketplaces(
   rootPath: string,
   options: MarketplaceCheckOptions = {}
 ): Promise<MarketplaceCheckReport> {
+  return (await resolveMarketplaceChecks(rootPath, options)).report;
+}
+
+export async function resolveMarketplaceChecks(
+  rootPath: string,
+  options: MarketplaceCheckOptions = {}
+): Promise<MarketplaceCheckResolution> {
   const rootGraph = await loadBuildGraph(rootPath, options);
   const catalogs = selectedCatalogs(rootGraph.root.marketplaces, options.name);
   const lockEntries = await readMarketplaceLockEntries(rootPath);
   const current = await inspectSource(rootPath, "current", options);
   const inspections = new Map<string, Promise<SourceInspection | undefined>>();
   const entries: MarketplaceCheckEntryReport[] = [];
+  const sourceRoots = new Map<string, string>();
 
   for (const [catalogName, catalog] of catalogs) {
     for (const entry of catalog.plugins) {
+      const requested = marketplaceRequestedRefPolicy(entry);
       const inspection = entry.repo === undefined
         ? current
-        : await resolveExternalInspection(entry.repo, options, inspections);
+        : await resolveExternalInspection(entry.repo, requested, options, inspections);
       for (const target of entry.targets ?? catalog.targets) {
-        entries.push(checkMarketplaceEntry(catalogName, entry, target, inspection, lockEntries, options.lockMode ?? "check"));
+        const checked = checkMarketplaceEntry(
+          catalogName,
+          entry,
+          target,
+          inspection,
+          lockEntries,
+          options.lockMode ?? "check",
+          requested
+        );
+        entries.push(checked);
+        if (inspection?.path !== undefined) sourceRoots.set(marketplaceEntryResolutionKey(checked), inspection.path);
       }
     }
   }
 
   return {
-    entries: entries.sort(compareMarketplaceEntries),
-    marketplaces: catalogs.map(([name]) => name),
-    ok: entries.every((entry) => entry.readiness === "marketplace-ready"),
+    report: {
+      entries: entries.sort(compareMarketplaceEntries),
+      marketplaces: catalogs.map(([name]) => name),
+      ok: entries.every((entry) => entry.readiness === "marketplace-ready"),
+    },
+    sourceRoots,
   };
+}
+
+export function marketplaceEntryResolutionKey(entry: MarketplaceCheckEntryReport): string {
+  return `${entry.catalog}\0${entry.entryId}\0${entry.requestedTarget}`;
 }
 
 function selectedCatalogs(
@@ -179,37 +212,114 @@ function selectedCatalogs(
 
 async function resolveExternalInspection(
   repo: string,
+  requested: MarketplaceRequestedRefPolicy,
   options: SkillsetOptions,
   inspections: Map<string, Promise<SourceInspection | undefined>>
 ): Promise<SourceInspection | undefined> {
-  const existing = inspections.get(repo);
+  const key = `${repo}\0${JSON.stringify(requested)}`;
+  const existing = inspections.get(key);
   if (existing !== undefined) return existing;
-  const pending = resolveKnownSkillsetWorkspace(repo, options.xdg).then((entry) =>
-    entry === undefined ? undefined : inspectKnownSource(entry, options).catch((error: unknown) => failedKnownSourceInspection(entry, error))
-  );
-  inspections.set(repo, pending);
+  const pending = resolveKnownSkillsetWorkspace(repo, options.xdg).then(async (entry) => {
+    if (entry !== undefined && requested.kind === "sha" && requested.sha !== undefined) {
+      const known = await inspectKnownSource(entry, repo, options).catch(() => undefined);
+      if (known?.sha === requested.sha) {
+        const { ref: _localRef, ...pinnedKnown } = known;
+        return pinnedKnown;
+      }
+    }
+    return inspectRemoteSource(repo, requested, options).catch((error: unknown) =>
+      failedRemoteSourceInspection(repo, error)
+    );
+  });
+  inspections.set(key, pending);
   return pending;
 }
 
-function failedKnownSourceInspection(entry: KnownSkillsetEntry, error: unknown): SourceInspection {
+function failedRemoteSourceInspection(repo: string, error: unknown): SourceInspection {
   return {
-    cacheKey: entry.cacheKey,
-    error: error instanceof Error ? error.message : String(error),
-    kind: "known-index",
-    path: entry.path,
-    ...(entry.repository === undefined ? {} : { repository: entry.repository }),
+    error: portableRemoteInspectionError(error),
+    kind: "remote-cache",
+    repository: canonicalRepository(repo),
     renderResults: [],
     verifyFailures: [],
   };
 }
 
+function portableRemoteInspectionError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.startsWith("skillset: corrupt remote cache")) return "skillset: remote cache is corrupt";
+  if (message.startsWith("skillset: origin mismatch in remote cache")) {
+    return "skillset: remote cache origin does not match the requested repository";
+  }
+  if (message.startsWith("skillset: timed out waiting for the remote cache lock")) {
+    return "skillset: timed out waiting for the remote cache lock";
+  }
+  const portablePrefixes = [
+    "skillset: remote ",
+    "skillset: resolved remote commit changed",
+  ];
+  if (portablePrefixes.some((prefix) => message.startsWith(prefix))) return message;
+  return "skillset: resolved remote repository is not a valid generated Skillset workspace";
+}
+
 async function inspectKnownSource(
   entry: KnownSkillsetEntry,
+  repo: string,
   options: SkillsetOptions
 ): Promise<SourceInspection> {
+  await assertKnownRepositoryIdentity(entry.path, repo);
   return inspectSource(entry.path, "known-index", options, {
     cacheKey: entry.cacheKey,
-    ...(entry.repository === undefined ? {} : { repository: entry.repository }),
+    repository: canonicalRepository(repo),
+  });
+}
+
+async function assertKnownRepositoryIdentity(path: string, repo: string): Promise<void> {
+  const origin = await runGit(path, ["config", "--get", "remote.origin.url"]);
+  if (origin === undefined) throw new Error("skillset: known Skillset checkout is missing an origin remote");
+  let canonical: string;
+  try {
+    canonical = canonicalRepository(origin);
+  } catch {
+    throw new Error("skillset: known Skillset checkout has an unsupported origin remote");
+  }
+  if (canonical !== canonicalRepository(repo)) {
+    throw new Error("skillset: known Skillset checkout origin does not match the marketplace repository");
+  }
+  const status = await execFileAsync("git", [
+    "-C",
+    path,
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.untrackedCache=false",
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+  ], {
+    env: { ...gitCommandEnv(), GIT_OPTIONAL_LOCKS: "0" },
+    timeout: 5000,
+  });
+  if (String(status.stdout).trim().length > 0) {
+    throw new Error("skillset: known Skillset checkout has uncommitted content");
+  }
+}
+
+async function inspectRemoteSource(
+  repo: string,
+  requested: MarketplaceRequestedRefPolicy,
+  options: SkillsetOptions
+): Promise<SourceInspection> {
+  const acquired = await acquireRemoteRepository({
+    repository: repo,
+    revision: remoteRevision(requested),
+    ...(options.xdg === undefined ? {} : { xdg: options.xdg }),
+  });
+  return inspectSource(acquired.rootPath, "remote-cache", options, {
+    cacheKey: acquired.cacheKey,
+    ...(acquired.ref === undefined ? {} : { ref: acquired.ref }),
+    repository: acquired.repository,
+    sha: acquired.sha,
   });
 }
 
@@ -217,17 +327,26 @@ async function inspectSource(
   path: string,
   kind: MarketplaceSourceKind,
   options: SkillsetOptions,
-  metadata: { readonly cacheKey?: string; readonly repository?: string } = {}
+  metadata: {
+    readonly cacheKey?: string;
+    readonly ref?: string;
+    readonly repository?: string;
+    readonly sha?: string;
+  } = {}
 ): Promise<SourceInspection> {
   const graph = await loadBuildGraph(path, options);
   const verified = await verifySkillsetResult(path, options);
+  const identity = await gitIdentity(path);
+  const ref = metadata.ref ?? identity.ref;
+  const sha = metadata.sha ?? identity.sha;
   return {
     graph,
     kind,
     path,
     ...(metadata.cacheKey === undefined ? {} : { cacheKey: metadata.cacheKey }),
     ...(metadata.repository === undefined ? {} : { repository: metadata.repository }),
-    ...(await gitIdentity(path)),
+    ...(ref === undefined ? {} : { ref }),
+    ...(sha === undefined ? {} : { sha }),
     renderResults: verified.renderResults,
     verifyFailures: verified.data.failures,
   };
@@ -239,9 +358,9 @@ function checkMarketplaceEntry(
   target: TargetName,
   inspection: SourceInspection | undefined,
   lockEntries: readonly MarketplaceLockEntry[],
-  lockMode: "check" | "refresh"
+  lockMode: "check" | "refresh",
+  refPolicy: MarketplaceRequestedRefPolicy
 ): MarketplaceCheckEntryReport {
-  const refPolicy = requestedRefPolicy(entry);
   const policyStates = statesForRefPolicy(refPolicy);
   const declared = ["declared", ...policyStates] as const;
   if (inspection === undefined) {
@@ -399,21 +518,11 @@ function notReady(
 
 function sourceReport(inspection: SourceInspection): MarketplaceCheckSourceReport {
   return {
-    ...(inspection.cacheKey === undefined ? {} : { cacheKey: inspection.cacheKey }),
     kind: inspection.kind,
-    ...(inspection.path === undefined ? {} : { path: inspection.path }),
     ...(inspection.ref === undefined ? {} : { ref: inspection.ref }),
     ...(inspection.repository === undefined ? {} : { repository: inspection.repository }),
     ...(inspection.sha === undefined ? {} : { sha: inspection.sha }),
   };
-}
-
-function requestedRefPolicy(entry: MarketplacePluginEntryConfig): MarketplaceRequestedRefPolicy {
-  if (entry.sha !== undefined) return { kind: "sha", sha: entry.sha };
-  if (entry.ref !== undefined) return { kind: "ref", ref: entry.ref };
-  if (entry.channel !== undefined) return { channel: entry.channel, kind: "channel" };
-  if (entry.version !== undefined) return { kind: "version", version: entry.version };
-  return { kind: "local" };
 }
 
 function statesForRefPolicy(policy: MarketplaceRequestedRefPolicy): readonly MarketplaceReadinessState[] {
@@ -464,7 +573,6 @@ function marketplaceLockEntryFor(args: {
     requested: args.requested,
     requestedTarget: args.target,
     resolved: {
-      ...(args.inspection?.cacheKey === undefined ? {} : { cacheKey: args.inspection.cacheKey }),
       ...(args.generatedPath === undefined ? {} : { generatedPath: args.generatedPath }),
       generatedPaths: args.generatedPaths,
       ...(args.pluginVersion === undefined ? {} : { pluginVersion: args.pluginVersion }),
@@ -472,8 +580,7 @@ function marketplaceLockEntryFor(args: {
       ...(args.inspection?.ref === undefined ? {} : { ref: args.inspection.ref }),
       ...(args.inspection?.repository === undefined ? {} : { repository: args.inspection.repository }),
       ...(args.inspection?.sha === undefined ? {} : { sha: args.inspection.sha }),
-      sourceKind: args.inspection?.kind ?? "unresolved",
-      ...(args.inspection?.path === undefined ? {} : { sourcePath: args.inspection.path }),
+      sourceKind: marketplaceLockSourceKind(args.entry, args.inspection),
     },
   };
 }
@@ -557,7 +664,6 @@ function stableMarketplaceLockFingerprint(entry: MarketplaceLockEntry): string {
   if (entry.requested.kind === "local") {
     delete resolved.ref;
     delete resolved.sha;
-    delete resolved.sourcePath;
   }
   return stableJson({
     catalog: entry.catalog,
@@ -581,6 +687,31 @@ function compareMarketplaceLockEntries(left: MarketplaceLockEntry, right: Market
   );
 }
 
+function marketplaceLockSourceKind(
+  entry: MarketplacePluginEntryConfig,
+  inspection: SourceInspection | undefined
+): MarketplaceLockSourceKind {
+  if (inspection?.graph === undefined) return "unresolved";
+  return entry.repo === undefined ? "current" : "external";
+}
+
+function remoteRevision(policy: MarketplaceRequestedRefPolicy): RemoteRepositoryRevision {
+  if (policy.kind === "sha" && policy.sha !== undefined) return { kind: "sha", sha: policy.sha };
+  if (policy.kind === "ref" && policy.ref !== undefined) return { kind: "ref", ref: policy.ref };
+  if (policy.kind === "version" && policy.version !== undefined) {
+    return { kind: "version", version: policy.version };
+  }
+  if (policy.kind === "channel" && policy.channel === "latest") return { kind: "default" };
+  if (policy.kind === "channel") {
+    throw new Error(`skillset: unsupported marketplace channel ${policy.channel ?? ""}`);
+  }
+  throw new Error("skillset: external marketplace repositories require a remote ref policy");
+}
+
+function canonicalRepository(repo: string): string {
+  return parseRemoteRepositoryReference(repo).canonical;
+}
+
 async function readMarketplaceLockEntries(rootPath: string): Promise<readonly MarketplaceLockEntry[]> {
   const lockPath = join(rootPath, "skillset.lock");
   if (!(await exists(lockPath))) return [];
@@ -597,7 +728,7 @@ async function readMarketplaceLockEntries(rootPath: string): Promise<readonly Ma
 }
 
 function isMarketplaceLockEntry(value: unknown): value is MarketplaceLockEntry {
-  return isRecord(value) &&
+  if (!(isRecord(value) &&
     typeof value.catalog === "string" &&
     typeof value.entryId === "string" &&
     Array.isArray(value.generatedPaths) &&
@@ -612,7 +743,12 @@ function isMarketplaceLockEntry(value: unknown): value is MarketplaceLockEntry {
     Array.isArray(value.resolved.generatedPaths) &&
     value.resolved.generatedPaths.every((path) => typeof path === "string") &&
     typeof value.resolved.providerSource === "string" &&
-    typeof value.resolved.sourceKind === "string";
+    typeof value.resolved.sourceKind === "string")) {
+    return false;
+  }
+  return value.repo === undefined ||
+    value.requestedTarget !== "claude" ||
+    storedClaudeMarketplaceProviderEntry(value as unknown as JsonRecord) !== undefined;
 }
 
 function pluginTargetRenderable(graph: BuildGraph, plugin: SourcePlugin, target: TargetName): boolean {

--- a/packages/core/src/marketplace-ref-policy.ts
+++ b/packages/core/src/marketplace-ref-policy.ts
@@ -1,0 +1,22 @@
+import type { MarketplacePluginEntryConfig } from "./types";
+
+export type MarketplaceRefPolicyKind = "channel" | "local" | "ref" | "sha" | "version";
+
+export interface MarketplaceRequestedRefPolicy {
+  readonly channel?: string;
+  readonly kind: MarketplaceRefPolicyKind;
+  readonly ref?: string;
+  readonly sha?: string;
+  readonly version?: string;
+}
+
+export function marketplaceRequestedRefPolicy(
+  entry: MarketplacePluginEntryConfig
+): MarketplaceRequestedRefPolicy {
+  if (entry.sha !== undefined) return { kind: "sha", sha: entry.sha };
+  if (entry.ref !== undefined) return { kind: "ref", ref: entry.ref };
+  if (entry.channel !== undefined) return { channel: entry.channel, kind: "channel" };
+  if (entry.version !== undefined) return { kind: "version", version: entry.version };
+  if (entry.repo !== undefined) return { channel: "latest", kind: "channel" };
+  return { kind: "local" };
+}

--- a/packages/core/src/marketplace-update.ts
+++ b/packages/core/src/marketplace-update.ts
@@ -1,14 +1,21 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
-import { readRecord, readString } from "./config";
-import { checkMarketplaces, type MarketplaceCheckEntryReport, type MarketplaceCheckReport, type MarketplaceLockEntry } from "./marketplace-check";
+import { writeAtomicFileSet } from "./atomic-file-set";
+import { claudeMarketplacePluginRoot, claudeMarketplaceRepoSource } from "./claude-marketplace";
+import {
+  marketplaceEntryResolutionKey,
+  resolveMarketplaceChecks,
+  type MarketplaceCheckEntryReport,
+  type MarketplaceCheckReport,
+  type MarketplaceLockEntry,
+} from "./marketplace-check";
 import { compareStrings, resolveInside } from "./path";
 import { claudeMarketplacePath } from "./plugin-output";
+import { renderBuildGraph, renderClaudeMarketplaceDocument } from "./render";
 import { loadBuildGraph } from "./resolver";
 import { renderValidatedJson } from "./structured-output";
 import type { BuildGraph, JsonRecord, JsonValue, SkillsetOptions, TargetName } from "./types";
-import { rootVersion } from "./versioning";
 
 export interface MarketplaceUpdateOptions extends SkillsetOptions {
   readonly name?: string;
@@ -37,10 +44,14 @@ export async function updateMarketplaces(
   options: MarketplaceUpdateOptions = {}
 ): Promise<MarketplaceUpdateReport> {
   const graph = await loadBuildGraph(rootPath, options);
-  const check = await checkMarketplaces(rootPath, { ...options, lockMode: "refresh" });
-  const files = check.ok ? await renderMarketplaceUpdateFiles(rootPath, graph, check) : [];
+  const resolution = await resolveMarketplaceChecks(rootPath, { ...options, lockMode: "refresh" });
+  const check = resolution.report;
+  const rendered = check.ok
+    ? await renderMarketplaceUpdateFiles(rootPath, graph, check, resolution.sourceRoots)
+    : { files: [], providerEntries: new Map<string, JsonRecord>() };
+  const files = rendered.files;
   const writtenPaths = options.write === true && check.ok
-    ? await writeMarketplaceUpdate(rootPath, check, files)
+    ? await writeMarketplaceUpdate(rootPath, graph, check, files, rendered.providerEntries)
     : [];
 
   return {
@@ -56,52 +67,53 @@ export async function updateMarketplaces(
 async function renderMarketplaceUpdateFiles(
   rootPath: string,
   graph: BuildGraph,
-  check: MarketplaceCheckReport
-): Promise<readonly MarketplaceUpdateFileWithContent[]> {
+  check: MarketplaceCheckReport,
+  sourceRoots: ReadonlyMap<string, string>
+): Promise<RenderedMarketplaceUpdate> {
   const claudeEntries = check.entries.filter((entry) => entry.requestedTarget === "claude");
   const catalogs = new Set(claudeEntries.map((entry) => entry.catalog));
   if (catalogs.size > 1) {
     throw new Error("skillset: marketplace update requires a marketplace name when multiple Claude catalogs are configured");
   }
   const catalog = [...catalogs][0];
-  if (catalog === undefined) return [];
+  if (catalog === undefined) return { files: [], providerEntries: new Map() };
   const catalogConfig = graph.root.marketplaces[catalog];
   if (catalogConfig === undefined) throw new Error(`skillset: unknown marketplace ${catalog}`);
 
   const path = claudeMarketplacePath(graph.root.outputs.plugins.claude);
-  const plugins = await Promise.all(claudeEntries.map((entry) => claudeMarketplacePlugin(rootPath, entry)));
-  const root = graph.root.metadata;
-  const owner = readRecord(root, "owner") ?? readRecord(root, "author") ?? { name: readString(root, "name") ?? catalog };
-  const marketplace = {
-    name: catalog,
-    owner,
-    ...(catalogConfig.description === undefined ? {} : { description: catalogConfig.description }),
-    metadata: {
-      description:
-        catalogConfig.description ??
-        readString(root, "summary") ??
-        readString(root, "description") ??
-        "Source-first Skillset plugins",
-      generatedBy: "skillset@0.1.0",
-      version: rootVersion(graph),
-    },
-    plugins: plugins.sort((left, right) => compareStrings(String(left.name), String(right.name))),
-  } satisfies JsonRecord;
+  const resolvedPlugins = await Promise.all(
+    claudeEntries.map(async (entry) => ({
+      entry,
+      plugin: await claudeMarketplacePlugin(rootPath, entry, sourceRoots),
+    }))
+  );
+  const plugins = resolvedPlugins.map(({ plugin }) => plugin);
+  const providerEntries = new Map(
+    resolvedPlugins
+      .filter(({ entry }) => entry.repo !== undefined)
+      .map(({ entry, plugin }) => [marketplaceEntryResolutionKey(entry), plugin] as const)
+  );
+  const marketplace = renderClaudeMarketplaceDocument(graph, catalog, catalogConfig, plugins);
 
-  return [{
-    catalog,
-    content: textEncoder.encode(renderValidatedJson(marketplace, "Claude marketplace")),
-    path,
-    target: "claude",
-  }];
+  return {
+    files: [{
+      catalog,
+      content: textEncoder.encode(renderValidatedJson(marketplace, "Claude marketplace")),
+      path,
+      target: "claude",
+    }],
+    providerEntries,
+  };
 }
 
 async function claudeMarketplacePlugin(
   rootPath: string,
-  entry: MarketplaceCheckEntryReport
+  entry: MarketplaceCheckEntryReport,
+  sourceRoots: ReadonlyMap<string, string>
 ): Promise<JsonRecord> {
   if (entry.generatedPath === undefined) throw new Error(`skillset: marketplace entry ${entry.catalog}/${entry.entryId} is missing a generated Claude plugin manifest path`);
-  const sourceRoot = entry.source.path ?? (entry.source.kind === "current" ? rootPath : undefined);
+  const sourceRoot = sourceRoots.get(marketplaceEntryResolutionKey(entry)) ??
+    (entry.source.kind === "current" ? rootPath : undefined);
   if (sourceRoot === undefined) throw new Error(`skillset: marketplace entry ${entry.catalog}/${entry.entryId} is missing a resolved source path`);
   const manifest = await readJsonRecord(resolveInside(sourceRoot, entry.generatedPath), entry.generatedPath);
   const marketplaceEntry = pickClaudeMarketplaceFields(manifest);
@@ -133,7 +145,7 @@ function claudeMarketplaceSource(entry: MarketplaceCheckEntryReport): JsonValue 
   return stripUndefinedJsonRecord({
     path: pluginRootPath(entry.generatedPath),
     source: "git-subdir",
-    url: claudeRepoSource(entry.repo),
+    url: claudeMarketplaceRepoSource(entry.repo),
     ...claudeRefFields(entry),
   });
 }
@@ -151,75 +163,58 @@ function fortyCharSha(value: string | undefined): string | undefined {
   return value !== undefined && /^[a-f0-9]{40}$/u.test(value) ? value : undefined;
 }
 
-function claudeRepoSource(repo: string): string {
-  const github = repo.match(/^github:([^/]+\/[^/]+)$/u);
-  return github?.[1] ?? repo;
-}
-
 function pluginRootPath(generatedPath: string): string {
-  const suffix = "/.claude-plugin/plugin.json";
-  if (!generatedPath.endsWith(suffix)) return dirname(generatedPath).replaceAll("\\", "/");
-  return generatedPath.slice(0, -suffix.length);
+  return claudeMarketplacePluginRoot(generatedPath);
 }
 
 async function writeMarketplaceUpdate(
   rootPath: string,
+  graph: BuildGraph,
   check: MarketplaceCheckReport,
-  files: readonly MarketplaceUpdateFileWithContent[]
+  files: readonly MarketplaceUpdateFileWithContent[],
+  providerEntries: ReadonlyMap<string, JsonRecord>
 ): Promise<readonly string[]> {
-  const written: string[] = [];
-  for (const file of files) {
-    const absolute = resolveInside(rootPath, file.path);
-    await mkdir(dirname(absolute), { recursive: true });
-    await writeFile(absolute, file.content);
-    written.push(file.path);
-  }
-  await writeMarketplaceLock(rootPath, check);
-  written.push("skillset.lock");
-  return written.sort(compareStrings);
+  const lockContent = await renderMarketplaceLock(graph, check, files, providerEntries);
+  await writeAtomicFileSet([
+    ...files.map((file) => ({ content: file.content, path: resolveInside(rootPath, file.path) })),
+    { content: lockContent, path: resolveInside(rootPath, "skillset.lock") },
+  ]);
+  return [...files.map(({ path }) => path), "skillset.lock"].sort(compareStrings);
 }
 
-async function writeMarketplaceLock(rootPath: string, check: MarketplaceCheckReport): Promise<void> {
-  const lockPath = resolveInside(rootPath, "skillset.lock");
-  const existing = await readExistingLock(lockPath);
+async function renderMarketplaceLock(
+  graph: BuildGraph,
+  check: MarketplaceCheckReport,
+  files: readonly MarketplaceUpdateFileWithContent[],
+  providerEntries: ReadonlyMap<string, JsonRecord>
+): Promise<string> {
+  const rendered = await renderBuildGraph(graph);
+  const baseline = rendered.find((file) => file.path === "skillset.lock");
+  if (baseline === undefined) throw new Error("skillset: marketplace update could not render skillset.lock");
+  const existing = JSON.parse(new TextDecoder().decode(baseline.content)) as JsonRecord;
   const selected = new Set(check.marketplaces);
   const previousEntries = marketplaceLockEntries(existing);
   const nextEntries = [
     ...previousEntries.filter((entry) => !selected.has(entry.catalog)),
-    ...check.entries.map((entry) => entry.provenance),
+    ...check.entries.map((entry) => {
+      const providerEntry = providerEntries.get(marketplaceEntryResolutionKey(entry));
+      return providerEntry === undefined ? entry.provenance : { ...entry.provenance, providerEntry };
+    }),
   ].sort(compareMarketplaceLockEntries);
+  const previousMarketplaces = isRecord(existing.marketplaces) ? existing.marketplaces : {};
+  const activeCatalogs = isRecord(previousMarketplaces.activeCatalogs)
+    ? { ...previousMarketplaces.activeCatalogs }
+    : {};
+  for (const file of files) activeCatalogs[file.target] = file.catalog;
   const next = stripUndefinedJsonRecord({
-    generatedBy: existing.generatedBy ?? "skillset@0.1.0",
-    items: Array.isArray(existing.items) ? existing.items : [],
     ...existing,
     marketplaces: {
-      ...(isRecord(existing.marketplaces) ? existing.marketplaces : {}),
+      ...previousMarketplaces,
+      activeCatalogs,
       entries: nextEntries as unknown as JsonValue,
     },
-    outputRoot: existing.outputRoot ?? ".",
-    schemaVersion: existing.schemaVersion ?? 1,
-    target: existing.target ?? "workspace",
   });
-  await writeFile(lockPath, renderValidatedJson(next, "skillset.lock"));
-}
-
-async function readExistingLock(path: string): Promise<JsonRecord> {
-  let raw: string;
-  try {
-    raw = await readFile(path, "utf8");
-  } catch (error) {
-    if (isNotFoundError(error)) return {};
-    throw error;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw) as unknown;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`skillset: cannot update corrupt skillset.lock: ${message}`);
-  }
-  if (!isRecord(parsed)) throw new Error("skillset: cannot update skillset.lock because it is not a JSON object");
-  return parsed as JsonRecord;
+  return renderValidatedJson(next, "skillset.lock");
 }
 
 function marketplaceLockEntries(lock: JsonRecord): readonly MarketplaceLockEntry[] {
@@ -259,10 +254,11 @@ function isRecord(value: unknown): value is Record<string, JsonValue> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isNotFoundError(error: unknown): boolean {
-  return isRecord(error) && error.code === "ENOENT";
-}
-
 interface MarketplaceUpdateFileWithContent extends MarketplaceUpdateFile {
   readonly content: Uint8Array;
+}
+
+interface RenderedMarketplaceUpdate {
+  readonly files: readonly MarketplaceUpdateFileWithContent[];
+  readonly providerEntries: ReadonlyMap<string, JsonRecord>;
 }

--- a/packages/core/src/output-safety.ts
+++ b/packages/core/src/output-safety.ts
@@ -587,7 +587,7 @@ function corruptManagedLock(lockPath: string, displayLockPath: string, reason: s
   );
 }
 
-function corruptWorkspaceLock(displayLockPath: string, reason: string): Error {
+export function corruptWorkspaceLock(displayLockPath: string, reason: string): Error {
   return new Error(
     `skillset: workspace lock ${displayLockPath} cannot guard generated state because ${reason}. ` +
       "Restore it from a clean build (skillset build) or remove it deliberately before rebuilding."

--- a/packages/core/src/remote-repository-cache.ts
+++ b/packages/core/src/remote-repository-cache.ts
@@ -1,0 +1,521 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstat, mkdir, mkdtemp, realpath, rename, rm, stat } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { resolveSkillsetXdgPaths, type SkillsetXdgOptions } from "./xdg";
+import {
+  parseRemoteRepositoryReference,
+  validateRemoteRepositoryRevision,
+  type ParsedRemoteRepositoryReference,
+  type RemoteRepositoryRevision,
+} from "./remote-repository-reference";
+
+export {
+  parseRemoteRepositoryReference,
+  type ParsedRemoteRepositoryReference,
+  type RemoteRepositoryRevision,
+} from "./remote-repository-reference";
+
+const execFileAsync = promisify(execFile);
+
+export interface RemoteRepositoryCacheLocation {
+  readonly cacheKey: string;
+  readonly path: string;
+}
+
+export interface RemoteRepositoryCheckout {
+  readonly cacheHit: boolean;
+  readonly cacheKey: string;
+  readonly ref?: string;
+  readonly repository: string;
+  readonly rootPath: string;
+  readonly sha: string;
+}
+
+export interface AcquireRemoteRepositoryOptions {
+  readonly repository: string;
+  readonly revision: RemoteRepositoryRevision;
+  readonly xdg?: SkillsetXdgOptions;
+}
+
+interface ResolvedRevision {
+  readonly fetch: string;
+  readonly ref?: string;
+  readonly sha: string;
+}
+
+interface RemoteRefRecord {
+  readonly ref: string;
+  readonly sha: string;
+}
+
+export function resolveRemoteRepositoryCache(
+  repository: string,
+  revision: RemoteRepositoryRevision,
+  xdg: SkillsetXdgOptions = {}
+): RemoteRepositoryCacheLocation {
+  const parsed = parseRemoteRepositoryReference(repository);
+  validateRemoteRepositoryRevision(revision);
+  const repositoryKey = `${slug(parsed.canonical)}--${digest(parsed.canonical, 24)}`;
+  const revisionIdentity = stableRevisionIdentity(revision);
+  const revisionKey = `${slug(revisionIdentity)}--${digest(revisionIdentity, 16)}`;
+  const cacheKey = `${repositoryKey}/${revisionKey}`;
+  return {
+    cacheKey,
+    path: join(resolveSkillsetXdgPaths(xdg).cache, "remotes", cacheKey),
+  };
+}
+
+export async function acquireRemoteRepository(
+  options: AcquireRemoteRepositoryOptions
+): Promise<RemoteRepositoryCheckout> {
+  const parsed = parseRemoteRepositoryReference(options.repository);
+  const location = resolveRemoteRepositoryCache(options.repository, options.revision, options.xdg);
+  await ensureCacheParent(location, options.xdg);
+  return withCacheLock(location.path, () => acquireRemoteRepositoryUnlocked(options, parsed, location));
+}
+
+async function acquireRemoteRepositoryUnlocked(
+  options: AcquireRemoteRepositoryOptions,
+  parsed: ParsedRemoteRepositoryReference,
+  location: RemoteRepositoryCacheLocation
+): Promise<RemoteRepositoryCheckout> {
+  const existing = await pathKind(location.path);
+  if (existing === "other") throw new Error(`skillset: corrupt remote cache ${location.cacheKey}`);
+  if (existing === "directory") {
+    return acquireExisting(location, parsed, options.revision, options.xdg);
+  }
+
+  const temporary = await mkdtemp(join(dirname(location.path), ".acquire-"));
+  try {
+    await runGit(temporary, ["init", "--quiet"], options.xdg, "initialize");
+    await runGit(temporary, ["remote", "add", "origin", parsed.fetchUrl], options.xdg, "configure origin");
+    const resolved = await synchronizeRevision(temporary, parsed.canonical, options.revision, options.xdg);
+    try {
+      await rename(temporary, location.path);
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) throw error;
+      await rm(temporary, { force: true, recursive: true });
+      return acquireExisting(location, parsed, options.revision, options.xdg);
+    }
+    return checkout(location, parsed.canonical, resolved, false);
+  } catch (error) {
+    await rm(temporary, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+async function withCacheLock<T>(cachePath: string, operation: () => Promise<T>): Promise<T> {
+  const lockPath = `${cachePath}.lock`;
+  const startedAt = Date.now();
+  while (true) {
+    try {
+      await mkdir(lockPath);
+      break;
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) throw error;
+      const lock = await stat(lockPath).catch(() => undefined);
+      if (lock !== undefined && Date.now() - lock.mtimeMs > 10 * 60_000) {
+        await rm(lockPath, { force: true, recursive: true });
+        continue;
+      }
+      if (Date.now() - startedAt > 30_000) {
+        throw new Error("skillset: timed out waiting for the remote cache lock");
+      }
+      await sleep(50);
+    }
+  }
+
+  try {
+    return await operation();
+  } finally {
+    await rm(lockPath, { force: true, recursive: true });
+  }
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function acquireExisting(
+  location: RemoteRepositoryCacheLocation,
+  parsed: ParsedRemoteRepositoryReference,
+  revision: RemoteRepositoryRevision,
+  xdg: SkillsetXdgOptions | undefined
+): Promise<RemoteRepositoryCheckout> {
+  if (!(await isGitRepository(location.path, xdg))) {
+    throw new Error(`skillset: corrupt remote cache ${location.cacheKey}`);
+  }
+  const origin = await runGit(
+    location.path,
+    ["config", "--get", "remote.origin.url"],
+    xdg,
+    "read origin",
+    true
+  );
+  let cached: ParsedRemoteRepositoryReference;
+  try {
+    cached = parseRemoteRepositoryReference(origin);
+  } catch {
+    throw new Error(`skillset: origin mismatch in remote cache ${location.cacheKey}`);
+  }
+  if (cached.canonical !== parsed.canonical) {
+    throw new Error(`skillset: origin mismatch in remote cache ${location.cacheKey}`);
+  }
+  const resolved = await synchronizeRevision(location.path, parsed.canonical, revision, xdg);
+  return checkout(location, parsed.canonical, resolved, true);
+}
+
+async function synchronizeRevision(
+  rootPath: string,
+  repository: string,
+  revision: RemoteRepositoryRevision,
+  xdg: SkillsetXdgOptions | undefined
+): Promise<ResolvedRevision> {
+  validateRemoteRepositoryRevision(revision);
+  if (revision.kind === "sha" && await hasCommit(rootPath, revision.sha, xdg)) {
+    await checkoutCommit(rootPath, revision.sha, xdg);
+    return { fetch: revision.sha, sha: revision.sha };
+  }
+
+  const resolved = await resolveRevision(rootPath, revision, xdg);
+  try {
+    await runGit(rootPath, ["fetch", "--force", "--depth=1", "--no-tags", "origin", resolved.fetch], xdg, "fetch");
+  } catch {
+    throw new Error(`skillset: remote acquisition failed for ${repository} during fetch`);
+  }
+  await checkoutCommit(rootPath, "FETCH_HEAD", xdg);
+  const sha = await runGit(
+    rootPath,
+    ["rev-parse", "--verify", "HEAD^{commit}"],
+    xdg,
+    "verify checkout",
+    true
+  );
+  if (sha !== resolved.sha) {
+    throw new Error(`skillset: resolved remote commit changed during acquisition for ${repository}`);
+  }
+  return resolved;
+}
+
+async function resolveRevision(
+  rootPath: string,
+  revision: RemoteRepositoryRevision,
+  xdg: SkillsetXdgOptions | undefined
+): Promise<ResolvedRevision> {
+  if (revision.kind === "sha") return { fetch: revision.sha, sha: revision.sha };
+  if (revision.kind === "default") {
+    const output = await lsRemote(rootPath, ["--symref", "origin", "HEAD"], xdg);
+    const records = parseRemoteRefs(output);
+    const head = records.find((record) => record.ref === "HEAD");
+    const symbolic = parseSymbolicHead(output);
+    if (head === undefined) throw new Error("skillset: could not resolve the remote default branch");
+    return { fetch: symbolic ?? "HEAD", ...(symbolic === undefined ? {} : { ref: symbolic }), sha: head.sha };
+  }
+  if (revision.kind === "ref") {
+    const candidates = revision.ref.startsWith("refs/")
+      ? [revision.ref, `${revision.ref}^{}`]
+      : [`refs/heads/${revision.ref}`, `refs/tags/${revision.ref}`, `refs/tags/${revision.ref}^{}`];
+    const records = parseRemoteRefs(await lsRemote(rootPath, ["origin", ...candidates], xdg));
+    const selected = selectRequestedRef(records, revision.ref);
+    if (selected === undefined) throw new Error(`skillset: could not resolve ref ${revision.ref}`);
+    return { fetch: selected.ref.replace(/\^\{\}$/u, ""), ref: revision.ref, sha: selected.sha };
+  }
+
+  const tagNames = [`refs/tags/v${revision.version}`, `refs/tags/${revision.version}`];
+  const records = parseRemoteRefs(await lsRemote(
+    rootPath,
+    ["origin", ...tagNames.flatMap((tag) => [tag, `${tag}^{}`])],
+    xdg
+  ));
+  const selected = selectVersionTag(records, tagNames);
+  if (selected === undefined) throw new Error(`skillset: could not resolve version ${revision.version}`);
+  return {
+    fetch: selected.ref.replace(/\^\{\}$/u, ""),
+    ref: selected.ref.replace(/\^\{\}$/u, ""),
+    sha: selected.sha,
+  };
+}
+
+async function lsRemote(
+  rootPath: string,
+  args: readonly string[],
+  xdg: SkillsetXdgOptions | undefined
+): Promise<string> {
+  try {
+    return await runGit(rootPath, ["ls-remote", ...args], xdg, "resolve remote");
+  } catch {
+    throw new Error("skillset: remote repository could not be reached");
+  }
+}
+
+function selectRequestedRef(records: readonly RemoteRefRecord[], requested: string): RemoteRefRecord | undefined {
+  if (requested.startsWith("refs/")) return peeledRecord(records, requested);
+  const branch = peeledRecord(records, `refs/heads/${requested}`);
+  const tag = peeledRecord(records, `refs/tags/${requested}`);
+  if (branch !== undefined && tag !== undefined && branch.sha !== tag.sha) {
+    throw new Error(`skillset: ref ${requested} is ambiguous between a branch and tag`);
+  }
+  return branch ?? tag;
+}
+
+function selectVersionTag(
+  records: readonly RemoteRefRecord[],
+  tagNames: readonly string[]
+): RemoteRefRecord | undefined {
+  const matches = tagNames.flatMap((tag) => {
+    const record = peeledRecord(records, tag);
+    return record === undefined ? [] : [record];
+  });
+  const distinct = new Set(matches.map((record) => record.sha));
+  if (distinct.size > 1) throw new Error("skillset: version tags resolve to different commits");
+  return matches[0];
+}
+
+function peeledRecord(records: readonly RemoteRefRecord[], ref: string): RemoteRefRecord | undefined {
+  return records.find((record) => record.ref === `${ref}^{}`) ?? records.find((record) => record.ref === ref);
+}
+
+function parseRemoteRefs(output: string): readonly RemoteRefRecord[] {
+  const records: RemoteRefRecord[] = [];
+  for (const line of output.split("\n")) {
+    const match = line.match(/^([0-9a-f]{40})\s+(.+)$/u);
+    if (match === null || match[1] === undefined || match[2] === undefined) continue;
+    records.push({ ref: match[2], sha: match[1] });
+  }
+  return records;
+}
+
+function parseSymbolicHead(output: string): string | undefined {
+  const line = output.split("\n").find((candidate) => candidate.startsWith("ref: ") && candidate.endsWith("\tHEAD"));
+  return line?.slice("ref: ".length, -"\tHEAD".length);
+}
+
+async function checkoutCommit(
+  rootPath: string,
+  commit: string,
+  xdg: SkillsetXdgOptions | undefined
+): Promise<void> {
+  await assertSafeWorktree(rootPath, xdg);
+  await runGit(
+    rootPath,
+    ["-c", "core.hooksPath=/dev/null", "checkout", "--quiet", "--detach", "--force", commit],
+    xdg,
+    "checkout",
+    true
+  );
+  await runGit(rootPath, ["clean", "-fdx", "--quiet"], xdg, "clean checkout", true);
+}
+
+async function hasCommit(
+  rootPath: string,
+  sha: string,
+  xdg: SkillsetXdgOptions | undefined
+): Promise<boolean> {
+  try {
+    await runGit(
+      rootPath,
+      ["cat-file", "-e", `${sha}^{commit}`],
+      xdg,
+      "verify cached commit",
+      true
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isGitRepository(rootPath: string, xdg: SkillsetXdgOptions | undefined): Promise<boolean> {
+  try {
+    await assertSafeWorktree(rootPath, xdg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertSafeWorktree(rootPath: string, xdg: SkillsetXdgOptions | undefined): Promise<void> {
+  const expectedRoot = await realpath(rootPath);
+  const worktree = await runGit(
+    rootPath,
+    ["rev-parse", "--show-toplevel"],
+    xdg,
+    "inspect worktree",
+    true
+  );
+  const gitDirectory = await runGit(
+    rootPath,
+    ["rev-parse", "--absolute-git-dir"],
+    xdg,
+    "inspect git directory",
+    true
+  );
+  const [actualWorktree, actualGitDirectory] = await Promise.all([
+    realpath(worktree),
+    realpath(gitDirectory),
+  ]);
+  if (actualWorktree !== expectedRoot || !isContainedPath(expectedRoot, actualGitDirectory)) {
+    throw new Error("skillset: remote cache Git paths escape their cache entry");
+  }
+  const unsafeConfig = await runGitOptional(
+    rootPath,
+    ["config", "--local", "--name-only", "--get-regexp", "^(core\\.(attributesfile|hookspath|worktree)|filter\\.)"],
+    xdg,
+    true
+  );
+  if (unsafeConfig !== undefined) {
+    throw new Error("skillset: remote cache contains unsafe local Git configuration");
+  }
+}
+
+async function runGit(
+  rootPath: string,
+  args: readonly string[],
+  xdg: SkillsetXdgOptions | undefined,
+  operation: string,
+  isolatedConfig = false
+): Promise<string> {
+  try {
+    const result = await execFileAsync("git", ["-C", rootPath, ...args], {
+      env: gitCommandEnv(xdg, isolatedConfig),
+      maxBuffer: 1024 * 1024,
+      timeout: 30_000,
+    });
+    return String(result.stdout).trim();
+  } catch {
+    throw new Error(`skillset: git ${operation} failed`);
+  }
+}
+
+async function runGitOptional(
+  rootPath: string,
+  args: readonly string[],
+  xdg: SkillsetXdgOptions | undefined,
+  isolatedConfig = false
+): Promise<string | undefined> {
+  try {
+    return await runGit(rootPath, args, xdg, "inspect optional config", isolatedConfig);
+  } catch {
+    return undefined;
+  }
+}
+
+function checkout(
+  location: RemoteRepositoryCacheLocation,
+  repository: string,
+  revision: ResolvedRevision,
+  cacheHit: boolean
+): RemoteRepositoryCheckout {
+  return {
+    cacheHit,
+    cacheKey: location.cacheKey,
+    ...(revision.ref === undefined ? {} : { ref: revision.ref }),
+    repository,
+    rootPath: location.path,
+    sha: revision.sha,
+  };
+}
+
+function stableRevisionIdentity(revision: RemoteRepositoryRevision): string {
+  if (revision.kind === "default") return "default";
+  if (revision.kind === "ref") return `ref-${revision.ref}`;
+  if (revision.kind === "sha") return `sha-${revision.sha}`;
+  return `version-${revision.version}`;
+}
+
+function slug(value: string): string {
+  const result = value.toLowerCase().replace(/[^a-z0-9._-]+/gu, "-").replace(/^-+|-+$/gu, "");
+  return result.slice(0, 80) || "remote";
+}
+
+function digest(value: string, length: number): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, length);
+}
+
+function gitCommandEnv(
+  xdg: SkillsetXdgOptions | undefined,
+  isolatedConfig: boolean
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...(xdg?.env ?? {}), GIT_TERMINAL_PROMPT: "0" };
+  for (const key of Object.keys(env)) {
+    if (isGitRepositoryEnv(key)) delete env[key];
+  }
+  if (isolatedConfig) {
+    env.GIT_CONFIG_GLOBAL = "/dev/null";
+    env.GIT_CONFIG_NOSYSTEM = "1";
+    for (const key of Object.keys(env)) {
+      if (/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/u.test(key)) delete env[key];
+    }
+  }
+  return env;
+}
+
+function isGitRepositoryEnv(key: string): boolean {
+  return key === "GIT_DIR" ||
+    key === "GIT_WORK_TREE" ||
+    key === "GIT_INDEX_FILE" ||
+    key === "GIT_OBJECT_DIRECTORY" ||
+    key === "GIT_COMMON_DIR" ||
+    key === "GIT_NAMESPACE" ||
+    key.startsWith("GIT_ALTERNATE_OBJECT");
+}
+
+async function pathKind(path: string): Promise<"directory" | "missing" | "other"> {
+  try {
+    const entry = await lstat(path);
+    return !entry.isSymbolicLink() && entry.isDirectory() ? "directory" : "other";
+  } catch (error) {
+    if (isNotFoundError(error)) return "missing";
+    throw error;
+  }
+}
+
+async function ensureCacheParent(
+  location: RemoteRepositoryCacheLocation,
+  xdg: SkillsetXdgOptions | undefined
+): Promise<void> {
+  const cacheBase = resolveSkillsetXdgPaths(xdg).cache;
+  await mkdir(cacheBase, { recursive: true });
+  const trustedBase = await realpath(cacheBase);
+  const parent = dirname(location.path);
+  const relativeParent = relative(resolve(cacheBase), resolve(parent));
+  if (!isContainedRelativePath(relativeParent)) {
+    throw new Error(`skillset: remote cache ${location.cacheKey} escapes the XDG cache`);
+  }
+
+  let current = cacheBase;
+  for (const segment of relativeParent.split(/[\\/]+/u)) {
+    current = join(current, segment);
+    try {
+      await mkdir(current);
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) throw error;
+    }
+    const entry = await lstat(current);
+    if (entry.isSymbolicLink() || !entry.isDirectory()) {
+      throw new Error(`skillset: corrupt remote cache ${location.cacheKey}`);
+    }
+  }
+  if (!isContainedPath(trustedBase, await realpath(parent))) {
+    throw new Error(`skillset: remote cache ${location.cacheKey} escapes the XDG cache`);
+  }
+}
+
+function isContainedPath(parent: string, candidate: string): boolean {
+  return isContainedRelativePath(relative(parent, candidate));
+}
+
+function isContainedRelativePath(path: string): boolean {
+  return path === "" || (path !== ".." && !path.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute(path));
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && (error.code === "EEXIST" || error.code === "ENOTEMPTY");
+}

--- a/packages/core/src/remote-repository-reference.ts
+++ b/packages/core/src/remote-repository-reference.ts
@@ -1,0 +1,136 @@
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
+
+export type RemoteRepositoryRevision =
+  | { readonly kind: "default" }
+  | { readonly kind: "ref"; readonly ref: string }
+  | { readonly kind: "sha"; readonly sha: string }
+  | { readonly kind: "version"; readonly version: string };
+
+export interface ParsedRemoteRepositoryReference {
+  readonly canonical: string;
+  readonly fetchUrl: string;
+}
+
+export function parseRemoteRepositoryReference(value: string): ParsedRemoteRepositoryReference {
+  const repository = value.trim();
+  if (repository.length === 0) throw new Error("skillset: remote repository reference must be non-empty");
+
+  const github = repository.match(/^github:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/u);
+  if (github !== null) {
+    const owner = github[1];
+    const repo = github[2];
+    if (owner === undefined || repo === undefined) {
+      throw new Error(`skillset: unsupported remote repository reference ${repository}`);
+    }
+    return {
+      canonical: `github:${owner.toLowerCase()}/${repo.toLowerCase()}`,
+      fetchUrl: `https://github.com/${owner}/${repo}.git`,
+    };
+  }
+
+  if (repository.includes("://")) return parseRepositoryUrl(repository);
+
+  const scp = repository.match(/^([^:@/\s]+)@([^:\s/]+):([^\s]+)$/u);
+  if (scp !== null) {
+    const user = scp[1];
+    const host = scp[2];
+    const rawPath = scp[3];
+    const path = rawPath?.replace(/^\/+|\.git$/gu, "");
+    if (user === undefined || host === undefined || path === undefined || path.length === 0 || path.includes("..")) {
+      throw new Error(`skillset: unsupported remote repository reference ${repository}`);
+    }
+    return {
+      canonical: canonicalRemote(host, path, user, "ssh", rawPath?.startsWith("/") === true),
+      fetchUrl: repository,
+    };
+  }
+
+  return parseRepositoryUrl(repository);
+}
+
+function parseRepositoryUrl(repository: string): ParsedRemoteRepositoryReference {
+  let url: URL;
+  try {
+    url = new URL(repository);
+  } catch {
+    throw new Error(`skillset: unsupported remote repository reference ${repository}`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "ssh:") {
+    throw new Error(`skillset: unsupported remote repository protocol ${url.protocol.replace(/:$/u, "")}`);
+  }
+  if (url.password.length > 0 || (url.protocol === "https:" && url.username.length > 0)) {
+    throw new Error("skillset: remote repository references must not contain credentials");
+  }
+  if (url.search.length > 0 || url.hash.length > 0) {
+    throw new Error("skillset: remote repository references must not contain query or fragment data");
+  }
+  let path: string;
+  try {
+    path = decodeURIComponent(url.pathname).replace(/^\/+|\.git$/gu, "");
+  } catch {
+    throw new Error(`skillset: unsupported remote repository reference ${repository}`);
+  }
+  if (url.hostname.length === 0 || path.length === 0 || path.includes("..")) {
+    throw new Error(`skillset: unsupported remote repository reference ${repository}`);
+  }
+  return {
+    canonical: canonicalRemote(
+      url.host,
+      path,
+      url.protocol === "ssh:" ? url.username || "git" : undefined,
+      url.protocol === "ssh:" ? "ssh" : "https"
+    ),
+    fetchUrl: repository,
+  };
+}
+
+export function validateRemoteRepositoryRevision(revision: RemoteRepositoryRevision): void {
+  if (revision.kind === "sha" && !FULL_SHA_PATTERN.test(revision.sha)) {
+    throw new Error("skillset: remote repository sha must be a full lowercase 40-character commit");
+  }
+  if (revision.kind === "version" && !SEMVER_PATTERN.test(revision.version)) {
+    throw new Error("skillset: remote repository version must be a semantic version");
+  }
+  if (revision.kind === "ref" && !isSafeRemoteRepositoryRef(revision.ref)) {
+    throw new Error(`skillset: unsupported remote repository ref ${revision.ref}`);
+  }
+}
+
+export function isSafeRemoteRepositoryRef(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._/-]*$/u.test(value) &&
+    !value.includes("..") &&
+    !value.includes("//") &&
+    !value.includes("@{") &&
+    !value.endsWith(".") &&
+    !value.endsWith("/") &&
+    !value.endsWith(".lock");
+}
+
+export function isFullRemoteRepositorySha(value: string): boolean {
+  return FULL_SHA_PATTERN.test(value);
+}
+
+export function isRemoteRepositoryVersion(value: string): boolean {
+  return SEMVER_PATTERN.test(value);
+}
+
+function canonicalRemote(
+  host: string,
+  path: string,
+  user?: string,
+  protocol: "https" | "ssh" = "ssh",
+  absolutePath = true
+): string {
+  const normalizedHost = host.toLowerCase();
+  const normalizedPath = path.replace(/^\/+|\.git$/gu, "");
+  if (normalizedHost === "github.com") {
+    const [owner, repo, ...rest] = normalizedPath.split("/");
+    if (owner !== undefined && repo !== undefined && rest.length === 0) {
+      return `github:${owner.toLowerCase()}/${repo.toLowerCase()}`;
+    }
+  }
+  if (protocol === "https") return `https://${normalizedHost}/${normalizedPath}`;
+  return `ssh:${user === undefined ? "" : `${user}@`}${normalizedHost}${absolutePath ? ":/" : ":"}${normalizedPath}`;
+}

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -18,6 +18,7 @@ import {
   readStringArray,
   stripSourceFrontmatter,
 } from "./config";
+import { storedClaudeMarketplaceProviderEntry } from "./claude-marketplace";
 import {
   pluginDependencies,
   pluginDependencyHashSummaries,
@@ -28,7 +29,9 @@ import {
 import { nativeHookEventName } from "./hook-capabilities";
 import { validateHookDefinition } from "./hooks";
 import { resolveLicense, type ResolvedLicense } from "./licenses";
+import { marketplaceRequestedRefPolicy } from "./marketplace-ref-policy";
 import { compareStrings, validateSlug } from "./path";
+import { corruptWorkspaceLock } from "./output-safety";
 import {
   claudeMarketplacePath,
   isDefaultPluginOutputRoot,
@@ -37,6 +40,7 @@ import {
   providerSourceForPlugin,
 } from "./plugin-output";
 import { rewriteResourceLinks } from "./resources";
+import { parseRemoteRepositoryReference } from "./remote-repository-reference";
 import {
   readAllowedTools,
   readClaudeNativeToolRules,
@@ -62,6 +66,8 @@ import type {
   BuildGraph,
   JsonRecord,
   JsonValue,
+  MarketplaceCatalogConfig,
+  MarketplacePluginEntryConfig,
   RenderedFile,
   SourceIslandFile,
   SourceOrigin,
@@ -188,7 +194,7 @@ export async function renderBuildGraph(graph: BuildGraph): Promise<readonly Rend
   if (Object.keys(graph.root.marketplaces).length > 0) {
     lockRootsFor(lockRoots, WORKSPACE_LOCK_ROOT, "workspace");
   }
-  rendered.push(...renderLockFiles(graph, lockRoots));
+  rendered.push(...(await renderLockFiles(graph, lockRoots)));
   return [...coalesceRenderedFiles(rendered)]
     .sort((left, right) => compareStrings(left.path, right.path))
     .map((file) => validateRenderedFile(file));
@@ -303,28 +309,36 @@ function marketplaceReadmeLines(outputRoot: string, target: TargetName): readonl
 }
 
 async function renderClaudeMarketplace(graph: BuildGraph): Promise<readonly RenderedFile[]> {
-  const rootLicense = await resolveRootLicense(graph);
-  const plugins = [];
-  for (const plugin of graph.plugins.filter((candidate) => shouldRenderPlugin(graph, candidate, "claude"))) {
-    const metadata = plugin.metadata;
-    const pluginLicense = await resolvePluginLicense(graph, plugin, rootLicense);
-    plugins.push(
-      mergeRecords(
-        {
-          name: plugin.id,
-          source: providerSourceForPlugin(graph.root.outputs.plugins.claude, "claude", plugin.id),
-          description: readString(metadata, "summary") ?? readString(metadata, "description") ?? plugin.id,
-          version: pluginVersion(graph, plugin),
-          author: metadata.author,
-          repository: metadata.repository,
-          license: pluginLicense?.manifestValue,
-          keywords: metadata.keywords,
-          category: metadata.category,
-          strict: metadata.strict,
-        },
-        readRecord(plugin.targets.claude.options, "marketplace") ?? {}
+  const existingState = await readExistingMarketplaceState(graph.rootPath);
+  const declaredCatalog = selectClaudeMarketplaceCatalog(graph, existingState);
+  if (declaredCatalog !== undefined) {
+    const [catalogName, catalog] = declaredCatalog;
+    const rootLicense = await resolveRootLicense(graph);
+    const plugins: JsonRecord[] = [];
+    for (const entry of catalog.plugins) {
+      if (!(entry.targets ?? catalog.targets).includes("claude")) continue;
+      if (entry.repo !== undefined) {
+        const providerEntry = lockedClaudeProviderEntry(existingState.entries, catalogName, entry);
+        if (providerEntry !== undefined) plugins.push(providerEntry);
+        continue;
+      }
+      const plugin = graph.plugins.find((candidate) => candidate.id === entry.plugin);
+      if (plugin === undefined || !shouldRenderPlugin(graph, plugin, "claude")) continue;
+      plugins.push(await renderClaudeMarketplacePlugin(graph, plugin, rootLicense));
+    }
+    return [textFile(
+      claudeMarketplacePath(graph.root.outputs.plugins.claude),
+      renderValidatedJson(
+        renderClaudeMarketplaceDocument(graph, catalogName, catalog, plugins),
+        "Claude marketplace"
       )
-    );
+    )];
+  }
+
+  const rootLicense = await resolveRootLicense(graph);
+  const plugins: JsonRecord[] = [];
+  for (const plugin of graph.plugins.filter((candidate) => shouldRenderPlugin(graph, candidate, "claude"))) {
+    plugins.push(await renderClaudeMarketplacePlugin(graph, plugin, rootLicense));
   }
 
   if (plugins.length === 0) return [];
@@ -356,6 +370,94 @@ async function renderClaudeMarketplace(graph: BuildGraph): Promise<readonly Rend
       renderValidatedJson(marketplace, "Claude marketplace")
     ),
   ];
+}
+
+async function renderClaudeMarketplacePlugin(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  rootLicense: ResolvedLicense | undefined
+): Promise<JsonRecord> {
+  const metadata = plugin.metadata;
+  const pluginLicense = await resolvePluginLicense(graph, plugin, rootLicense);
+  return mergeRecords(
+    {
+      name: plugin.id,
+      source: providerSourceForPlugin(graph.root.outputs.plugins.claude, "claude", plugin.id),
+      description: readString(metadata, "summary") ?? readString(metadata, "description") ?? plugin.id,
+      version: pluginVersion(graph, plugin),
+      author: metadata.author,
+      repository: metadata.repository,
+      license: pluginLicense?.manifestValue,
+      keywords: metadata.keywords,
+      category: metadata.category,
+      strict: metadata.strict,
+    },
+    readRecord(plugin.targets.claude.options, "marketplace") ?? {}
+  );
+}
+
+export function renderClaudeMarketplaceDocument(
+  graph: BuildGraph,
+  catalogName: string,
+  catalog: MarketplaceCatalogConfig,
+  plugins: readonly JsonRecord[]
+): JsonRecord {
+  const root = graph.root.metadata;
+  const owner = readRecord(root, "owner") ??
+    readRecord(root, "author") ??
+    { name: readString(root, "name") ?? catalogName };
+  return {
+    name: catalogName,
+    owner,
+    ...(catalog.description === undefined ? {} : { description: catalog.description }),
+    metadata: {
+      description:
+        catalog.description ??
+        readString(root, "summary") ??
+        readString(root, "description") ??
+        "Source-first Skillset plugins",
+      generatedBy: GENERATED_BY,
+      version: rootVersion(graph),
+    },
+    plugins: [...plugins].sort((left, right) => compareStrings(String(left.name), String(right.name))),
+  };
+}
+
+function selectClaudeMarketplaceCatalog(
+  graph: BuildGraph,
+  existingState: ExistingMarketplaceState
+): readonly [string, MarketplaceCatalogConfig] | undefined {
+  const catalogs = Object.entries(graph.root.marketplaces)
+    .filter(([, catalog]) => catalog.plugins.some((entry) => (entry.targets ?? catalog.targets).includes("claude")))
+    .sort(([left], [right]) => compareStrings(left, right));
+  const activeCatalog = optionalString(existingState.activeCatalogs.claude);
+  if (activeCatalog !== undefined) {
+    const selected = catalogs.find(([name]) => name === activeCatalog);
+    if (selected !== undefined) return selected;
+  }
+  const onlyCatalog = catalogs[0];
+  if (catalogs.length === 1 && onlyCatalog !== undefined) return onlyCatalog;
+  return undefined;
+}
+
+function lockedClaudeProviderEntry(
+  existingEntries: readonly JsonRecord[],
+  catalogName: string,
+  entry: MarketplacePluginEntryConfig
+): JsonRecord | undefined {
+  if (entry.repo === undefined) return undefined;
+  const requested = marketplaceRequestedRefPolicy(entry) as unknown as JsonRecord;
+  const locked = existingEntries.find((candidate) =>
+    candidate.catalog === catalogName &&
+    candidate.entryId === entry.id &&
+    candidate.plugin === entry.plugin &&
+    candidate.repo === entry.repo &&
+    candidate.requestedTarget === "claude" &&
+    candidate.readiness === "marketplace-ready" &&
+    isJsonRecord(candidate.requested) &&
+    marketplaceRequestedPoliciesEqual(candidate.requested, requested)
+  );
+  return locked === undefined ? undefined : storedClaudeMarketplaceProviderEntry(locked);
 }
 
 async function renderCursorMarketplace(graph: BuildGraph): Promise<readonly RenderedFile[]> {
@@ -2411,11 +2513,12 @@ async function copyPath(sourcePath: string, targetPath: string): Promise<readonl
   return files;
 }
 
-function renderLockFiles(
+async function renderLockFiles(
   graph: BuildGraph,
   lockRoots: ReadonlyMap<string, LockRoot>
-): readonly RenderedFile[] {
+): Promise<readonly RenderedFile[]> {
   const rendered: RenderedFile[] = [];
+  const existingMarketplaceState = await readExistingMarketplaceState(graph.rootPath);
 
   for (const [outputRoot, lock] of [...lockRoots.entries()].sort(([left], [right]) => compareStrings(left, right))) {
     const value: JsonRecord = {
@@ -2427,7 +2530,9 @@ function renderLockFiles(
       items: lock.items
         .map((item) => stripUndefinedLockItem(item))
         .sort((left, right) => compareStrings(String(left.outputPath), String(right.outputPath))),
-      ...(outputRoot === WORKSPACE_LOCK_ROOT ? marketplaceLockProvenance(graph, lockRoots) : {}),
+      ...(outputRoot === WORKSPACE_LOCK_ROOT
+        ? marketplaceLockProvenance(graph, lockRoots, existingMarketplaceState)
+        : {}),
       selectedTargets: [...graph.root.compile.targets],
       skillsetMetadata: graph.root.compile.skillset.metadata,
       outputRoot,
@@ -2443,13 +2548,32 @@ function renderLockFiles(
 
 function marketplaceLockProvenance(
   graph: BuildGraph,
-  lockRoots: ReadonlyMap<string, LockRoot>
+  lockRoots: ReadonlyMap<string, LockRoot>,
+  existingState: ExistingMarketplaceState
 ): JsonRecord {
   const entries: JsonRecord[] = [];
   for (const [catalogName, catalog] of Object.entries(graph.root.marketplaces).sort(([left], [right]) => compareStrings(left, right))) {
     for (const entry of catalog.plugins) {
-      const plugin = graph.plugins.find((candidate) => candidate.id === entry.plugin);
+      const requested = marketplaceRequestedRefPolicy(entry) as unknown as JsonRecord;
+      const plugin = entry.repo === undefined
+        ? graph.plugins.find((candidate) => candidate.id === entry.plugin)
+        : undefined;
       for (const target of entry.targets ?? catalog.targets) {
+        if (entry.repo !== undefined) {
+          const preserved = preserveExternalMarketplaceEntry(
+            existingState.entries,
+            catalogName,
+            entry.id,
+            entry.plugin,
+            entry.repo,
+            requested,
+            target
+          );
+          if (preserved !== undefined) {
+            entries.push(preserved);
+            continue;
+          }
+        }
         const generatedPath = plugin === undefined ? undefined : marketplacePluginManifestPath(graph, plugin, target);
         const renderable = plugin !== undefined && plugin.targets[target].enabled && isOutputSelected(graph.root.outputs.targetOutputs[target].plugins, plugin.id);
         const generatedPaths = renderable ? marketplaceGeneratedPaths(lockRoots, graph.root.outputs.plugins[target], target, entry.plugin) : [];
@@ -2463,22 +2587,164 @@ function marketplaceLockProvenance(
           providerSource: provider,
           readiness: renderable ? "marketplace-ready" : "not-ready",
           repo: entry.repo,
-          requested: marketplaceRequestedPolicy(entry),
+          requested,
           requestedTarget: target,
           resolved: stripUndefinedJsonRecord({
             generatedPath,
             generatedPaths: [...generatedPaths],
             pluginVersion: plugin === undefined ? undefined : pluginVersion(graph, plugin),
             providerSource: provider,
-            repository: entry.repo,
+            repository: entry.repo === undefined
+              ? undefined
+              : parseRemoteRepositoryReference(entry.repo).canonical,
             sourceKind: entry.repo === undefined ? "current" : "unresolved",
-            sourcePath: entry.repo === undefined ? "." : undefined,
           }),
         }));
       }
     }
   }
-  return entries.length === 0 ? {} : { marketplaces: { entries: entries.sort((left, right) => compareStrings(`${left.catalog}\0${left.entryId}\0${left.requestedTarget}`, `${right.catalog}\0${right.entryId}\0${right.requestedTarget}`)) } };
+  return entries.length === 0 ? {} : {
+    marketplaces: {
+      activeCatalogs: activeMarketplaceCatalogs(graph, existingState.activeCatalogs),
+      entries: entries.sort((left, right) => compareStrings(`${left.catalog}\0${left.entryId}\0${left.requestedTarget}`, `${right.catalog}\0${right.entryId}\0${right.requestedTarget}`)),
+    },
+  };
+}
+
+interface ExistingMarketplaceState {
+  readonly activeCatalogs: JsonRecord;
+  readonly entries: readonly JsonRecord[];
+}
+
+const EMPTY_MARKETPLACE_STATE: ExistingMarketplaceState = { activeCatalogs: {}, entries: [] };
+
+async function readExistingMarketplaceState(rootPath: string): Promise<ExistingMarketplaceState> {
+  let raw: string;
+  try {
+    raw = await readFile(join(rootPath, "skillset.lock"), "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return EMPTY_MARKETPLACE_STATE;
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw corruptWorkspaceLock("skillset.lock", `it is not valid JSON: ${message}`);
+  }
+  if (!isJsonRecord(parsed)) {
+    throw corruptWorkspaceLock("skillset.lock", "it is missing a string generatedBy field");
+  }
+  const marketplaces = parsed.marketplaces;
+  if (!isJsonRecord(marketplaces)) return EMPTY_MARKETPLACE_STATE;
+  return {
+    activeCatalogs: isJsonRecord(marketplaces.activeCatalogs) ? marketplaces.activeCatalogs : {},
+    entries: Array.isArray(marketplaces.entries) ? marketplaces.entries.filter(isJsonRecord) : [],
+  };
+}
+
+function activeMarketplaceCatalogs(graph: BuildGraph, existing: JsonRecord): JsonRecord {
+  const active: Record<string, JsonValue> = {};
+  for (const target of targetNames()) {
+    const catalogs = Object.entries(graph.root.marketplaces)
+      .filter(([, catalog]) => catalog.plugins.some((entry) => (entry.targets ?? catalog.targets).includes(target)))
+      .sort(([left], [right]) => compareStrings(left, right));
+    const requested = optionalString(existing[target]);
+    const selected = requested === undefined ? undefined : catalogs.find(([name]) => name === requested);
+    if (selected !== undefined) {
+      active[target] = selected[0];
+      continue;
+    }
+    const onlyCatalog = catalogs[0];
+    if (catalogs.length === 1 && onlyCatalog !== undefined) active[target] = onlyCatalog[0];
+  }
+  return active;
+}
+
+function preserveExternalMarketplaceEntry(
+  existingEntries: readonly JsonRecord[],
+  catalog: string,
+  entryId: string,
+  plugin: string,
+  repo: string,
+  requested: JsonRecord,
+  target: TargetName
+): JsonRecord | undefined {
+  const existing = existingEntries.find((candidate) =>
+    candidate.catalog === catalog &&
+    candidate.entryId === entryId &&
+    candidate.plugin === plugin &&
+    candidate.repo === repo &&
+    candidate.requestedTarget === target &&
+    isJsonRecord(candidate.requested) &&
+    marketplaceRequestedPoliciesEqual(candidate.requested, requested)
+  );
+  if (existing === undefined || existing.readiness !== "marketplace-ready" || !isJsonRecord(existing.resolved)) {
+    return undefined;
+  }
+  const resolved = existing.resolved;
+  if (!isStringArray(existing.generatedPaths) || !isStringArray(resolved.generatedPaths)) return undefined;
+  const providerEntry = target === "claude" ? storedClaudeMarketplaceProviderEntry(existing) : undefined;
+  if (target === "claude" && providerEntry === undefined) return undefined;
+  if (typeof existing.providerSource !== "string" || typeof resolved.providerSource !== "string") return undefined;
+  if (typeof resolved.sha !== "string" || !/^[0-9a-f]{40}$/u.test(resolved.sha)) return undefined;
+  const generatedPath = optionalString(existing.generatedPath);
+  const resolvedGeneratedPath = optionalString(resolved.generatedPath);
+  if (generatedPath !== undefined && !isPortableMarketplacePath(generatedPath)) return undefined;
+  if (resolvedGeneratedPath !== undefined && !isPortableMarketplacePath(resolvedGeneratedPath)) return undefined;
+  if (!existing.generatedPaths.every(isPortableMarketplacePath)) return undefined;
+  if (!resolved.generatedPaths.every(isPortableMarketplacePath)) return undefined;
+  if (!isPortableMarketplacePath(existing.providerSource) || !isPortableMarketplacePath(resolved.providerSource)) {
+    return undefined;
+  }
+
+  return stripUndefinedJsonRecord({
+    catalog,
+    entryId,
+    generatedPath,
+    generatedPaths: [...existing.generatedPaths],
+    plugin,
+    ...(providerEntry === undefined ? {} : { providerEntry }),
+    providerSource: existing.providerSource,
+    readiness: "marketplace-ready",
+    repo,
+    requested,
+    requestedTarget: target,
+    resolved: stripUndefinedJsonRecord({
+      generatedPath: resolvedGeneratedPath,
+      generatedPaths: [...resolved.generatedPaths],
+      pluginVersion: optionalString(resolved.pluginVersion),
+      providerSource: resolved.providerSource,
+      ref: optionalString(resolved.ref),
+      repository: parseRemoteRepositoryReference(repo).canonical,
+      sha: resolved.sha,
+      sourceKind: "external",
+    }),
+  });
+}
+
+function marketplaceRequestedPoliciesEqual(left: JsonRecord, right: JsonRecord): boolean {
+  return left.kind === right.kind &&
+    left.channel === right.channel &&
+    left.ref === right.ref &&
+    left.sha === right.sha &&
+    left.version === right.version;
+}
+
+function isStringArray(value: JsonValue | undefined): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function optionalString(value: JsonValue | undefined): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isPortableMarketplacePath(value: string): boolean {
+  return !value.startsWith("/") &&
+    !value.startsWith("~") &&
+    !/^[A-Za-z]:[\\/]/u.test(value) &&
+    !value.split(/[\\/]+/u).includes("..");
 }
 
 function marketplaceGeneratedPaths(
@@ -2498,20 +2764,6 @@ function marketplaceGeneratedPaths(
     }
   }
   return [...paths].sort(compareStrings);
-}
-
-function marketplaceRequestedPolicy(entry: {
-  readonly channel?: string;
-  readonly ref?: string;
-  readonly repo?: string;
-  readonly sha?: string;
-  readonly version?: string;
-}): JsonRecord {
-  if (entry.sha !== undefined) return { kind: "sha", sha: entry.sha };
-  if (entry.ref !== undefined) return { kind: "ref", ref: entry.ref };
-  if (entry.channel !== undefined) return { channel: entry.channel, kind: "channel" };
-  if (entry.version !== undefined) return { kind: "version", version: entry.version };
-  return { kind: "local" };
 }
 
 function marketplacePluginManifestPath(graph: BuildGraph, plugin: SourcePlugin, target: TargetName): string {

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -345,6 +345,46 @@ describe("@skillset/schema contracts", () => {
     });
   });
 
+  it("keeps marketplace repository and revision policy structurally safe", () => {
+    expect(validateWorkspaceConfig({
+      marketplaces: {
+        outfitter: {
+          plugins: [
+            { plugin: "github", repo: "github:outfitter-dev/skillset", sha: "a".repeat(40) },
+            { plugin: "https", ref: "release/1.0", repo: "https://git.example:8443/acme/plugin.git" },
+            { plugin: "ssh", repo: "ssh://git@git.example/acme/plugin.git", version: "1.2.3" },
+            { channel: "latest", plugin: "scp", repo: "git@git.example:acme/plugin.git" },
+          ],
+        },
+      },
+    }).diagnostics).toEqual([]);
+
+    const invalid = validateWorkspaceConfig({
+      marketplaces: {
+        outfitter: {
+          plugins: [
+            {
+              channel: "nightly",
+              plugin: "bad",
+              ref: "../main",
+              repo: "https://user:SENTINEL@git.example:443/acme/plugin.git",
+              sha: "deadbeef",
+              version: "next",
+            },
+          ],
+        },
+      },
+    });
+    expect(invalid.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(expect.arrayContaining([
+      "schema/workspace-config/marketplace-plugin-channel",
+      "schema/workspace-config/marketplace-plugin-policy",
+      "schema/workspace-config/marketplace-plugin-ref",
+      "schema/workspace-config/marketplace-plugin-repo",
+      "schema/workspace-config/marketplace-plugin-sha",
+      "schema/workspace-config/marketplace-plugin-version",
+    ]));
+  });
+
   it("validates shared source metadata and frontmatter", () => {
     expect(validateSourceMetadata({
       author: { name: "Outfitter" },

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -400,21 +400,29 @@ function marketplaceCatalogsSchema(): SchemaJsonRecord {
 function marketplacePluginEntrySchema(): SchemaJsonRecord {
   return {
     ...strictObjectSchema({
-      channel: nonEmptyStringSchema(),
+      channel: { const: "latest", type: "string" },
       id: { pattern: "^[a-z0-9][a-z0-9-]*$", type: "string" },
       plugin: { pattern: "^[a-z0-9][a-z0-9-]*$", type: "string" },
-      ref: nonEmptyStringSchema(),
-      repo: {
-        minLength: 1,
-        not: {
-          pattern: "^(?:\\.|/|~|file:|[A-Za-z]:[\\\\/])",
-        },
+      ref: {
+        pattern: "^(?!.*(?:\\.\\.|//|@\\{|\\.lock$))[A-Za-z0-9][A-Za-z0-9._/-]*(?<![./])$",
         type: "string",
       },
-      sha: nonEmptyStringSchema(),
+      repo: {
+        pattern: "^(?:github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\\.git)?|[^:@/\\s]+@[^:\\s/]+:[^\\s]+|https://(?![^/]*@)[^\\s/?#]+/[^\\s?#]+|ssh://(?:[^:@\\s]+@)?[^\\s/?#]+/[^\\s?#]+)$",
+        type: "string",
+      },
+      sha: { pattern: "^[0-9a-f]{40}$", type: "string" },
       targets: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
-      version: nonEmptyStringSchema(),
+      version: semverStringSchema(),
     }),
+    allOf: [
+      ["channel", "ref"],
+      ["channel", "sha"],
+      ["channel", "version"],
+      ["ref", "sha"],
+      ["ref", "version"],
+      ["sha", "version"],
+    ].map((required) => ({ not: { required } })),
     required: ["plugin"],
   };
 }

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -30,6 +30,8 @@ const toolsPolicyKeys = new Set<string>(["claude", "codex", "cursor", "mcp", "re
 const toolsProviderKeys = new Set<string>(["allow", "deny", "mcp", "read", "search", "shell", "write"]);
 const semverPattern =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const fullGitShaPattern = /^[0-9a-f]{40}$/;
+const safeGitRefPattern = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 
 export function validateWorkspaceConfig(value: unknown, path = "$"): SkillsetSchemaValidationResult {
   const diagnostics: SkillsetSchemaDiagnostic[] = [];
@@ -272,10 +274,22 @@ function checkMarketplacePluginEntry(value: SchemaJsonValue, path: string, diagn
   } else {
     checkOptionalMarketplaceId(value.plugin, `${path}.plugin`, diagnostics);
   }
-  checkOptionalNonEmptyString(value.channel, `${path}.channel`, "schema/workspace-config/marketplace-plugin-channel", diagnostics);
-  checkOptionalNonEmptyString(value.ref, `${path}.ref`, "schema/workspace-config/marketplace-plugin-ref", diagnostics);
-  checkOptionalNonEmptyString(value.sha, `${path}.sha`, "schema/workspace-config/marketplace-plugin-sha", diagnostics);
-  checkOptionalNonEmptyString(value.version, `${path}.version`, "schema/workspace-config/marketplace-plugin-version", diagnostics);
+  if (value.channel !== undefined && value.channel !== "latest") {
+    diagnostics.push(diagnostic(`${path}.channel`, "schema/workspace-config/marketplace-plugin-channel", "marketplace plugin channel must be latest"));
+  }
+  if (value.ref !== undefined && (typeof value.ref !== "string" || !isSafeGitRef(value.ref))) {
+    diagnostics.push(diagnostic(`${path}.ref`, "schema/workspace-config/marketplace-plugin-ref", "marketplace plugin ref must be a safe Git ref"));
+  }
+  if (value.sha !== undefined && (typeof value.sha !== "string" || !fullGitShaPattern.test(value.sha))) {
+    diagnostics.push(diagnostic(`${path}.sha`, "schema/workspace-config/marketplace-plugin-sha", "marketplace plugin sha must be a full lowercase 40-character commit"));
+  }
+  if (value.version !== undefined && (typeof value.version !== "string" || !semverPattern.test(value.version))) {
+    diagnostics.push(diagnostic(`${path}.version`, "schema/workspace-config/marketplace-plugin-version", "marketplace plugin version must be a semantic version"));
+  }
+  const policies = [value.channel, value.ref, value.sha, value.version].filter((item) => item !== undefined);
+  if (policies.length > 1) {
+    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin-policy", "marketplace plugin entries may set at most one of channel, ref, sha, or version"));
+  }
   checkMarketplaceRepo(value.repo, `${path}.repo`, diagnostics);
   if (value.targets !== undefined) checkTargets(value.targets, `${path}.targets`, diagnostics, "marketplace plugin targets");
 }
@@ -293,8 +307,42 @@ function checkMarketplaceRepo(value: SchemaJsonValue | undefined, path: string, 
     diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin-repo", "marketplace plugin repo must be a non-empty string"));
     return;
   }
-  if (value.startsWith(".") || value.startsWith("/") || value.startsWith("~") || value.startsWith("file:") || /^[A-Za-z]:[\\/]/.test(value)) {
-    diagnostics.push(diagnostic(path, "schema/workspace-config/marketplace-plugin-repo", "marketplace plugin repo must be a remote repo reference, not a filesystem path"));
+  if (!isSupportedRemoteRepository(value)) {
+    diagnostics.push(diagnostic(
+      path,
+      "schema/workspace-config/marketplace-plugin-repo",
+      "marketplace plugin repo must be a remote repo reference using credential-free GitHub, HTTPS, SSH, or SCP syntax, not a filesystem path"
+    ));
+  }
+}
+
+function isSafeGitRef(value: string): boolean {
+  return safeGitRefPattern.test(value) &&
+    !value.includes("..") &&
+    !value.includes("//") &&
+    !value.includes("@{") &&
+    !value.endsWith(".") &&
+    !value.endsWith("/") &&
+    !value.endsWith(".lock");
+}
+
+function isSupportedRemoteRepository(value: string): boolean {
+  if (/^github:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(value)) return true;
+  if (!value.includes("://") && /^[^:@/\s]+@[^:\s/]+:[^\s]+$/.test(value)) return !value.includes("..");
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "ssh:") return false;
+  if (url.password.length > 0 || (url.protocol === "https:" && url.username.length > 0)) return false;
+  if (url.search.length > 0 || url.hash.length > 0 || url.hostname.length === 0) return false;
+  try {
+    const path = decodeURIComponent(url.pathname).replace(/^\/+|\.git$/g, "");
+    return path.length > 0 && !path.includes("..");
+  } catch {
+    return false;
   }
 }
 

--- a/scripts/test-helpers/git-remote.ts
+++ b/scripts/test-helpers/git-remote.ts
@@ -1,0 +1,66 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface TestGitRemote {
+  readonly env: Record<string, string>;
+  readonly remotePath: string;
+  readonly repository: string;
+  readonly sha: string;
+  readonly workPath: string;
+  readonly xdg: {
+    readonly env: Record<string, string>;
+    readonly homeDir: string;
+  };
+}
+
+export async function createTestGitRemote(
+  workPath: string,
+  options: { readonly repository?: string; readonly rootPath?: string } = {}
+): Promise<TestGitRemote> {
+  const rootPath = options.rootPath ?? await mkdtemp(join(tmpdir(), "skillset-test-git-remote-"));
+  const remotePath = join(rootPath, "origin.git");
+  const repository = options.repository ?? "https://git.example/acme/plugin.git";
+  await runTestGit(workPath, "init", "--initial-branch=main");
+  await runTestGit(workPath, "config", "user.email", "skillset@example.test");
+  await runTestGit(workPath, "config", "user.name", "Skillset Tests");
+  await runTestGit(workPath, "add", "--all");
+  await runTestGit(workPath, "commit", "-m", "fixture");
+  const sha = await runTestGit(workPath, "rev-parse", "HEAD");
+  await runTestGit(rootPath, "clone", "--bare", workPath, remotePath);
+  const env = {
+    GIT_ALLOW_PROTOCOL: "file",
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: `url.file://${remotePath}/.insteadOf`,
+    GIT_CONFIG_VALUE_0: repository,
+    XDG_CACHE_HOME: join(rootPath, "cache"),
+    XDG_CONFIG_HOME: join(rootPath, "config"),
+  };
+  return {
+    env,
+    remotePath,
+    repository,
+    sha,
+    workPath,
+    xdg: {
+      env,
+      homeDir: join(rootPath, "home"),
+    },
+  };
+}
+
+export async function runTestGit(cwd: string, ...args: readonly string[]): Promise<string> {
+  const proc = Bun.spawn({
+    cmd: ["git", "-C", cwd, ...args],
+    env: process.env,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`${stdout}${stderr}`.trim());
+  return stdout.trim();
+}


### PR DESCRIPTION
## Context

SET-268 is the Skillset-local prerequisite for catalog-owned marketplace refresh automation. Marketplace entries may point at plugins in another repository, so `skillset marketplace check` and `skillset marketplace update` need deterministic, automatic remote resolution without repo-local cache state or user-supplied cache configuration.

This PR is stacked on #254, which contains the accepted SET-237 design and follow-up issue split.

## What changed

- resolves GitHub, HTTPS, SSH, and SCP repository references into revision-specific XDG cache entries
- supports exact SHA, ref, semantic-version tag, and `latest` resolution policies with strict validation
- serializes concurrent acquisition, publishes cold caches atomically, verifies origins and containment, and disables inherited Git hooks/filter configuration
- keeps checkout roots and cache keys private while writing portable repository/ref/SHA provenance to `skillset.lock`
- falls back from dirty or invalid known-Skillset checkouts to immutable remote-cache state without refreshing the external Git index
- validates stored external Claude provider entries and fails closed when their lock proof is missing or malformed
- records the active catalog for each provider output so sequential named updates remain deterministic and verify offline
- renders provider-index and lock bytes before mutation, then installs both through a rollback-capable staged file-set transaction
- preserves external Claude marketplace entries through ordinary network-free build and verify
- adds schema, CLI, core, cache, security, determinism, tamper, multi-catalog, transaction, and mixed local/external regression coverage
- documents the automatic cache and refresh behavior and adds a public patch Changeset

## Verification

- focused cache/marketplace slice (154 passed during standing review)
- `bun run schema:check`
- `bun run check` (889 passed across 77 files)
- `bun run conformance:fast` (21 passed)
- `bun run hooks:pre-push`
- exact-SHA hosted `changeset`, `check`, and `skillset-ci` checks pass
- standing local review: 5/5, zero open P0-P3 findings
- targeted local review: 5/5, zero open P0-P3 findings

## Risks

Remote acquisition is intentionally read-only with respect to source repositories. Floating policies re-resolve the remote and do not claim a warm cache is current while offline; exact SHA caches may be reused offline after origin and commit verification. Reports and committed locks omit local checkout paths, cache keys, credentials, and local Git URLs. Provider-native snapshots and active catalog ownership live in the existing `skillset.lock`; malformed or missing external proof invalidates readiness instead of silently removing a catalog entry. Provider-index and lock replacement is rollback-capable for runtime failures; an interrupted process may leave a private staging directory but cannot expose it as committed output.

## Tracking

- [SET-268](https://linear.app/outfitter/issue/SET-268/resolve-external-marketplace-repositories-into-deterministic-xdg-cache)