### PR TITLE
fix(release): verify generated release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch: {}
   push:
     branches: [main]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.repository == 'outfitter-dev/skillset' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -49,6 +50,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: bun run publish:label-release-pr
+      - name: Trigger version PR CI
+        if: steps.pending-changesets.outputs.has_changesets == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yml --ref changeset-release/main
 
   publish-plan:
     name: Publish Plan

--- a/scripts/__tests__/release-policy.test.ts
+++ b/scripts/__tests__/release-policy.test.ts
@@ -5,6 +5,8 @@ import {
   type ReleasePolicyInput,
   ciStateFromCheckRuns,
   evaluateReleasePolicy,
+  planReleasePullRequestLabels,
+  readReleaseLabelVersions,
   shouldReadExactShaCi,
 } from "../release-policy";
 import { distTagForVersion } from "../publish";
@@ -282,6 +284,56 @@ describe("npm dist-tag derivation", () => {
     expect(distTagForVersion("0.13.4")).toBe("latest");
     expect(distTagForVersion("0.14.0-beta.1")).toBe("beta");
     expect(distTagForVersion("0.14.0-canary.20260615")).toBe("canary");
+  });
+});
+
+describe("release PR label planning", () => {
+  test("reads the previous version from the pushed base SHA instead of local disk", async () => {
+    const refs: string[] = [];
+    const versions = await readReleaseLabelVersions(
+      "outfitter-dev/skillset",
+      {
+        baseRefName: "main",
+        headRefName: "changeset-release/main",
+      },
+      "immutable-base-sha",
+      async (_repository, ref) => {
+        refs.push(ref);
+        return {
+          version: ref === "immutable-base-sha" ? "0.16.3" : "0.16.4",
+        };
+      }
+    );
+
+    expect(refs).toEqual(["immutable-base-sha", "changeset-release/main"]);
+    expect(versions).toEqual({
+      nextVersion: "0.16.4",
+      previousVersion: "0.16.3",
+    });
+  });
+
+  test("adds the version delta label when publish and channel labels already exist", () => {
+    expect(
+      planReleasePullRequestLabels({
+        labels: ["publish:manual", "channel:stable"],
+        nextTag: "latest",
+        nextVersion: "0.16.4",
+        previousVersion: "0.16.3",
+        stackReady: true,
+      })
+    ).toEqual(["release:patch"]);
+  });
+
+  test("plans every missing label family from immutable base and release versions", () => {
+    expect(
+      planReleasePullRequestLabels({
+        labels: [],
+        nextTag: "latest",
+        nextVersion: "1.0.0",
+        previousVersion: "0.16.4",
+        stackReady: true,
+      })
+    ).toEqual(["publish:auto", "channel:stable", "release:major"]);
   });
 });
 

--- a/scripts/__tests__/release-workflow-contract.test.ts
+++ b/scripts/__tests__/release-workflow-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+type Workflow = {
+  jobs?: Record<string, {
+    permissions?: Record<string, string>;
+    steps?: Array<{ name?: string; run?: string }>;
+  }>;
+  on?: Record<string, unknown>;
+};
+
+const root = join(import.meta.dir, "..", "..");
+
+async function readWorkflow(name: string): Promise<Workflow> {
+  return Bun.YAML.parse(
+    await readFile(join(root, ".github", "workflows", name), "utf8")
+  ) as Workflow;
+}
+
+describe("generated release PR workflow contract", () => {
+  test("CI exposes an explicit dispatch path for bot-authored release heads", async () => {
+    const workflow = await readWorkflow("ci.yml");
+
+    expect(workflow.on?.workflow_dispatch).toEqual({});
+  });
+
+  test("release automation dispatches CI after updating and labeling the version PR", async () => {
+    const workflow = await readWorkflow("release.yml");
+    const version = workflow.jobs?.version;
+    const steps = version?.steps ?? [];
+    const labelIndex = steps.findIndex((step) => step.name === "Label version PR");
+    const dispatchIndex = steps.findIndex((step) => step.name === "Trigger version PR CI");
+
+    expect(version?.permissions?.actions).toBe("write");
+    expect(labelIndex).toBeGreaterThan(-1);
+    expect(dispatchIndex).toBeGreaterThan(labelIndex);
+    expect(steps[dispatchIndex]?.run).toBe(
+      "gh workflow run ci.yml --ref changeset-release/main"
+    );
+  });
+});

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -26,6 +26,19 @@ export type ReleaseIntent = "release:major" | "release:minor" | "release:patch";
 export type ReleasePolicyDecision = "auto" | "block" | "manual" | "none";
 export type StackIntent = "stack:boundary";
 
+export type ReleasePullRequestLabelPlanInput = {
+  labels: readonly string[];
+  nextTag: string;
+  nextVersion: string;
+  previousVersion: string;
+  stackReady: boolean;
+};
+
+type PackageVersionReader = (
+  repository: string,
+  ref: string
+) => Promise<{ version: string }>;
+
 export type ChangedFile = {
   path: string;
   status: string;
@@ -557,7 +570,6 @@ async function commandPolicy() {
 }
 
 async function commandLabelReleasePr() {
-  const packageInfo = await readPackageInfo();
   const repository = process.env.GITHUB_REPOSITORY ?? (await runText(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]));
   const releasePullRequest = await readOpenReleasePullRequest(repository);
 
@@ -566,30 +578,26 @@ async function commandLabelReleasePr() {
     return;
   }
 
-  const nextPackageInfo = await readPackageInfoFromRef(repository, releasePullRequest.headRefName);
-  const nextTag = distTagForVersion(nextPackageInfo.version);
-  const sourcePullRequests = await readSourcePullRequests(repository, packageInfo.version, "HEAD");
+  const versions = await readReleaseLabelVersions(
+    repository,
+    releasePullRequest,
+    process.env.GITHUB_SHA
+  );
+  const nextTag = distTagForVersion(versions.nextVersion);
+  const sourcePullRequests = await readSourcePullRequests(repository, versions.previousVersion, "HEAD");
   const stack = readSourceStackLabels(sourcePullRequests);
   const stackDiagnostics = [
     ...stack.conflicts,
     ...stack.unknown,
     ...evaluateSourceStackEvidence(sourcePullRequests, stack.value),
   ];
-  const expectedRelease = releaseIntentForVersionDelta(packageInfo.version, nextPackageInfo.version);
-  const labels = new Set(releasePullRequest.labels);
-  const labelsToAdd: string[] = [];
-
-  if (!hasLabelFamily(labels, "publish:")) {
-    labelsToAdd.push(stackDiagnostics.length === 0 && nextTag === "latest" ? "publish:auto" : "publish:manual");
-  }
-
-  if (!hasLabelFamily(labels, "channel:") && nextTag === "latest") {
-    labelsToAdd.push("channel:stable");
-  }
-
-  if (expectedRelease && !hasLabelFamily(labels, "release:")) {
-    labelsToAdd.push(expectedRelease);
-  }
+  const labelsToAdd = planReleasePullRequestLabels({
+    labels: releasePullRequest.labels,
+    nextTag,
+    nextVersion: versions.nextVersion,
+    previousVersion: versions.previousVersion,
+    stackReady: stackDiagnostics.length === 0,
+  });
 
   if (labelsToAdd.length === 0) {
     console.error(`skillset: release PR #${releasePullRequest.number} already has release intent labels`);
@@ -604,6 +612,51 @@ async function commandLabelReleasePr() {
   for (const diagnostic of stackDiagnostics) {
     console.error(`skillset: stack diagnostic: ${diagnostic}`);
   }
+}
+
+export async function readReleaseLabelVersions(
+  repository: string,
+  releasePullRequest: Pick<ReleasePullRequest, "baseRefName" | "headRefName">,
+  githubSha: string | undefined,
+  readVersion: PackageVersionReader = readPackageInfoFromRef
+) {
+  const previousRef = githubSha ?? releasePullRequest.baseRefName;
+  const [previous, next] = await Promise.all([
+    readVersion(repository, previousRef),
+    readVersion(repository, releasePullRequest.headRefName),
+  ]);
+
+  return {
+    nextVersion: next.version,
+    previousVersion: previous.version,
+  };
+}
+
+export function planReleasePullRequestLabels(
+  input: ReleasePullRequestLabelPlanInput
+): string[] {
+  const labels = new Set(input.labels);
+  const labelsToAdd: string[] = [];
+
+  if (!hasLabelFamily(labels, "publish:")) {
+    labelsToAdd.push(
+      input.stackReady && input.nextTag === "latest" ? "publish:auto" : "publish:manual"
+    );
+  }
+
+  if (!hasLabelFamily(labels, "channel:") && input.nextTag === "latest") {
+    labelsToAdd.push("channel:stable");
+  }
+
+  const expectedRelease = releaseIntentForVersionDelta(
+    input.previousVersion,
+    input.nextVersion
+  );
+  if (expectedRelease && !hasLabelFamily(labels, "release:")) {
+    labelsToAdd.push(expectedRelease);
+  }
+
+  return labelsToAdd;
 }
 
 async function readPolicyInput(): Promise<ReleasePolicyInput> {


### PR DESCRIPTION
## Context

The generated `0.16.4` release PR exposed two systemic gaps in the release path: `release:*` labeling compared the Changesets-mutated working tree to the release head, and GitHub suppressed bot-authored `pull_request` CI runs. SET-271 fixes both root causes before the release is merged.

## What changed

- reads the previous package version from the immutable push SHA or base ref through the GitHub contents API
- reads the next version from the generated release branch and plans missing label families through a pure helper
- directly tests that the immutable base SHA and `changeset-release/main` are the only version refs queried
- exposes `workflow_dispatch` on the CI workflow
- dispatches CI against `changeset-release/main` after Changesets updates and labels the release PR
- grants only `actions: write` to the version job for that dispatch
- structurally tests trigger ordering, permissions, and workflow shape

## Verification

- focused release/workflow tests: 24 passed
- `bun run typecheck`
- `bun run check`: 894 passed across 78 files
- `bun run check:workflows`
- `bun run hooks:pre-push`
- standing local review: 5/5, zero open P0-P3 findings
- targeted release-pipeline review: 5/5, zero open P0-P3 findings

## Risks

The explicit dispatch is intentionally limited to the generated release branch. On `workflow_dispatch`, PR-only changeset validation, stack detection, mechanical fixes, and PR comments remain disabled; `check` and read-only `skillset-ci` run on the selected exact head. Live acceptance still requires the post-merge Release workflow to add `release:patch` to PR #256 and produce successful exact-head `check` and `skillset-ci` runs before that release merges.

## Tracking

- [SET-271](https://linear.app/outfitter/issue/SET-271/make-generated-release-pr-labels-and-exact-head-ci-authoritative)
- Follow-up required to close [SET-267](https://linear.app/outfitter/issue/SET-267/unblock-the-accumulated-0x-release-by-normalizing-mixed-changesets)
