### PR TITLE
feat(cli): replace runtime tester with skillset try

### DIFF
--- a/.changeset/skillset-try-command.md
+++ b/.changeset/skillset-try-command.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Replace the implementation-shaped `runtime-tester` command with `skillset try`, including direct prompt execution, retained status/tail/list workflows, `SKILLSET_TRY_*` overrides, and XDG-backed `.skillset/cache/runtime-tests/` reports.

--- a/.envrc.example
+++ b/.envrc.example
@@ -5,11 +5,11 @@
 # Package release preflight / publish recovery.
 export NPM_TOKEN="npm_REPLACE_ME"
 
-# Claude Code non-interactive runtime tester.
+# Claude Code non-interactive runtime tries.
 # `claude setup-token` prints this export line for subscription-backed CLI use.
 export CLAUDE_CODE_OAUTH_TOKEN="REPLACE_WITH_CLAUDE_SETUP_TOKEN"
 # Optional: isolated is the default; alternatives are user, project, or local.
-# export SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES="isolated"
+# export SKILLSET_TRY_CLAUDE_SETTING_SOURCES="isolated"
 
 # API-key fallback for Claude SDK/API workflows. Usually leave unset when using
 # CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -7171,7 +7171,7 @@ Audit body.
 
   const misplacedJson = await runSkillsetCli("list", "--json");
   expect(misplacedJson.exitCode).toBe(1);
-  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, lookup, marketplace, or runtime-tester");
+  expect(misplacedJson.stderr).toContain("--json is only supported with doctor, explain, features, lookup, marketplace, or try");
 });
 
 test("SET-78: feature capability inspection surfaces registry ids in explain, doctor, and features", async () => {

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -6,13 +6,13 @@ import { expect, test } from "bun:test";
 import { createOperationalPathContext, resolveOperationalPath } from "@skillset/core";
 
 import {
-  listRuntimeTesterRuns,
-  readRuntimeTesterStatus,
-  startRuntimeTesterRun,
-  tailRuntimeTesterRun,
-} from "../runtime-tester";
+  listTryRuns,
+  readTryStatus,
+  startTryRun,
+  tailTryRun,
+} from "../try";
 
-test("runtime tester runs a Codex prompt and records inspectable artifacts", async () => {
+test("try runs a Codex prompt and records inspectable artifacts", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -22,7 +22,7 @@ codex: true
     ".skillset/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo runtime tester skill.
+description: Demo try skill.
 ---
 
 Use this skill to answer fixture questions.
@@ -31,8 +31,8 @@ Use this skill to answer fixture questions.
   const bin = await fakeCodexBin(root);
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
-  const report = await startRuntimeTesterRun(root, {
-    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CODEX_BIN: bin },
+  const report = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CODEX_BIN: bin },
     prompt: "List the available fixture skills.",
     target: "codex",
     xdg,
@@ -40,25 +40,25 @@ Use this skill to answer fixture questions.
 
   expect(report.ok).toBe(true);
   expect(report.state).toBe("passed");
-  expect(report.runPath).toStartWith(".skillset/cache/runtime-tester/runs/");
+  expect(report.runPath).toStartWith(".skillset/cache/runtime-tests/runs/");
   expect(await exists(cachePath(root, xdg, report.tailPath))).toBe(true);
   expect(await readFile(cachePath(root, xdg, report.reportPath), "utf8")).toContain("fake codex final");
 
-  const status = await readRuntimeTesterStatus(root, report.runId, { xdg });
+  const status = await readTryStatus(root, report.runId, { xdg });
   expect(status.state).toBe("passed");
   expect(status.command?.join(" ")).toContain("--output-last-message");
   expect(status.command?.join(" ")).toContain("--skip-git-repo-check");
   expect(status.finalMessagePath).toBeDefined();
 
-  const tail = await tailRuntimeTesterRun(root, report.runId, 20, { xdg });
+  const tail = await tailTryRun(root, report.runId, 20, { xdg });
   expect(tail.map((line) => line.stream)).toContain("stdout");
   expect(tail.some((line) => line.message.includes("List the available fixture skills."))).toBe(true);
 
-  const runs = await listRuntimeTesterRuns(root, { xdg });
+  const runs = await listTryRuns(root, { xdg });
   expect(runs.map((run) => run.runId)).toContain(report.runId);
 });
 
-test("runtime tester runs a Claude prompt with isolated settings and explicit plugin dirs", async () => {
+test("try runs a Claude prompt with isolated settings and explicit plugin dirs", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -75,7 +75,7 @@ claude: true
     ".skillset/plugins/acme/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo Claude runtime tester skill.
+description: Demo Claude try skill.
 ---
 
 Use this skill to answer fixture questions.
@@ -84,8 +84,8 @@ Use this skill to answer fixture questions.
   const bin = await fakeClaudeBin(root);
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
-  const report = await startRuntimeTesterRun(root, {
-    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin },
+  const report = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CLAUDE_BIN: bin },
     plugins: ["acme"],
     prompt: "Inspect Claude fixture.",
     target: "claude",
@@ -95,17 +95,17 @@ Use this skill to answer fixture questions.
   expect(report.ok).toBe(true);
   expect(report.state).toBe("passed");
 
-  const status = await readRuntimeTesterStatus(root, report.runId, { xdg });
+  const status = await readTryStatus(root, report.runId, { xdg });
   const command = status.command?.join(" ");
   expect(command).toContain("--setting-sources \"\"");
   expect(command).toContain("--plugin-dir");
   expect(command).toContain("plugins/acme/claude");
 
-  const tail = await tailRuntimeTesterRun(root, report.runId, 20, { xdg });
+  const tail = await tailTryRun(root, report.runId, 20, { xdg });
   expect(tail.some((line) => line.message.includes("fake-claude prompt=Inspect Claude fixture."))).toBe(true);
 });
 
-test("runtime tester runs a Cursor prompt with trusted isolated workspace and explicit plugin dirs", async () => {
+test("try runs a Cursor prompt with trusted isolated workspace and explicit plugin dirs", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -124,7 +124,7 @@ cursor: true
     ".skillset/plugins/acme/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo Cursor runtime tester skill.
+description: Demo Cursor try skill.
 ---
 
 Use this skill to answer fixture questions.
@@ -133,8 +133,8 @@ Use this skill to answer fixture questions.
   const bin = await fakeCursorBin(root);
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
-  const report = await startRuntimeTesterRun(root, {
-    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CURSOR_BIN: bin },
+  const report = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CURSOR_BIN: bin },
     plugins: ["acme"],
     prompt: "Inspect Cursor fixture.",
     target: "cursor",
@@ -144,7 +144,7 @@ Use this skill to answer fixture questions.
   expect(report.ok).toBe(true);
   expect(report.state).toBe("passed");
 
-  const status = await readRuntimeTesterStatus(root, report.runId, { xdg });
+  const status = await readTryStatus(root, report.runId, { xdg });
   const command = status.command?.join(" ");
   expect(command).toContain("--print");
   expect(command).toContain("--output-format json");
@@ -154,11 +154,11 @@ Use this skill to answer fixture questions.
   expect(command).toContain("--plugin-dir");
   expect(command).toContain("plugins/acme/cursor");
 
-  const tail = await tailRuntimeTesterRun(root, report.runId, 20, { xdg });
+  const tail = await tailTryRun(root, report.runId, 20, { xdg });
   expect(tail.some((line) => line.message.includes("fake-cursor prompt=Inspect Cursor fixture."))).toBe(true);
 });
 
-test("runtime tester resolves Claude setting sources from defaults, env, and CLI options", async () => {
+test("try resolves Claude setting sources from defaults, env, and CLI options", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -175,7 +175,7 @@ claude: true
     ".skillset/plugins/acme/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo Claude runtime tester skill.
+description: Demo Claude try skill.
 ---
 
 Use this skill to answer fixture questions.
@@ -184,41 +184,41 @@ Use this skill to answer fixture questions.
   const bin = await fakeClaudeBin(root);
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
-  const fromDefault = await startRuntimeTesterRun(root, {
-    env: { ...process.env, SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin },
+  const fromDefault = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CLAUDE_BIN: bin },
     prompt: "Inspect Claude default fixture.",
     target: "claude",
     xdg,
   });
-  expect((await readRuntimeTesterStatus(root, fromDefault.runId, { xdg })).command?.join(" ")).toContain("--setting-sources \"\"");
+  expect((await readTryStatus(root, fromDefault.runId, { xdg })).command?.join(" ")).toContain("--setting-sources \"\"");
 
-  const fromEnv = await startRuntimeTesterRun(root, {
+  const fromEnv = await startTryRun(root, {
     env: {
       ...process.env,
-      SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin,
-      SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES: "user",
+      SKILLSET_TRY_CLAUDE_BIN: bin,
+      SKILLSET_TRY_CLAUDE_SETTING_SOURCES: "user",
     },
     prompt: "Inspect Claude env fixture.",
     target: "claude",
     xdg,
   });
-  expect((await readRuntimeTesterStatus(root, fromEnv.runId, { xdg })).command?.join(" ")).toContain("--setting-sources user");
+  expect((await readTryStatus(root, fromEnv.runId, { xdg })).command?.join(" ")).toContain("--setting-sources user");
 
-  const fromOption = await startRuntimeTesterRun(root, {
+  const fromOption = await startTryRun(root, {
     claudeSettingSources: "local",
     env: {
       ...process.env,
-      SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin,
-      SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES: "user",
+      SKILLSET_TRY_CLAUDE_BIN: bin,
+      SKILLSET_TRY_CLAUDE_SETTING_SOURCES: "user",
     },
     prompt: "Inspect Claude option fixture.",
     target: "claude",
     xdg,
   });
-  expect((await readRuntimeTesterStatus(root, fromOption.runId, { xdg })).command?.join(" ")).toContain("--setting-sources local");
+  expect((await readTryStatus(root, fromOption.runId, { xdg })).command?.join(" ")).toContain("--setting-sources local");
 });
 
-test("runtime tester validates selected plugins before running", async () => {
+test("try validates selected plugins before running", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -236,7 +236,7 @@ claude: true
     ".skillset/plugins/acme/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo Claude runtime tester skill.
+description: Demo Claude try skill.
 ---
 
 Use this skill to answer fixture questions.
@@ -252,7 +252,7 @@ codex: true
     ".skillset/plugins/codex-only/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo Codex-only runtime tester skill.
+description: Demo Codex-only try skill.
 ---
 
 Use this skill to answer fixture questions.
@@ -260,36 +260,36 @@ Use this skill to answer fixture questions.
   });
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
-  await expect(startRuntimeTesterRun(root, {
+  await expect(startTryRun(root, {
     plugins: ["missing"],
     prompt: "Inspect missing plugin.",
     target: "claude",
     xdg,
-  })).rejects.toThrow("unknown runtime tester plugin \"missing\"; available plugins: acme, codex-only");
+  })).rejects.toThrow("unknown try plugin \"missing\"; available plugins: acme, codex-only");
 
-  await expect(startRuntimeTesterRun(root, {
+  await expect(startTryRun(root, {
     plugins: ["acme", "acme"],
     prompt: "Inspect duplicate plugin.",
     target: "claude",
     xdg,
-  })).rejects.toThrow("duplicate runtime tester plugin \"acme\"");
+  })).rejects.toThrow("duplicate try plugin \"acme\"");
 
-  await expect(startRuntimeTesterRun(root, {
+  await expect(startTryRun(root, {
     plugins: ["codex-only"],
     prompt: "Inspect disabled plugin.",
     target: "claude",
     xdg,
-  })).rejects.toThrow("runtime tester plugin \"codex-only\" is not enabled for claude");
+  })).rejects.toThrow("try plugin \"codex-only\" is not enabled for claude");
 
-  await expect(startRuntimeTesterRun(root, {
+  await expect(startTryRun(root, {
     plugins: ["acme"],
     prompt: "Inspect Codex plugin selection.",
     target: "codex",
     xdg,
-  })).rejects.toThrow("runtime tester --plugin is only supported for targets with local plugin-dir support: claude, cursor");
+  })).rejects.toThrow("try --plugin is only supported for targets with local plugin-dir support: claude, cursor");
 });
 
-test("runtime tester CLI supports run, status, tail, and list", async () => {
+test("SET-272: try CLI starts directly and supports status, tail, and list", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -299,7 +299,7 @@ codex: true
     ".skillset/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo runtime tester CLI skill.
+description: Demo try CLI skill.
 ---
 
 CLI fixture body.
@@ -308,29 +308,34 @@ CLI fixture body.
   const bin = await fakeCodexBin(root);
   const env = {
     ...process.env,
-    SKILLSET_RUNTIME_TESTER_CODEX_BIN: bin,
+    SKILLSET_TRY_CODEX_BIN: bin,
     XDG_CACHE_HOME: join(root, "xdg-cache"),
   };
 
-  const run = await runSkillsetCli(env, "runtime-tester", "run", "--target", "codex", "--prompt", "Inspect CLI fixture.", "--json", "--root", root);
+  const run = await runSkillsetCli(env, "try", "--target", "codex", "--prompt", "Inspect CLI fixture.", "--json", "--root", root);
   expect(run.exitCode).toBe(0);
-  const report = JSON.parse(run.stdout) as { runId: string; state: string };
+  const report = JSON.parse(run.stdout) as { runId: string; runPath: string; state: string };
   expect(report.state).toBe("passed");
+  expect(report.runPath).toStartWith(".skillset/cache/runtime-tests/runs/");
 
-  const status = await runSkillsetCli(env, "runtime-tester", "status", report.runId, "--json", "--root", root);
+  const status = await runSkillsetCli(env, "try", "status", report.runId, "--json", "--root", root);
   expect(status.exitCode).toBe(0);
   expect(JSON.parse(status.stdout)).toEqual(expect.objectContaining({ runId: report.runId, state: "passed" }));
 
-  const tail = await runSkillsetCli(env, "runtime-tester", "tail", report.runId, "--lines", "10", "--json", "--root", root);
+  const tail = await runSkillsetCli(env, "try", "tail", report.runId, "--lines", "10", "--json", "--root", root);
   expect(tail.exitCode).toBe(0);
   expect(tail.stdout).toContain("Inspect CLI fixture.");
 
-  const list = await runSkillsetCli(env, "runtime-tester", "list", "--json", "--root", root);
+  const list = await runSkillsetCli(env, "try", "list", "--json", "--root", root);
   expect(list.exitCode).toBe(0);
   expect(list.stdout).toContain(report.runId);
+
+  const retired = await runSkillsetCli(env, "runtime-tester", "run", "--target", "codex", "--prompt", "Old command.", "--root", root);
+  expect(retired.exitCode).toBe(1);
+  expect(retired.stderr).toContain("expected command");
 });
 
-test("runtime tester CLI supports Claude setting source override", async () => {
+test("try CLI supports Claude setting source override", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -340,7 +345,7 @@ claude: true
     ".skillset/skills/demo/SKILL.md": `
 ---
 name: demo
-description: Demo runtime tester CLI Claude skill.
+description: Demo try CLI Claude skill.
 ---
 
 CLI Claude fixture body.
@@ -349,14 +354,13 @@ CLI Claude fixture body.
   const bin = await fakeClaudeBin(root);
   const env = {
     ...process.env,
-    SKILLSET_RUNTIME_TESTER_CLAUDE_BIN: bin,
+    SKILLSET_TRY_CLAUDE_BIN: bin,
     XDG_CACHE_HOME: join(root, "xdg-cache"),
   };
 
   const run = await runSkillsetCli(
     env,
-    "runtime-tester",
-    "run",
+    "try",
     "--target",
     "claude",
     "--prompt",
@@ -371,13 +375,61 @@ CLI Claude fixture body.
   const report = JSON.parse(run.stdout) as { runId: string; state: string };
   expect(report.state).toBe("passed");
 
-  const status = await runSkillsetCli(env, "runtime-tester", "status", report.runId, "--json", "--root", root);
+  const status = await runSkillsetCli(env, "try", "status", report.runId, "--json", "--root", root);
   expect(status.exitCode).toBe(0);
   expect(JSON.parse(status.stdout).command.join(" ")).toContain("--setting-sources local");
 });
 
+test("SET-272: background tries complete through the renamed worker command", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: background-try-fixture
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Background try fixture.
+---
+
+Background fixture body.
+`,
+  });
+  const env = {
+    ...process.env,
+    SKILLSET_TRY_CODEX_BIN: await fakeCodexBin(root),
+    XDG_CACHE_HOME: join(root, "xdg-cache"),
+  };
+  const xdg = { env };
+
+  const started = await runSkillsetCli(
+    env,
+    "try",
+    "--target",
+    "codex",
+    "--prompt",
+    "Inspect background fixture.",
+    "--background",
+    "--json",
+    "--root",
+    root
+  );
+  expect(started.exitCode).toBe(0);
+  const report = JSON.parse(started.stdout) as { runId: string; state: string };
+  expect(report.state).toBe("queued");
+
+  let state = report.state;
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline && state !== "passed" && state !== "failed") {
+    await Bun.sleep(20);
+    state = (await readTryStatus(root, report.runId, { xdg })).state;
+  }
+  expect(state).toBe("passed");
+}, 15_000);
+
 async function fixture(files: Record<string, string>): Promise<string> {
-  const root = await mkdtemp(join(tmpdir(), "skillset-runtime-tester-"));
+  const root = await mkdtemp(join(tmpdir(), "skillset-try-"));
   for (const [path, content] of Object.entries(files)) {
     const fullPath = join(root, path);
     await mkdir(dirname(fullPath), { recursive: true });

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -102,19 +102,19 @@ import {
   renderProviderFormatUpdateReport,
   runProviderFormatUpdates,
 } from "./provider-format-updates";
-import { readClaudeSettingSources, type RuntimeTesterClaudeSettingSources, type RuntimeTesterSubcommand } from "./runtime-tester";
+import { readClaudeSettingSources, type TryClaudeSettingSources, type TrySubcommand } from "./try";
 import {
-  isRuntimeTesterSubcommand,
-  runRuntimeTesterCommand,
-  validateRuntimeTesterFlags,
-} from "./runtime-tester-cli";
+  isTrySubcommand,
+  runTryCommand,
+  validateTryFlags,
+} from "./try-cli";
 import { createSkillset, initSkillset, type SetupInclude, type SetupLayoutOption, type SetupReport } from "./setup";
 import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "@skillset/core/internal/source-unit-selector";
 import { renderValidatedJson } from "@skillset/core/internal/structured-output";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
 import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, SourceOrigin, TargetName } from "@skillset/core/internal/types";
 
-type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "marketplace" | "new" | "providers" | "release" | "restore" | "runtime-tester" | "suggest-source" | "test" | "update" | "verify";
+type Command = "adopt" | "build" | "change" | "check" | "ci" | "create" | "dev" | "diff" | "distribute" | "doctor" | "explain" | "features" | "hooks" | "import" | "init" | "lint" | "list" | "lookup" | "marketplace" | "new" | "providers" | "release" | "restore" | "try" | "suggest-source" | "test" | "update" | "verify";
 type DistributionSubcommand = "plan";
 type MarketplaceSubcommand = "check" | "update";
 
@@ -151,9 +151,9 @@ const USAGE = [
   "       skillset features [feature-id] [--json]",
   "       skillset lookup [subject] [aspect...] [--frontmatter] [--fields] [--field <path>] [--values] [--events] [--compat [claude|codex|cursor...]] [--examples] [--schema] [--claude] [--codex] [--cursor] [--json]",
   "       skillset test [name] [--root <path>] [--source <dir>]",
-  "       skillset runtime-tester run --target <claude|codex|cursor> [--prompt <text>|--prompt-file <path>] [--plugin <id>] [--name <name>] [--timeout-ms <ms>] [--claude-setting-sources <isolated|user|project|local>] [--background] [--json] [--root <path>] [--source <dir>]",
-  "       skillset runtime-tester <status|tail> [run-id] [--lines <count>] [--json] [--root <path>]",
-  "       skillset runtime-tester list [--json] [--root <path>]",
+  "       skillset try --target <claude|codex|cursor> [--prompt <text>|--prompt-file <path>] [--plugin <id>] [--name <name>] [--timeout-ms <ms>] [--claude-setting-sources <isolated|user|project|local>] [--background] [--json] [--root <path>] [--source <dir>]",
+  "       skillset try <status|tail> [run-id] [--lines <count>] [--json] [--root <path>]",
+  "       skillset try list [--json] [--root <path>]",
   "       skillset hooks print --runner <lefthook|husky|pre-commit|git> [--pre-commit] [--pre-push]",
   "       skillset hooks print --target <claude|codex> --agent-runtime",
   "       skillset hooks run <post-tool-use|stop> [--root <path>]",
@@ -229,17 +229,17 @@ export async function runCli(
     releaseSubcommand,
     releaseReason,
     releaseRef,
-    runtimeTesterBackground,
-    runtimeTesterClaudeSettingSources,
-    runtimeTesterLines,
-    runtimeTesterName,
-    runtimeTesterPlugins,
-    runtimeTesterPrompt,
-    runtimeTesterPromptFile,
-    runtimeTesterRunId,
-    runtimeTesterSubcommand,
-    runtimeTesterTarget,
-    runtimeTesterTimeoutMs,
+    tryBackground,
+    tryClaudeSettingSources,
+    tryLines,
+    tryName,
+    tryPlugins,
+    tryPrompt,
+    tryPromptFile,
+    tryRunId,
+    trySubcommand,
+    tryTarget,
+    tryTimeoutMs,
     setupGlobal,
     setupIncludes,
     setupLayout,
@@ -297,21 +297,21 @@ export async function runCli(
     return;
   }
 
-  if (command === "runtime-tester") {
-    await runRuntimeTesterCommand(rootPath, {
-      background: runtimeTesterBackground,
-      ...(runtimeTesterClaudeSettingSources === undefined ? {} : { claudeSettingSources: runtimeTesterClaudeSettingSources }),
+  if (command === "try") {
+    await runTryCommand(rootPath, {
+      background: tryBackground,
+      ...(tryClaudeSettingSources === undefined ? {} : { claudeSettingSources: tryClaudeSettingSources }),
       json: jsonOutput,
-      ...(runtimeTesterLines === undefined ? {} : { lines: runtimeTesterLines }),
-      ...(runtimeTesterName === undefined ? {} : { name: runtimeTesterName }),
-      plugins: runtimeTesterPlugins,
-      ...(runtimeTesterPrompt === undefined ? {} : { prompt: runtimeTesterPrompt }),
-      ...(runtimeTesterPromptFile === undefined ? {} : { promptFile: runtimeTesterPromptFile }),
-      ...(runtimeTesterRunId === undefined ? {} : { runId: runtimeTesterRunId }),
+      ...(tryLines === undefined ? {} : { lines: tryLines }),
+      ...(tryName === undefined ? {} : { name: tryName }),
+      plugins: tryPlugins,
+      ...(tryPrompt === undefined ? {} : { prompt: tryPrompt }),
+      ...(tryPromptFile === undefined ? {} : { promptFile: tryPromptFile }),
+      ...(tryRunId === undefined ? {} : { runId: tryRunId }),
       skillsetOptions: options,
-      ...(runtimeTesterSubcommand === undefined ? {} : { subcommand: runtimeTesterSubcommand }),
-      ...(runtimeTesterTarget === undefined ? {} : { target: runtimeTesterTarget }),
-      ...(runtimeTesterTimeoutMs === undefined ? {} : { timeoutMs: runtimeTesterTimeoutMs }),
+      ...(trySubcommand === undefined ? {} : { subcommand: trySubcommand }),
+      ...(tryTarget === undefined ? {} : { target: tryTarget }),
+      ...(tryTimeoutMs === undefined ? {} : { timeoutMs: tryTimeoutMs }),
     });
     return;
   }
@@ -937,17 +937,17 @@ interface ParsedArgs {
   readonly releaseSubcommand?: ReleaseSubcommand;
   readonly releaseReason?: ChangeReasonInput;
   readonly releaseRef?: string;
-  readonly runtimeTesterBackground: boolean;
-  readonly runtimeTesterClaudeSettingSources?: RuntimeTesterClaudeSettingSources;
-  readonly runtimeTesterLines?: number;
-  readonly runtimeTesterName?: string;
-  readonly runtimeTesterPlugins: readonly string[];
-  readonly runtimeTesterPrompt?: string;
-  readonly runtimeTesterPromptFile?: string;
-  readonly runtimeTesterRunId?: string;
-  readonly runtimeTesterSubcommand?: RuntimeTesterSubcommand;
-  readonly runtimeTesterTarget?: TargetName;
-  readonly runtimeTesterTimeoutMs?: number;
+  readonly tryBackground: boolean;
+  readonly tryClaudeSettingSources?: TryClaudeSettingSources;
+  readonly tryLines?: number;
+  readonly tryName?: string;
+  readonly tryPlugins: readonly string[];
+  readonly tryPrompt?: string;
+  readonly tryPromptFile?: string;
+  readonly tryRunId?: string;
+  readonly trySubcommand?: TrySubcommand;
+  readonly tryTarget?: TargetName;
+  readonly tryTimeoutMs?: number;
   readonly rootExplicit: boolean;
   readonly rootPath: string;
   readonly setupGlobal: boolean;
@@ -1558,14 +1558,14 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     command !== "providers" &&
     command !== "release" &&
     command !== "restore" &&
-    command !== "runtime-tester" &&
+    command !== "try" &&
     command !== "suggest-source" &&
     command !== "test" &&
     command !== "update" &&
     command !== "verify"
   ) {
     throw new Error(
-        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, marketplace, new, providers, release, restore, runtime-tester, suggest-source, test, update, or verify\n" +
+        "skillset: expected command adopt, build, change, check, ci, create, dev, diff, distribute, doctor, explain, features, hooks, import, init, lint, list, lookup, marketplace, new, providers, release, restore, try, suggest-source, test, update, or verify\n" +
         USAGE
     );
   }
@@ -1576,17 +1576,17 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let releaseSubcommand: ReleaseSubcommand | undefined;
   let releaseReason: ChangeReasonInput | undefined;
   let releaseRef: string | undefined;
-  let runtimeTesterBackground = false;
-  let runtimeTesterClaudeSettingSources: RuntimeTesterClaudeSettingSources | undefined;
-  let runtimeTesterLines: number | undefined;
-  let runtimeTesterName: string | undefined;
-  let runtimeTesterPlugins: string[] = [];
-  let runtimeTesterPrompt: string | undefined;
-  let runtimeTesterPromptFile: string | undefined;
-  let runtimeTesterRunId: string | undefined;
-  let runtimeTesterSubcommand: RuntimeTesterSubcommand | undefined;
-  let runtimeTesterTarget: TargetName | undefined;
-  let runtimeTesterTimeoutMs: number | undefined;
+  let tryBackground = false;
+  let tryClaudeSettingSources: TryClaudeSettingSources | undefined;
+  let tryLines: number | undefined;
+  let tryName: string | undefined;
+  let tryPlugins: string[] = [];
+  let tryPrompt: string | undefined;
+  let tryPromptFile: string | undefined;
+  let tryRunId: string | undefined;
+  let trySubcommand: TrySubcommand | undefined;
+  let tryTarget: TargetName | undefined;
+  let tryTimeoutMs: number | undefined;
   let changeAppend = false;
   let changeBump: ChangeBump | undefined;
   let changeGroup: string | undefined;
@@ -1723,16 +1723,18 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     index += 1;
   }
 
-  if (command === "runtime-tester") {
+  if (command === "try") {
     const subcommand = args[index];
-    if (!isRuntimeTesterSubcommand(subcommand)) {
-      throw new Error("skillset: expected runtime-tester subcommand list, run, status, tail, or worker");
+    if (subcommand !== undefined && !subcommand.startsWith("--") && !isTrySubcommand(subcommand)) {
+      throw new Error("skillset: expected try options or subcommand list, status, or tail");
     }
-    runtimeTesterSubcommand = subcommand;
-    index += 1;
+    if (isTrySubcommand(subcommand)) {
+      trySubcommand = subcommand;
+      index += 1;
+    }
     const rawRunId = args[index];
-    if ((subcommand === "status" || subcommand === "tail" || subcommand === "worker") && rawRunId !== undefined && !rawRunId.startsWith("--")) {
-      runtimeTesterRunId = rawRunId;
+    if ((trySubcommand === "status" || trySubcommand === "tail" || trySubcommand === "worker") && rawRunId !== undefined && !rawRunId.startsWith("--")) {
+      tryRunId = rawRunId;
       index += 1;
     }
   }
@@ -1966,7 +1968,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       if (flag === "--claude") lookupTargets = addLookupTarget(lookupTargets, "claude");
       if (flag === "--codex") lookupTargets = addLookupTarget(lookupTargets, "codex");
       if (flag === "--cursor") lookupTargets = addLookupTarget(lookupTargets, "cursor");
-      if (flag === "--background") runtimeTesterBackground = true;
+      if (flag === "--background") tryBackground = true;
       continue;
     }
 
@@ -2019,17 +2021,17 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--format") hookContextFormat = readHookRuntimeContextFormat(value);
     if (flag === "--context-fields") hookContextFields = readHookRuntimeContextFields(value);
     if (flag === "--target") {
-      if (command === "runtime-tester") runtimeTesterTarget = readTargetName(value);
+      if (command === "try") tryTarget = readTargetName(value);
       else hookTarget = readHookTarget(value);
     }
-    if (flag === "--prompt") runtimeTesterPrompt = value;
-    if (flag === "--prompt-file") runtimeTesterPromptFile = value;
-    if (flag === "--plugin") runtimeTesterPlugins = [...runtimeTesterPlugins, value];
+    if (flag === "--prompt") tryPrompt = value;
+    if (flag === "--prompt-file") tryPromptFile = value;
+    if (flag === "--plugin") tryPlugins = [...tryPlugins, value];
     if (flag === "--claude-setting-sources") {
-      runtimeTesterClaudeSettingSources = readClaudeSettingSources(value, "--claude-setting-sources");
+      tryClaudeSettingSources = readClaudeSettingSources(value, "--claude-setting-sources");
     }
-    if (flag === "--timeout-ms") runtimeTesterTimeoutMs = readPositiveInteger(value, "--timeout-ms");
-    if (flag === "--lines") runtimeTesterLines = readPositiveInteger(value, "--lines");
+    if (flag === "--timeout-ms") tryTimeoutMs = readPositiveInteger(value, "--timeout-ms");
+    if (flag === "--lines") tryLines = readPositiveInteger(value, "--lines");
     if (flag === "--targets") setupTargets = readSetupTargets(value);
     if (flag === "--include") setupIncludes = mergeSetupIncludes(setupIncludes, value);
     if (flag === "--layout") setupLayout = readSetupLayout(value);
@@ -2037,7 +2039,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--in") newContainer = value;
     if (flag === "--name") {
       if (command === "new") newName = value;
-      else if (command === "runtime-tester") runtimeTesterName = value;
+      else if (command === "try") tryName = value;
       else importName = value;
     }
     if (flag === "--preset") newPresets = [...(newPresets ?? []), value];
@@ -2127,20 +2129,20 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(scopes === undefined ? {} : { scopes }),
   });
-  validateRuntimeTesterFlags(command, runtimeTesterSubcommand, {
-    background: runtimeTesterBackground,
+  validateTryFlags(command, trySubcommand, {
+    background: tryBackground,
     ...(buildMode === undefined ? {} : { buildMode }),
-    ...(runtimeTesterClaudeSettingSources === undefined ? {} : { claudeSettingSources: runtimeTesterClaudeSettingSources }),
+    ...(tryClaudeSettingSources === undefined ? {} : { claudeSettingSources: tryClaudeSettingSources }),
     ...(distDir === undefined ? {} : { distDir }),
     dryRun,
-    ...(runtimeTesterLines === undefined ? {} : { lines: runtimeTesterLines }),
-    ...(runtimeTesterName === undefined ? {} : { name: runtimeTesterName }),
-    plugins: runtimeTesterPlugins,
-    ...(runtimeTesterPrompt === undefined ? {} : { prompt: runtimeTesterPrompt }),
-    ...(runtimeTesterPromptFile === undefined ? {} : { promptFile: runtimeTesterPromptFile }),
+    ...(tryLines === undefined ? {} : { lines: tryLines }),
+    ...(tryName === undefined ? {} : { name: tryName }),
+    plugins: tryPlugins,
+    ...(tryPrompt === undefined ? {} : { prompt: tryPrompt }),
+    ...(tryPromptFile === undefined ? {} : { promptFile: tryPromptFile }),
     ...(scopes === undefined ? {} : { scopes }),
-    ...(runtimeTesterTarget === undefined ? {} : { target: runtimeTesterTarget }),
-    ...(runtimeTesterTimeoutMs === undefined ? {} : { timeoutMs: runtimeTesterTimeoutMs }),
+    ...(tryTarget === undefined ? {} : { target: tryTarget }),
+    ...(tryTimeoutMs === undefined ? {} : { timeoutMs: tryTimeoutMs }),
     yes,
   });
   validateJsonFlags(command, jsonOutput);
@@ -2288,17 +2290,17 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
     ...(releaseReason === undefined ? {} : { releaseReason }),
     ...(releaseRef === undefined ? {} : { releaseRef }),
-    runtimeTesterBackground,
-    ...(runtimeTesterClaudeSettingSources === undefined ? {} : { runtimeTesterClaudeSettingSources }),
-    ...(runtimeTesterLines === undefined ? {} : { runtimeTesterLines }),
-    ...(runtimeTesterName === undefined ? {} : { runtimeTesterName }),
-    runtimeTesterPlugins,
-    ...(runtimeTesterPrompt === undefined ? {} : { runtimeTesterPrompt }),
-    ...(runtimeTesterPromptFile === undefined ? {} : { runtimeTesterPromptFile }),
-    ...(runtimeTesterRunId === undefined ? {} : { runtimeTesterRunId }),
-    ...(runtimeTesterSubcommand === undefined ? {} : { runtimeTesterSubcommand }),
-    ...(runtimeTesterTarget === undefined ? {} : { runtimeTesterTarget }),
-    ...(runtimeTesterTimeoutMs === undefined ? {} : { runtimeTesterTimeoutMs }),
+    tryBackground,
+    ...(tryClaudeSettingSources === undefined ? {} : { tryClaudeSettingSources }),
+    ...(tryLines === undefined ? {} : { tryLines }),
+    ...(tryName === undefined ? {} : { tryName }),
+    tryPlugins,
+    ...(tryPrompt === undefined ? {} : { tryPrompt }),
+    ...(tryPromptFile === undefined ? {} : { tryPromptFile }),
+    ...(tryRunId === undefined ? {} : { tryRunId }),
+    ...(trySubcommand === undefined ? {} : { trySubcommand }),
+    ...(tryTarget === undefined ? {} : { tryTarget }),
+    ...(tryTimeoutMs === undefined ? {} : { tryTimeoutMs }),
     rootExplicit,
     rootPath: resolve(rootPath),
     setupGlobal,
@@ -2923,8 +2925,8 @@ function validateAdoptFlags(
 
 function validateJsonFlags(command: Command, jsonOutput: boolean): void {
   if (!jsonOutput) return;
-  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup" || command === "marketplace" || command === "runtime-tester") return;
-  throw new Error("skillset: --json is only supported with doctor, explain, features, lookup, marketplace, or runtime-tester");
+  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup" || command === "marketplace" || command === "try") return;
+  throw new Error("skillset: --json is only supported with doctor, explain, features, lookup, marketplace, or try");
 }
 
 function validateLookupFlags(

--- a/apps/skillset/src/try-cli.ts
+++ b/apps/skillset/src/try-cli.ts
@@ -2,25 +2,25 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import {
-  executeRuntimeTesterRun,
-  listRuntimeTesterRuns,
-  readRuntimeTesterStatus,
-  startRuntimeTesterRun,
-  tailRuntimeTesterRun,
-  type RuntimeTesterClaudeSettingSources,
-  type RuntimeTesterListEntry,
-  type RuntimeTesterRunReport,
-  type RuntimeTesterState,
-  type RuntimeTesterStatus,
-  type RuntimeTesterSubcommand,
-  type RuntimeTesterTailLine,
-} from "./runtime-tester";
+  executeTryRun,
+  listTryRuns,
+  readTryStatus,
+  startTryRun,
+  tailTryRun,
+  type TryClaudeSettingSources,
+  type TryListEntry,
+  type TryRunReport,
+  type TryState,
+  type TryStatus,
+  type TrySubcommand,
+  type TryTailLine,
+} from "./try";
 import { renderValidatedJson } from "@skillset/core/internal/structured-output";
 import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, TargetName } from "@skillset/core/internal/types";
 
-export interface RuntimeTesterCommandOptions {
+export interface TryCommandOptions {
   readonly background: boolean;
-  readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+  readonly claudeSettingSources?: TryClaudeSettingSources;
   readonly json: boolean;
   readonly lines?: number;
   readonly name?: string;
@@ -29,65 +29,65 @@ export interface RuntimeTesterCommandOptions {
   readonly promptFile?: string;
   readonly runId?: string;
   readonly skillsetOptions: SkillsetOptions;
-  readonly subcommand?: RuntimeTesterSubcommand;
+  readonly subcommand?: TrySubcommand;
   readonly target?: TargetName;
   readonly timeoutMs?: number;
 }
 
-export async function runRuntimeTesterCommand(rootPath: string, options: RuntimeTesterCommandOptions): Promise<void> {
-  if (options.subcommand === "run") {
-    const report = await startRuntimeTesterRun(rootPath, {
+export async function runTryCommand(rootPath: string, options: TryCommandOptions): Promise<void> {
+  if (options.subcommand === undefined) {
+    const report = await startTryRun(rootPath, {
       ...options.skillsetOptions,
       background: options.background,
       ...(options.claudeSettingSources === undefined ? {} : { claudeSettingSources: options.claudeSettingSources }),
       ...(options.name === undefined ? {} : { name: options.name }),
       plugins: options.plugins,
-      prompt: await readRuntimeTesterPrompt(rootPath, options.prompt, options.promptFile),
-      target: requireRuntimeTesterTarget(options.target),
+      prompt: await readTryPrompt(rootPath, options.prompt, options.promptFile),
+      target: requireTryTarget(options.target),
       ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
     });
-    if (options.json) console.log(renderValidatedJson(report as unknown as JsonRecord, "runtime tester run"));
-    else printRuntimeTesterRun(report);
+    if (options.json) console.log(renderValidatedJson(report as unknown as JsonRecord, "try run"));
+    else printTryRun(report);
     if (!report.ok) process.exitCode = 1;
     return;
   }
   if (options.subcommand === "worker") {
-    if (options.runId === undefined) throw new Error("skillset: runtime-tester worker requires run id");
-    await executeRuntimeTesterRun(rootPath, options.runId);
+    if (options.runId === undefined) throw new Error("skillset: try worker requires run id");
+    await executeTryRun(rootPath, options.runId);
     return;
   }
   if (options.subcommand === "status") {
-    const status = await readRuntimeTesterStatus(rootPath, options.runId);
-    if (options.json) console.log(renderValidatedJson(status as unknown as JsonRecord, "runtime tester status"));
-    else printRuntimeTesterStatus(status);
+    const status = await readTryStatus(rootPath, options.runId);
+    if (options.json) console.log(renderValidatedJson(status as unknown as JsonRecord, "try status"));
+    else printTryStatus(status);
     if (status.state === "failed") process.exitCode = 1;
     return;
   }
   if (options.subcommand === "tail") {
-    const lines = await tailRuntimeTesterRun(rootPath, options.runId, options.lines ?? 40);
-    if (options.json) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "runtime tester tail"));
-    else printRuntimeTesterTail(lines);
+    const lines = await tailTryRun(rootPath, options.runId, options.lines ?? 40);
+    if (options.json) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "try tail"));
+    else printTryTail(lines);
     return;
   }
   if (options.subcommand === "list") {
-    const entries = await listRuntimeTesterRuns(rootPath);
-    if (options.json) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "runtime tester list"));
-    else printRuntimeTesterList(entries);
+    const entries = await listTryRuns(rootPath);
+    if (options.json) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "try list"));
+    else printTryList(entries);
     return;
   }
 }
 
-export function isRuntimeTesterSubcommand(value: string | undefined): value is RuntimeTesterSubcommand {
-  return value === "list" || value === "run" || value === "status" || value === "tail" || value === "worker";
+export function isTrySubcommand(value: string | undefined): value is TrySubcommand {
+  return value === "list" || value === "status" || value === "tail" || value === "worker";
 }
 
-export function validateRuntimeTesterFlags(
+export function validateTryFlags(
   command: string,
-  subcommand: RuntimeTesterSubcommand | undefined,
+  subcommand: TrySubcommand | undefined,
   runtime: {
     readonly background: boolean;
     readonly buildMode?: CompileBuildMode;
-    readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+    readonly claudeSettingSources?: TryClaudeSettingSources;
     readonly distDir?: string;
     readonly dryRun: boolean;
     readonly lines?: number;
@@ -110,46 +110,45 @@ export function validateRuntimeTesterFlags(
     runtime.promptFile !== undefined ||
     runtime.target !== undefined ||
     runtime.timeoutMs !== undefined;
-  if (hasRuntimeFlag && command !== "runtime-tester") {
-    throw new Error("skillset: runtime tester options are only supported with runtime-tester");
+  if (hasRuntimeFlag && command !== "try") {
+    throw new Error("skillset: try options are only supported with try");
   }
-  if (command !== "runtime-tester") return;
-  if (subcommand === undefined) throw new Error("skillset: expected runtime-tester subcommand");
+  if (command !== "try") return;
   if (runtime.buildMode !== undefined || runtime.distDir !== undefined || runtime.dryRun || runtime.scopes !== undefined || runtime.yes) {
-    throw new Error("skillset: build/write options are not supported with runtime-tester; runtime tester builds an isolated projection under logical .skillset/cache/runtime-tester");
+    throw new Error("skillset: build/write options are not supported with try; try builds an isolated projection under logical .skillset/cache/runtime-tests");
   }
-  if (subcommand === "run") {
-    if (runtime.target === undefined) throw new Error("skillset: runtime-tester run requires --target claude, codex, or cursor");
+  if (subcommand === undefined) {
+    if (runtime.target === undefined) throw new Error("skillset: try requires --target claude, codex, or cursor");
     if ((runtime.prompt === undefined && runtime.promptFile === undefined) || (runtime.prompt !== undefined && runtime.promptFile !== undefined)) {
-      throw new Error("skillset: runtime-tester run requires exactly one of --prompt or --prompt-file");
+      throw new Error("skillset: try requires exactly one of --prompt or --prompt-file");
     }
     return;
   }
   if (runtime.background || runtime.claudeSettingSources !== undefined || runtime.name !== undefined || runtime.plugins.length > 0 || runtime.prompt !== undefined || runtime.promptFile !== undefined || runtime.target !== undefined || runtime.timeoutMs !== undefined) {
-    throw new Error(`skillset: runtime tester run options are not supported with ${subcommand}`);
+    throw new Error(`skillset: try execution options are not supported with ${subcommand}`);
   }
   if (runtime.lines !== undefined && subcommand !== "tail") {
-    throw new Error("skillset: --lines is only supported with runtime-tester tail");
+    throw new Error("skillset: --lines is only supported with try tail");
   }
 }
 
-async function readRuntimeTesterPrompt(
+async function readTryPrompt(
   rootPath: string,
   prompt: string | undefined,
   promptFile: string | undefined
 ): Promise<string> {
   if (prompt !== undefined) return prompt;
-  if (promptFile === undefined) throw new Error("skillset: runtime-tester run requires --prompt or --prompt-file");
+  if (promptFile === undefined) throw new Error("skillset: try requires --prompt or --prompt-file");
   return readFile(resolve(rootPath, promptFile), "utf8");
 }
 
-function requireRuntimeTesterTarget(target: TargetName | undefined): TargetName {
-  if (target === undefined) throw new Error("skillset: runtime-tester run requires --target claude, codex, or cursor");
+function requireTryTarget(target: TargetName | undefined): TargetName {
+  if (target === undefined) throw new Error("skillset: try requires --target claude, codex, or cursor");
   return target;
 }
 
-function printRuntimeTesterRun(report: RuntimeTesterRunReport): void {
-  console.log(`skillset: runtime tester ${formatRuntimeTesterState(report.state)}${report.background ? " in background" : ""}`);
+function printTryRun(report: TryRunReport): void {
+  console.log(`skillset: try ${formatTryState(report.state)}${report.background ? " in background" : ""}`);
   console.log(`  run: ${report.runPath}`);
   console.log(`  latest: ${report.latestPath}`);
   console.log(`  status: ${report.statusPath}`);
@@ -157,8 +156,8 @@ function printRuntimeTesterRun(report: RuntimeTesterRunReport): void {
   console.log(`  report: ${report.reportPath}`);
 }
 
-function printRuntimeTesterStatus(status: RuntimeTesterStatus): void {
-  console.log(`skillset: runtime tester ${status.runId} ${formatRuntimeTesterState(status.state)}`);
+function printTryStatus(status: TryStatus): void {
+  console.log(`skillset: try ${status.runId} ${formatTryState(status.state)}`);
   console.log(`  target: ${status.target}`);
   console.log(`  name: ${status.name}`);
   if (status.pid !== undefined) console.log(`  pid: ${status.pid}`);
@@ -176,24 +175,24 @@ function printRuntimeTesterStatus(status: RuntimeTesterStatus): void {
   if (status.finalMessagePath !== undefined) console.log(`  final: ${status.finalMessagePath}`);
 }
 
-function printRuntimeTesterTail(lines: readonly RuntimeTesterTailLine[]): void {
+function printTryTail(lines: readonly TryTailLine[]): void {
   for (const line of lines) {
     const prefix = line.timestamp.length === 0 ? line.stream : `${line.timestamp} ${line.stream}`;
     process.stdout.write(`${prefix}: ${line.message.endsWith("\n") ? line.message : `${line.message}\n`}`);
   }
 }
 
-function printRuntimeTesterList(entries: readonly RuntimeTesterListEntry[]): void {
+function printTryList(entries: readonly TryListEntry[]): void {
   if (entries.length === 0) {
-    console.log("skillset: no runtime tester runs");
+    console.log("skillset: no try runs");
     return;
   }
   for (const entry of entries) {
     const ended = entry.endedAt === undefined ? "" : ` ended ${entry.endedAt}`;
-    console.log(`${entry.runId} ${entry.target} ${formatRuntimeTesterState(entry.state)} started ${entry.startedAt}${ended} ${entry.name}`);
+    console.log(`${entry.runId} ${entry.target} ${formatTryState(entry.state)} started ${entry.startedAt}${ended} ${entry.name}`);
   }
 }
 
-function formatRuntimeTesterState(state: RuntimeTesterState): string {
+function formatTryState(state: TryState): string {
   return state;
 }

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -23,13 +23,13 @@ import { loadBuildGraph } from "@skillset/core/internal/resolver";
 import { renderValidatedJson } from "@skillset/core/internal/structured-output";
 import type { BuildGraph, JsonRecord, SkillsetOptions, TargetName } from "@skillset/core/internal/types";
 
-export type RuntimeTesterSubcommand = "list" | "run" | "status" | "tail" | "worker";
-export type RuntimeTesterState = "building" | "failed" | "passed" | "queued" | "running";
-export type RuntimeTesterClaudeSettingSources = "isolated" | "local" | "project" | "user";
+export type TrySubcommand = "list" | "status" | "tail" | "worker";
+export type TryState = "building" | "failed" | "passed" | "queued" | "running";
+export type TryClaudeSettingSources = "isolated" | "local" | "project" | "user";
 
-export interface RuntimeTesterRunOptions extends SkillsetOptions {
+export interface TryRunOptions extends SkillsetOptions {
   readonly background?: boolean;
-  readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+  readonly claudeSettingSources?: TryClaudeSettingSources;
   readonly env?: Record<string, string | undefined>;
   readonly name?: string;
   readonly plugins?: readonly string[];
@@ -38,7 +38,7 @@ export interface RuntimeTesterRunOptions extends SkillsetOptions {
   readonly timeoutMs?: number;
 }
 
-export interface RuntimeTesterStatus {
+export interface TryStatus {
   readonly command?: readonly string[];
   readonly endedAt?: string;
   readonly error?: string;
@@ -54,41 +54,41 @@ export interface RuntimeTesterStatus {
   readonly runPath: string;
   readonly schemaVersion: 1;
   readonly startedAt: string;
-  readonly state: RuntimeTesterState;
+  readonly state: TryState;
   readonly target: TargetName;
   readonly timeoutMs: number;
   readonly updatedAt: string;
 }
 
-export interface RuntimeTesterRunReport {
+export interface TryRunReport {
   readonly background: boolean;
   readonly latestPath: string;
   readonly ok: boolean;
   readonly reportPath: string;
   readonly runId: string;
   readonly runPath: string;
-  readonly state: RuntimeTesterState;
+  readonly state: TryState;
   readonly statusPath: string;
   readonly tailPath: string;
 }
 
-export interface RuntimeTesterListEntry {
+export interface TryListEntry {
   readonly endedAt?: string;
   readonly name: string;
   readonly runId: string;
   readonly runPath: string;
   readonly startedAt: string;
-  readonly state: RuntimeTesterState;
+  readonly state: TryState;
   readonly target: TargetName;
 }
 
-export interface RuntimeTesterTailLine {
+export interface TryTailLine {
   readonly message: string;
   readonly stream: string;
   readonly timestamp: string;
 }
 
-interface RuntimeTesterRunPaths {
+interface TryRunPaths {
   readonly retained: RetainedRunPaths;
   readonly absolute: {
     readonly finalMessagePath: string;
@@ -111,8 +111,8 @@ interface RuntimeTesterRunPaths {
   };
 }
 
-interface RuntimeTesterStoredConfig {
-  readonly claudeSettingSources?: RuntimeTesterClaudeSettingSources;
+interface TryStoredConfig {
+  readonly claudeSettingSources?: TryClaudeSettingSources;
   readonly name: string;
   readonly plugins: readonly string[];
   readonly prompt: string;
@@ -121,30 +121,30 @@ interface RuntimeTesterStoredConfig {
   readonly timeoutMs: number;
 }
 
-const RUNTIME_TESTER_ROOT = ".skillset/cache/runtime-tester";
+const RUNTIME_TEST_ROOT = ".skillset/cache/runtime-tests";
 const DEFAULT_TIMEOUT_MS = 120_000;
-const DEFAULT_CLAUDE_SETTING_SOURCES: RuntimeTesterClaudeSettingSources = "isolated";
-const RUNTIME_TESTER_CLAUDE_SETTING_SOURCES_ENV = "SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES";
+const DEFAULT_CLAUDE_SETTING_SOURCES: TryClaudeSettingSources = "isolated";
+const TRY_CLAUDE_SETTING_SOURCES_ENV = "SKILLSET_TRY_CLAUDE_SETTING_SOURCES";
 // Empty --setting-sources keeps Claude probes independent from user/project/local settings while preserving env auth and explicit --plugin-dir inputs.
 const ISOLATED_CLAUDE_SETTING_SOURCES_ARG = "";
 const CLAUDE_SETTING_SOURCES_DISPLAY = "\"\"";
 
-export async function startRuntimeTesterRun(
+export async function startTryRun(
   rootPath: string,
-  options: RuntimeTesterRunOptions
-): Promise<RuntimeTesterRunReport> {
+  options: TryRunOptions
+): Promise<TryRunReport> {
   const root = resolve(rootPath);
   const graph = await loadBuildGraph(root, options);
   if (!graph.root.targets[options.target].enabled) {
-    throw new Error(`skillset: runtime tester target ${options.target} is not enabled by root target configuration`);
+    throw new Error(`skillset: try target ${options.target} is not enabled by root target configuration`);
   }
-  const name = options.name ?? `runtime-${options.target}`;
-  const plugins = validateRuntimeTesterPlugins(graph, options.target, options.plugins ?? []);
-  const runId = makeRetainedRunId(name, { fallbackName: "runtime", includeName: true });
-  const paths = runtimeTesterPaths(root, graph, runId, options.xdg);
+  const name = options.name ?? `try-${options.target}`;
+  const plugins = validateTryPlugins(graph, options.target, options.plugins ?? []);
+  const runId = makeRetainedRunId(name, { fallbackName: "try", includeName: true });
+  const paths = tryPaths(root, graph, runId, options.xdg);
   await mkdir(paths.absolute.runPath, { recursive: true });
 
-  const config: RuntimeTesterStoredConfig = {
+  const config: TryStoredConfig = {
     ...(options.target === "claude" ? { claudeSettingSources: resolveClaudeSettingSources(options) } : {}),
     name,
     plugins,
@@ -177,7 +177,7 @@ export async function startRuntimeTesterRun(
   await writeLatest(paths, runId);
 
   if (options.background === true) {
-    const pid = spawnRuntimeWorker(root, runId);
+    const pid = spawnTryWorker(root, runId);
     const status = await readStatus(paths.absolute.statusPath);
     await writeStatus(paths, {
       ...status,
@@ -188,19 +188,19 @@ export async function startRuntimeTesterRun(
     return runReport(paths, runId, "queued", true);
   }
 
-  await executeRuntimeTesterRun(root, runId, options.env, options.xdg);
+  await executeTryRun(root, runId, options.env, options.xdg);
   const status = await readStatus(paths.absolute.statusPath);
   return runReport(paths, runId, status.state, false);
 }
 
-export async function executeRuntimeTesterRun(
+export async function executeTryRun(
   rootPath: string,
   runId: string,
   env: Record<string, string | undefined> = process.env,
   xdg: SkillsetOptions["xdg"] = undefined
 ): Promise<void> {
   const root = resolve(rootPath);
-  const paths = runtimeTesterPaths(root, await loadBuildGraph(root, xdg === undefined ? {} : { xdg }), runId, xdg);
+  const paths = tryPaths(root, await loadBuildGraph(root, xdg === undefined ? {} : { xdg }), runId, xdg);
   const config = await readConfig(join(paths.absolute.runPath, "config.json"));
   const target = config.target;
   const runOptions: SkillsetOptions = {
@@ -241,7 +241,7 @@ export async function executeRuntimeTesterRun(
     timedOut: result.timedOut,
   };
   await writeFile(paths.absolute.reportPath, renderValidatedJson(report, paths.logical.reportPath), "utf8");
-  const nextState: RuntimeTesterState = report.ok === true ? "passed" : "failed";
+  const nextState: TryState = report.ok === true ? "passed" : "failed";
   await writeStatus(paths, {
     ...status,
     endedAt: String(report.endedAt),
@@ -250,33 +250,33 @@ export async function executeRuntimeTesterRun(
     reportPath: paths.logical.reportPath,
     state: nextState,
     updatedAt: new Date().toISOString(),
-    ...(result.timedOut ? { error: `runtime tester command timed out after ${config.timeoutMs}ms` } : {}),
+    ...(result.timedOut ? { error: `try command timed out after ${config.timeoutMs}ms` } : {}),
   });
-  await appendEvent(paths, "status", `runtime tester ${nextState}`);
+  await appendEvent(paths, "status", `try ${nextState}`);
 }
 
-export async function readRuntimeTesterStatus(
+export async function readTryStatus(
   rootPath: string,
   runId?: string,
   options: Pick<SkillsetOptions, "xdg"> = {}
-): Promise<RuntimeTesterStatus> {
+): Promise<TryStatus> {
   const root = resolve(rootPath);
   const graph = await loadBuildGraph(root, options);
   const resolvedRunId = runId ?? await readLatestRunId(root, graph, options.xdg);
-  const paths = runtimeTesterPaths(root, graph, resolvedRunId, options.xdg);
+  const paths = tryPaths(root, graph, resolvedRunId, options.xdg);
   return readStatus(paths.absolute.statusPath);
 }
 
-export async function listRuntimeTesterRuns(
+export async function listTryRuns(
   rootPath: string,
   options: Pick<SkillsetOptions, "xdg"> = {}
-): Promise<readonly RuntimeTesterListEntry[]> {
+): Promise<readonly TryListEntry[]> {
   const root = resolve(rootPath);
   const graph = await loadBuildGraph(root, options);
-  const runsRoot = retainedRunRootPaths(root, graph, RUNTIME_TESTER_ROOT, options.xdg).absolute.runsRoot;
+  const runsRoot = retainedRunRootPaths(root, graph, RUNTIME_TEST_ROOT, options.xdg).absolute.runsRoot;
   if (!await pathExists(runsRoot)) return [];
   const entries = await readdir(runsRoot, { withFileTypes: true });
-  const runs: RuntimeTesterListEntry[] = [];
+  const runs: TryListEntry[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     try {
@@ -297,16 +297,16 @@ export async function listRuntimeTesterRuns(
   return runs.sort((left, right) => compareStrings(right.startedAt, left.startedAt));
 }
 
-export async function tailRuntimeTesterRun(
+export async function tailTryRun(
   rootPath: string,
   runId: string | undefined,
   lines: number,
   options: Pick<SkillsetOptions, "xdg"> = {}
-): Promise<readonly RuntimeTesterTailLine[]> {
+): Promise<readonly TryTailLine[]> {
   const root = resolve(rootPath);
   const graph = await loadBuildGraph(root, options);
   const resolvedRunId = runId ?? await readLatestRunId(root, graph, options.xdg);
-  const paths = runtimeTesterPaths(root, graph, resolvedRunId, options.xdg);
+  const paths = tryPaths(root, graph, resolvedRunId, options.xdg);
   const raw = await readOptional(paths.absolute.outputPath);
   if (raw === undefined) return [];
   return raw
@@ -319,15 +319,15 @@ export async function tailRuntimeTesterRun(
 function runtimeCommand(
   rootPath: string,
   graph: BuildGraph,
-  paths: RuntimeTesterRunPaths,
-  config: RuntimeTesterStoredConfig,
+  paths: TryRunPaths,
+  config: TryStoredConfig,
   env: Record<string, string | undefined>,
   xdg: SkillsetOptions["xdg"]
 ): { readonly cmd: readonly string[]; readonly cwd: string; readonly display: readonly string[] } {
   const latestRoot = resolveRetainedRunPath(rootPath, graph, ISOLATED_OUT_ROOT, xdg);
   if (config.target === "claude") {
-    const bin = env.SKILLSET_RUNTIME_TESTER_CLAUDE_BIN ?? "claude";
-    const pluginArgs = runtimeTesterPluginDirs(graph, latestRoot, config.target, config.plugins).flatMap((pluginDir) => [
+    const bin = env.SKILLSET_TRY_CLAUDE_BIN ?? "claude";
+    const pluginArgs = tryPluginDirs(graph, latestRoot, config.target, config.plugins).flatMap((pluginDir) => [
       "--plugin-dir",
       pluginDir,
     ]);
@@ -353,8 +353,8 @@ function runtimeCommand(
   }
 
   if (config.target === "cursor") {
-    const bin = env.SKILLSET_RUNTIME_TESTER_CURSOR_BIN ?? "cursor-agent";
-    const pluginArgs = runtimeTesterPluginDirs(graph, latestRoot, config.target, config.plugins).flatMap((pluginDir) => [
+    const bin = env.SKILLSET_TRY_CURSOR_BIN ?? "cursor-agent";
+    const pluginArgs = tryPluginDirs(graph, latestRoot, config.target, config.plugins).flatMap((pluginDir) => [
       "--plugin-dir",
       pluginDir,
     ]);
@@ -374,7 +374,7 @@ function runtimeCommand(
     return { cmd, cwd: latestRoot, display: cmd };
   }
 
-  const bin = env.SKILLSET_RUNTIME_TESTER_CODEX_BIN ?? "codex";
+  const bin = env.SKILLSET_TRY_CODEX_BIN ?? "codex";
   const cmd = [
     bin,
     "exec",
@@ -391,21 +391,21 @@ function runtimeCommand(
   return { cmd, cwd: latestRoot, display: cmd };
 }
 
-function resolveClaudeSettingSources(options: RuntimeTesterRunOptions): RuntimeTesterClaudeSettingSources {
+function resolveClaudeSettingSources(options: TryRunOptions): TryClaudeSettingSources {
   const env = options.env ?? process.env;
   return options.claudeSettingSources ??
-    readClaudeSettingSources(env[RUNTIME_TESTER_CLAUDE_SETTING_SOURCES_ENV], RUNTIME_TESTER_CLAUDE_SETTING_SOURCES_ENV) ??
+    readClaudeSettingSources(env[TRY_CLAUDE_SETTING_SOURCES_ENV], TRY_CLAUDE_SETTING_SOURCES_ENV) ??
     DEFAULT_CLAUDE_SETTING_SOURCES;
 }
 
-function claudeSettingSourcesArg(value: RuntimeTesterClaudeSettingSources): string {
+function claudeSettingSourcesArg(value: TryClaudeSettingSources): string {
   return value === "isolated" ? ISOLATED_CLAUDE_SETTING_SOURCES_ARG : value;
 }
 
 export function readClaudeSettingSources(
   value: string | undefined,
   label: string
-): RuntimeTesterClaudeSettingSources | undefined {
+): TryClaudeSettingSources | undefined {
   if (value === undefined) return undefined;
   const normalized = value.trim();
   if (normalized === "isolated" || normalized === "user" || normalized === "project" || normalized === "local") {
@@ -414,7 +414,7 @@ export function readClaudeSettingSources(
   throw new Error(`skillset: expected ${label} to be isolated, user, project, or local`);
 }
 
-function runtimeTesterPluginDirs(
+function tryPluginDirs(
   graph: BuildGraph,
   latestRoot: string,
   target: "claude" | "cursor",
@@ -434,28 +434,28 @@ function runtimeTesterPluginDirs(
     .map((plugin) => join(latestRoot, pluginTargetRoot(graph.root.outputs.plugins[target], target, plugin)));
 }
 
-function validateRuntimeTesterPlugins(
+function validateTryPlugins(
   graph: BuildGraph,
   target: TargetName,
   plugins: readonly string[]
 ): readonly string[] {
   if (plugins.length === 0) return [];
   if (target === "codex") {
-    throw new Error("skillset: runtime tester --plugin is only supported for targets with local plugin-dir support: claude, cursor");
+    throw new Error("skillset: try --plugin is only supported for targets with local plugin-dir support: claude, cursor");
   }
   const seen = new Set<string>();
   const selected: string[] = [];
   const knownPlugins = graph.plugins.map((plugin) => plugin.id).sort(compareStrings);
   for (const pluginId of plugins) {
-    if (seen.has(pluginId)) throw new Error(`skillset: duplicate runtime tester plugin ${JSON.stringify(pluginId)}`);
+    if (seen.has(pluginId)) throw new Error(`skillset: duplicate try plugin ${JSON.stringify(pluginId)}`);
     seen.add(pluginId);
     const plugin = graph.plugins.find((candidate) => candidate.id === pluginId);
     if (plugin === undefined) {
       const available = knownPlugins.length === 0 ? "none configured" : knownPlugins.join(", ");
-      throw new Error(`skillset: unknown runtime tester plugin ${JSON.stringify(pluginId)}; available plugins: ${available}`);
+      throw new Error(`skillset: unknown try plugin ${JSON.stringify(pluginId)}; available plugins: ${available}`);
     }
     if (!plugin.targets[target].enabled) {
-      throw new Error(`skillset: runtime tester plugin ${JSON.stringify(pluginId)} is not enabled for ${target}`);
+      throw new Error(`skillset: try plugin ${JSON.stringify(pluginId)} is not enabled for ${target}`);
     }
     selected.push(pluginId);
   }
@@ -465,7 +465,7 @@ function validateRuntimeTesterPlugins(
 async function runCommand(
   command: { readonly cmd: readonly string[]; readonly cwd: string },
   prompt: string,
-  paths: RuntimeTesterRunPaths,
+  paths: TryRunPaths,
   timeoutMs: number,
   env: Record<string, string | undefined>
 ): Promise<{ readonly exitCode: number; readonly timedOut: boolean }> {
@@ -496,7 +496,7 @@ async function runCommand(
 }
 
 async function collectStream(
-  paths: RuntimeTesterRunPaths,
+  paths: TryRunPaths,
   streamName: "stderr" | "stdout",
   stream: ReadableStream<Uint8Array>
 ): Promise<void> {
@@ -517,10 +517,10 @@ function cleanEnv(env: Record<string, string | undefined>): Record<string, strin
   return cleaned;
 }
 
-function spawnRuntimeWorker(rootPath: string, runId: string): number | undefined {
+function spawnTryWorker(rootPath: string, runId: string): number | undefined {
   const cliPath = process.argv[1];
-  if (cliPath === undefined) throw new Error("skillset: runtime tester cannot locate CLI entrypoint for background worker");
-  const child = spawnNode(process.execPath, [cliPath, "runtime-tester", "worker", runId, "--root", rootPath], {
+  if (cliPath === undefined) throw new Error("skillset: try cannot locate CLI entrypoint for background worker");
+  const child = spawnNode(process.execPath, [cliPath, "try", "worker", runId, "--root", rootPath], {
     cwd: rootPath,
     detached: true,
     env: process.env,
@@ -530,13 +530,13 @@ function spawnRuntimeWorker(rootPath: string, runId: string): number | undefined
   return child.pid;
 }
 
-function runtimeTesterPaths(
+function tryPaths(
   rootPath: string,
   graph: BuildGraph,
   runId: string,
   xdg: SkillsetOptions["xdg"] = undefined
-): RuntimeTesterRunPaths {
-  const retained = retainedRunPaths(rootPath, graph, RUNTIME_TESTER_ROOT, runId, xdg);
+): TryRunPaths {
+  const retained = retainedRunPaths(rootPath, graph, RUNTIME_TEST_ROOT, runId, xdg);
   return {
     retained,
     absolute: {
@@ -562,19 +562,19 @@ function runtimeTesterPaths(
 }
 
 async function updateRunState(
-  paths: RuntimeTesterRunPaths,
-  status: RuntimeTesterStatus,
-  state: RuntimeTesterState,
-  updates: Partial<RuntimeTesterStatus> = {}
-): Promise<RuntimeTesterStatus> {
+  paths: TryRunPaths,
+  status: TryStatus,
+  state: TryState,
+  updates: Partial<TryStatus> = {}
+): Promise<TryStatus> {
   const next = { ...status, ...updates, state, updatedAt: new Date().toISOString() };
   await writeStatus(paths, next);
   return next;
 }
 
 async function failRun(
-  paths: RuntimeTesterRunPaths,
-  status: RuntimeTesterStatus,
+  paths: TryRunPaths,
+  status: TryStatus,
   error: string
 ): Promise<void> {
   const endedAt = new Date().toISOString();
@@ -598,15 +598,15 @@ async function failRun(
     state: "failed",
     updatedAt: endedAt,
   });
-  await appendEvent(paths, "status", `runtime tester failed: ${error}`);
+  await appendEvent(paths, "status", `try failed: ${error}`);
 }
 
-async function writeStatus(paths: RuntimeTesterRunPaths, status: RuntimeTesterStatus): Promise<void> {
+async function writeStatus(paths: TryRunPaths, status: TryStatus): Promise<void> {
   await mkdir(paths.absolute.runPath, { recursive: true });
   await writeFile(paths.absolute.statusPath, renderValidatedJson(status as unknown as JsonRecord, paths.logical.statusPath), "utf8");
 }
 
-async function writeLatest(paths: RuntimeTesterRunPaths, runId: string): Promise<void> {
+async function writeLatest(paths: TryRunPaths, runId: string): Promise<void> {
   await mkdir(paths.absolute.runsRoot, { recursive: true });
   await writeRetainedRunLatest(paths.retained, {
     runId,
@@ -616,7 +616,7 @@ async function writeLatest(paths: RuntimeTesterRunPaths, runId: string): Promise
   });
 }
 
-async function appendEvent(paths: RuntimeTesterRunPaths, stream: string, message: string): Promise<void> {
+async function appendEvent(paths: TryRunPaths, stream: string, message: string): Promise<void> {
   const event = {
     message,
     stream,
@@ -630,20 +630,20 @@ async function readLatestRunId(
   graph: BuildGraph,
   xdg: SkillsetOptions["xdg"] = undefined
 ): Promise<string> {
-  const latest = await readRetainedRunLatest(rootPath, graph, RUNTIME_TESTER_ROOT, xdg);
+  const latest = await readRetainedRunLatest(rootPath, graph, RUNTIME_TEST_ROOT, xdg);
   if (!isRecord(latest) || typeof latest.runId !== "string") {
-    throw new Error("skillset: runtime tester latest run is malformed");
+    throw new Error("skillset: try latest run is malformed");
   }
   return latest.runId;
 }
 
-async function readConfig(path: string): Promise<RuntimeTesterStoredConfig> {
+async function readConfig(path: string): Promise<TryStoredConfig> {
   const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
-  if (!isRecord(raw)) throw new Error("skillset: runtime tester config is malformed");
-  if (!isTargetName(raw.target)) throw new Error("skillset: runtime tester config target is malformed");
-  if (typeof raw.prompt !== "string") throw new Error("skillset: runtime tester config prompt is malformed");
+  if (!isRecord(raw)) throw new Error("skillset: try config is malformed");
+  if (!isTargetName(raw.target)) throw new Error("skillset: try config target is malformed");
+  if (typeof raw.prompt !== "string") throw new Error("skillset: try config prompt is malformed");
   const claudeSettingSources = typeof raw.claudeSettingSources === "string"
-    ? readClaudeSettingSources(raw.claudeSettingSources, "runtime tester config claudeSettingSources")
+    ? readClaudeSettingSources(raw.claudeSettingSources, "try config claudeSettingSources")
     : undefined;
   return {
     ...(claudeSettingSources === undefined ? {} : { claudeSettingSources }),
@@ -656,12 +656,12 @@ async function readConfig(path: string): Promise<RuntimeTesterStoredConfig> {
   };
 }
 
-async function readStatus(path: string): Promise<RuntimeTesterStatus> {
+async function readStatus(path: string): Promise<TryStatus> {
   const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
   if (!isRecord(raw) || typeof raw.runId !== "string" || !isTargetName(raw.target)) {
-    throw new Error("skillset: runtime tester status is malformed");
+    throw new Error("skillset: try status is malformed");
   }
-  return raw as unknown as RuntimeTesterStatus;
+  return raw as unknown as TryStatus;
 }
 
 async function readOptional(path: string): Promise<string | undefined> {
@@ -681,7 +681,7 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-function parseTailLine(line: string): RuntimeTesterTailLine {
+function parseTailLine(line: string): TryTailLine {
   const parsed = JSON.parse(line) as unknown;
   if (!isRecord(parsed)) return { message: line, stream: "raw", timestamp: "" };
   return {
@@ -692,11 +692,11 @@ function parseTailLine(line: string): RuntimeTesterTailLine {
 }
 
 function runReport(
-  paths: RuntimeTesterRunPaths,
+  paths: TryRunPaths,
   runId: string,
-  state: RuntimeTesterState,
+  state: TryState,
   background: boolean
-): RuntimeTesterRunReport {
+): TryRunReport {
   return {
     background,
     latestPath: paths.logical.latestJsonPath,

--- a/docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md
+++ b/docs/adrs/drafts/20260702-cursor-is-a-first-class-provider.md
@@ -88,7 +88,7 @@ This means:
 
 The provider contract is deliberately stronger than "make Cursor compile." The
 test is whether `skillset lookup`, `skillset explain`, build diagnostics,
-render results, locks, docs, fixtures, and runtime-tester output all tell the same
+render results, locks, docs, fixtures, and `skillset try` output all tell the same
 truth for Cursor that they tell for Claude and Codex.
 
 ## Implementation Milestones
@@ -102,7 +102,7 @@ instead of patching the renderer locally.
 | Evidence and contract | Cursor docs and local CLI evidence are recorded; this ADR and the portable capability/permission intent model define what can be native, transformed, shimmed, degraded, lossy, or unsupported. |
 | Target and output plumbing | `cursor` is accepted by schema/core/registry/Workbench/lookup; output roots, `_cursor` source islands, locks, safety checks, and generated schema artifacts include Cursor. |
 | Native renderers | Skills, rules, subagents, plugins, marketplaces, MCP, hooks, commands, and provider-native companions render only where Cursor has a faithful destination. |
-| Import and runtime proof | Cursor imports preserve native source unless a faithful adaptive lift exists; runtime-tester dogfoods generated Cursor output with the local CLI in isolated workspaces. |
+| Import and runtime proof | Cursor imports preserve native source unless a faithful adaptive lift exists; `skillset try` dogfoods generated Cursor output with the local CLI in isolated workspaces. |
 | Parity gate | Adapter conformance, deterministic projection, fixtures, docs, generated guidance, Linear, PR checks, and local review all agree that Cursor is fully working. |
 
 ## Consequences

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -9,10 +9,10 @@ Runtime adapters describe how a Skillset rendering can be used by an actual agen
 ## Status
 
 Runtime adapter records describe how a generated provider rendering can be
-smoke-tested or consumed by a concrete runtime. `skillset runtime-tester` can
+smoke-tested or consumed by a concrete runtime. `skillset try` can
 run non-interactive Claude, Codex, and Cursor prompts against isolated local
 renderings while retaining inspectable run artifacts under the logical
-`.skillset/cache/runtime-tester` path.
+`.skillset/cache/runtime-tests` path.
 
 Cursor is a first-class provider target, not a runtime-only compatibility
 candidate. It participates in the default provider plan alongside Claude and
@@ -59,7 +59,7 @@ Runtime support records live in the feature registry as `runtimeSupport` rows. A
 | Build target | A provider rendering Skillset can render directly. | `claude`, `codex`, `cursor` |
 | Runtime adapter | A concrete runtime or harness that can consume a rendering or compatibility shim. | `claude-code`, `codex-cli`, `codex-app`, `cursor` |
 | Distribution surface | A repo, marketplace, extension root, or package shape a rendering may be synced into. | Implemented `distributions.*` plan config; sync/publish remains future |
-| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation probe assets under `skillset test`; implemented live non-interactive prompt runs through `skillset runtime-tester` |
+| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation probe assets under `skillset test`; implemented ad hoc live non-interactive prompt runs through `skillset try` |
 
 The test: adding a runtime must not make `compile.targets` accept a new value. It should add evidence and support records first, then a specific adapter or distribution flow only when the target behavior is proven.
 
@@ -82,7 +82,7 @@ Runtime support diagnostics should name whether behavior is native, pass-through
 
 When behavior is shimmed, diagnostics must identify the mechanism and caveat. For example, a Codex agent can receive an instruction to load skills first, but Skillset should not say Codex has native Claude-style agent `skills` metadata.
 
-`skillset runtime-tester status` reports live harness state as `queued`, `building`, `running`, `passed`, or `failed`, and `skillset runtime-tester tail` reads retained output from the logical `.skillset/cache/runtime-tester` path backed by XDG storage.
+`skillset try status` reports live harness state as `queued`, `building`, `running`, `passed`, or `failed`, and `skillset try tail` reads retained output from the logical `.skillset/cache/runtime-tests` path backed by XDG storage.
 
 ## Provenance
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -17,7 +17,7 @@ Skillset currently uses internal compiler fixtures and validation commands:
 | Validation commands | `skillset check`, `skillset verify`, `doctor`, `diff`, `change check`, `release plan` | `implemented` | Public commands that validate real source and generated output. |
 | Dogfooding | repo scripts, Linear acceptance criteria, real Skillset source changes | internal practice | Proves workflows by using them on this repo. |
 | `skillset test` | `<source-root>/tests.yaml` and `<source-root>/tests/*.yaml` | `implemented` | Deterministic isolated projection and check runner for authored source. |
-| `skillset runtime-tester` | `.skillset/cache/runtime-tester/` logical reports backed by XDG cache storage | `implemented` / maintainer harness | Runs non-interactive Claude or Codex prompts against an isolated rendering and retains status, output, tail, and report files. |
+| `skillset try` | `.skillset/cache/runtime-tests/` logical reports backed by XDG cache storage | `implemented` / maintainer harness | Runs non-interactive Claude, Codex, or Cursor prompts against an isolated rendering and retains status, output, tail, and report files. |
 | `.skillset/evals/` | n/a | `future` | Future adapter-aware behavioral eval declarations or pointers. |
 
 Checked-in internal fixtures use the current workspace layout: `fixtures/<case>/skillset.yaml` as the workspace manifest and `fixtures/<case>/.skillset/` as the source root.
@@ -150,22 +150,22 @@ Each probe requires `prompt` and `expect`. The v1 `expect` object must name exac
 
 Edge cases stay explicit: multiple matching skills should be disambiguated in the expected selector, provider source may need target-specific probes, missing plugin dependencies should appear as activation setup failures rather than build successes, and compatibility shims should be reported as shims in the generated probe material.
 
-## Runtime Tester
+## Runtime Tries
 
-`skillset runtime-tester` is the first live runtime harness. It is separate from `skillset test`: deterministic tests prove projection and generated files, while the runtime tester builds an isolated latest rendering and asks a real local runtime a non-interactive prompt.
+`skillset try` is the ad hoc live-runtime harness. It is separate from `skillset test`: deterministic tests prove projection and generated files, while a try builds an isolated latest rendering and asks a real local runtime a non-interactive prompt. A successful try means the runtime process completed; it does not claim that the response satisfied a committed assertion.
 
 ```bash
-skillset runtime-tester run --target codex --prompt "What skills can you see?"
-skillset runtime-tester run --target claude --prompt-file prompts/smoke.md --claude-setting-sources isolated --background
-skillset runtime-tester status
-skillset runtime-tester tail --lines 80
-skillset runtime-tester list
+skillset try --target codex --prompt "What skills can you see?"
+skillset try --target claude --prompt-file prompts/smoke.md --claude-setting-sources isolated --background
+skillset try status
+skillset try tail --lines 80
+skillset try list
 ```
 
 Runs write retained artifacts under the logical repo cache path:
 
 ```text
-.skillset/cache/runtime-tester/
+.skillset/cache/runtime-tests/
   latest.json
   runs/<run-id>/
     config.json
@@ -187,13 +187,13 @@ The tester does not install, trust, publish, or enable generated artifacts. It i
 Claude setting sources can be overridden for probes that intentionally need more runtime context. Precedence is CLI flag, then env var, then the isolated default:
 
 ```bash
-skillset runtime-tester run --target claude --claude-setting-sources user --prompt "What do you see?"
-SKILLSET_RUNTIME_TESTER_CLAUDE_SETTING_SOURCES=project skillset runtime-tester run --target claude --prompt "What do you see?"
+skillset try --target claude --claude-setting-sources user --prompt "What do you see?"
+SKILLSET_TRY_CLAUDE_SETTING_SOURCES=project skillset try --target claude --prompt "What do you see?"
 ```
 
-Override runtime binaries with `SKILLSET_RUNTIME_TESTER_CODEX_BIN` or `SKILLSET_RUNTIME_TESTER_CLAUDE_BIN` for tests, shims, or machine-specific installs.
+Override runtime binaries with `SKILLSET_TRY_CODEX_BIN`, `SKILLSET_TRY_CLAUDE_BIN`, or `SKILLSET_TRY_CURSOR_BIN` for tests, shims, or machine-specific installs.
 
-For Claude Code non-interactive runs, the CLI process must see a non-interactive credential. If `claude --print` reports `Not logged in`, run `claude setup-token`, put the printed `CLAUDE_CODE_OAUTH_TOKEN` export in the repo-local ignored `.envrc`, and run `direnv allow`. The committed `.envrc.example` shows the expected shape without storing secrets. From shells or automation that do not load the direnv hook, run the tester through `direnv exec . skillset runtime-tester ...`.
+For Claude Code non-interactive runs, the CLI process must see a non-interactive credential. If `claude --print` reports `Not logged in`, run `claude setup-token`, put the printed `CLAUDE_CODE_OAUTH_TOKEN` export in the repo-local ignored `.envrc`, and run `direnv allow`. The committed `.envrc.example` shows the expected shape without storing secrets. From shells or automation that do not load the direnv hook, run the try through `direnv exec . skillset try ...`.
 
 ## Compiler Determinism and Adapter Conformance
 


### PR DESCRIPTION
## Context

SET-272 hard-cuts the implementation-shaped `runtime-tester` surface before declared live-runtime assertions build on it.

## What changed

- replace the public command with direct `skillset try` execution plus `status`, `tail`, and `list`
- retain runs under the XDG-backed logical `.skillset/cache/runtime-tests/` path
- rename runtime overrides to `SKILLSET_TRY_*` and remove the old command/env contract
- align tests, docs, active ADR guidance, and release intent

## Verification

- `bun test apps/skillset/src/__tests__/try.test.ts`
- five repeated background-worker contract runs
- `bun run check` (895 tests)
- `bun run hooks:pre-push`
- targeted local review: 5/5 clean, no open P0-P2

## Risk

This is an intentional hard cutover. Existing `runtime-tester` invocations and `SKILLSET_RUNTIME_TESTER_*` variables are rejected rather than aliased.