### PR TITLE
feat(test): add declared live runtime assertions

### DIFF
--- a/.changeset/declared-runtime-tests.md
+++ b/.changeset/declared-runtime-tests.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Allow explicit activation probes in `skillset test` declarations to invoke Claude, Codex, or Cursor through the shared `skillset try` harness, assert literal response facts, classify provider and assertion failures, and retain raw evidence in the XDG-backed runtime-test cache.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1906,7 +1906,7 @@ Demo body.
     workspacePath: string;
   };
   expect(firstLatest.runId).toMatch(/^\d{8}T\d{6}Z-[0-9a-f]{8}$/);
-  expect(firstLatest.schemaVersion).toBe(2);
+  expect(firstLatest.schemaVersion).toBe(3);
   expect(await fileExists(cachePath(root, join(firstLatest.runPath, "report.json")))).toBe(true);
   expect(await fileExists(cachePath(root, ".skillset/cache/tests/latest/report.json"))).toBe(true);
   expect(await fileExists(cachePath(root, ".skillset/cache/tests/latest/workspace/.claude/skills/demo/SKILL.md"))).toBe(true);
@@ -1917,7 +1917,7 @@ Demo body.
     schemaVersion: number;
     targets: readonly string[];
   };
-  expect(firstReport.schemaVersion).toBe(2);
+  expect(firstReport.schemaVersion).toBe(3);
   expect(firstReport.targets).toEqual(["claude"]);
 
   const second = await runSkillsetCli("test", "self", "--root", root);

--- a/apps/skillset/src/__tests__/provider-maintenance.test.ts
+++ b/apps/skillset/src/__tests__/provider-maintenance.test.ts
@@ -141,7 +141,7 @@ describe("provider maintainer commands", () => {
       readonly listProviderSchemaSnapshots: () => readonly ProviderSchemaSnapshot[];
     };
     expect(imported.listProviderSchemaSnapshots().length).toBe(listProviderSchemaSnapshots().length);
-  }, 15_000);
+  });
 });
 
 function schemaBody(properties: readonly string[]): string {

--- a/apps/skillset/src/__tests__/provider-maintenance.test.ts
+++ b/apps/skillset/src/__tests__/provider-maintenance.test.ts
@@ -141,7 +141,7 @@ describe("provider maintainer commands", () => {
       readonly listProviderSchemaSnapshots: () => readonly ProviderSchemaSnapshot[];
     };
     expect(imported.listProviderSchemaSnapshots().length).toBe(listProviderSchemaSnapshots().length);
-  });
+  }, 15_000);
 });
 
 function schemaBody(properties: readonly string[]): string {

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -11,6 +11,7 @@ import {
   startTryRun,
   tailTryRun,
 } from "../try";
+import { runSkillsetTest } from "../test-runner";
 
 test("try runs a Codex prompt and records inspectable artifacts", async () => {
   const root = await fixture({
@@ -428,6 +429,391 @@ Background fixture body.
   expect(state).toBe("passed");
 }, 15_000);
 
+test("SET-273: declared runtime tests reuse try across providers and retain normalized evidence", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: declared-runtime-fixture
+claude: true
+codex: true
+cursor: true
+`,
+    ".skillset/prompts/claude.md": "Inspect the Claude runtime fixture.",
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Declared runtime fixture.
+---
+
+Runtime fixture body.
+`,
+    ".skillset/tests/runtime.yaml": `
+select:
+  skills:
+    primary: [demo]
+targets: [claude, codex, cursor]
+activation:
+  - name: codex runtime
+    targets: [codex]
+    prompt: Inspect the Codex runtime fixture.
+    expect:
+      skill: demo
+    runtime:
+      timeoutMs: 5000
+      expect:
+        contains: fake codex final
+        notContains: impossible failure text
+  - name: claude runtime
+    targets: [claude]
+    promptFile: prompts/claude.md
+    expect:
+      skill: demo
+    runtime:
+      claude:
+        settingSources: isolated
+      expect:
+        contains: Inspect the Claude runtime fixture.
+  - name: cursor runtime
+    targets: [cursor]
+    prompt: Inspect the Cursor runtime fixture.
+    expect:
+      skill: demo
+    runtime:
+      expect:
+        contains: fake-cursor
+checks:
+  projection: true
+`,
+  });
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+  const runtimeEnv = {
+    ...process.env,
+    SKILLSET_TRY_CLAUDE_BIN: await fakeClaudeBin(root),
+    SKILLSET_TRY_CODEX_BIN: await fakeCodexBin(root),
+    SKILLSET_TRY_CURSOR_BIN: await fakeCursorBin(root),
+  };
+  const report = await runSkillsetTest(root, "runtime", {
+    runtimeEnv,
+    xdg,
+  });
+
+  expect(report.ok).toBe(true);
+  expect(report.runtimeTests).toHaveLength(3);
+  expect(report.runtimeTests.map((result) => result.target)).toEqual(["codex", "claude", "cursor"]);
+  expect(report.runtimeTests.every((result) => result.ok)).toBe(true);
+  expect(report.runtimeTests.map((result) => result.promptProvenance)).toEqual([
+    "inline",
+    ".skillset/prompts/claude.md",
+    "inline",
+  ]);
+  for (const result of report.runtimeTests) {
+    expect(result.runPath).toStartWith(".skillset/cache/runtime-tests/runs/");
+    expect(await exists(cachePath(root, xdg, String(result.reportPath)))).toBe(true);
+    expect(await exists(cachePath(root, xdg, String(result.outputPath)))).toBe(true);
+    expect(result.assertions.every((assertion) => assertion.ok)).toBe(true);
+  }
+  const structured = JSON.parse(await readFile(cachePath(root, xdg, report.reportPath), "utf8")) as {
+    runtimeTests: Array<{ promptProvenance: string; target: string }>;
+  };
+  expect(structured.runtimeTests.map((result) => result.target)).toEqual(["codex", "claude", "cursor"]);
+  expect(await readFile(cachePath(root, xdg, report.reportMarkdownPath), "utf8")).toContain("## Runtime Tests");
+
+  const cli = await runSkillsetCli(
+    { ...runtimeEnv, XDG_CACHE_HOME: xdg.env.XDG_CACHE_HOME },
+    "test",
+    "runtime",
+    "--root",
+    root
+  );
+  expect(cli.exitCode).toBe(0);
+  expect(cli.stdout).toContain("runtime tests: 3");
+  expect(cli.stdout).toContain("pass: runtime claude runtime [claude]");
+});
+
+test("SET-273: declared runtime expectation failures are distinct from provider failures", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: declared-runtime-assertion-fixture
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Assertion fixture.
+---
+
+Assertion fixture body.
+`,
+    ".skillset/tests/runtime.yaml": `
+select:
+  skills:
+    primary: [demo]
+targets: [codex]
+activation:
+  - prompt: Inspect the assertion fixture.
+    expect:
+      skill: demo
+    runtime:
+      expect:
+        contains: text that is not returned
+checks:
+  projection: true
+`,
+  });
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+  const report = await runSkillsetTest(root, "runtime", {
+    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: await fakeCodexBin(root) },
+    xdg,
+  });
+
+  expect(report.ok).toBe(false);
+  expect(report.runtimeTests).toHaveLength(1);
+  expect(report.runtimeTests[0]).toEqual(expect.objectContaining({
+    failureClass: "assertion",
+    ok: false,
+    state: "passed",
+    target: "codex",
+  }));
+
+  const authBin = await fakeFailureBin(root, "declared-auth-codex", "Not logged in. Run setup-token.", 1);
+  const authReport = await runSkillsetTest(root, "runtime", {
+    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: authBin },
+    xdg,
+  });
+  expect(authReport.runtimeTests[0]).toEqual(expect.objectContaining({
+    assertions: [],
+    detail: "Not logged in. Run setup-token.",
+    failureClass: "auth",
+    ok: false,
+  }));
+});
+
+test("SET-273: declared runtime render failures stop before provider invocation", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: declared-runtime-setup-fixture
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Setup fixture.
+---
+
+Setup fixture body.
+`,
+    ".skillset/tests/runtime.yaml": `
+select:
+  skills:
+    primary: [demo]
+targets: [codex]
+activation:
+  - prompt: Inspect the missing unit.
+    expect:
+      skill: missing
+    runtime:
+      expect:
+        contains: never invoked
+checks:
+  projection: true
+`,
+  });
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+  const report = await runSkillsetTest(root, "runtime", {
+    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: join(root, "must-not-run") },
+    xdg,
+  });
+
+  expect(report.ok).toBe(false);
+  expect(report.runtimeTests).toEqual([
+    expect.objectContaining({
+      detail: "expected skill missing was not rendered for codex",
+      failureClass: "render",
+      ok: false,
+      target: "codex",
+    }),
+  ]);
+  expect(await exists(cachePath(root, xdg, ".skillset/cache/runtime-tests/latest.json"))).toBe(false);
+});
+
+test("SET-273: failed isolated builds produce normalized render failures", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: declared-runtime-build-fixture
+codex: true
+`,
+    ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+bin: true
+`,
+    ".skillset/plugins/demo/skills/helper/SKILL.md": `
+---
+name: helper
+description: Render failure fixture.
+---
+
+Render failure body.
+`,
+    ".skillset/plugins/demo/bin/tool": "#!/bin/sh\n",
+    ".skillset/tests/runtime.yaml": `
+select:
+  plugins: [demo]
+targets: [codex]
+activation:
+  - prompt: Inspect the render failure.
+    expect:
+      plugin: demo
+    runtime:
+      expect:
+        contains: never invoked
+checks:
+  projection: true
+`,
+  });
+  const report = await runSkillsetTest(root, "runtime", {
+    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: join(root, "must-not-run") },
+  });
+
+  expect(report.ok).toBe(false);
+  expect(report.checks[0]).toEqual(expect.objectContaining({ kind: "projection", ok: false }));
+  expect(report.runtimeTests).toEqual([
+    expect.objectContaining({ failureClass: "render", ok: false, target: "codex" }),
+  ]);
+});
+
+test("SET-273: runtime prompt files stay source-local and are exclusive with inline prompts", async () => {
+  const files = {
+    "skillset.yaml": `
+skillset:
+  name: runtime-prompt-contract
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Prompt contract fixture.
+---
+
+Prompt fixture body.
+`,
+  };
+  const bothRoot = await fixture({
+    ...files,
+    ".skillset/prompts/demo.md": "Prompt file.",
+    ".skillset/tests/runtime.yaml": `
+select:
+  skills:
+    primary: [demo]
+activation:
+  - prompt: Inline prompt.
+    promptFile: prompts/demo.md
+    expect:
+      skill: demo
+    runtime:
+      expect:
+        contains: demo
+checks:
+  projection: true
+`,
+  });
+  await expect(runSkillsetTest(bothRoot, "runtime")).rejects.toThrow("must name exactly one of prompt or promptFile");
+
+  const escapeRoot = await fixture({
+    ...files,
+    ".skillset/tests/runtime.yaml": `
+select:
+  skills:
+    primary: [demo]
+activation:
+  - promptFile: ../skillset.yaml
+    expect:
+      skill: demo
+    runtime:
+      expect:
+        contains: demo
+checks:
+  projection: true
+`,
+  });
+  await expect(runSkillsetTest(escapeRoot, "runtime")).rejects.toThrow("inside the source root");
+
+  const symlinkRoot = await fixture({
+    ...files,
+    ".skillset/tests/runtime.yaml": `
+select:
+  skills:
+    primary: [demo]
+activation:
+  - promptFile: prompts/leak.md
+    expect:
+      skill: demo
+    runtime:
+      expect:
+        contains: sentinel
+checks:
+  projection: true
+`,
+    "outside.md": "external prompt sentinel",
+  });
+  await mkdir(join(symlinkRoot, ".skillset/prompts"), { recursive: true });
+  await symlink("../../outside.md", join(symlinkRoot, ".skillset/prompts/leak.md"));
+  await expect(runSkillsetTest(symlinkRoot, "runtime")).rejects.toThrow("resolves outside the source root");
+});
+
+test("SET-273: try classifies setup, auth, and timeout failures", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: runtime-failure-fixture
+claude: true
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Runtime failure fixture.
+---
+
+Runtime failure body.
+`,
+  });
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+
+  const missing = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CODEX_BIN: join(root, "missing-codex") },
+    name: "missing-runtime",
+    prompt: "Missing runtime.",
+    target: "codex",
+    xdg,
+  });
+  expect((await readTryStatus(root, missing.runId, { xdg })).failureClass).toBe("binary");
+
+  const authBin = await fakeFailureBin(root, "auth-claude", "Not logged in. Run setup-token.", 1);
+  const auth = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CLAUDE_BIN: authBin },
+    name: "auth-runtime",
+    prompt: "Auth runtime.",
+    target: "claude",
+    xdg,
+  });
+  expect((await readTryStatus(root, auth.runId, { xdg })).failureClass).toBe("auth");
+
+  const timeoutBin = await fakeSleepingBin(root);
+  const timeout = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TRY_CODEX_BIN: timeoutBin },
+    name: "timeout-runtime",
+    prompt: "Timeout runtime.",
+    target: "codex",
+    timeoutMs: 10,
+    xdg,
+  });
+  expect((await readTryStatus(root, timeout.runId, { xdg })).failureClass).toBe("timeout");
+});
+
 async function fixture(files: Record<string, string>): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "skillset-try-"));
   for (const [path, content] of Object.entries(files)) {
@@ -487,6 +873,22 @@ done
 echo "fake-cursor cwd=$(pwd)"
 echo "fake-cursor prompt=$last"
 `, "utf8");
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function fakeFailureBin(root: string, name: string, message: string, exitCode: number): Promise<string> {
+  const bin = join(root, "bin", name);
+  await mkdir(dirname(bin), { recursive: true });
+  await writeFile(bin, `#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(message)} >&2\nexit ${exitCode}\n`, "utf8");
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function fakeSleepingBin(root: string): Promise<string> {
+  const bin = join(root, "bin", "sleeping-codex");
+  await mkdir(dirname(bin), { recursive: true });
+  await writeFile(bin, "#!/bin/sh\nsleep 1\n", "utf8");
   await chmod(bin, 0o755);
   return bin;
 }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1473,6 +1473,13 @@ function printSkillsetTest(report: SkillsetTestReport): void {
   console.log(`  generated files: ${report.generatedFiles}`);
   console.log(`  activation probes: ${report.activationProbes}`);
   if (report.activationPath !== undefined) console.log(`  activation: ${report.activationPath}`);
+  console.log(`  runtime tests: ${report.runtimeTests.length}`);
+  for (const runtimeTest of report.runtimeTests) {
+    const failure = runtimeTest.failureClass === undefined ? "" : ` (${runtimeTest.failureClass})`;
+    const detail = runtimeTest.detail === undefined ? "" : ` - ${runtimeTest.detail}`;
+    console.log(`  ${runtimeTest.ok ? "pass" : "fail"}: runtime ${runtimeTest.name} [${runtimeTest.target}]${failure}${detail}`);
+    if (runtimeTest.outputPath !== undefined) console.log(`    output: ${runtimeTest.outputPath}`);
+  }
 }
 
 function formatTestSelection(selection: SkillsetTestReport["selection"]): string {

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -1,5 +1,5 @@
-import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 
 import { buildSkillset, diffSkillset } from "@skillset/core";
@@ -17,9 +17,18 @@ import { renderValidatedJson } from "@skillset/core/internal/structured-output";
 import type { BuildGraph, JsonRecord, JsonValue, SkillsetOptions, TargetName } from "@skillset/core/internal/types";
 import { pluginVersion } from "@skillset/core/internal/versioning";
 import { isJsonRecord, parseYamlRecord } from "@skillset/core/internal/yaml";
+import { validateTestDeclaration } from "@skillset/schema";
+import {
+  readTryEvidence,
+  readTryStatus,
+  startTryRun,
+  type TryClaudeSettingSources,
+  type TryFailureClass,
+  type TryState,
+} from "./try";
 
 const TEST_BUILD_DIR = "cache/tests";
-const TEST_SCHEMA = 2;
+const TEST_SCHEMA = 3;
 
 export interface SkillsetTestReport {
   readonly activationPath?: string;
@@ -34,9 +43,38 @@ export interface SkillsetTestReport {
   readonly runId: string;
   readonly selection: SkillsetTestSelectionReport;
   readonly runPath: string;
+  readonly runtimeTests: readonly SkillsetRuntimeTestResult[];
   readonly source: string;
   readonly targets: readonly TargetName[];
   readonly workspacePath: string;
+}
+
+export interface SkillsetTestOptions extends SkillsetOptions {
+  readonly runtimeEnv?: Record<string, string | undefined>;
+}
+
+export interface SkillsetRuntimeAssertionResult extends JsonRecord {
+  readonly actual: boolean;
+  readonly expected: string;
+  readonly kind: "contains" | "notContains";
+  readonly ok: boolean;
+}
+
+export interface SkillsetRuntimeTestResult extends JsonRecord {
+  readonly assertions: SkillsetRuntimeAssertionResult[];
+  readonly command: string[];
+  readonly detail?: string;
+  readonly failureClass?: TryFailureClass | "assertion";
+  readonly name: string;
+  readonly ok: boolean;
+  readonly outputPath?: string;
+  readonly promptPath?: string;
+  readonly promptProvenance: string;
+  readonly reportPath?: string;
+  readonly runId?: string;
+  readonly runPath?: string;
+  readonly state: TryState;
+  readonly target: TargetName;
 }
 
 export interface SkillsetTestCheckResult {
@@ -91,7 +129,16 @@ interface ActivationProbe {
   readonly expect: ActivationExpectation;
   readonly name: string;
   readonly prompt: string;
+  readonly promptProvenance: string;
+  readonly runtime?: ActivationRuntime;
   readonly targets: readonly TargetName[];
+}
+
+interface ActivationRuntime {
+  readonly claudeSettingSources?: TryClaudeSettingSources;
+  readonly contains?: string;
+  readonly notContains?: string;
+  readonly timeoutMs?: number;
 }
 
 interface ActivationExpectation {
@@ -102,7 +149,7 @@ interface ActivationExpectation {
 export async function runSkillsetTest(
   rootPath: string,
   name: string | undefined,
-  options: SkillsetOptions = {}
+  options: SkillsetTestOptions = {}
 ): Promise<SkillsetTestReport> {
   await rejectRetiredWorkspaceTestConfig(rootPath, options);
   const graph = await loadBuildGraph(rootPath, options);
@@ -169,7 +216,12 @@ export async function runSkillsetTest(
       ? undefined
       : join(logicalRunPath, "activation").replaceAll("\\", "/");
 
-    const ok = checks.every((check) => check.ok);
+    const runtimeTests = buildError !== undefined
+      ? runtimeRenderFailures(declaration, buildError)
+      : checks.every((check) => check.ok)
+        ? await runDeclaredRuntimeTests(rootPath, workspacePath, declaration, options)
+        : [];
+    const ok = checks.every((check) => check.ok) && runtimeTests.every((result) => result.ok);
     const reportPath = join(runPath, "report.json");
     const reportMarkdownPath = join(runPath, "report.md");
     const latestPath = join(buildRoot, "latest");
@@ -193,6 +245,7 @@ export async function runSkillsetTest(
       source: `repo:${sourceDir}`,
       targets: [...declaration.targets],
       ...activationReport,
+      runtimeTests,
       workspacePath: logicalWorkspacePath,
     };
 
@@ -213,6 +266,7 @@ export async function runSkillsetTest(
       runId,
       selection: selectionRecord(declaration.selection),
       runPath: logicalRunPath,
+      runtimeTests,
       source: `repo:${sourceDir}`,
       targets: declaration.targets,
       workspacePath: logicalWorkspacePath,
@@ -317,13 +371,17 @@ function testDeclarationRootForSourceDir(sourceDir: string): string {
   return sourceDir;
 }
 
-function readTestObject(
+async function readTestObject(
   graph: BuildGraph,
   record: JsonRecord,
   label: string,
   name: string,
   defaultTargets: readonly TargetName[]
-): TestDeclaration {
+): Promise<TestDeclaration> {
+  if (usesDeclaredRuntimeContract(record)) {
+    const diagnostic = validateTestDeclaration(record).diagnostics[0];
+    if (diagnostic !== undefined) throw new Error(`skillset: ${label}: ${diagnostic.message}`);
+  }
   for (const key of Object.keys(record)) {
     if (key === "assertions" || key === "assert") {
       throw new Error(`skillset: ${label}.${key} is retired; use ${label}.checks`);
@@ -339,7 +397,7 @@ function readTestObject(
   const targets = readTargets(record.targets, `${label}.targets`, defaultTargets);
   const selection = readSelection(graph, record.select, `${label}.select`);
   const checks = readChecks(record.checks, `${label}.checks`, selection);
-  const activationProbes = readActivationProbes(record.activation, `${label}.activation`, targets);
+  const activationProbes = await readActivationProbes(graph, record.activation, `${label}.activation`, targets);
   validateActivationProbeNames(activationProbes, targets);
   const output = record.output;
   if (output !== undefined) {
@@ -354,6 +412,13 @@ function readTestObject(
   }
 
   return { activationProbes, checks, name, selection, targets };
+}
+
+function usesDeclaredRuntimeContract(record: JsonRecord): boolean {
+  if (!Array.isArray(record.activation)) return false;
+  return record.activation.some((probe) =>
+    isJsonRecord(probe) && (probe.runtime !== undefined || probe.promptFile !== undefined)
+  );
 }
 
 function readTargets(value: JsonValue | undefined, label: string, defaultTargets: readonly TargetName[]): readonly TargetName[] {
@@ -458,6 +523,7 @@ function readPluginSelection(
     return;
   }
   if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be true, a string array, or an object`);
+  if (Object.keys(value).length === 0) throw new Error(`skillset: ${label} must include include or skills; use true to select all plugins`);
   for (const key of Object.keys(value)) {
     if (key !== "include" && key !== "skills") throw new Error(`skillset: unsupported selector key ${key} in ${label}`);
   }
@@ -491,6 +557,7 @@ function readSkillSelection(
     return;
   }
   if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be true, a string array, or an object`);
+  if (Object.keys(value).length === 0) throw new Error(`skillset: ${label} must include primary or plugin; use true to select all skills`);
   for (const key of Object.keys(value)) {
     if (key !== "primary" && key !== "plugin") throw new Error(`skillset: unsupported selector key ${key} in ${label}`);
   }
@@ -528,6 +595,7 @@ function readPluginSkillSelection(
     return;
   }
   if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be true, a string array, or an object`);
+  if (Object.keys(value).length === 0) throw new Error(`skillset: ${label} must include at least one plugin; use true to select all plugin skills`);
   for (const [pluginId, raw] of Object.entries(value).sort(([left], [right]) => compareStrings(left, right))) {
     assertPlugin(graph, pluginId, label);
     readPluginSkillSelectionForPlugins(graph, [pluginId], raw, `${label}.${pluginId}`, addPluginSkill);
@@ -648,38 +716,115 @@ function readFileCheck(value: JsonValue, label: string): TestCheck {
   return { kind: "exists", path };
 }
 
-function readActivationProbes(
+async function readActivationProbes(
+  graph: BuildGraph,
   value: JsonValue | undefined,
   label: string,
   defaultTargets: readonly TargetName[]
-): readonly ActivationProbe[] {
+): Promise<readonly ActivationProbe[]> {
   if (value === undefined) return [];
   if (!Array.isArray(value)) throw new Error(`skillset: expected ${label} to be an array`);
-  return value.map((item, index) => readActivationProbe(item, `${label}[${index}]`, defaultTargets));
+  return Promise.all(value.map((item, index) => readActivationProbe(graph, item, `${label}[${index}]`, defaultTargets)));
 }
 
-function readActivationProbe(
+async function readActivationProbe(
+  graph: BuildGraph,
   value: JsonValue,
   label: string,
   defaultTargets: readonly TargetName[]
-): ActivationProbe {
+): Promise<ActivationProbe> {
   if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
   for (const key of Object.keys(value)) {
-    if (key !== "expect" && key !== "name" && key !== "prompt" && key !== "targets") {
+    if (key !== "expect" && key !== "name" && key !== "prompt" && key !== "promptFile" && key !== "runtime" && key !== "targets") {
       throw new Error(`skillset: unsupported activation key ${key} in ${label}`);
     }
   }
-  const prompt = readString(value, "prompt");
-  if (prompt === undefined) throw new Error(`skillset: ${label}.prompt is required`);
+  const inlinePrompt = readString(value, "prompt");
+  const promptFile = readString(value, "promptFile");
+  if (value.prompt !== undefined && inlinePrompt === undefined) throw new Error(`skillset: ${label}.prompt is required`);
+  if (value.promptFile !== undefined && promptFile === undefined) throw new Error(`skillset: ${label}.promptFile is required`);
+  if ((inlinePrompt === undefined) === (promptFile === undefined)) {
+    throw new Error(`skillset: ${label} must name exactly one of prompt or promptFile`);
+  }
+  const promptPath = promptFile === undefined
+    ? undefined
+    : resolveInside(graph.sourceRootPath, promptFile);
+  const prompt = inlinePrompt ?? await readSourcePromptFile(graph.sourceRootPath, promptPath as string, label);
   const expect = readActivationExpectation(value.expect, `${label}.expect`);
   const targets = readTargets(value.targets, `${label}.targets`, defaultTargets);
   const configuredName = readString(value, "name");
+  const runtime = readActivationRuntime(value.runtime, `${label}.runtime`);
   return {
     expect,
     name: configuredName ?? activationProbeName(expect),
     prompt,
+    promptProvenance: promptFile === undefined ? "inline" : join(graph.sourceRoot, promptFile).replaceAll("\\", "/"),
+    ...(runtime === undefined ? {} : { runtime }),
     targets,
   };
+}
+
+async function readSourcePromptFile(sourceRootPath: string, promptPath: string, label: string): Promise<string> {
+  const [sourceRootRealPath, promptRealPath] = await Promise.all([
+    realpath(sourceRootPath),
+    realpath(promptPath),
+  ]);
+  const relativePromptPath = relative(sourceRootRealPath, promptRealPath);
+  if (relativePromptPath === "" || relativePromptPath.startsWith(`..${sep}`) || relativePromptPath === ".." || isAbsolute(relativePromptPath)) {
+    throw new Error(`skillset: ${label}.promptFile resolves outside the source root`);
+  }
+  return readFile(promptRealPath, "utf8");
+}
+
+function readActivationRuntime(value: JsonValue | undefined, label: string): ActivationRuntime | undefined {
+  if (value === undefined) return undefined;
+  if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "claude" && key !== "expect" && key !== "timeoutMs") {
+      throw new Error(`skillset: unsupported runtime key ${key} in ${label}`);
+    }
+  }
+  if (!isJsonRecord(value.expect)) throw new Error(`skillset: ${label}.expect is required`);
+  for (const key of Object.keys(value.expect)) {
+    if (key !== "contains" && key !== "notContains") {
+      throw new Error(`skillset: unsupported runtime expectation ${key} in ${label}.expect`);
+    }
+  }
+  const contains = readString(value.expect, "contains");
+  const notContains = readString(value.expect, "notContains");
+  if (contains === undefined && notContains === undefined) {
+    throw new Error(`skillset: ${label}.expect must include contains or notContains`);
+  }
+  const timeoutMs = readOptionalPositiveInteger(value.timeoutMs, `${label}.timeoutMs`);
+  const claudeSettingSources = readRuntimeClaudeSettings(value.claude, `${label}.claude`);
+  return {
+    ...(claudeSettingSources === undefined ? {} : { claudeSettingSources }),
+    ...(contains === undefined ? {} : { contains }),
+    ...(notContains === undefined ? {} : { notContains }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  };
+}
+
+function readRuntimeClaudeSettings(value: JsonValue | undefined, label: string): TryClaudeSettingSources | undefined {
+  if (value === undefined) return undefined;
+  if (!isJsonRecord(value)) throw new Error(`skillset: expected ${label} to be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "settingSources") throw new Error(`skillset: unsupported Claude runtime key ${key} in ${label}`);
+  }
+  const settingSources = readString(value, "settingSources");
+  if (settingSources === undefined) return undefined;
+  if (settingSources === "isolated" || settingSources === "local" || settingSources === "project" || settingSources === "user") {
+    return settingSources;
+  }
+  throw new Error(`skillset: expected ${label}.settingSources to be isolated, user, project, or local`);
+}
+
+function readOptionalPositiveInteger(value: JsonValue | undefined, label: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`skillset: expected ${label} to be a positive integer`);
+  }
+  return value;
 }
 
 function readActivationExpectation(value: JsonValue | undefined, label: string): ActivationExpectation {
@@ -872,6 +1017,7 @@ async function validateActivationExpectations(
   if (declaration.activationProbes.length === 0) return;
   const graph = await loadBuildGraph(workspacePath, options);
   for (const probe of declaration.activationProbes) {
+    if (probe.runtime !== undefined) continue;
     for (const target of probe.targets) {
       const candidates = activationExpectationCandidatePaths(graph, target, probe.expect);
       const matched = await Promise.all(candidates.map(async (path) => pathExists(resolveInside(workspacePath, path))));
@@ -879,6 +1025,109 @@ async function validateActivationExpectations(
       throw new Error(`skillset: activation expected ${probe.expect.kind} ${probe.expect.name} was not emitted for target ${target}`);
     }
   }
+}
+
+async function runDeclaredRuntimeTests(
+  rootPath: string,
+  workspacePath: string,
+  declaration: TestDeclaration,
+  options: SkillsetTestOptions
+): Promise<SkillsetRuntimeTestResult[]> {
+  const results: SkillsetRuntimeTestResult[] = [];
+  const graph = await loadBuildGraph(workspacePath, options);
+  for (const probe of declaration.activationProbes) {
+    if (probe.runtime === undefined) continue;
+    for (const target of probe.targets) {
+      const candidates = activationExpectationCandidatePaths(graph, target, probe.expect);
+      const rendered = await Promise.all(candidates.map(async (path) => pathExists(resolveInside(workspacePath, path))));
+      if (!rendered.some(Boolean)) {
+        results.push({
+          assertions: [],
+          command: [],
+          detail: `expected ${probe.expect.kind} ${probe.expect.name} was not rendered for ${target}`,
+          failureClass: "render",
+          name: probe.name,
+          ok: false,
+          promptProvenance: probe.promptProvenance,
+          state: "failed",
+          target,
+        });
+        continue;
+      }
+      const run = await startTryRun(workspacePath, {
+        cacheRootPath: rootPath,
+        ...(probe.runtime.claudeSettingSources === undefined
+          ? {}
+          : { claudeSettingSources: probe.runtime.claudeSettingSources }),
+        ...(options.runtimeEnv === undefined ? {} : { env: options.runtimeEnv }),
+        name: `${declaration.name}-${slugifyProbeName(probe.name)}-${target}`,
+        prompt: probe.prompt,
+        target,
+        ...(probe.runtime.timeoutMs === undefined ? {} : { timeoutMs: probe.runtime.timeoutMs }),
+        ...(options.xdg === undefined ? {} : { xdg: options.xdg }),
+      });
+      const status = await readTryStatus(rootPath, run.runId, options);
+      const evidence = await readTryEvidence(rootPath, run.runId, options);
+      const assertions = status.state === "passed" ? runtimeAssertions(evidence.response, probe.runtime) : [];
+      const assertionsPassed = assertions.every((assertion) => assertion.ok);
+      const ok = status.state === "passed" && assertionsPassed;
+      results.push({
+        assertions,
+        command: [...(status.command ?? [])],
+        ...(status.error === undefined ? {} : { detail: status.error }),
+        ...(ok
+          ? {}
+          : { failureClass: status.failureClass ?? (status.state === "passed" ? "assertion" : "runtime") }),
+        name: probe.name,
+        ok,
+        outputPath: evidence.outputPath,
+        promptPath: status.promptPath,
+        promptProvenance: probe.promptProvenance,
+        reportPath: evidence.reportPath,
+        runId: run.runId,
+        runPath: run.runPath,
+        state: status.state,
+        target,
+      });
+    }
+  }
+  return results;
+}
+
+function runtimeRenderFailures(
+  declaration: TestDeclaration,
+  detail: string
+): SkillsetRuntimeTestResult[] {
+  return declaration.activationProbes.flatMap((probe) => {
+    if (probe.runtime === undefined) return [];
+    return probe.targets.map((target) => ({
+      assertions: [],
+      command: [],
+      detail,
+      failureClass: "render" as const,
+      name: probe.name,
+      ok: false,
+      promptProvenance: probe.promptProvenance,
+      state: "failed" as const,
+      target,
+    }));
+  });
+}
+
+function runtimeAssertions(
+  response: string,
+  runtime: ActivationRuntime
+): SkillsetRuntimeAssertionResult[] {
+  const assertions: SkillsetRuntimeAssertionResult[] = [];
+  if (runtime.contains !== undefined) {
+    const actual = response.includes(runtime.contains);
+    assertions.push({ actual, expected: runtime.contains, kind: "contains", ok: actual });
+  }
+  if (runtime.notContains !== undefined) {
+    const actual = !response.includes(runtime.notContains);
+    assertions.push({ actual, expected: runtime.notContains, kind: "notContains", ok: actual });
+  }
+  return assertions;
 }
 
 function activationExpectationCandidatePaths(
@@ -941,12 +1190,14 @@ async function writeActivationProbes(
 
 function activationProbeRecord(probe: ActivationProbe, target: TargetName): JsonRecord {
   return {
+    execution: probe.runtime === undefined ? "manual" : "live",
     expect: {
       [probe.expect.kind]: probe.expect.name,
     },
     harness: activationHarness(target),
     name: slugifyProbeName(probe.name),
     prompt: probe.prompt,
+    promptProvenance: probe.promptProvenance,
     status: target === "codex" ? "manual-shimmed" : "manual-native",
     target,
   };
@@ -1016,6 +1267,7 @@ async function refreshLatest(
 
 function renderMarkdownReport(report: JsonRecord): string {
   const checks = Array.isArray(report.checks) ? report.checks : [];
+  const runtimeTests = Array.isArray(report.runtimeTests) ? report.runtimeTests : [];
   const lines = [
     `# Skillset Test ${report.name}`,
     "",
@@ -1035,6 +1287,18 @@ function renderMarkdownReport(report: JsonRecord): string {
     const path = typeof check.path === "string" ? ` ${check.path}` : "";
     const detail = typeof check.detail === "string" ? ` - ${check.detail}` : "";
     lines.push(`- ${mark}: ${check.kind}${path}${detail}`);
+  }
+  if (runtimeTests.length > 0) {
+    lines.push("", "## Runtime Tests", "");
+    for (const runtimeTest of runtimeTests) {
+      if (!isJsonRecord(runtimeTest)) continue;
+      const mark = runtimeTest.ok === true ? "pass" : "fail";
+      const failureClass = typeof runtimeTest.failureClass === "string" ? ` (${runtimeTest.failureClass})` : "";
+      const detail = typeof runtimeTest.detail === "string" ? ` - ${runtimeTest.detail}` : "";
+      lines.push(`- ${mark}: ${runtimeTest.name} [${runtimeTest.target}]${failureClass}${detail}`);
+      if (typeof runtimeTest.outputPath === "string") lines.push(`  - output: ${runtimeTest.outputPath}`);
+      if (typeof runtimeTest.reportPath === "string") lines.push(`  - report: ${runtimeTest.reportPath}`);
+    }
   }
   return `${lines.join("\n").trimEnd()}\n`;
 }

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -26,9 +26,11 @@ import type { BuildGraph, JsonRecord, SkillsetOptions, TargetName } from "@skill
 export type TrySubcommand = "list" | "status" | "tail" | "worker";
 export type TryState = "building" | "failed" | "passed" | "queued" | "running";
 export type TryClaudeSettingSources = "isolated" | "local" | "project" | "user";
+export type TryFailureClass = "auth" | "binary" | "render" | "runtime" | "setup" | "timeout";
 
 export interface TryRunOptions extends SkillsetOptions {
   readonly background?: boolean;
+  readonly cacheRootPath?: string;
   readonly claudeSettingSources?: TryClaudeSettingSources;
   readonly env?: Record<string, string | undefined>;
   readonly name?: string;
@@ -43,6 +45,7 @@ export interface TryStatus {
   readonly endedAt?: string;
   readonly error?: string;
   readonly exitCode?: number;
+  readonly failureClass?: TryFailureClass;
   readonly finalMessagePath?: string;
   readonly latestRoot: string;
   readonly name: string;
@@ -58,6 +61,15 @@ export interface TryStatus {
   readonly target: TargetName;
   readonly timeoutMs: number;
   readonly updatedAt: string;
+}
+
+export interface TryEvidence {
+  readonly finalMessage?: string;
+  readonly outputPath: string;
+  readonly reportPath: string;
+  readonly response: string;
+  readonly stderr: string;
+  readonly stdout: string;
 }
 
 export interface TryRunReport {
@@ -134,6 +146,10 @@ export async function startTryRun(
   options: TryRunOptions
 ): Promise<TryRunReport> {
   const root = resolve(rootPath);
+  const cacheRoot = resolve(options.cacheRootPath ?? root);
+  if (options.background === true && cacheRoot !== root) {
+    throw new Error("skillset: background tries cannot use a separate cache root");
+  }
   const graph = await loadBuildGraph(root, options);
   if (!graph.root.targets[options.target].enabled) {
     throw new Error(`skillset: try target ${options.target} is not enabled by root target configuration`);
@@ -141,7 +157,7 @@ export async function startTryRun(
   const name = options.name ?? `try-${options.target}`;
   const plugins = validateTryPlugins(graph, options.target, options.plugins ?? []);
   const runId = makeRetainedRunId(name, { fallbackName: "try", includeName: true });
-  const paths = tryPaths(root, graph, runId, options.xdg);
+  const paths = tryPaths(cacheRoot, graph, runId, options.xdg);
   await mkdir(paths.absolute.runPath, { recursive: true });
 
   const config: TryStoredConfig = {
@@ -188,7 +204,7 @@ export async function startTryRun(
     return runReport(paths, runId, "queued", true);
   }
 
-  await executeTryRun(root, runId, options.env, options.xdg);
+  await executeTryRun(root, runId, options.env, options.xdg, cacheRoot);
   const status = await readStatus(paths.absolute.statusPath);
   return runReport(paths, runId, status.state, false);
 }
@@ -197,10 +213,11 @@ export async function executeTryRun(
   rootPath: string,
   runId: string,
   env: Record<string, string | undefined> = process.env,
-  xdg: SkillsetOptions["xdg"] = undefined
+  xdg: SkillsetOptions["xdg"] = undefined,
+  cacheRootPath: string = rootPath
 ): Promise<void> {
   const root = resolve(rootPath);
-  const paths = tryPaths(root, await loadBuildGraph(root, xdg === undefined ? {} : { xdg }), runId, xdg);
+  const paths = tryPaths(resolve(cacheRootPath), await loadBuildGraph(root, xdg === undefined ? {} : { xdg }), runId, xdg);
   const config = await readConfig(join(paths.absolute.runPath, "config.json"));
   const target = config.target;
   const runOptions: SkillsetOptions = {
@@ -217,16 +234,26 @@ export async function executeTryRun(
   try {
     await buildSkillset(root, runOptions);
   } catch (error) {
-    await failRun(paths, status, messageFor(error));
+    await failRun(paths, status, messageFor(error), "render");
     return;
   }
 
   const graph = await loadBuildGraph(root, runOptions);
-  const command = runtimeCommand(root, graph, paths, config, env, xdg);
-  await appendEvent(paths, "status", `running ${target} non-interactive prompt`);
-  status = await updateRunState(paths, status, "running", { command: command.display });
-  const result = await runCommand(command, config.prompt, paths, config.timeoutMs, env);
+  let command: ReturnType<typeof runtimeCommand>;
+  let result: { readonly exitCode: number; readonly timedOut: boolean };
+  try {
+    command = runtimeCommand(root, graph, paths, config, env, xdg);
+    await appendEvent(paths, "status", `running ${target} non-interactive prompt`);
+    status = await updateRunState(paths, status, "running", { command: command.display });
+    result = await runCommand(command, config.prompt, paths, config.timeoutMs, env);
+  } catch (error) {
+    await failRun(paths, status, messageFor(error), isMissingBinaryError(error) ? "binary" : "setup");
+    return;
+  }
   const finalMessage = await readOptional(paths.absolute.finalMessagePath);
+  const stdout = await readOptional(join(paths.absolute.runPath, "stdout.txt")) ?? "";
+  const stderr = await readOptional(join(paths.absolute.runPath, "stderr.txt")) ?? "";
+  const failureClass = classifyTryFailure(result, `${stderr}\n${stdout}`);
   const report: JsonRecord = {
     command: [...command.display],
     endedAt: new Date().toISOString(),
@@ -239,6 +266,7 @@ export async function executeTryRun(
     state: result.exitCode === 0 && !result.timedOut ? "passed" : "failed",
     target,
     timedOut: result.timedOut,
+    ...(failureClass === undefined ? {} : { failureClass }),
   };
   await writeFile(paths.absolute.reportPath, renderValidatedJson(report, paths.logical.reportPath), "utf8");
   const nextState: TryState = report.ok === true ? "passed" : "failed";
@@ -250,9 +278,52 @@ export async function executeTryRun(
     reportPath: paths.logical.reportPath,
     state: nextState,
     updatedAt: new Date().toISOString(),
-    ...(result.timedOut ? { error: `try command timed out after ${config.timeoutMs}ms` } : {}),
+    ...(failureClass === undefined ? {} : { failureClass }),
+    ...(result.timedOut
+      ? { error: `try command timed out after ${config.timeoutMs}ms` }
+      : result.exitCode === 0 ? {} : { error: stderr.trim() || `try command exited with code ${result.exitCode}` }),
   });
   await appendEvent(paths, "status", `try ${nextState}`);
+}
+
+export async function readTryEvidence(
+  rootPath: string,
+  runId: string,
+  options: Pick<SkillsetOptions, "xdg"> = {}
+): Promise<TryEvidence> {
+  const root = resolve(rootPath);
+  const graph = await loadBuildGraph(root, options);
+  const paths = tryPaths(root, graph, runId, options.xdg);
+  const finalMessage = await readOptional(paths.absolute.finalMessagePath);
+  const stdout = await readOptional(join(paths.absolute.runPath, "stdout.txt")) ?? "";
+  const stderr = await readOptional(join(paths.absolute.runPath, "stderr.txt")) ?? "";
+  const status = await readStatus(paths.absolute.statusPath);
+  return {
+    ...(finalMessage === undefined ? {} : { finalMessage }),
+    outputPath: paths.logical.outputPath,
+    reportPath: paths.logical.reportPath,
+    response: normalizeTryResponse(status.target, finalMessage, stdout),
+    stderr,
+    stdout,
+  };
+}
+
+function normalizeTryResponse(target: TargetName, finalMessage: string | undefined, stdout: string): string {
+  if (finalMessage !== undefined) return finalMessage;
+  if (target === "codex") return stdout;
+  const candidates = [stdout.trim(), ...stdout.trim().split("\n").reverse()];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (!isRecord(parsed)) continue;
+      for (const key of ["result", "text", "message"]) {
+        if (typeof parsed[key] === "string") return parsed[key];
+      }
+    } catch {
+      // Provider output may be plain text or mixed JSONL; preserve it verbatim.
+    }
+  }
+  return stdout;
 }
 
 export async function readTryStatus(
@@ -575,13 +646,15 @@ async function updateRunState(
 async function failRun(
   paths: TryRunPaths,
   status: TryStatus,
-  error: string
+  error: string,
+  failureClass: TryFailureClass
 ): Promise<void> {
   const endedAt = new Date().toISOString();
   const report: JsonRecord = {
     endedAt,
     error,
     exitCode: 1,
+    failureClass,
     name: status.name,
     ok: false,
     runId: status.runId,
@@ -595,10 +668,28 @@ async function failRun(
     endedAt,
     error,
     exitCode: 1,
+    failureClass,
     state: "failed",
     updatedAt: endedAt,
   });
   await appendEvent(paths, "status", `try failed: ${error}`);
+}
+
+function classifyTryFailure(
+  result: { readonly exitCode: number; readonly timedOut: boolean },
+  stderr: string
+): TryFailureClass | undefined {
+  if (result.timedOut) return "timeout";
+  if (result.exitCode === 0) return undefined;
+  if (/not logged in|unauthori[sz]ed|authentication|authenticate|credential|api[ -]?key|oauth|setup-token/iu.test(stderr)) {
+    return "auth";
+  }
+  return "runtime";
+}
+
+function isMissingBinaryError(error: unknown): boolean {
+  if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+  return /enoent|failed to spawn|no such file or directory/iu.test(messageFor(error));
 }
 
 async function writeStatus(paths: TryRunPaths, status: TryStatus): Promise<void> {

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -59,7 +59,7 @@ Runtime support records live in the feature registry as `runtimeSupport` rows. A
 | Build target | A provider rendering Skillset can render directly. | `claude`, `codex`, `cursor` |
 | Runtime adapter | A concrete runtime or harness that can consume a rendering or compatibility shim. | `claude-code`, `codex-cli`, `codex-app`, `cursor` |
 | Distribution surface | A repo, marketplace, extension root, or package shape a rendering may be synced into. | Implemented `distributions.*` plan config; sync/publish remains future |
-| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation probe assets under `skillset test`; implemented ad hoc live non-interactive prompt runs through `skillset try` |
+| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation assets and explicit declared live assertions under `skillset test`; implemented ad hoc live non-interactive prompt runs through `skillset try` |
 
 The test: adding a runtime must not make `compile.targets` accept a new value. It should add evidence and support records first, then a specific adapter or distribution flow only when the target behavior is proven.
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -116,7 +116,7 @@ Release state and inline versions are observable, not migrated, by deterministic
 
 ## Activation Probes
 
-Activation probes are a first layer above deterministic build checks and below evals. They answer “can a target harness notice or invoke the expected skill, agent, or plugin?” They do not judge answer quality, call a model, install a plugin, trust global runtime config, or mutate live build roots.
+Activation probes are a first layer above deterministic build checks and below evals. They answer “can a target harness notice or invoke the expected skill, agent, or plugin?” By default they do not call a model, install a plugin, trust global runtime config, or mutate live build roots. A probe calls a provider only when it includes an explicit `runtime` block.
 
 Source-root test declarations can include lightweight activation probes:
 
@@ -138,7 +138,7 @@ activation:
     projection: true
 ```
 
-Each probe requires `prompt` and `expect`. The v1 `expect` object must name exactly one of `skill`, `agent`, or `plugin`. Probe `targets` can narrow to enabled test targets; absent probe targets inherit the enclosing test targets. Empty target arrays fail. Before a retained run is written, Skillset verifies that the expected unit was rendered for every selected target in the isolated workspace, so typos and target-disabled units fail without creating partial run directories. Probe assets are generated under the retained test run:
+Each probe requires exactly one of `prompt` or `promptFile` plus `expect`. The v1 `expect` object must name exactly one of `skill`, `agent`, or `plugin`. Probe `targets` can narrow to enabled test targets; absent probe targets inherit the enclosing test targets. Empty target arrays fail. Manual probes verify that the expected unit was rendered before a retained run is written. Declared runtime probes report a missing unit as a `render` failure without launching the provider. Probe assets are generated under the retained test run:
 
 ```text
 .skillset/cache/tests/runs/<run-id>/activation/<target>/
@@ -149,6 +149,54 @@ Each probe requires `prompt` and `expect`. The v1 `expect` object must name exac
 `latest/` receives the same activation directory when the run refreshes. Claude and Cursor probes are rendered as manual native harness prompts. Codex probes are rendered as manual shim-aware prompts because Codex can follow generated loading instructions, but Skillset should not pretend that every Claude-style activation signal is target-enforced in Codex. Future Codex plugin-eval integration can consume the same `probes.json` shape once that runner boundary is proven.
 
 Edge cases stay explicit: multiple matching skills should be disambiguated in the expected selector, provider source may need target-specific probes, missing plugin dependencies should appear as activation setup failures rather than build successes, and compatibility shims should be reported as shims in the generated probe material.
+
+### Declared Runtime Tests
+
+An activation probe becomes a committed live-runtime test when it includes `runtime`. The enclosing `skillset test` declaration still performs its deterministic checks first; only then does Skillset invoke each selected target through the same isolated runner used by `skillset try`.
+
+```yaml
+select:
+  skills:
+    primary: [docs-cli]
+targets: [claude, codex]
+activation:
+  - name: docs activation
+    targets: [claude]
+    promptFile: prompts/docs-activation.md
+    expect:
+      skill: docs-cli
+    runtime:
+      claude:
+        settingSources: isolated
+      timeoutMs: 30000
+      expect:
+        contains: docs-cli
+        notContains: missing skill
+  - name: codex docs activation
+    targets: [codex]
+    prompt: Which documentation skill is available?
+    expect:
+      skill: docs-cli
+    runtime:
+      expect:
+        contains: docs-cli
+checks:
+  projection: true
+```
+
+`prompt` and `promptFile` are mutually exclusive. Prompt files resolve inside the active Skillset source root, so committed declarations remain portable. Probe `targets` select the provider invocations; the expected `skill`, `agent`, or `plugin` must be present in the isolated rendering before Skillset launches a runtime. `runtime.expect` supports literal `contains` and `notContains` assertions. This deliberately small vocabulary proves a repeatable fact without introducing model graders, scores, comparisons, or repeated trials.
+
+Run the declaration through the normal command:
+
+```bash
+skillset test docs-activation
+```
+
+The command remains credential-free when the selected declaration has no `runtime` block. Live declarations use provider credentials and binaries already available to the process; they do not install, trust, publish, or edit user-level provider configuration. Claude defaults to isolated setting sources and can explicitly select `isolated`, `user`, `project`, or `local` for a declared probe.
+
+Runtime results distinguish `render`, `binary`, `setup`, `auth`, `timeout`, `runtime`, and `assertion` failures. A provider process can therefore complete successfully while its declared expectation fails as `assertion`; missing generated units fail as `render` before provider launch, while a missing executable fails as `binary`. JSON and Markdown test reports record the target, command context, prompt provenance, normalized assertion results, and logical raw evidence paths. The raw try report, stdout/stderr events, prompt, and final response remain under the repo's XDG-backed `.skillset/cache/runtime-tests/` bucket.
+
+The promotion path is intentionally direct: use `skillset try` to refine a provider prompt, move the prompt inline or into a source-root file, add the expected rendered unit and literal response assertion to an activation probe, then run it with `skillset test`. Subjective quality evaluation remains separate work under SET-51.
 
 ## Runtime Tries
 

--- a/docs/reference/examples/test-declaration.yaml
+++ b/docs/reference/examples/test-declaration.yaml
@@ -1,0 +1,26 @@
+activation:
+  - expect:
+      skill: docs-cli
+    name: docs activation
+    promptFile: prompts/docs-activation.md
+    runtime:
+      claude:
+        settingSources: isolated
+      expect:
+        contains: docs-cli
+        notContains: missing skill
+      timeoutMs: 30000
+    targets:
+      - claude
+checks:
+  projection: true
+output:
+  kind: isolated
+select:
+  skills:
+    primary:
+      - docs-cli
+targets:
+  - claude
+  - codex
+  - cursor

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -1809,6 +1809,417 @@
       "title": "Source Metadata",
       "type": "object"
     },
+    "test-declaration": {
+      "additionalProperties": false,
+      "properties": {
+        "activation": {
+          "items": {
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "prompt"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "promptFile"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "expect": {
+                "additionalProperties": false,
+                "oneOf": [
+                  {
+                    "required": [
+                      "agent"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "plugin"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "skill"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "agent": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "plugin": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "skill": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "prompt": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "promptFile": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "runtime": {
+                "additionalProperties": false,
+                "properties": {
+                  "claude": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "settingSources": {
+                        "enum": [
+                          "isolated",
+                          "local",
+                          "project",
+                          "user"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "settingSources"
+                    ],
+                    "type": "object"
+                  },
+                  "expect": {
+                    "additionalProperties": false,
+                    "anyOf": [
+                      {
+                        "required": [
+                          "contains"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "notContains"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "contains": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "notContains": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "timeoutMs": {
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "expect"
+                ],
+                "type": "object"
+              },
+              "targets": {
+                "items": {
+                  "enum": [
+                    "claude",
+                    "codex",
+                    "cursor"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array",
+                "uniqueItems": true
+              }
+            },
+            "required": [
+              "expect"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "checks": {
+          "additionalProperties": false,
+          "anyOf": [
+            {
+              "required": [
+                "files"
+              ]
+            },
+            {
+              "properties": {
+                "pluginManifests": {
+                  "const": true
+                }
+              },
+              "required": [
+                "pluginManifests"
+              ]
+            },
+            {
+              "properties": {
+                "projection": {
+                  "const": true
+                }
+              },
+              "required": [
+                "projection"
+              ]
+            }
+          ],
+          "properties": {
+            "files": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "contains": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "path": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "pluginManifests": {
+              "type": "boolean"
+            },
+            "projection": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "isolated",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "select": {
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "agents": {
+              "anyOf": [
+                {
+                  "const": true,
+                  "type": "boolean"
+                },
+                {
+                  "items": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              ]
+            },
+            "plugins": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "minProperties": 1,
+                  "properties": {
+                    "include": {
+                      "anyOf": [
+                        {
+                          "const": true,
+                          "type": "boolean"
+                        },
+                        {
+                          "items": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array",
+                          "uniqueItems": true
+                        }
+                      ]
+                    },
+                    "skills": {
+                      "anyOf": [
+                        {
+                          "const": true,
+                          "type": "boolean"
+                        },
+                        {
+                          "items": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array",
+                          "uniqueItems": true
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              ]
+            },
+            "skills": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "minProperties": 1,
+                  "properties": {
+                    "plugin": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "const": true,
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": "array",
+                              "uniqueItems": true
+                            }
+                          ]
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "const": true,
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array",
+                                "uniqueItems": true
+                              }
+                            ]
+                          },
+                          "minProperties": 1,
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "primary": {
+                      "anyOf": [
+                        {
+                          "const": true,
+                          "type": "boolean"
+                        },
+                        {
+                          "items": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array",
+                          "uniqueItems": true
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "targets": {
+          "items": {
+            "enum": [
+              "claude",
+              "codex",
+              "cursor"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "checks"
+      ],
+      "title": "Test Declaration",
+      "type": "object"
+    },
     "workspace-config": {
       "additionalProperties": false,
       "properties": {
@@ -2319,6 +2730,9 @@
     },
     {
       "$ref": "#/$defs/change-entry"
+    },
+    {
+      "$ref": "#/$defs/test-declaration"
     }
   ],
   "title": "Skillset Source Contracts"

--- a/docs/reference/schemas/0.1.0/test-declaration.schema.json
+++ b/docs/reference/schemas/0.1.0/test-declaration.schema.json
@@ -1,0 +1,413 @@
+{
+  "$id": "https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas/0.1.0/test-declaration.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "activation": {
+      "items": {
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "prompt"
+                ]
+              },
+              {
+                "required": [
+                  "promptFile"
+                ]
+              }
+            ]
+          }
+        ],
+        "properties": {
+          "expect": {
+            "additionalProperties": false,
+            "oneOf": [
+              {
+                "required": [
+                  "agent"
+                ]
+              },
+              {
+                "required": [
+                  "plugin"
+                ]
+              },
+              {
+                "required": [
+                  "skill"
+                ]
+              }
+            ],
+            "properties": {
+              "agent": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "plugin": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "skill": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "prompt": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "promptFile": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "runtime": {
+            "additionalProperties": false,
+            "properties": {
+              "claude": {
+                "additionalProperties": false,
+                "properties": {
+                  "settingSources": {
+                    "enum": [
+                      "isolated",
+                      "local",
+                      "project",
+                      "user"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "settingSources"
+                ],
+                "type": "object"
+              },
+              "expect": {
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "required": [
+                      "contains"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "notContains"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "contains": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "notContains": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "timeoutMs": {
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "expect"
+            ],
+            "type": "object"
+          },
+          "targets": {
+            "items": {
+              "enum": [
+                "claude",
+                "codex",
+                "cursor"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "expect"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "checks": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "files"
+          ]
+        },
+        {
+          "properties": {
+            "pluginManifests": {
+              "const": true
+            }
+          },
+          "required": [
+            "pluginManifests"
+          ]
+        },
+        {
+          "properties": {
+            "projection": {
+              "const": true
+            }
+          },
+          "required": [
+            "projection"
+          ]
+        }
+      ],
+      "properties": {
+        "files": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "contains": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "path": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "pluginManifests": {
+          "type": "boolean"
+        },
+        "projection": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "output": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "isolated",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "select": {
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "agents": {
+          "anyOf": [
+            {
+              "const": true,
+              "type": "boolean"
+            },
+            {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            }
+          ]
+        },
+        "plugins": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "const": true,
+                  "type": "boolean"
+                },
+                {
+                  "items": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              ]
+            },
+            {
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "include": {
+                  "anyOf": [
+                    {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                "skills": {
+                  "anyOf": [
+                    {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "skills": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "const": true,
+                  "type": "boolean"
+                },
+                {
+                  "items": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              ]
+            },
+            {
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "plugin": {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "const": true,
+                          "type": "boolean"
+                        },
+                        {
+                          "items": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array",
+                          "uniqueItems": true
+                        }
+                      ]
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "const": true,
+                            "type": "boolean"
+                          },
+                          {
+                            "items": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "uniqueItems": true
+                          }
+                        ]
+                      },
+                      "minProperties": 1,
+                      "type": "object"
+                    }
+                  ]
+                },
+                "primary": {
+                  "anyOf": [
+                    {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "targets": {
+      "items": {
+        "enum": [
+          "claude",
+          "codex",
+          "cursor"
+        ],
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "checks"
+  ],
+  "title": "Test Declaration",
+  "type": "object"
+}

--- a/docs/reference/schemas/README.md
+++ b/docs/reference/schemas/README.md
@@ -18,6 +18,7 @@ The combined schema is [`skillset.schema.json`](./0.1.0/skillset.schema.json). U
 | `hook` | [`hook.schema.json`](./0.1.0/hook.schema.json) | Skillset hook definition source contract for aggregate hook event maps. |
 | `adaptive-hook` | [`adaptive-hook.schema.json`](./0.1.0/adaptive-hook.schema.json) | Skillset adaptive hook unit source contract for reusable portable hooks. |
 | `change-entry` | [`change-entry.schema.json`](./0.1.0/change-entry.schema.json) | Compatibility-only legacy pending change-entry frontmatter contract. |
+| `test-declaration` | [`test-declaration.schema.json`](./0.1.0/test-declaration.schema.json) | A deterministic Skillset test with optional explicit live-runtime activation assertions. |
 
 ## Examples
 
@@ -33,6 +34,7 @@ The examples are generated from typed fixtures and checked against the same sche
 | `hook` | [`hook.yaml`](../examples/hook.yaml) | Hook definition source object. |
 | `adaptive-hook` | [`adaptive-hook.yaml`](../examples/adaptive-hook.yaml) | Adaptive reusable hook unit. |
 | `change-entry` | [`change-entry.yaml`](../examples/change-entry.yaml) | Compatibility-only legacy pending change-entry frontmatter. |
+| `test-declaration` | [`test-declaration.yaml`](../examples/test-declaration.yaml) | Deterministic test with an explicit live-runtime activation assertion. |
 
 ## Editor Integration
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "skillset:ci:report": "bun ./apps/skillset/src/cli.ts ci --root . --since \"$(scripts/git-trunk.sh)\" --report .skillset/cache/reports/skillset-ci-report.md",
     "skillset:lint": "bun ./apps/skillset/src/cli.ts lint --root .",
     "skillset:verify": "bun ./apps/skillset/src/cli.ts verify --root .",
-    "test": "bun test $(git ls-files 'apps/**/*.test.ts' 'packages/**/*.test.ts' 'scripts/**/*.test.ts')",
+    "test": "bun test --timeout 15000 $(git ls-files 'apps/**/*.test.ts' 'packages/**/*.test.ts' 'scripts/**/*.test.ts')",
     "typecheck": "tsc --noEmit",
     "ultracite:check": "ultracite check",
     "ultracite:doctor": "ultracite doctor",

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -227,6 +227,7 @@ describe("feature registry", () => {
     expect(listSkillsetFeaturesByTarget("claude").map((entry) => entry.id)).not.toContain("changes");
     expect(listSkillsetFeaturesByTarget("codex").map((entry) => entry.id)).not.toContain("workflows");
     expect(listSkillsetFeaturesByRuntime("codex-cli").map((entry) => entry.id)).toEqual([
+      "activation-probes",
       "project-agents",
       "runtime-adapters",
     ]);

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -143,13 +143,33 @@ const CURSOR_PROVIDER_EVIDENCE = [
 export const skillsetFeatureRegistry = defineFeatureRegistry([
   feature({
     docs: ["docs/features/tests-and-evals.md"],
-    evidence: [test("apps/skillset/src/__tests__/contract.test.ts", "SET-112 activation probe coverage")],
+    evidence: [
+      test("apps/skillset/src/__tests__/contract.test.ts", "SET-112 activation probe coverage"),
+      test("apps/skillset/src/__tests__/try.test.ts", "SET-273 declared runtime provider coverage"),
+    ],
     id: "activation-probes",
     kind: "workflow",
     renderOwner: "apps/skillset/src/test-runner.ts",
+    runtimeSupport: {
+      "claude-code": {
+        evidence: [test("apps/skillset/src/__tests__/try.test.ts", "SET-273 declared runtime provider coverage")],
+        mechanism: "Explicit runtime activation probes invoke Claude Code through the shared isolated try harness.",
+        status: "native",
+      },
+      "codex-cli": {
+        evidence: [test("apps/skillset/src/__tests__/try.test.ts", "SET-273 declared runtime provider coverage")],
+        mechanism: "Explicit runtime activation probes invoke Codex CLI through the shared isolated try harness.",
+        status: "native",
+      },
+      cursor: {
+        evidence: [test("apps/skillset/src/__tests__/try.test.ts", "SET-273 declared runtime provider coverage")],
+        mechanism: "Explicit runtime activation probes invoke Cursor Agent through the shared isolated try harness.",
+        status: "native",
+      },
+    },
     sourceShape: "<source-root>/tests.yaml or <source-root>/tests/*.yaml activation[]",
     status: "implemented",
-    summary: "Compiles target-aware manual activation probe assets inside isolated test runs.",
+    summary: "Compiles target-aware manual activation assets and runs explicit declared runtime assertions through isolated provider harnesses.",
     targetSupport: notTargetRuntime(),
     title: "Activation Probes",
     validationOwner: "apps/skillset/src/test-runner.ts",

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -18,6 +18,7 @@ import {
   validateInstructionFrontmatter,
   validateSkillFrontmatter,
   validateSourceMetadata,
+  validateTestDeclaration,
   validateWorkspaceConfig,
   workspaceConfigContract,
 } from "../index";
@@ -34,6 +35,7 @@ describe("@skillset/schema contracts", () => {
       "hook",
       "adaptive-hook",
       "change-entry",
+      "test-declaration",
     ]);
     expect(workspaceConfigContract.schema.$id).toBe("https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas/0.1.0/workspace-config.schema.json");
     expect(adaptiveHookContract.schema.$id).toBe("https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas/0.1.0/adaptive-hook.schema.json");
@@ -51,6 +53,7 @@ describe("@skillset/schema contracts", () => {
       "docs/reference/schemas/0.1.0/hook.schema.json",
       "docs/reference/schemas/0.1.0/adaptive-hook.schema.json",
       "docs/reference/schemas/0.1.0/change-entry.schema.json",
+      "docs/reference/schemas/0.1.0/test-declaration.schema.json",
     ]);
 
     const combined = artifacts[0]?.schema;
@@ -68,6 +71,7 @@ describe("@skillset/schema contracts", () => {
       { $ref: "#/$defs/hook" },
       { $ref: "#/$defs/adaptive-hook" },
       { $ref: "#/$defs/change-entry" },
+      { $ref: "#/$defs/test-declaration" },
     ]);
     const defs = combined?.$defs as Record<string, Record<string, unknown>>;
     expect(Object.keys(defs).sort()).toEqual([
@@ -78,6 +82,7 @@ describe("@skillset/schema contracts", () => {
       "instruction-frontmatter",
       "skill-frontmatter",
       "source-metadata",
+      "test-declaration",
       "workspace-config",
     ]);
     expect(defs["workspace-config"]).not.toHaveProperty("$id");
@@ -95,6 +100,7 @@ describe("@skillset/schema contracts", () => {
       "docs/reference/examples/hook.yaml",
       "docs/reference/examples/adaptive-hook.yaml",
       "docs/reference/examples/change-entry.yaml",
+      "docs/reference/examples/test-declaration.yaml",
     ]);
 
     const byId = Object.fromEntries(examples.map((example) => [example.contractId, example.value]));
@@ -305,6 +311,30 @@ describe("@skillset/schema contracts", () => {
     });
 
     expect(valid).toEqual({ diagnostics: [], ok: true });
+  });
+
+  it("validates declared runtime test structure", () => {
+    expect(validateTestDeclaration({
+      activation: [{
+        expect: { skill: "demo" },
+        prompt: "Inspect demo.",
+        runtime: { expect: { contains: "demo" }, timeoutMs: 30_000 },
+        targets: ["codex"],
+      }],
+      checks: { projection: true },
+    }).diagnostics).toEqual([]);
+    expect(validateTestDeclaration({
+      activation: [{
+        expect: { skill: "demo" },
+        promptFile: "../outside.md",
+        runtime: { expect: {}, timeoutMs: 0 },
+      }],
+      checks: { projection: true },
+    }).diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "schema/test-declaration/prompt-file",
+      "schema/test-declaration/runtime-expect",
+      "schema/test-declaration/runtime-timeout",
+    ]);
   });
 
   it("reports invalid workspace config structure without raw schema noise", () => {

--- a/packages/schema/src/artifacts.ts
+++ b/packages/schema/src/artifacts.ts
@@ -11,6 +11,7 @@ import {
   skillFrontmatterContract,
   skillsetSchemaContracts,
   sourceMetadataContract,
+  testDeclarationContract,
   workspaceConfigContract,
 } from "./contracts";
 
@@ -28,6 +29,7 @@ const schemaFileNames = {
   "instruction-frontmatter": "instruction-frontmatter.schema.json",
   "skill-frontmatter": "skill-frontmatter.schema.json",
   "source-metadata": "source-metadata.schema.json",
+  "test-declaration": "test-declaration.schema.json",
   "workspace-config": "workspace-config.schema.json",
 } as const satisfies Record<SkillsetSchemaContractId, string>;
 
@@ -65,6 +67,7 @@ function combinedSchemaArtifact(): SkillsetJsonSchemaArtifact {
         { $ref: "#/$defs/hook" },
         { $ref: "#/$defs/adaptive-hook" },
         { $ref: "#/$defs/change-entry" },
+        { $ref: "#/$defs/test-declaration" },
       ],
       title: "Skillset Source Contracts",
     }),
@@ -92,3 +95,4 @@ export const skillsetInstructionFrontmatterJsonSchema = instructionFrontmatterCo
 export const skillsetHookJsonSchema = hookContract.schema;
 export const skillsetAdaptiveHookJsonSchema = adaptiveHookContract.schema;
 export const skillsetChangeEntryJsonSchema = changeEntryContract.schema;
+export const skillsetTestDeclarationJsonSchema = testDeclarationContract.schema;

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -295,6 +295,116 @@ export const changeEntryContract = contract("change-entry", "Change Entry", "Com
   type: "object",
 });
 
+export const testDeclarationContract = contract("test-declaration", "Test Declaration", "A deterministic Skillset test with optional explicit live-runtime activation assertions.", {
+  additionalProperties: false,
+  properties: {
+    activation: arraySchema({
+      additionalProperties: false,
+      allOf: [
+        { oneOf: [{ required: ["prompt"] }, { required: ["promptFile"] }] },
+      ],
+      properties: {
+        expect: {
+          additionalProperties: false,
+          oneOf: [
+            { required: ["agent"] },
+            { required: ["plugin"] },
+            { required: ["skill"] },
+          ],
+          properties: {
+            agent: nonEmptyStringSchema(),
+            plugin: nonEmptyStringSchema(),
+            skill: nonEmptyStringSchema(),
+          },
+          type: "object",
+        },
+        name: nonEmptyStringSchema(),
+        prompt: nonEmptyStringSchema(),
+        promptFile: nonEmptyStringSchema(),
+        runtime: {
+          ...strictObjectSchema({
+            claude: {
+              ...strictObjectSchema({ settingSources: enumSchema(["isolated", "local", "project", "user"]) }),
+              required: ["settingSources"],
+            },
+            expect: {
+              ...strictObjectSchema({
+                contains: nonEmptyStringSchema(),
+                notContains: nonEmptyStringSchema(),
+              }),
+              anyOf: [{ required: ["contains"] }, { required: ["notContains"] }],
+            },
+            timeoutMs: { minimum: 1, type: "integer" },
+          }),
+          required: ["expect"],
+        },
+        targets: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
+      },
+      required: ["expect"],
+      type: "object",
+    }),
+    checks: {
+      ...strictObjectSchema({
+        files: arraySchema({
+          ...strictObjectSchema({
+            contains: nonEmptyStringSchema(),
+            path: nonEmptyStringSchema(),
+          }),
+          required: ["path"],
+        }, { minItems: 1 }),
+        pluginManifests: { type: "boolean" },
+        projection: { type: "boolean" },
+      }),
+      anyOf: [
+        { required: ["files"] },
+        { properties: { pluginManifests: { const: true } }, required: ["pluginManifests"] },
+        { properties: { projection: { const: true } }, required: ["projection"] },
+      ],
+    },
+    output: {
+      ...strictObjectSchema({ kind: { const: "isolated", type: "string" } }),
+    },
+    select: {
+      ...strictObjectSchema({
+        agents: selectorSchema(),
+        plugins: {
+          anyOf: [
+            selectorSchema(),
+            {
+              ...strictObjectSchema({
+                include: selectorSchema(),
+                skills: selectorSchema(),
+              }),
+              minProperties: 1,
+            },
+          ],
+        },
+        skills: {
+          anyOf: [
+            selectorSchema(),
+            {
+              ...strictObjectSchema({
+                plugin: {
+                  anyOf: [
+                    selectorSchema(),
+                    { additionalProperties: selectorSchema(), minProperties: 1, type: "object" },
+                  ],
+                },
+                primary: selectorSchema(),
+              }),
+              minProperties: 1,
+            },
+          ],
+        },
+      }),
+      minProperties: 1,
+    },
+    targets: arraySchema(enumSchema(TARGET_NAMES), { minItems: 1, uniqueItems: true }),
+  },
+  required: ["checks"],
+  type: "object",
+});
+
 export const skillsetSchemaContracts = [
   workspaceConfigContract,
   sourceMetadataContract,
@@ -304,6 +414,7 @@ export const skillsetSchemaContracts = [
   hookContract,
   adaptiveHookContract,
   changeEntryContract,
+  testDeclarationContract,
 ] as const satisfies readonly SkillsetSchemaContract[];
 
 export function schemaUri(id: SkillsetSchemaContract["id"], version = SKILLSET_SCHEMA_VERSION): string {
@@ -676,6 +787,15 @@ function semverStringSchema(): SchemaJsonRecord {
 
 function nonEmptyStringSchema(): SchemaJsonRecord {
   return { minLength: 1, type: "string" };
+}
+
+function selectorSchema(): SchemaJsonRecord {
+  return {
+    anyOf: [
+      { const: true, type: "boolean" },
+      arraySchema(nonEmptyStringSchema(), { minItems: 1, uniqueItems: true }),
+    ],
+  };
 }
 
 function strictObjectSchema(properties: Record<string, SchemaJsonRecord>): SchemaJsonRecord {

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -397,6 +397,37 @@ export const skillsetSchemaExamples = [
       scopes: ["skill:docs-cli", "plugin:docs"],
     },
   },
+  {
+    description: "Deterministic test with an explicit live-runtime activation assertion.",
+    id: "test-declaration",
+    path: "test-declaration.yaml",
+    value: {
+      activation: [
+        {
+          expect: { skill: "docs-cli" },
+          name: "docs activation",
+          promptFile: "prompts/docs-activation.md",
+          runtime: {
+            claude: { settingSources: "isolated" },
+            expect: {
+              contains: "docs-cli",
+              notContains: "missing skill",
+            },
+            timeoutMs: 30_000,
+          },
+          targets: ["claude"],
+        },
+      ],
+      checks: {
+        projection: true,
+      },
+      output: { kind: "isolated" },
+      select: {
+        skills: { primary: ["docs-cli"] },
+      },
+      targets: ["claude", "codex", "cursor"],
+    },
+  },
 ] as const satisfies readonly SkillsetSchemaExample[];
 
 export function deriveSkillsetExampleArtifacts(): readonly SkillsetExampleArtifact[] {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -21,6 +21,7 @@ export {
   skillFrontmatterContract,
   skillsetSchemaContracts,
   sourceMetadataContract,
+  testDeclarationContract,
   workspaceConfigContract,
 } from "./contracts";
 export { skillsetSchemaExamples } from "./examples";
@@ -34,6 +35,7 @@ export {
   skillsetInstructionFrontmatterJsonSchema,
   skillsetSkillFrontmatterJsonSchema,
   skillsetSourceMetadataJsonSchema,
+  skillsetTestDeclarationJsonSchema,
   skillsetWorkspaceJsonSchema,
 } from "./artifacts";
 export { deriveSkillsetExampleArtifacts } from "./examples";
@@ -57,5 +59,6 @@ export {
   validateInstructionFrontmatter,
   validateSkillFrontmatter,
   validateSourceMetadata,
+  validateTestDeclaration,
   validateWorkspaceConfig,
 } from "./validate";

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -13,6 +13,7 @@ export type SkillsetSchemaContractId =
   | "instruction-frontmatter"
   | "skill-frontmatter"
   | "source-metadata"
+  | "test-declaration"
   | "workspace-config";
 
 export interface SkillsetSchemaDiagnostic {

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -53,6 +53,215 @@ export function validateWorkspaceConfig(value: unknown, path = "$"): SkillsetSch
   return result(diagnostics);
 }
 
+export function validateTestDeclaration(value: unknown, path = "$"): SkillsetSchemaValidationResult {
+  const diagnostics: SkillsetSchemaDiagnostic[] = [];
+  if (!isSchemaRecord(value)) return result([diagnostic(path, "schema/test-declaration/type", "test declaration must be an object")]);
+  checkAllowedKeys(value, new Set(["activation", "checks", "output", "select", "targets"]), path, "schema/test-declaration/key", diagnostics);
+  if (!isSchemaRecord(value.checks)) {
+    diagnostics.push(diagnostic(`${path}.checks`, "schema/test-declaration/checks", "test declaration checks must be an object"));
+  } else {
+    checkTestChecks(value.checks, `${path}.checks`, diagnostics);
+  }
+  if (value.output !== undefined) checkTestOutput(value.output, `${path}.output`, diagnostics);
+  if (value.select !== undefined) checkTestSelection(value.select, `${path}.select`, diagnostics);
+  if (value.targets !== undefined) {
+    checkTargetNameArray(value.targets, `${path}.targets`, "schema/test-declaration/targets", diagnostics);
+  }
+  if (value.activation !== undefined) {
+    if (!Array.isArray(value.activation)) {
+      diagnostics.push(diagnostic(`${path}.activation`, "schema/test-declaration/activation", "activation must be an array"));
+    } else {
+      for (const [index, probe] of value.activation.entries()) {
+        checkTestActivationProbe(probe, `${path}.activation[${index}]`, diagnostics);
+      }
+    }
+  }
+  return result(diagnostics);
+}
+
+function checkTestChecks(value: SchemaJsonRecord, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  checkAllowedKeys(value, new Set(["files", "pluginManifests", "projection"]), path, "schema/test-declaration/check-key", diagnostics);
+  for (const key of ["pluginManifests", "projection"] as const) {
+    if (value[key] !== undefined && typeof value[key] !== "boolean") {
+      diagnostics.push(diagnostic(`${path}.${key}`, "schema/test-declaration/check", `${key} must be true or false`));
+    }
+  }
+  if (value.files !== undefined) {
+    if (!Array.isArray(value.files) || value.files.length === 0) {
+      diagnostics.push(diagnostic(`${path}.files`, "schema/test-declaration/check-files", "checks.files must be a non-empty array"));
+    } else {
+      for (const [index, file] of value.files.entries()) {
+        const filePath = `${path}.files[${index}]`;
+        if (!isSchemaRecord(file)) {
+          diagnostics.push(diagnostic(filePath, "schema/test-declaration/check-file", "file check must be an object"));
+          continue;
+        }
+        checkAllowedKeys(file, new Set(["contains", "path"]), filePath, "schema/test-declaration/check-file-key", diagnostics);
+        checkOptionalNonEmptyString(file.path, `${filePath}.path`, "schema/test-declaration/check-file", diagnostics);
+        if (file.path === undefined) diagnostics.push(diagnostic(`${filePath}.path`, "schema/test-declaration/check-file", "file check path is required"));
+        checkOptionalNonEmptyString(file.contains, `${filePath}.contains`, "schema/test-declaration/check-file", diagnostics);
+      }
+    }
+  }
+  if (value.files === undefined && value.pluginManifests !== true && value.projection !== true) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/checks", "test checks must enable files, pluginManifests, or projection"));
+  }
+}
+
+function checkTestOutput(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/output", "test output must be an object"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["kind"]), path, "schema/test-declaration/output-key", diagnostics);
+  if (value.kind !== undefined && value.kind !== "isolated") {
+    diagnostics.push(diagnostic(`${path}.kind`, "schema/test-declaration/output-kind", "test output kind must be isolated"));
+  }
+}
+
+function checkTestSelection(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/select", "test select must be an object"));
+    return;
+  }
+  if (Object.keys(value).length === 0) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/select", "test select must include agents, plugins, or skills"));
+  }
+  checkAllowedKeys(value, new Set(["agents", "plugins", "skills"]), path, "schema/test-declaration/select-key", diagnostics);
+  if (value.agents !== undefined) checkTestSelector(value.agents, `${path}.agents`, diagnostics);
+  if (value.plugins !== undefined) {
+    if (isSchemaRecord(value.plugins)) {
+      if (Object.keys(value.plugins).length === 0) {
+        diagnostics.push(diagnostic(`${path}.plugins`, "schema/test-declaration/select", "test plugin selector must include include or skills"));
+      }
+      checkAllowedKeys(value.plugins, new Set(["include", "skills"]), `${path}.plugins`, "schema/test-declaration/select-key", diagnostics);
+      if (value.plugins.include !== undefined) checkTestSelector(value.plugins.include, `${path}.plugins.include`, diagnostics);
+      if (value.plugins.skills !== undefined) checkTestSelector(value.plugins.skills, `${path}.plugins.skills`, diagnostics);
+    } else {
+      checkTestSelector(value.plugins, `${path}.plugins`, diagnostics);
+    }
+  }
+  if (value.skills !== undefined) checkTestSkillSelection(value.skills, `${path}.skills`, diagnostics);
+}
+
+function checkTestSkillSelection(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    checkTestSelector(value, path, diagnostics);
+    return;
+  }
+  if (Object.keys(value).length === 0) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/select", "test skill selector must include primary or plugin"));
+  }
+  checkAllowedKeys(value, new Set(["plugin", "primary"]), path, "schema/test-declaration/select-key", diagnostics);
+  if (value.primary !== undefined) checkTestSelector(value.primary, `${path}.primary`, diagnostics);
+  if (value.plugin !== undefined) {
+    if (isSchemaRecord(value.plugin)) {
+      if (Object.keys(value.plugin).length === 0) {
+        diagnostics.push(diagnostic(`${path}.plugin`, "schema/test-declaration/select", "test plugin-skill selector must include at least one plugin"));
+      }
+      for (const [plugin, selector] of Object.entries(value.plugin)) {
+        if (selector !== undefined) checkTestSelector(selector, `${path}.plugin.${plugin}`, diagnostics);
+      }
+    } else {
+      checkTestSelector(value.plugin, `${path}.plugin`, diagnostics);
+    }
+  }
+}
+
+function checkTestSelector(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value === true) return;
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string" || item.trim().length === 0)) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/select", "test selector must be true or a non-empty string array"));
+    return;
+  }
+  if (new Set(value).size !== value.length) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/select", "test selector entries must be unique"));
+  }
+}
+
+function checkTestActivationProbe(
+  value: SchemaJsonValue,
+  path: string,
+  diagnostics: SkillsetSchemaDiagnostic[]
+): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/activation", "activation probe must be an object"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["expect", "name", "prompt", "promptFile", "runtime", "targets"]), path, "schema/test-declaration/activation-key", diagnostics);
+  const hasPrompt = typeof value.prompt === "string" && value.prompt.trim().length > 0;
+  const hasPromptFile = typeof value.promptFile === "string" && value.promptFile.trim().length > 0;
+  if (hasPrompt === hasPromptFile) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/prompt", "activation probe must name exactly one of prompt or promptFile"));
+  }
+  if (value.promptFile !== undefined && hasPromptFile) {
+    const promptFile = String(value.promptFile);
+    if (promptFile.startsWith("/") || /^[A-Za-z]:[\\/]/.test(promptFile) || promptFile.split(/[\\/]+/).includes("..")) {
+      diagnostics.push(diagnostic(`${path}.promptFile`, "schema/test-declaration/prompt-file", "test promptFile must stay inside the source root"));
+    }
+  }
+  if (!isSchemaRecord(value.expect)) {
+    diagnostics.push(diagnostic(`${path}.expect`, "schema/test-declaration/expect", "activation expectation must be an object"));
+  } else {
+    checkAllowedKeys(value.expect, new Set(["agent", "plugin", "skill"]), `${path}.expect`, "schema/test-declaration/expect-key", diagnostics);
+    const expected = [value.expect.agent, value.expect.plugin, value.expect.skill]
+      .filter((item) => typeof item === "string" && item.trim().length > 0);
+    if (expected.length !== 1) {
+      diagnostics.push(diagnostic(`${path}.expect`, "schema/test-declaration/expect", "activation expectation must name exactly one of agent, plugin, or skill"));
+    }
+  }
+  if (value.targets !== undefined) {
+    checkTargetNameArray(value.targets, `${path}.targets`, "schema/test-declaration/targets", diagnostics);
+  }
+  if (value.runtime !== undefined) checkTestRuntime(value.runtime, `${path}.runtime`, diagnostics);
+}
+
+function checkTestRuntime(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (!isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, "schema/test-declaration/runtime", "runtime must be an object"));
+    return;
+  }
+  checkAllowedKeys(value, new Set(["claude", "expect", "timeoutMs"]), path, "schema/test-declaration/runtime-key", diagnostics);
+  if (!isSchemaRecord(value.expect)) {
+    diagnostics.push(diagnostic(`${path}.expect`, "schema/test-declaration/runtime-expect", "runtime expect must be an object"));
+  } else {
+    checkAllowedKeys(value.expect, new Set(["contains", "notContains"]), `${path}.expect`, "schema/test-declaration/runtime-expect-key", diagnostics);
+    const contains = typeof value.expect.contains === "string" && value.expect.contains.trim().length > 0;
+    const notContains = typeof value.expect.notContains === "string" && value.expect.notContains.trim().length > 0;
+    if (!contains && !notContains) {
+      diagnostics.push(diagnostic(`${path}.expect`, "schema/test-declaration/runtime-expect", "runtime expect must include contains or notContains"));
+    }
+  }
+  if (value.timeoutMs !== undefined && (typeof value.timeoutMs !== "number" || !Number.isSafeInteger(value.timeoutMs) || value.timeoutMs <= 0)) {
+    diagnostics.push(diagnostic(`${path}.timeoutMs`, "schema/test-declaration/runtime-timeout", "runtime timeoutMs must be a positive integer"));
+  }
+  if (value.claude !== undefined) {
+    if (!isSchemaRecord(value.claude)) {
+      diagnostics.push(diagnostic(`${path}.claude`, "schema/test-declaration/runtime-claude", "runtime claude settings must be an object"));
+    } else {
+      checkAllowedKeys(value.claude, new Set(["settingSources"]), `${path}.claude`, "schema/test-declaration/runtime-claude-key", diagnostics);
+      if (!new Set(["isolated", "local", "project", "user"]).has(String(value.claude.settingSources))) {
+        diagnostics.push(diagnostic(`${path}.claude.settingSources`, "schema/test-declaration/runtime-claude", "Claude runtime settingSources must be isolated, local, project, or user"));
+      }
+    }
+  }
+}
+
+function checkTargetNameArray(
+  value: SchemaJsonValue,
+  path: string,
+  code: string,
+  diagnostics: SkillsetSchemaDiagnostic[]
+): void {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string" || !targetNames.has(item))) {
+    diagnostics.push(diagnostic(path, code, `targets must be a non-empty array of ${targetListText}`));
+    return;
+  }
+  if (new Set(value).size !== value.length) {
+    diagnostics.push(diagnostic(path, code, "test targets must be unique"));
+  }
+}
+
 export function validateSourceMetadata(value: unknown, path = "$"): SkillsetSchemaValidationResult {
   const diagnostics: SkillsetSchemaDiagnostic[] = [];
   if (value !== undefined && !isSchemaRecord(value)) {

--- a/packages/workbench/src/__tests__/schema.test.ts
+++ b/packages/workbench/src/__tests__/schema.test.ts
@@ -15,6 +15,25 @@ describe("workbench source contract schema checks", () => {
     })).toEqual([]);
 
     expect(checkWorkbenchSourceContract({
+      content: [
+        "select:",
+        "  skills:",
+        "    primary: [demo]",
+        "activation:",
+        "  - prompt: Inspect demo.",
+        "    expect:",
+        "      skill: demo",
+        "    runtime:",
+        "      expect:",
+        "        contains: demo",
+        "checks:",
+        "  projection: true",
+      ].join("\n"),
+      kind: "test-declaration",
+      path: ".skillset/tests/demo.yaml",
+    })).toEqual([]);
+
+    expect(checkWorkbenchSourceContract({
       content: "---\ndescription: Demo skill.\nname: demo\nresources: {}\n---\nUse this skill.\n",
       kind: "skill",
       path: ".skillset/skills/demo/SKILL.md",
@@ -42,6 +61,74 @@ describe("workbench source contract schema checks", () => {
       kind: "hook",
       path: ".skillset/plugins/demo/hooks/hooks.json",
     })).toEqual([]);
+  });
+
+  test("reports declared runtime test contract diagnostics", () => {
+    const diagnostics = checkWorkbenchSourceContract({
+      content: [
+        "activation:",
+        "  - prompt: Inline.",
+        "    promptFile: ../outside.md",
+        "    expect:",
+        "      skill: demo",
+        "    runtime:",
+        "      timeoutMs: 0",
+        "      expect: {}",
+        "checks:",
+        "  projection: true",
+      ].join("\n"),
+      kind: "test-declaration",
+      path: ".skillset/tests/demo.yaml",
+    });
+
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "activation probe must name exactly one of prompt or promptFile",
+      "runtime expect must include contains or notContains",
+      "runtime timeoutMs must be a positive integer",
+      "test promptFile must stay inside the source root",
+    ]);
+    expect(diagnostics.every((diagnostic) => diagnostic.ruleId === "schema/test-declaration")).toBe(true);
+
+    const grammarDiagnostics = checkWorkbenchSourceContract({
+      content: [
+        "select:",
+        "  invented: true",
+        "output:",
+        "  kind: live",
+        "checks:",
+        "  imaginary: true",
+      ].join("\n"),
+      kind: "test-declaration",
+      path: ".skillset/tests/invalid.yaml",
+    });
+    expect(grammarDiagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "unsupported key invented",
+      "test output kind must be isolated",
+      "test checks must enable files, pluginManifests, or projection",
+      "unsupported key imaginary",
+    ]);
+
+    expect(checkWorkbenchSourceContract({
+      content: "select: {}\nchecks:\n  projection: true\n",
+      kind: "test-declaration",
+      path: ".skillset/tests/empty-select.yaml",
+    }).map((diagnostic) => diagnostic.message)).toEqual([
+      "test select must include agents, plugins, or skills",
+    ]);
+    expect(checkWorkbenchSourceContract({
+      content: "select:\n  skills: {}\nchecks:\n  projection: true\n",
+      kind: "test-declaration",
+      path: ".skillset/tests/empty-skills.yaml",
+    }).map((diagnostic) => diagnostic.message)).toEqual([
+      "test skill selector must include primary or plugin",
+    ]);
+    expect(checkWorkbenchSourceContract({
+      content: "select:\n  plugins: {}\nchecks:\n  projection: true\n",
+      kind: "test-declaration",
+      path: ".skillset/tests/empty-plugins.yaml",
+    }).map((diagnostic) => diagnostic.message)).toEqual([
+      "test plugin selector must include include or skills",
+    ]);
   });
 
   test("reports skill frontmatter and body contract diagnostics", () => {

--- a/packages/workbench/src/schema.ts
+++ b/packages/workbench/src/schema.ts
@@ -4,6 +4,7 @@ import {
   validateHookDefinitionSource,
   validateInstructionFrontmatter,
   validateSkillFrontmatter,
+  validateTestDeclaration,
   validateWorkspaceConfig,
   type SkillsetSchemaDiagnostic,
 } from "@skillset/schema";
@@ -18,7 +19,7 @@ import type {
   WorkbenchParseResult,
 } from "./types";
 
-export type WorkbenchSourceContractKind = "agent" | "hook" | "instruction" | "skill" | "workspace-config";
+export type WorkbenchSourceContractKind = "agent" | "hook" | "instruction" | "skill" | "test-declaration" | "workspace-config";
 
 const TARGET_LIST = TARGET_NAMES.join(", ");
 
@@ -52,6 +53,9 @@ export function checkWorkbenchSourceContract(
   }
   if (input.kind === "skill") {
     return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkSkillContract(parsed, input.path, input.content)]);
+  }
+  if (input.kind === "test-declaration") {
+    return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkTestDeclarationContract(parsed, input.path, input.content)]);
   }
   return sortWorkbenchDiagnostics([...parseDiagnostics, ...checkWorkspaceConfigContract(parsed, input.path, input.content)]);
 }
@@ -211,6 +215,31 @@ function checkWorkspaceConfigContract(
   return diagnostics
     .filter((diagnostic) => !isRedundantWorkspaceSchemaDiagnostic(diagnostic, diagnostics, data))
     .map((diagnostic) => workspaceSchemaDiagnostic(diagnostic, data, path, content));
+}
+
+function checkTestDeclarationContract(
+  parsed: WorkbenchParseResult,
+  path: string,
+  content: string
+): readonly WorkbenchDiagnostic[] {
+  if (parsed.kind !== "yaml") return [wrongKind(path, "test", "YAML")];
+  if (!isRecord(parsed.data)) {
+    return [schemaDiagnostic({
+      message: "test declaration must be a YAML object",
+      path,
+      ruleId: "schema/test-declaration",
+      subjectKind: "test",
+    })];
+  }
+  return validateTestDeclaration(parsed.data).diagnostics.map((diagnostic) =>
+    schemaDiagnostic({
+      locationLine: sourceLineForSchemaPath(content, diagnostic.path, "yaml"),
+      message: diagnostic.message.replaceAll("$.", ""),
+      path,
+      ruleId: "schema/test-declaration",
+      subjectKind: "test",
+    })
+  );
 }
 
 function workspaceSchemaDiagnostic(
@@ -448,7 +477,7 @@ function checkSkillsetSkillMetadata(
 
 function wrongKind(
   path: string,
-  subjectKind: "agent" | "hook" | "instruction" | "skill" | "workspace",
+  subjectKind: "agent" | "hook" | "instruction" | "skill" | "test" | "workspace",
   expected: string
 ): WorkbenchDiagnostic {
   return schemaDiagnostic({
@@ -466,7 +495,7 @@ function schemaDiagnostic(args: {
   readonly path: string;
   readonly ruleId: string;
   readonly scope?: "source" | "workspace";
-  readonly subjectKind: "agent" | "hook" | "instruction" | "skill" | "workspace";
+  readonly subjectKind: "agent" | "hook" | "instruction" | "skill" | "test" | "workspace";
 }): WorkbenchDiagnostic {
   return createWorkbenchDiagnostic({
     featureId: "source-contracts",


### PR DESCRIPTION
## Context

SET-273 builds on #259 by promoting successful ad hoc tries into explicit committed runtime assertions through the existing `skillset test` declaration model. It preserves deterministic tests as the default and keeps eval scoring out of scope.

## What changed

- add opt-in `activation[].runtime` declarations with inline or source-local prompt files
- reuse the shared Claude, Codex, and Cursor try harness while retaining raw XDG-backed runtime evidence
- add literal `contains` / `notContains` assertions and normalized `render`, `binary`, `setup`, `auth`, `timeout`, `runtime`, and `assertion` failure classes
- add typed/generated `test-declaration` schema, compiler validation, Workbench diagnostics, registry support, docs, and examples
- harden prompt files against lexical and symlink escapes and preserve provider diagnostics in parent reports

## Verification

- focused schema, Workbench, feature-registry, try, report, failure, and adversarial tests
- real non-interactive Claude, Codex, and Cursor tries returned `SKILLSET_RUNTIME_OK`
- `bun run schema:generate` / `bun run schema:check`
- `bun run skillset:build` / `bun run skillset:verify`
- `bun run check` (903 tests)
- `bun run hooks:pre-push`
- standing review: 5/5 clean; targeted review: 5/5 clean; no open P0-P2

## Risk

Live runtime tests are intentionally opt-in and depend on locally available provider binaries and credentials. Ordinary declarations remain deterministic and credential-free. Subjective graders, repeated trials, scoring, and provider installation or trust changes remain out of scope.