### PR TITLE
docs: define the final CLI flag contract

### DIFF
--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -39,7 +39,7 @@ The entries below are the complete final public flag set. Positional arguments a
 | `new` | `--root`, `--id`, `--name`, `--in`, `--scope`, `--preset`, `--yes` | Preview by default. |
 | `check` | `--root`, `--only`, `--write`, `--ci`, `--fix`, `--since`, `--report` | `--fix` requires `--ci`; `--since` and `--report` are CI-only. |
 | `dev` | `--root`, `--write` | Watching is the command's default; `--watch` and `--apply` disappear. |
-| `reconcile <path>` | `--root`, `--use source|output`, `--yes` | Diagnosis is default; direction can be previewed before confirmation. |
+| `reconcile <path>` | `--root`, `--use source` or `--use output`, `--yes` | Diagnosis is default; direction can be previewed before confirmation. |
 | `build` | `--root`, `--updated`, `--all`, `--isolated`, `--scope`, `--yes` | Plan-first explicit compilation. |
 | `update` | `--root`, `--yes` | Whole-workspace registered provider/compiler format migrations only. |
 | `diff` | `--root`, `--updated`, `--all`, `--isolated`, `--scope` | Always read-only. |
@@ -49,7 +49,7 @@ The entries below are the complete final public flag set. Positional arguments a
 | `explain <path>` | `--root`, `--scope`; structured output deferred | Workspace-specific provenance. |
 | `lookup` | `--root`, `--frontmatter`, `--fields`, `--field`, `--values`, `--events`, `--compat`, `--examples`, `--schema`; structured output deferred | Provider aliases become values of `--compat`, not separate `--claude`/`--codex`/`--cursor` flags. |
 | `test [name]` | `--root`, `--target`, `--prompt`, `--prompt-file`, `--plugin`, `--name`, `--timeout-ms`, `--claude-setting-sources`, `--background`; structured output deferred | Runtime flags select ad hoc execution; named declarations remain positional. |
-| `test status|list` | `--root`; structured output deferred | Retained-run lifecycle. |
+| `test status` or `test list` | `--root`; structured output deferred | Retained-run lifecycle. |
 | `test tail` | `--root`, `--lines`; structured output deferred | Retained output view. |
 | `change status` | `--root`, `--since`, `--staged` | Read-only ledger status. |
 | `change check` | `--root`, `--ref`, `--since`, `--staged` | Read-only ledger gate. |
@@ -57,9 +57,9 @@ The entries below are the complete final public flag set. Positional arguments a
 | `change reason` | `--root`, `--ref`, `--append`, `--reason`, `--reason-file` | Explicit ledger edit. |
 | `change amend` | `--root`, `--ref`, `--reason`, `--reason-file` | Explicit corrective record. |
 | `change migrate` | `--root`, `--yes` | Plan-first migration. |
-| `change show|history` | `--root`, `--ref` | Read-only. |
+| `change show` or `change history` | `--root`, `--ref` | Read-only. |
 | `change list` | `--root`, `--group` | Read-only. |
-| `release audit|plan` | `--root` | Read-only. |
+| `release audit` or `release plan` | `--root` | Read-only. |
 | `release apply` | `--root`, `--yes` | Plan-first ledger application. |
 | `release amend` | `--root`, `--ref`, `--reason`, `--reason-file` | Explicit corrective record. |
 | `marketplace check` | `--root`; structured output deferred | Read-only catalog readiness. |
@@ -85,7 +85,7 @@ The entries below are the complete final public flag set. Positional arguments a
 | --- | --- |
 | `--source <dir>` | Removed; canonical `.skillset/` source is configured by the workspace. |
 | `--dist <dir>` | Removed; output roots are workspace configuration. |
-| `--layout root|nested` | Removed; retired layout compatibility is not public. |
+| `--layout root` or `--layout nested` | Removed; retired layout compatibility is not public. |
 | `--global` | Removed with top-level `create`; external destination uses `init [destination]`. |
 | `--dry-run` | Removed; preview is already the default. |
 | `dev --watch --apply` | Becomes bare `dev` and explicit `dev --write`. |

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -1,0 +1,114 @@
+# CLI Flag Contract
+
+Status: accepted implementation input for SET-275; structured output values remain owned by SET-284.
+
+The [workflow-oriented CLI ADR](../adrs/drafts/20260712-workflow-oriented-cli.md) fixes the top-level commands. This document fixes the flag vocabulary those command-family implementations consume. The machine-readable planning contract is `scripts/cli-contract.ts`; implementation slices move its facts into the owned CLI modules instead of creating a second runtime registry.
+
+## Rules
+
+- `--root <path>` is the only public workspace-location override. `--source` and `--dist` are removed because canonical source and output roots come from `skillset.yaml` and `.skillset/`.
+- Preview is the default for plan-first mutations. `--dry-run` is removed as redundant.
+- `--yes` confirms a fully specified plan-first mutation without prompting. It never selects what the mutation should do.
+- `--write` enables deterministic ordinary output writes for comprehensive or continuous workflows: `check` and `dev`.
+- `--fix` exists only with `check --ci`; it performs the same narrow repair as local `check --write`.
+- `--use source|output` selects reconciliation direction. Reconcile still requires `--yes` to apply the selected plan non-interactively.
+- `--scope` selects source units or generated destination groups owned by the route. It never redirects workspace roots.
+- `--from` always identifies input origin. Init accepts a path or Git URL; import accepts a provider origin.
+- General structured output remains entirely owned by SET-284. SET-275 neither removes `--json` nor replaces it with a guessed global flag. Protocol commands may retain a route-specific `--format` where the value changes protocol encoding.
+- Removed flags fail as unknown. There are no aliases for `--apply`, `--dist`, `--dry-run`, `--global`, `--layout`, `--source`, or `--watch`.
+
+## Canonical families
+
+| Family | Purpose | Examples |
+| --- | --- | --- |
+| Context | Select repository context without rewriting config | `--root` |
+| Input | Supply authored or acquired input | `--from`, `--prompt`, `--reason-file` |
+| Selection | Narrow subjects, targets, scopes, or views | `--scope`, `--target`, `--only`, `--field` |
+| Mode | Select an execution mode without confirming a write | `--ci`, `--isolated`, `--background`, `--use` |
+| Mutation | Confirm or enable an explicitly bounded write | `--yes`, `--write`, `--fix` |
+| Output | Select or write a representation/report | `--report`; general structured output deferred to SET-284 |
+
+## Command matrix
+
+The entries below are the complete final public flag set. Positional arguments and domain subcommands are omitted unless needed to distinguish routes.
+
+| Route | Flags | Notes |
+| --- | --- | --- |
+| `init [destination]` | `--root`, `--from`, `--adopt`, `--targets`, `--include`, `--name`, `--yes` | `--adopt all` or repeat stable candidate ids. A TTY may select candidates interactively. |
+| `import` | `--root`, `--from`, `--kind`, `--name` | Repeated-use asset conversion; import itself remains explicit. |
+| `new` | `--root`, `--id`, `--name`, `--in`, `--scope`, `--preset`, `--yes` | Preview by default. |
+| `check` | `--root`, `--only`, `--write`, `--ci`, `--fix`, `--since`, `--report` | `--fix` requires `--ci`; `--since` and `--report` are CI-only. |
+| `dev` | `--root`, `--write` | Watching is the command's default; `--watch` and `--apply` disappear. |
+| `reconcile <path>` | `--root`, `--use source|output`, `--yes` | Diagnosis is default; direction can be previewed before confirmation. |
+| `build` | `--root`, `--updated`, `--all`, `--isolated`, `--scope`, `--yes` | Plan-first explicit compilation. |
+| `update` | `--root`, `--yes` | Whole-workspace registered provider/compiler format migrations only. |
+| `diff` | `--root`, `--updated`, `--all`, `--isolated`, `--scope` | Always read-only. |
+| `restore <backup-id>` | `--root`, `--yes` | Preview by default. |
+| `status` | `--root`; structured output deferred | Read-only human health/advisory view. |
+| `list` | `--root`, `--scope`; structured output deferred | Inventory, not build-mode selection. |
+| `explain <path>` | `--root`, `--scope`; structured output deferred | Workspace-specific provenance. |
+| `lookup` | `--root`, `--frontmatter`, `--fields`, `--field`, `--values`, `--events`, `--compat`, `--examples`, `--schema`; structured output deferred | Provider aliases become values of `--compat`, not separate `--claude`/`--codex`/`--cursor` flags. |
+| `test [name]` | `--root`, `--target`, `--prompt`, `--prompt-file`, `--plugin`, `--name`, `--timeout-ms`, `--claude-setting-sources`, `--background`; structured output deferred | Runtime flags select ad hoc execution; named declarations remain positional. |
+| `test status|list` | `--root`; structured output deferred | Retained-run lifecycle. |
+| `test tail` | `--root`, `--lines`; structured output deferred | Retained output view. |
+| `change status` | `--root`, `--since`, `--staged` | Read-only ledger status. |
+| `change check` | `--root`, `--ref`, `--since`, `--staged` | Read-only ledger gate. |
+| `change add` | `--root`, `--scope`, `--bump`, `--group`, `--reason`, `--reason-file`, `--since` | The subcommand is already an explicit write; no generic write-mode flag. |
+| `change reason` | `--root`, `--ref`, `--append`, `--reason`, `--reason-file` | Explicit ledger edit. |
+| `change amend` | `--root`, `--ref`, `--reason`, `--reason-file` | Explicit corrective record. |
+| `change migrate` | `--root`, `--yes` | Plan-first migration. |
+| `change show|history` | `--root`, `--ref` | Read-only. |
+| `change list` | `--root`, `--group` | Read-only. |
+| `release audit|plan` | `--root` | Read-only. |
+| `release apply` | `--root`, `--yes` | Plan-first ledger application. |
+| `release amend` | `--root`, `--ref`, `--reason`, `--reason-file` | Explicit corrective record. |
+| `marketplace check` | `--root`; structured output deferred | Read-only catalog readiness. |
+| `marketplace update` | `--root`, `--yes`; structured output deferred | Plan-first provider index update. |
+| `distribute plan` | `--root` | Read-only; no destination override. |
+| `hooks print` | `--runner`, `--pre-commit`, `--pre-push`, `--target`, `--agent-runtime` | Prints reviewed integration material. |
+| `hooks run` | `--root` | Event stays positional. |
+| `hooks context` | `--root`, `--event`, `--format`, `--context-fields` | Protocol output values remain a SET-284 exception surface. |
+
+## Reserved combinations
+
+- `check --fix` without `--ci` fails.
+- `check --ci --write` fails; CI uses `--fix` so automation intent is visible.
+- `check --since` and `--report` without `--ci` fail.
+- `--updated` and `--all` are mutually exclusive.
+- `--prompt` and `--prompt-file` are mutually exclusive and imply ad hoc `test`.
+- `--use` accepts exactly `source` or `output`; `--yes` without `--use` cannot apply reconcile.
+- General structured-output support, including the fate and semantics of `--json`, is defined by SET-284 and not silently accepted globally.
+
+## Hard-cut inventory
+
+| Current surface | Final treatment |
+| --- | --- |
+| `--source <dir>` | Removed; canonical `.skillset/` source is configured by the workspace. |
+| `--dist <dir>` | Removed; output roots are workspace configuration. |
+| `--layout root|nested` | Removed; retired layout compatibility is not public. |
+| `--global` | Removed with top-level `create`; external destination uses `init [destination]`. |
+| `--dry-run` | Removed; preview is already the default. |
+| `dev --watch --apply` | Becomes bare `dev` and explicit `dev --write`. |
+| `suggest-source --write --yes` | Becomes `reconcile --use output --yes`. |
+| `check --fix` | Becomes local `check --write`; `--fix` remains CI-only. |
+| `--claude`, `--codex`, `--cursor` lookup aliases | Removed; use `--compat <providers>`. |
+| command-local `--json` | Preserved as an explicit open contract for SET-284; SET-275 does not rename or spread it. |
+
+## Environment contract
+
+Environment overrides exist only for explicit runtime-test and installed-hook integration boundaries. Ordinary source, check, build, update, and reconcile behavior has no environment-variable compatibility layer.
+
+| Variable | Contract |
+| --- | --- |
+| `SKILLSET_TEST_CLAUDE_BIN` | Override the Claude executable used by an explicit test. |
+| `SKILLSET_TEST_CODEX_BIN` | Override the Codex executable used by an explicit test. |
+| `SKILLSET_TEST_CURSOR_BIN` | Override the Cursor executable used by an explicit test. |
+| `SKILLSET_TEST_CLAUDE_SETTING_SOURCES` | Default Claude-native setting-source isolation for an explicit test. |
+| `SKILLSET_HOOK_COMMAND` | Override the Skillset command used by an explicitly installed hook integration. |
+| `SKILLSET_PROVIDER` | Normalized provider context carried into an explicit hook command. |
+| `SKILLSET_HOOK_EVENT` | Normalized event context carried into an explicit hook command. |
+| `SKILLSET_SESSION_ID` | Normalized provider session id carried into an explicit hook command. |
+
+`SKILLSET_TRY_CLAUDE_BIN`, `SKILLSET_TRY_CODEX_BIN`, `SKILLSET_TRY_CURSOR_BIN`, and `SKILLSET_TRY_CLAUDE_SETTING_SOURCES` are removed without fallback. Standard `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` behavior remains platform context rather than Skillset CLI vocabulary.
+
+Every implementation issue must update `CLI_ROUTE_FLAGS` with any evidence-backed divergence before changing parser behavior. SET-285 closes the loop by asserting root help, route help, and parser acceptance against this contract.

--- a/scripts/__tests__/cli-contract.test.ts
+++ b/scripts/__tests__/cli-contract.test.ts
@@ -52,6 +52,9 @@ describe("SET-275 final CLI contract", () => {
   });
 
   test("removes compatibility and redundant mutation flags", () => {
+    for (const retiredAlias of ["--claude", "--codex", "--cursor"] as const) {
+      expect(RETIRED_CLI_FLAGS).toContain(retiredAlias);
+    }
     for (const retired of RETIRED_CLI_FLAGS) {
       expect(CLI_FLAGS[retired as keyof typeof CLI_FLAGS]).toBeUndefined();
     }

--- a/scripts/__tests__/cli-contract.test.ts
+++ b/scripts/__tests__/cli-contract.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CLI_COMMANDS,
+  CLI_ENVIRONMENT,
+  CLI_FLAGS,
+  CLI_ROUTE_FLAGS,
+  RETIRED_CLI_COMMANDS,
+  RETIRED_CLI_ENVIRONMENT,
+  RETIRED_CLI_FLAGS,
+} from "../cli-contract";
+
+describe("SET-275 final CLI contract", () => {
+  test("pins the exact 20-command top-level roster without retired aliases", () => {
+    expect(CLI_COMMANDS).toHaveLength(20);
+    expect(new Set(CLI_COMMANDS).size).toBe(CLI_COMMANDS.length);
+    expect(CLI_COMMANDS).toEqual([
+      "init",
+      "import",
+      "new",
+      "check",
+      "dev",
+      "reconcile",
+      "build",
+      "update",
+      "diff",
+      "restore",
+      "status",
+      "list",
+      "explain",
+      "lookup",
+      "test",
+      "change",
+      "release",
+      "marketplace",
+      "distribute",
+      "hooks",
+    ]);
+    for (const retired of RETIRED_CLI_COMMANDS) {
+      expect(CLI_COMMANDS).not.toContain(retired as never);
+    }
+  });
+
+  test("gives every route flag one canonical meaning", () => {
+    for (const [route, flags] of Object.entries(CLI_ROUTE_FLAGS)) {
+      expect(route.length).toBeGreaterThan(0);
+      expect(new Set(flags).size).toBe(flags.length);
+      for (const flag of flags) {
+        expect(CLI_FLAGS[flag]).toBeDefined();
+      }
+    }
+  });
+
+  test("removes compatibility and redundant mutation flags", () => {
+    for (const retired of RETIRED_CLI_FLAGS) {
+      expect(CLI_FLAGS[retired as keyof typeof CLI_FLAGS]).toBeUndefined();
+    }
+    expect(CLI_ROUTE_FLAGS.check).toContain("--write");
+    expect(CLI_ROUTE_FLAGS.check).toContain("--ci");
+    expect(CLI_ROUTE_FLAGS.check).toContain("--fix");
+    expect(CLI_ROUTE_FLAGS.update).toEqual(["--root", "--yes"]);
+    expect(CLI_ROUTE_FLAGS.reconcile).toEqual(["--root", "--use", "--yes"]);
+  });
+
+  test("hard-cuts try environment overrides to the test family", () => {
+    expect(Object.keys(CLI_ENVIRONMENT).toSorted()).toEqual([
+      "SKILLSET_HOOK_COMMAND",
+      "SKILLSET_HOOK_EVENT",
+      "SKILLSET_PROVIDER",
+      "SKILLSET_SESSION_ID",
+      "SKILLSET_TEST_CLAUDE_BIN",
+      "SKILLSET_TEST_CLAUDE_SETTING_SOURCES",
+      "SKILLSET_TEST_CODEX_BIN",
+      "SKILLSET_TEST_CURSOR_BIN",
+    ]);
+    for (const retired of RETIRED_CLI_ENVIRONMENT) {
+      expect(
+        CLI_ENVIRONMENT[retired as keyof typeof CLI_ENVIRONMENT]
+      ).toBeUndefined();
+    }
+  });
+});

--- a/scripts/cli-contract.ts
+++ b/scripts/cli-contract.ts
@@ -36,6 +36,9 @@ export const RETIRED_CLI_COMMANDS = [
 
 export const RETIRED_CLI_FLAGS = [
   "--apply",
+  "--claude",
+  "--codex",
+  "--cursor",
   "--dist",
   "--dry-run",
   "--global",

--- a/scripts/cli-contract.ts
+++ b/scripts/cli-contract.ts
@@ -1,0 +1,473 @@
+export const CLI_COMMANDS = [
+  "init",
+  "import",
+  "new",
+  "check",
+  "dev",
+  "reconcile",
+  "build",
+  "update",
+  "diff",
+  "restore",
+  "status",
+  "list",
+  "explain",
+  "lookup",
+  "test",
+  "change",
+  "release",
+  "marketplace",
+  "distribute",
+  "hooks",
+] as const;
+
+export const RETIRED_CLI_COMMANDS = [
+  "adopt",
+  "ci",
+  "create",
+  "doctor",
+  "features",
+  "lint",
+  "providers",
+  "suggest-source",
+  "try",
+  "verify",
+] as const;
+
+export const RETIRED_CLI_FLAGS = [
+  "--apply",
+  "--dist",
+  "--dry-run",
+  "--global",
+  "--layout",
+  "--source",
+  "--watch",
+] as const;
+
+export const CLI_ENVIRONMENT = {
+  SKILLSET_HOOK_COMMAND:
+    "Override the Skillset executable used by an explicitly installed hook integration.",
+  SKILLSET_HOOK_EVENT:
+    "Carry the normalized hook event into an explicit hook command.",
+  SKILLSET_PROVIDER:
+    "Carry the selected provider into an explicit hook command.",
+  SKILLSET_SESSION_ID:
+    "Carry the provider session id into an explicit hook command.",
+  SKILLSET_TEST_CLAUDE_BIN:
+    "Override the Claude executable for an explicit ad hoc or declared runtime test.",
+  SKILLSET_TEST_CLAUDE_SETTING_SOURCES:
+    "Set the default Claude setting-source isolation for an explicit runtime test.",
+  SKILLSET_TEST_CODEX_BIN:
+    "Override the Codex executable for an explicit ad hoc or declared runtime test.",
+  SKILLSET_TEST_CURSOR_BIN:
+    "Override the Cursor executable for an explicit ad hoc or declared runtime test.",
+} as const;
+
+export const RETIRED_CLI_ENVIRONMENT = [
+  "SKILLSET_TRY_CLAUDE_BIN",
+  "SKILLSET_TRY_CLAUDE_SETTING_SOURCES",
+  "SKILLSET_TRY_CODEX_BIN",
+  "SKILLSET_TRY_CURSOR_BIN",
+] as const;
+
+type FlagFamily =
+  | "context"
+  | "input"
+  | "mode"
+  | "mutation"
+  | "output"
+  | "selection";
+
+export interface CliFlagContract {
+  readonly family: FlagFamily;
+  readonly value: "boolean" | "optional-value" | "repeatable-value" | "value";
+  readonly meaning: string;
+}
+
+export const CLI_FLAGS = {
+  "--adopt": {
+    family: "mode",
+    meaning: "Select detected adoption candidates by stable id, or all.",
+    value: "repeatable-value",
+  },
+  "--agent-runtime": {
+    family: "mode",
+    meaning: "Render provider agent-runtime hook guidance.",
+    value: "boolean",
+  },
+  "--all": {
+    family: "selection",
+    meaning:
+      "Select every configured generated output rather than updated output.",
+    value: "boolean",
+  },
+  "--append": {
+    family: "mutation",
+    meaning: "Append to an existing pending change reason.",
+    value: "boolean",
+  },
+  "--background": {
+    family: "mode",
+    meaning: "Queue an ad hoc test and return after recording it.",
+    value: "boolean",
+  },
+  "--bump": {
+    family: "input",
+    meaning: "Set the release impact of a change entry.",
+    value: "value",
+  },
+  "--ci": {
+    family: "mode",
+    meaning: "Run check with strict non-interactive CI policy and reporting.",
+    value: "boolean",
+  },
+  "--claude-setting-sources": {
+    family: "input",
+    meaning:
+      "Select Claude-native setting sources for an explicit Claude ad hoc test.",
+    value: "value",
+  },
+  "--compat": {
+    family: "selection",
+    meaning: "Filter lookup facts by one or more providers.",
+    value: "optional-value",
+  },
+  "--context-fields": {
+    family: "selection",
+    meaning: "Select normalized hook runtime context fields.",
+    value: "value",
+  },
+  "--event": {
+    family: "input",
+    meaning: "Select the hook runtime event to normalize.",
+    value: "value",
+  },
+  "--events": {
+    family: "selection",
+    meaning: "Show lookup event facts.",
+    value: "boolean",
+  },
+  "--examples": {
+    family: "selection",
+    meaning: "Show lookup examples.",
+    value: "boolean",
+  },
+  "--field": {
+    family: "selection",
+    meaning: "Select one lookup field path.",
+    value: "value",
+  },
+  "--fields": {
+    family: "selection",
+    meaning: "Show lookup field facts.",
+    value: "boolean",
+  },
+  "--fix": {
+    family: "mutation",
+    meaning:
+      "With check --ci, repair the ordinary drift allowed by local check --write.",
+    value: "boolean",
+  },
+  "--format": {
+    family: "output",
+    meaning:
+      "Select a protocol command encoding such as hook context env or json.",
+    value: "value",
+  },
+  "--from": {
+    family: "input",
+    meaning:
+      "Identify the external path, Git URL, or provider origin supplying input.",
+    value: "value",
+  },
+  "--frontmatter": {
+    family: "selection",
+    meaning: "Show lookup frontmatter facts.",
+    value: "boolean",
+  },
+  "--group": {
+    family: "selection",
+    meaning: "Select or assign a change group.",
+    value: "value",
+  },
+  "--help": {
+    family: "output",
+    meaning: "Print help for the selected command route.",
+    value: "boolean",
+  },
+  "--id": {
+    family: "input",
+    meaning: "Set an explicit stable source-unit id.",
+    value: "value",
+  },
+  "--in": {
+    family: "selection",
+    meaning: "Select the containing plugin for a new source unit.",
+    value: "value",
+  },
+  "--include": {
+    family: "selection",
+    meaning: "Include an optional init scaffold component.",
+    value: "repeatable-value",
+  },
+  "--isolated": {
+    family: "mode",
+    meaning:
+      "Use the isolated generated-output mirror instead of live output roots.",
+    value: "boolean",
+  },
+  "--kind": {
+    family: "selection",
+    meaning: "Select the import source kind.",
+    value: "value",
+  },
+  "--lines": {
+    family: "selection",
+    meaning: "Limit retained test output lines.",
+    value: "value",
+  },
+  "--name": {
+    family: "input",
+    meaning:
+      "Set a route-specific human or stable name where the route permits it.",
+    value: "value",
+  },
+  "--only": {
+    family: "selection",
+    meaning: "Restrict check to one named readiness component.",
+    value: "value",
+  },
+  "--plugin": {
+    family: "selection",
+    meaning: "Select plugins for an ad hoc test rendering.",
+    value: "repeatable-value",
+  },
+  "--pre-commit": {
+    family: "selection",
+    meaning: "Select the pre-commit hook snippet.",
+    value: "boolean",
+  },
+  "--pre-push": {
+    family: "selection",
+    meaning: "Select the pre-push hook snippet.",
+    value: "boolean",
+  },
+  "--preset": {
+    family: "input",
+    meaning: "Apply a named new-source preset.",
+    value: "repeatable-value",
+  },
+  "--prompt": {
+    family: "input",
+    meaning: "Provide an inline ad hoc test prompt.",
+    value: "value",
+  },
+  "--prompt-file": {
+    family: "input",
+    meaning: "Provide a source-local ad hoc test prompt file.",
+    value: "value",
+  },
+  "--reason": {
+    family: "input",
+    meaning: "Provide change or release reason text, with '-' meaning stdin.",
+    value: "value",
+  },
+  "--reason-file": {
+    family: "input",
+    meaning: "Read change or release reason text from a file.",
+    value: "value",
+  },
+  "--ref": {
+    family: "selection",
+    meaning: "Select a change or release record by reference.",
+    value: "value",
+  },
+  "--report": {
+    family: "output",
+    meaning:
+      "Write an additional command-owned report artifact without changing source truth.",
+    value: "value",
+  },
+  "--root": {
+    family: "context",
+    meaning:
+      "Select the repository root; defaults to cwd or Git root according to the route.",
+    value: "value",
+  },
+  "--runner": {
+    family: "selection",
+    meaning: "Select the hook runner syntax to print.",
+    value: "value",
+  },
+  "--schema": {
+    family: "selection",
+    meaning: "Show lookup schema facts.",
+    value: "boolean",
+  },
+  "--scope": {
+    family: "selection",
+    meaning:
+      "Select a route-owned source unit or generated destination scope; never changes workspace roots.",
+    value: "repeatable-value",
+  },
+  "--since": {
+    family: "selection",
+    meaning: "Select the Git baseline for change-aware checks or ledgers.",
+    value: "value",
+  },
+  "--staged": {
+    family: "selection",
+    meaning: "Restrict a change check or status read to staged changes.",
+    value: "boolean",
+  },
+  "--target": {
+    family: "selection",
+    meaning: "Select one provider target for a route.",
+    value: "value",
+  },
+  "--targets": {
+    family: "selection",
+    meaning: "Select the initial provider set written by init.",
+    value: "value",
+  },
+  "--timeout-ms": {
+    family: "mode",
+    meaning: "Set the explicit ad hoc provider test timeout in milliseconds.",
+    value: "value",
+  },
+  "--updated": {
+    family: "selection",
+    meaning:
+      "Select only generated output affected by current source, the default build mode.",
+    value: "boolean",
+  },
+  "--use": {
+    family: "mode",
+    meaning:
+      "Select source or output as the authority for a reconciliation plan.",
+    value: "value",
+  },
+  "--values": {
+    family: "selection",
+    meaning: "Show lookup finite-value facts.",
+    value: "boolean",
+  },
+  "--write": {
+    family: "mutation",
+    meaning:
+      "Enable deterministic ordinary output writes for a route whose default is continuous or comprehensive preview.",
+    value: "boolean",
+  },
+  "--yes": {
+    family: "mutation",
+    meaning: "Confirm a fully specified plan-first mutation without prompting.",
+    value: "boolean",
+  },
+} as const satisfies Readonly<Record<string, CliFlagContract>>;
+
+export const CLI_ROUTE_FLAGS = {
+  build: ["--all", "--isolated", "--root", "--scope", "--updated", "--yes"],
+  "change add": [
+    "--bump",
+    "--group",
+    "--reason",
+    "--reason-file",
+    "--root",
+    "--scope",
+    "--since",
+  ],
+  "change amend": ["--reason", "--reason-file", "--ref", "--root"],
+  "change check": ["--ref", "--root", "--since", "--staged"],
+  "change history": ["--ref", "--root"],
+  "change list": ["--group", "--root"],
+  "change migrate": ["--root", "--yes"],
+  "change reason": ["--append", "--reason", "--reason-file", "--ref", "--root"],
+  "change show": ["--ref", "--root"],
+  "change status": ["--root", "--since", "--staged"],
+  check: [
+    "--ci",
+    "--fix",
+    "--only",
+    "--report",
+    "--root",
+    "--since",
+    "--write",
+  ],
+  dev: ["--root", "--write"],
+  diff: ["--all", "--isolated", "--root", "--scope", "--updated"],
+  "distribute plan": ["--root"],
+  explain: ["--root", "--scope"],
+  "hooks context": ["--context-fields", "--event", "--format", "--root"],
+  "hooks print": [
+    "--agent-runtime",
+    "--pre-commit",
+    "--pre-push",
+    "--runner",
+    "--target",
+  ],
+  "hooks run": ["--root"],
+  import: ["--from", "--kind", "--name", "--root"],
+  init: [
+    "--adopt",
+    "--from",
+    "--include",
+    "--name",
+    "--root",
+    "--targets",
+    "--yes",
+  ],
+  list: ["--root", "--scope"],
+  lookup: [
+    "--compat",
+    "--events",
+    "--examples",
+    "--field",
+    "--fields",
+    "--frontmatter",
+    "--root",
+    "--schema",
+    "--values",
+  ],
+  "marketplace check": ["--root"],
+  "marketplace update": ["--root", "--yes"],
+  new: ["--id", "--in", "--name", "--preset", "--root", "--scope", "--yes"],
+  reconcile: ["--root", "--use", "--yes"],
+  "release amend": ["--reason", "--reason-file", "--ref", "--root"],
+  "release apply": ["--root", "--yes"],
+  "release audit": ["--root"],
+  "release plan": ["--root"],
+  restore: ["--root", "--yes"],
+  status: ["--root"],
+  test: [
+    "--background",
+    "--claude-setting-sources",
+    "--name",
+    "--plugin",
+    "--prompt",
+    "--prompt-file",
+    "--root",
+    "--target",
+    "--timeout-ms",
+  ],
+  "test list": ["--root"],
+  "test status": ["--root"],
+  "test tail": ["--lines", "--root"],
+  update: ["--root", "--yes"],
+} as const;
+
+export const STRUCTURED_OUTPUT_CANDIDATE_ROUTES = [
+  "check",
+  "explain",
+  "list",
+  "lookup",
+  "marketplace check",
+  "marketplace update",
+  "status",
+  "test",
+  "test list",
+  "test status",
+  "test tail",
+] as const;
+
+export type CliCommand = (typeof CLI_COMMANDS)[number];
+export type CliFlag = keyof typeof CLI_FLAGS;


### PR DESCRIPTION
## Context

Locks the public flag and environment vocabulary before the command-family parser cutovers. This is the implementation input for SET-277 through SET-285.

## What changed

- inventories the complete final command-by-flag matrix and semantic flag families
- removes compatibility location flags and redundant mutation modes
- distinguishes `--yes`, `--write`, `--fix`, and `--use`
- removes `SKILLSET_TRY_*` without fallback and reserves `SKILLSET_TEST_*`
- leaves the exact `--json`/structured-output contract to SET-284
- adds a machine contract and drift tests for commands, routes, flags, and environment variables

## Verification

- `bun test scripts/__tests__/cli-contract.test.ts` (4 tests, 229 expectations)
- strict Ultracite check
- `bun run check` (903 tests)
- `bun run hooks:pre-push` (907 tests on committed stack)
- targeted local review: 5/5 clean, zero open P0-P2

## Tracking

Closes SET-275. Stacked on #262.

## Risk

Contract-only slice. Runtime/parser behavior changes in dependent issue-owned branches.