### PR TITLE
fix(ci): validate generated release dispatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,12 @@ jobs:
           else
             echo "skip_skillset_ci=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Check generated release package
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/changeset-release/main'
+        run: bun scripts/publish.ts check
       - name: Run skillset ci
         id: skillset
-        if: steps.stack.outputs.skip_skillset_ci != 'true'
+        if: steps.stack.outputs.skip_skillset_ci != 'true' && (github.event_name != 'workflow_dispatch' || github.ref != 'refs/heads/changeset-release/main')
         run: >-
           bun ./apps/skillset/src/cli.ts ci
           ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && '--fix' || '' }}

--- a/scripts/__tests__/release-workflow-contract.test.ts
+++ b/scripts/__tests__/release-workflow-contract.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 type Workflow = {
   jobs?: Record<string, {
     permissions?: Record<string, string>;
-    steps?: Array<{ name?: string; run?: string }>;
+    steps?: Array<{ if?: string; name?: string; run?: string }>;
   }>;
   on?: Record<string, unknown>;
 };
@@ -21,8 +21,18 @@ async function readWorkflow(name: string): Promise<Workflow> {
 describe("generated release PR workflow contract", () => {
   test("CI exposes an explicit dispatch path for bot-authored release heads", async () => {
     const workflow = await readWorkflow("ci.yml");
+    const steps = workflow.jobs?.["skillset-ci"]?.steps ?? [];
+    const releaseCheck = steps.find(
+      (step) => step.name === "Check generated release package"
+    );
+    const sourceCheck = steps.find((step) => step.name === "Run skillset ci");
 
     expect(workflow.on?.workflow_dispatch).toEqual({});
+    expect(releaseCheck?.run).toBe("bun scripts/publish.ts check");
+    expect(releaseCheck?.if).toContain("github.event_name == 'workflow_dispatch'");
+    expect(releaseCheck?.if).toContain("refs/heads/changeset-release/main");
+    expect(sourceCheck?.if).toContain("github.event_name != 'workflow_dispatch'");
+    expect(sourceCheck?.if).toContain("refs/heads/changeset-release/main");
   });
 
   test("release automation dispatches CI after updating and labeling the version PR", async () => {


### PR DESCRIPTION
## Context

SET-271's first live dispatched run proved exact-head CI delivery, but ordinary `skillset ci` rejected the generated release version bump because its consumed Changesets are intentionally deleted. This follow-up makes the dispatched release path use the package release checker while preserving ordinary source CI everywhere else.

## What changed

- routes only `workflow_dispatch` on `refs/heads/changeset-release/main` to `bun scripts/publish.ts check`
- keeps ordinary `skillset ci` active for pull requests, pushes, and dispatches on every other ref
- leaves the separate full `check` job unchanged
- extends the parsed workflow contract test to prove the two paths are mutually exclusive on the generated release signal

## Verification

- focused workflow contract: 2 passed, 10 assertions
- `bun run check:workflows`
- `bun run typecheck`
- `bun run hooks:pre-push`: 894 passed across 78 files
- standing local review: 5/5, zero open P0-P3 findings
- targeted GitHub Actions review: 5/5, zero open P0-P3 findings

## Risks

The generated-release package check performs registry reads and a dry-run package build, so transient npm registry failures remain visible as CI failures. It never publishes or pushes. Ordinary source branches retain the existing `skillset ci` behavior and permissions.

## Tracking

- [SET-271](https://linear.app/outfitter/issue/SET-271/make-generated-release-pr-labels-and-exact-head-ci-authoritative)
- Live failure: [workflow_dispatch run 29109633561](https://github.com/outfitter-dev/skillset/actions/runs/29109633561)
