### PR TITLE
feat(cli): migrate finite read routes to versioned json

### DIFF
--- a/.changeset/finite-read-json.md
+++ b/.changeset/finite-read-json.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Return versioned structured results from finite read-only CLI routes when `--json` is selected.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -7276,6 +7276,7 @@ Audit body.
 
   const featureJson = await runSkillsetCli("features", "plugin-bin", "--json");
   expect(featureJson.exitCode).toBe(0);
+  expect(JSON.parse(featureJson.stdout)).toMatchObject({ command: "features" });
   const featureReport = (JSON.parse(featureJson.stdout) as { readonly data: {
     features: readonly {
       docs: readonly string[];
@@ -7309,6 +7310,7 @@ Audit body.
   expect(doctor.stdout).toContain("feature support: claude");
   expect(doctor.stdout).toContain("feature support: codex");
   const doctorJson = await runSkillsetCli("doctor", "--root", root, "--json");
+  expect(JSON.parse(doctorJson.stdout)).toMatchObject({ command: "doctor" });
   const doctorReport = (JSON.parse(doctorJson.stdout) as { readonly data: {
     featureCapabilities: {
       byTargetSupport: { claude: Record<string, number>; codex: Record<string, number> };

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -726,9 +726,9 @@ Body.
 
   const doctorJson = await runSkillsetCli("doctor", "--root", root, "--json");
   expect(doctorJson.exitCode).toBe(1);
-  const doctorReport = JSON.parse(doctorJson.stdout) as {
-    buildDiagnostics: readonly { code: string; featureId: string; path?: string }[];
-  };
+  const doctorReport = (JSON.parse(doctorJson.stdout) as {
+    readonly data: { buildDiagnostics: readonly { code: string; featureId: string; path?: string }[] };
+  }).data;
   expect(doctorReport.buildDiagnostics).toContainEqual(expect.objectContaining({
     code: "plugin-manifest-invalid",
     featureId: "plugin-manifests",
@@ -1274,6 +1274,13 @@ Body.
   expect(planned.stdout).toContain("add: plugins/alpha/codex/.codex-plugin/plugin.json -> bundles/alpha/.codex-plugin/plugin.json");
   expect(planned.stdout).toContain("ownership: file:generated");
   expect(planned.stdout).toContain("destination-owned");
+  const json = await runSkillsetCli("distribute", "plan", "codex-marketplace", "--json", "--root", root);
+  expect(json).toMatchObject({ exitCode: 0, stderr: "" });
+  expect(JSON.parse(json.stdout)).toMatchObject({
+    command: "distribute.plan",
+    kind: "plan",
+    schemaVersion: "skillset.cli.result@1",
+  });
   expect(await fileExists(join(root, "plugins/alpha/codex/.codex-plugin/plugin.json"))).toBe(false);
   expect(await fileExists(join(destination, "bundles/alpha/.codex-plugin/plugin.json"))).toBe(false);
 });
@@ -7136,9 +7143,9 @@ Audit body.
     "--json"
   );
   expect(explainedJson.exitCode).toBe(0);
-  const explainReport = JSON.parse(explainedJson.stdout) as {
+  const explainReport = (JSON.parse(explainedJson.stdout) as { readonly data: {
     renderResults: readonly { destination?: string; featureId: string; status: string; target?: string }[];
-  };
+  } }).data;
   expect(explainReport.renderResults).toContainEqual(
     expect.objectContaining({
       destination: "plugin-manifest",
@@ -7155,10 +7162,10 @@ Audit body.
 
   const doctorJson = await runSkillsetCli("doctor", "--root", root, "--json");
   expect(doctorJson.exitCode).toBe(0);
-  const doctorReport = JSON.parse(doctorJson.stdout) as {
+  const doctorReport = (JSON.parse(doctorJson.stdout) as { readonly data: {
     renderResults: readonly { destination?: string; featureId: string; status: string; target?: string }[];
     notableRenderResults: readonly { destination?: string; featureId: string; status: string; target?: string }[];
-  };
+  } }).data;
   expect(doctorReport.renderResults.length).toBeGreaterThan(0);
   expect(doctorReport.notableRenderResults).toEqual([
     expect.objectContaining({
@@ -7169,11 +7176,11 @@ Audit body.
     }),
   ]);
 
-  const misplacedJson = await runSkillsetCli("list", "--json");
+  const misplacedJson = await runSkillsetCli("build", "--json");
   expect(misplacedJson.exitCode).toBe(2);
   expect(misplacedJson.stderr).toBe("");
   expect(JSON.parse(misplacedJson.stdout)).toMatchObject({
-    diagnostics: [{ message: expect.stringContaining("--json is only supported with doctor, explain, features, lookup, marketplace, or try") }],
+    diagnostics: [{ message: expect.stringContaining("--json is not supported for this command route") }],
     exitCode: 2,
     ok: false,
     schemaVersion: "skillset.cli.result@1",
@@ -7229,7 +7236,7 @@ Audit body.
 
   const skillExplain = await runSkillsetCli("explain", ".skillset/skills/demo/SKILL.md", "--root", root, "--json");
   expect(skillExplain.exitCode).toBe(0);
-  const skillReport = JSON.parse(skillExplain.stdout) as {
+  const skillReport = (JSON.parse(skillExplain.stdout) as { readonly data: {
     features: readonly {
       docs: readonly string[];
       id: string;
@@ -7237,7 +7244,7 @@ Audit body.
       targetSupport: { claude: { status: string }; codex: { status: string } };
       title: string;
     }[];
-  };
+  } }).data;
   expect(skillReport.features).toEqual([
     {
       docs: ["docs/features/resources.md"],
@@ -7269,7 +7276,7 @@ Audit body.
 
   const featureJson = await runSkillsetCli("features", "plugin-bin", "--json");
   expect(featureJson.exitCode).toBe(0);
-  const featureReport = JSON.parse(featureJson.stdout) as {
+  const featureReport = (JSON.parse(featureJson.stdout) as { readonly data: {
     features: readonly {
       docs: readonly string[];
       id: string;
@@ -7277,7 +7284,7 @@ Audit body.
       targetSupport: { claude: { status: string }; codex: { reason?: string; status: string } };
       title: string;
     }[];
-  };
+  } }).data;
   expect(featureReport.features).toEqual([
     {
       docs: ["docs/features/executables.md", "docs/features/feature-source-pointers.md"],
@@ -7294,7 +7301,7 @@ Audit body.
 
   const missingFeature = await runSkillsetCli("features", "no-such-feature", "--json");
   expect(missingFeature.exitCode).toBe(1);
-  expect(JSON.parse(missingFeature.stdout)).toEqual({ features: [] });
+  expect(JSON.parse(missingFeature.stdout)).toMatchObject({ data: { features: [] }, exitCode: 1, schemaVersion: "skillset.cli.result@1" });
 
   const doctor = await runSkillsetCli("doctor", "--root", root);
   expect(doctor.stdout).toContain("features:");
@@ -7302,13 +7309,13 @@ Audit body.
   expect(doctor.stdout).toContain("feature support: claude");
   expect(doctor.stdout).toContain("feature support: codex");
   const doctorJson = await runSkillsetCli("doctor", "--root", root, "--json");
-  const doctorReport = JSON.parse(doctorJson.stdout) as {
+  const doctorReport = (JSON.parse(doctorJson.stdout) as { readonly data: {
     featureCapabilities: {
       byTargetSupport: { claude: Record<string, number>; codex: Record<string, number> };
       featureIds: readonly string[];
       total: number;
     };
-  };
+  } }).data;
   expect(doctorReport.featureCapabilities.total).toBeGreaterThan(0);
   expect(doctorReport.featureCapabilities.byTargetSupport.claude.native).toBeGreaterThan(0);
   expect(doctorReport.featureCapabilities.byTargetSupport.codex.native).toBeGreaterThan(0);
@@ -7688,7 +7695,7 @@ function extractBackupId(stdout: string): string {
 }
 
 function featureIds(stdout: string): readonly string[] {
-  const report = JSON.parse(stdout) as { readonly features?: readonly { readonly id: string }[] };
+  const report = (JSON.parse(stdout) as { readonly data: { readonly features?: readonly { readonly id: string }[] } }).data;
   return report.features?.map((feature) => feature.id) ?? [];
 }
 

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1276,11 +1276,14 @@ Body.
   expect(planned.stdout).toContain("destination-owned");
   const json = await runSkillsetCli("distribute", "plan", "codex-marketplace", "--json", "--root", root);
   expect(json).toMatchObject({ exitCode: 0, stderr: "" });
-  expect(JSON.parse(json.stdout)).toMatchObject({
+  const jsonResult = JSON.parse(json.stdout) as { readonly data: Record<string, unknown> };
+  expect(jsonResult).toMatchObject({
     command: "distribute.plan",
     kind: "plan",
     schemaVersion: "skillset.cli.result@1",
   });
+  expect(jsonResult.data.rootPath).toBeUndefined();
+  expect(json.stdout).not.toContain(root);
   expect(await fileExists(join(root, "plugins/alpha/codex/.codex-plugin/plugin.json"))).toBe(false);
   expect(await fileExists(join(destination, "bundles/alpha/.codex-plugin/plugin.json"))).toBe(false);
 });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -14,7 +14,7 @@ describe("SET-287 finite read-only JSON", () => {
     ["check", "--root", fixtureRoot],
     ["diff", "--root", fixtureRoot],
     ["list", "--root", fixtureRoot],
-    ["explain", "skillset.yaml", "--root", fixtureRoot],
+    ["explain", ".skillset/plugins/kitchen/skills/sink/SKILL.md", "--root", fixtureRoot],
     ["lookup", "skill", "frontmatter"],
   ] as const) {
     test(`${route.join(" ")} emits one versioned result`, async () => {
@@ -25,6 +25,7 @@ describe("SET-287 finite read-only JSON", () => {
       const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
       expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
       expect(envelope.exitCode).toBe(result.exitCode);
+      if (route[0] === "diff" || route[0] === "explain") expect(envelope.kind).toBe("data");
       if (route[0] === "check") {
         expect(envelope.data).toHaveProperty("providerUpdates");
       }

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -55,6 +55,40 @@ describe("SET-287 finite read-only JSON", () => {
     expect(envelope.exitCode).toBe(result.exitCode);
   });
 
+  test("change entry JSON preserves source hash evidence", async () => {
+    const result = await runJsonRoute("change", "list", "--root", repoRoot);
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    const entries = envelope.data.entries as unknown as readonly {
+      readonly sourceHashes: Readonly<Record<string, readonly string[]>>;
+    }[];
+    expect(entries.length).toBeGreaterThan(0);
+    expect(Object.keys(entries[0]?.sourceHashes ?? {}).length).toBeGreaterThan(0);
+    expect(Object.values(entries[0]?.sourceHashes ?? {}).every(Array.isArray)).toBe(true);
+  });
+
+  test("diff JSON preserves source diagnostics", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-diff-json-"));
+    await mkdir(path.join(root, ".skillset", "plugins", "alpha", "skills", "modelish"), {
+      recursive: true,
+    });
+    await writeFile(path.join(root, "skillset.yaml"), "skillset:\n  name: diff-json\n");
+    await writeFile(
+      path.join(root, ".skillset", "plugins", "alpha", "skillset.yaml"),
+      "skillset:\n  name: alpha\n"
+    );
+    await writeFile(
+      path.join(root, ".skillset", "plugins", "alpha", "skills", "modelish", "SKILL.md"),
+      "---\nname: modelish\ndescription: Model warning.\nmodel: gpt-5\n---\n\nBody.\n"
+    );
+
+    const result = await runJsonRoute("diff", "--root", root);
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    expect(envelope.diagnostics).toEqual([
+      expect.objectContaining({ code: "source-warning", severity: "warning" }),
+    ]);
+  });
+
   test("check keeps lint failures structured", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-check-json-"));
     await mkdir(path.join(root, ".skillset", "skills", "demo"), { recursive: true });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -53,6 +53,10 @@ describe("SET-287 finite read-only JSON", () => {
     expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
     expect(envelope.command).toBe("change.check");
     expect(envelope.exitCode).toBe(result.exitCode);
+    if (result.exitCode !== 0) {
+      expect(envelope.kind).toBe("diagnostics");
+      expect(envelope.diagnostics.length).toBeGreaterThan(0);
+    }
   });
 
   test("change entry JSON preserves source hash evidence", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -93,6 +93,21 @@ describe("SET-287 finite read-only JSON", () => {
     ]);
   });
 
+  test("explain JSON promotes an unknown path note to a diagnostic", async () => {
+    const result = await runJsonRoute("explain", "missing/path", "--root", fixtureRoot);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+    expect(envelope).toMatchObject({
+      command: "explain",
+      diagnostics: [{ code: "explain.path-unknown", path: "missing/path", severity: "error" }],
+      exitCode: 1,
+      kind: "diagnostics",
+      ok: false,
+    });
+  });
+
   test("check keeps lint failures structured", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-check-json-"));
     await mkdir(path.join(root, ".skillset", "skills", "demo"), { recursive: true });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import { validateCliResult, type SkillsetCliResult } from "@skillset/schema";
+
+const cli = path.join(import.meta.dir, "..", "cli.ts");
+const repoRoot = path.resolve(import.meta.dir, "../../../..");
+const fixtureRoot = path.join(repoRoot, "fixtures", "kitchen-sink");
+
+describe("SET-287 finite read-only JSON", () => {
+  for (const route of [
+    ["check", "--root", fixtureRoot],
+    ["diff", "--root", fixtureRoot],
+    ["list", "--root", fixtureRoot],
+    ["explain", "skillset.yaml", "--root", fixtureRoot],
+    ["lookup", "skill", "frontmatter"],
+  ] as const) {
+    test(`${route.join(" ")} emits one versioned result`, async () => {
+      const result = await runJsonRoute(...route);
+      expect(result.stderr).toBe("");
+      expect(result.stdout.endsWith("\n")).toBe(true);
+      expect(result.stdout.trim().split("\n")).toHaveLength(1);
+      const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+      expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+      expect(envelope.exitCode).toBe(result.exitCode);
+    });
+  }
+
+  for (const route of [
+    ["change", "status", "--root", repoRoot],
+    ["change", "list", "--root", repoRoot],
+    ["change", "history", "--root", repoRoot],
+  ] as const) {
+    test(`${route.slice(0, 2).join(" ")} emits a versioned ledger result`, async () => {
+      const result = await runJsonRoute(...route);
+      expect(result.stderr).toBe("");
+      const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+      expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+      expect(envelope.exitCode).toBe(result.exitCode);
+    });
+  }
+
+
+  test("change check keeps a negative ledger result structured", async () => {
+    const result = await runJsonRoute("change", "check", "--root", repoRoot);
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+    expect(envelope.command).toBe("change.check");
+    expect(envelope.exitCode).toBe(result.exitCode);
+  });
+});
+
+async function runJsonRoute(...args: readonly string[]): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  const proc = Bun.spawn([process.execPath, cli, ...args, "--json"], {
+    cwd: repoRoot,
+    env: { ...process.env, NODE_ENV: "test" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -61,7 +61,41 @@ describe("SET-287 finite read-only JSON", () => {
   });
 
   test("change entry JSON preserves source hash evidence", async () => {
-    const result = await runJsonRoute("change", "list", "--root", repoRoot);
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-change-json-"));
+    const skillPath = path.join(root, ".skillset", "skills", "demo", "SKILL.md");
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    await writeFile(
+      path.join(root, "skillset.yaml"),
+      "skillset:\n  name: change-json\nclaude: true\ncodex: false\n"
+    );
+    await writeFile(
+      skillPath,
+      "---\nname: demo\ndescription: Demo.\n---\n\nOriginal body.\n"
+    );
+    await commitFixture(root);
+    await writeFile(
+      skillPath,
+      "---\nname: demo\ndescription: Demo.\n---\n\nChanged body.\n"
+    );
+    const reasonPath = path.join(root, "reason.md");
+    await writeFile(reasonPath, "Record source-hash evidence for the isolated JSON fixture.\n");
+    const added = await runRoute(
+      "change",
+      "add",
+      "--root",
+      root,
+      "--since",
+      "HEAD",
+      "--scope",
+      "skill:demo",
+      "--bump",
+      "patch",
+      "--reason-file",
+      reasonPath
+    );
+    expect(added.exitCode).toBe(0);
+
+    const result = await runJsonRoute("change", "list", "--root", root);
     const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
     const entries = envelope.data.entries as unknown as readonly {
       readonly sourceHashes: Readonly<Record<string, readonly string[]>>;
@@ -155,7 +189,11 @@ describe("SET-287 finite read-only JSON", () => {
 });
 
 async function runJsonRoute(...args: readonly string[]): Promise<{ exitCode: number; stderr: string; stdout: string }> {
-  const proc = Bun.spawn([process.execPath, cli, ...args, "--json"], {
+  return runRoute(...args, "--json");
+}
+
+async function runRoute(...args: readonly string[]): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  const proc = Bun.spawn([process.execPath, cli, ...args], {
     cwd: repoRoot,
     env: { ...process.env, NODE_ENV: "test" },
     stderr: "pipe",
@@ -167,4 +205,18 @@ async function runJsonRoute(...args: readonly string[]): Promise<{ exitCode: num
     proc.exited,
   ]);
   return { exitCode, stderr, stdout };
+}
+
+async function commitFixture(root: string): Promise<void> {
+  await runGit(root, "init", "-q");
+  await runGit(root, "config", "user.email", "skillset@example.com");
+  await runGit(root, "config", "user.name", "Skillset Test");
+  await runGit(root, "add", ".");
+  await runGit(root, "commit", "-qm", "baseline");
+}
+
+async function runGit(root: string, ...args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd: root, stderr: "pipe", stdout: "pipe" });
+  const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(stderr.trim());
 }

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { validateCliResult, type SkillsetCliResult } from "@skillset/schema";
@@ -23,6 +25,9 @@ describe("SET-287 finite read-only JSON", () => {
       const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
       expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
       expect(envelope.exitCode).toBe(result.exitCode);
+      if (route[0] === "check") {
+        expect(envelope.data).toHaveProperty("providerUpdates");
+      }
     });
   }
 
@@ -48,6 +53,27 @@ describe("SET-287 finite read-only JSON", () => {
     expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
     expect(envelope.command).toBe("change.check");
     expect(envelope.exitCode).toBe(result.exitCode);
+  });
+
+  test("check keeps lint failures structured", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-check-json-"));
+    await mkdir(path.join(root, ".skillset", "skills", "demo"), { recursive: true });
+    await writeFile(path.join(root, "skillset.yaml"), "skillset:\n  name: check-json\nclaude: true\ncodex: false\n");
+    await writeFile(
+      path.join(root, ".skillset", "skills", "demo", "SKILL.md"),
+      "---\nname: wrong-name\ndescription: Demo.\n---\n\nBody.\n"
+    );
+
+    const result = await runJsonRoute("check", "--root", root);
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+    expect(envelope).toMatchObject({
+      command: "check",
+      diagnostics: [{ code: "skill-name-directory-mismatch", severity: "error" }],
+      exitCode: 1,
+      ok: false,
+    });
   });
 });
 

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -113,6 +113,29 @@ describe("SET-287 finite read-only JSON", () => {
       ok: false,
     });
   });
+
+  test("check JSON remains stderr-clean when the known-workspace index is unwritable", async () => {
+    const configHome = path.join(await mkdtemp(path.join(tmpdir(), "skillset-json-xdg-")), "not-a-directory");
+    await writeFile(configHome, "occupied\n");
+    const proc = Bun.spawn(
+      [process.execPath, cli, "check", "--root", fixtureRoot, "--json"],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, NODE_ENV: "test", XDG_CONFIG_HOME: configHome },
+        stderr: "pipe",
+        stdout: "pipe",
+      }
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(validateCliResult(JSON.parse(stdout))).toEqual({ diagnostics: [], ok: true });
+  });
 });
 
 async function runJsonRoute(...args: readonly string[]): Promise<{ exitCode: number; stderr: string; stdout: string }> {

--- a/apps/skillset/src/__tests__/lookup-cli.test.ts
+++ b/apps/skillset/src/__tests__/lookup-cli.test.ts
@@ -184,6 +184,11 @@ test("SET-220: lookup invalid combinations and targets produce helpful diagnosti
   const invalidTarget = await runSkillsetCli("lookup", "hooks", "--compat", "unknown");
 
   expect(invalidView.exitCode).toBe(1);
+  expect(JSON.parse(invalidView.stdout)).toMatchObject({
+    diagnostics: [{ code: "lookup/frontmatter/not-applicable", severity: "error" }],
+    kind: "diagnostics",
+    ok: false,
+  });
   const report = readResultData(invalidView.stdout) as {
     readonly diagnostics: readonly { readonly code: string; readonly message: string; readonly severity: string }[];
   };

--- a/apps/skillset/src/__tests__/lookup-cli.test.ts
+++ b/apps/skillset/src/__tests__/lookup-cli.test.ts
@@ -20,7 +20,7 @@ test("SET-220: lookup skill frontmatter renders schema-backed fields", async () 
   expect(text.stdout).toContain("resources:");
 
   expect(json.exitCode).toBe(0);
-  const report = JSON.parse(json.stdout) as {
+  const report = readResultData(json.stdout) as {
     readonly fields: readonly { readonly contractId: string; readonly path: string }[];
   };
   expect(report.fields.map((field) => `${field.contractId}:${field.path}`)).toContain("skill-frontmatter:resources");
@@ -30,7 +30,7 @@ test("SET-220: lookup workspace nested field values", async () => {
   const result = await runSkillsetCli("lookup", "workspace", "--field", "compile.targets", "--values", "--json");
 
   expect(result.exitCode).toBe(0);
-  const report = JSON.parse(result.stdout) as {
+  const report = readResultData(result.stdout) as {
     readonly fields: readonly { readonly path: string; readonly values?: readonly string[] }[];
   };
   expect(report.fields).toEqual([
@@ -64,7 +64,7 @@ test("SET-130: lookup skill tools exposes the realization matrix", async () => {
   expect(text.stdout).toContain("[cursor] mcp: unsupported via none (not rendered)");
 
   expect(json.exitCode).toBe(0);
-  const report = JSON.parse(json.stdout) as {
+  const report = readResultData(json.stdout) as {
     readonly compatibility: readonly { readonly featureId: string; readonly status: string; readonly target: string }[];
     readonly realizations: readonly {
       readonly aspect: string;
@@ -103,7 +103,7 @@ test("SET-220: lookup hooks adaptive lens shows adaptive hook fields", async () 
   const result = await runSkillsetCli("lookup", "hooks", "adaptive", "--fields", "--schema", "--examples", "--compat", "codex", "--json");
 
   expect(result.exitCode).toBe(0);
-  const report = JSON.parse(result.stdout) as {
+  const report = readResultData(result.stdout) as {
     readonly compatibility: readonly { readonly featureId: string }[];
     readonly examples: readonly { readonly contractId: string }[];
     readonly fields: readonly { readonly contractId: string; readonly path: string }[];
@@ -119,7 +119,7 @@ test("SET-232: lookup hooks toolkit lens reports runtime context support", async
   const result = await runSkillsetCli("lookup", "hooks", "toolkit", "--field", "context.env", "--values", "--compat", "codex", "--json");
 
   expect(result.exitCode).toBe(0);
-  const report = JSON.parse(result.stdout) as {
+  const report = readResultData(result.stdout) as {
     readonly compatibility: readonly { readonly featureId: string; readonly note?: string; readonly status: string; readonly target: string }[];
     readonly fields: readonly { readonly path: string; readonly values?: readonly string[] }[];
   };
@@ -143,7 +143,7 @@ test("SET-220: lookup plugin bin compatibility reports Codex unsupported reason"
   const result = await runSkillsetCli("lookup", "plugin", "bin", "--compat", "codex", "--json");
 
   expect(result.exitCode).toBe(0);
-  const report = JSON.parse(result.stdout) as {
+  const report = readResultData(result.stdout) as {
     readonly compatibility: readonly { readonly featureId: string; readonly reason?: string; readonly status: string; readonly target: string }[];
   };
   expect(report.compatibility).toEqual([
@@ -160,7 +160,7 @@ test("SET-220: lookup target lens aliases filter non-compat views", async () => 
   const result = await runSkillsetCli("lookup", "hooks", "--events", "--cursor", "--json");
 
   expect(result.exitCode).toBe(0);
-  const report = JSON.parse(result.stdout) as {
+  const report = readResultData(result.stdout) as {
     readonly diagnostics: readonly { readonly code: string; readonly severity: string }[];
     readonly events: readonly { readonly handlerTypes: readonly string[]; readonly matcherEvaluation: string; readonly matcherKind: string; readonly matcherValues: readonly string[]; readonly name: string; readonly providerRef: string; readonly target: string }[];
     readonly targets: readonly string[];
@@ -184,7 +184,7 @@ test("SET-220: lookup invalid combinations and targets produce helpful diagnosti
   const invalidTarget = await runSkillsetCli("lookup", "hooks", "--compat", "unknown");
 
   expect(invalidView.exitCode).toBe(1);
-  const report = JSON.parse(invalidView.stdout) as {
+  const report = readResultData(invalidView.stdout) as {
     readonly diagnostics: readonly { readonly code: string; readonly message: string; readonly severity: string }[];
   };
   expect(report.diagnostics).toContainEqual({
@@ -194,7 +194,7 @@ test("SET-220: lookup invalid combinations and targets produce helpful diagnosti
   });
 
   expect(cursorTarget.exitCode).toBe(0);
-  expect(JSON.parse(cursorTarget.stdout).targets).toEqual(["cursor"]);
+  expect((readResultData(cursorTarget.stdout) as { readonly targets: readonly string[] }).targets).toEqual(["cursor"]);
   expect(invalidTarget.exitCode).toBe(1);
   expect(invalidTarget.stderr).toContain("unknown lookup compatibility target unknown");
 });
@@ -215,4 +215,8 @@ async function runSkillsetCli(...args: readonly string[]): Promise<{
     proc.exited,
   ]);
   return { exitCode, stderr, stdout };
+}
+
+function readResultData(stdout: string): unknown {
+  return (JSON.parse(stdout) as { readonly data: unknown }).data;
 }

--- a/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
+++ b/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
@@ -41,14 +41,19 @@ Use this demo skill.
   expect(checked.stdout).toContain("marketplace-ready: outfitter/local-tools claude plugin local-tools");
 
   const json = await runSkillsetCli("marketplace", "check", "outfitter", "--json", "--root", root);
-  const report = JSON.parse(json.stdout) as {
-    readonly ok: boolean;
-    readonly entries: readonly { readonly readiness: string; readonly generatedPath?: string }[];
+  const envelope = JSON.parse(json.stdout) as {
+    readonly command: string;
+    readonly data: {
+      readonly ok: boolean;
+      readonly entries: readonly { readonly readiness: string; readonly generatedPath?: string }[];
+    };
+    readonly schemaVersion: string;
   };
 
   expect(json).toMatchObject({ exitCode: 0, stderr: "" });
-  expect(report.ok).toBe(true);
-  expect(report.entries).toEqual([expect.objectContaining({
+  expect(envelope).toMatchObject({ command: "marketplace.check", schemaVersion: "skillset.cli.result@1" });
+  expect(envelope.data.ok).toBe(true);
+  expect(envelope.data.entries).toEqual([expect.objectContaining({
     generatedPath: "plugins/local-tools/claude/.claude-plugin/plugin.json",
     readiness: "marketplace-ready",
   })]);
@@ -189,9 +194,9 @@ Use this demo skill.
   );
   expect(checkedJson).toMatchObject({ exitCode: 0, stderr: "" });
   expect(updateJson).toMatchObject({ exitCode: 0, stderr: "" });
-  const checkedReport = JSON.parse(checkedJson.stdout) as {
-    readonly entries: readonly { readonly provenance: unknown }[];
-  };
+  const checkedReport = (JSON.parse(checkedJson.stdout) as {
+    readonly data: { readonly entries: readonly { readonly provenance: unknown }[] };
+  }).data;
   const updateReport = JSON.parse(updateJson.stdout) as {
     readonly check: { readonly entries: readonly { readonly provenance: unknown }[] };
   };

--- a/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
+++ b/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
@@ -84,6 +84,17 @@ skillset:
   expect(checked.stdout).toContain("skillset: marketplace check failed");
   expect(checked.stdout).toContain("missing generated file: plugins/local-tools/claude/.claude-plugin/plugin.json");
   await expect(readdir(root)).resolves.toEqual(before);
+
+  const json = await runSkillsetCli("marketplace", "check", "--json", "--root", root);
+  const envelope = JSON.parse(json.stdout) as {
+    readonly diagnostics: readonly { readonly code: string; readonly message: string; readonly path?: string }[];
+  };
+  expect(json).toMatchObject({ exitCode: 1, stderr: "" });
+  expect(envelope.diagnostics).toEqual([expect.objectContaining({
+    code: "marketplace.not-ready",
+    message: expect.stringContaining("missing generated file"),
+    path: "plugins/local-tools/claude/.claude-plugin/plugin.json",
+  })]);
 });
 
 test("SET-236: marketplace update previews and writes an external Claude marketplace index", async () => {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -735,7 +735,7 @@ export async function runCli(
         "diff",
         result.data,
         exitCode,
-        "diagnostics",
+        "data",
         serializeDiagnostics(result.diagnostics)
       );
       return;
@@ -823,7 +823,13 @@ export async function runCli(
             severity: "error",
           }))
         : [];
-      printCliJsonData("explain", result, exitCode, "diagnostics", diagnostics);
+      printCliJsonData(
+        "explain",
+        result,
+        exitCode,
+        result.kind === "unknown" ? "diagnostics" : "data",
+        diagnostics
+      );
       if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -23,6 +23,7 @@ import {
   type MarketplaceCheckReport,
   type MarketplaceUpdateReport,
   type OutputBackupRestoreReport,
+  type SkillsetDiagnostic,
   type VersionAuditReport,
 } from "@skillset/core";
 
@@ -338,7 +339,10 @@ export async function runCli(
         ...(changeRef === undefined ? {} : { ref: changeRef }),
         ...(changeStaged ? { staged: true } : {}),
       });
-      if (jsonOutput) printCliJsonData("change.check", report, report.ok ? 0 : 1);
+      if (jsonOutput) printCliJsonData("change.check", {
+        ...report,
+        entries: report.entries.map(serializeChangeEntry),
+      }, report.ok ? 0 : 1);
       else printChangeCheck(report);
       return;
     }
@@ -376,7 +380,10 @@ export async function runCli(
     if (changeSubcommand === "show") {
       if (changeRef === undefined) throw new Error("skillset: change show requires @ref");
       const report = await showChangeEntry(rootPath, { ...changeOptions, ref: changeRef });
-      if (jsonOutput) printCliJsonData("change.show", report);
+      if (jsonOutput) printCliJsonData("change.show", {
+        ...report,
+        entry: serializeChangeEntry(report.entry),
+      });
       else printChangeEntry("show", report.entry);
       return;
     }
@@ -385,7 +392,10 @@ export async function runCli(
         ...changeOptions,
         ...(changeGroup === undefined ? {} : { group: changeGroup }),
       });
-      if (jsonOutput) printCliJsonData("change.list", report);
+      if (jsonOutput) printCliJsonData("change.list", {
+        ...report,
+        entries: report.entries.map(serializeChangeEntry),
+      });
       else printChangeList(report.entries);
       return;
     }
@@ -394,7 +404,10 @@ export async function runCli(
         ...changeOptions,
         ...(changeRef === undefined ? {} : { ref: changeRef }),
       });
-      if (jsonOutput) printCliJsonData("change.history", report);
+      if (jsonOutput) printCliJsonData("change.history", {
+        ...report,
+        entries: report.entries.map(serializeChangeEntry),
+      });
       else printChangeHistory(report.entries);
       return;
     }
@@ -705,7 +718,14 @@ export async function runCli(
   if (command === "diff") {
     const result = await diffSkillsetResult(rootPath, options);
     if (jsonOutput) {
-      printCliJsonData("diff", result.data);
+      const exitCode = result.ok ? 0 : 1;
+      printCliJsonData(
+        "diff",
+        result.data,
+        exitCode,
+        "diagnostics",
+        serializeDiagnostics(result.diagnostics)
+      );
       return;
     }
     printDiagnostics(result.diagnostics);
@@ -938,6 +958,32 @@ function printCliJsonData(
     kind,
   }));
   if (exitCode !== 0) process.exitCode = exitCode;
+}
+
+function serializeChangeEntry<
+  T extends { readonly sourceHashes: ReadonlyMap<string, readonly string[]> },
+>(entry: T): Omit<T, "sourceHashes"> & {
+  readonly sourceHashes: Readonly<Record<string, readonly string[]>>;
+} {
+  return {
+    ...entry,
+    sourceHashes: Object.fromEntries(
+      [...entry.sourceHashes].sort(([left], [right]) => left.localeCompare(right))
+    ),
+  };
+}
+
+function serializeDiagnostics(
+  diagnostics: readonly SkillsetDiagnostic[]
+): readonly SkillsetCliDiagnostic[] {
+  return diagnostics.map((diagnostic) => ({
+    code: diagnostic.code,
+    message: diagnostic.message,
+    ...(diagnostic.path === undefined && diagnostic.outputPath === undefined
+      ? {}
+      : { path: diagnostic.path ?? diagnostic.outputPath }),
+    severity: diagnostic.severity,
+  }));
 }
 
 async function rememberKnownSkillsetWorkspace(rootPath: string, options: SkillsetOptions): Promise<void> {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -514,7 +514,15 @@ export async function runCli(
         ...(marketplaceName === undefined ? {} : { name: marketplaceName }),
       });
       if (jsonOutput) {
-        printCliJsonData("marketplace.check", report, report.ok ? 0 : 1, "diagnostics");
+        const diagnostics = report.entries
+          .filter((entry) => entry.readiness === "not-ready")
+          .map((entry): SkillsetCliDiagnostic => ({
+            code: "marketplace.not-ready",
+            message: `${entry.catalog}/${entry.entryId}: ${entry.reason}`,
+            ...(entry.generatedPath === undefined ? {} : { path: entry.generatedPath }),
+            severity: "error",
+          }));
+        printCliJsonData("marketplace.check", report, report.ok ? 0 : 1, "diagnostics", diagnostics);
       } else {
         printMarketplaceCheck(report);
       }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -7,6 +7,7 @@ import {
   checkMarketplaces,
   createOperationalPathContext,
   diffSkillsetResult,
+  inspectSkillset,
   isRepoOperationalCachePath,
   planDistributions,
   recordKnownSkillsetWorkspace,
@@ -572,18 +573,26 @@ export async function runCli(
   }
 
   if (command === "check") {
-    const result = await lintSkillset(rootPath, options);
     if (jsonOutput) {
+      const result = await inspectSkillset(await loadBuildGraph(rootPath, options));
       const diagnostics = result.issues.map((issue): SkillsetCliDiagnostic => ({
         code: issue.code,
         message: issue.message,
         path: issue.path,
         severity: issue.severity === "warn" ? "warning" : "error",
       }));
-      printCliJsonData("check", { checkedSkills: result.checkedSkills }, 0, "diagnostics", diagnostics);
-      await rememberKnownSkillsetWorkspace(rootPath, options);
+      const providerUpdates = ciFix
+        ? await runProviderFormatUpdates(rootPath, "check", { ...options, write: true })
+        : await runProviderFormatUpdateAdvisory(rootPath, options);
+      const exitCode = result.issues.some((issue) => issue.severity === "error") ||
+          (ciFix && (!providerUpdates.ok || providerUpdates.blocked))
+        ? 1
+        : 0;
+      printCliJsonData("check", { checkedSkills: result.checkedSkills, providerUpdates }, exitCode, "diagnostics", diagnostics);
+      if (exitCode === 0) await rememberKnownSkillsetWorkspace(rootPath, options);
       return;
     }
+    const result = await lintSkillset(rootPath, options);
     for (const issue of result.issues) {
       if (issue.severity !== "warn") continue;
       console.log(`  warn: ${issue.path}: ${issue.code}: ${issue.message}`);
@@ -739,7 +748,7 @@ export async function runCli(
     const features = listFeatureCapabilities(importPath);
     if (jsonOutput) {
       const exitCode = importPath !== undefined && features.length === 0 ? 1 : 0;
-      printCliJsonData("lookup.features", { features }, exitCode);
+      printCliJsonData("features", { features }, exitCode);
       if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }
@@ -850,7 +859,7 @@ export async function runCli(
     const report = await doctorSkillset(rootPath, options);
     if (jsonOutput) {
       const exitCode = report.ok ? 0 : 1;
-      printCliJsonData("check.doctor", report, exitCode, "diagnostics");
+      printCliJsonData("doctor", report, exitCode, "diagnostics");
       if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -342,7 +342,12 @@ export async function runCli(
       if (jsonOutput) printCliJsonData("change.check", {
         ...report,
         entries: report.entries.map(serializeChangeEntry),
-      }, report.ok ? 0 : 1);
+      }, report.ok ? 0 : 1, report.ok ? "data" : "diagnostics", report.issues.map((issue) => ({
+        code: issue.code,
+        message: issue.message,
+        ...(issue.path === undefined ? {} : { path: issue.path }),
+        severity: issue.severity,
+      })));
       else printChangeCheck(report);
       return;
     }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -607,7 +607,6 @@ export async function runCli(
         ? 1
         : 0;
       printCliJsonData("check", { checkedSkills: result.checkedSkills, providerUpdates }, exitCode, "diagnostics", diagnostics);
-      if (exitCode === 0) await rememberKnownSkillsetWorkspace(rootPath, options);
       return;
     }
     const result = await lintSkillset(rootPath, options);

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -113,8 +113,10 @@ import {
 import { createSkillset, initSkillset, type SetupInclude, type SetupLayoutOption, type SetupReport } from "./setup";
 import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "@skillset/core/internal/source-unit-selector";
 import { renderValidatedJson } from "@skillset/core/internal/structured-output";
+import { renderCliDataResult } from "./cli-output";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
 import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, SourceOrigin, TargetName } from "@skillset/core/internal/types";
+import type { SchemaJsonRecord, SkillsetCliDiagnostic } from "@skillset/schema";
 
 type Command = CliCommand;
 type DistributionSubcommand = "plan";
@@ -321,18 +323,22 @@ export async function runCli(
   if (command === "change") {
     const changeOptions = { ...options, ...(changeSince === undefined ? {} : { since: changeSince }) };
     if (changeSubcommand === "status") {
-      printChangeStatus(await changeStatus(rootPath, {
+      const report = await changeStatus(rootPath, {
         ...changeOptions,
         ...(changeStaged ? { staged: true } : {}),
-      }));
+      });
+      if (jsonOutput) printCliJsonData("change.status", report);
+      else printChangeStatus(report);
       return;
     }
     if (changeSubcommand === "check") {
-      printChangeCheck(await changeCheck(rootPath, {
+      const report = await changeCheck(rootPath, {
         ...changeOptions,
         ...(changeRef === undefined ? {} : { ref: changeRef }),
         ...(changeStaged ? { staged: true } : {}),
-      }));
+      });
+      if (jsonOutput) printCliJsonData("change.check", report, report.ok ? 0 : 1);
+      else printChangeCheck(report);
       return;
     }
     if (changeSubcommand === "add") {
@@ -368,21 +374,27 @@ export async function runCli(
     }
     if (changeSubcommand === "show") {
       if (changeRef === undefined) throw new Error("skillset: change show requires @ref");
-      printChangeEntry("show", (await showChangeEntry(rootPath, { ...changeOptions, ref: changeRef })).entry);
+      const report = await showChangeEntry(rootPath, { ...changeOptions, ref: changeRef });
+      if (jsonOutput) printCliJsonData("change.show", report);
+      else printChangeEntry("show", report.entry);
       return;
     }
     if (changeSubcommand === "list") {
-      printChangeList((await listChangeEntries(rootPath, {
+      const report = await listChangeEntries(rootPath, {
         ...changeOptions,
         ...(changeGroup === undefined ? {} : { group: changeGroup }),
-      })).entries);
+      });
+      if (jsonOutput) printCliJsonData("change.list", report);
+      else printChangeList(report.entries);
       return;
     }
     if (changeSubcommand === "history") {
-      printChangeHistory((await readChangeHistory(rootPath, {
+      const report = await readChangeHistory(rootPath, {
         ...changeOptions,
         ...(changeRef === undefined ? {} : { ref: changeRef }),
-      })).entries);
+      });
+      if (jsonOutput) printCliJsonData("change.history", report);
+      else printChangeHistory(report.entries);
       return;
     }
     if (changeSubcommand === "migrate") {
@@ -465,10 +477,12 @@ export async function runCli(
 
   if (command === "distribute") {
     if (distributionSubcommand === "plan") {
-      printDistributionPlan(await planDistributions(rootPath, {
+      const report = await planDistributions(rootPath, {
         ...options,
         ...(distributionName === undefined ? {} : { name: distributionName }),
-      }));
+      });
+      if (jsonOutput) printCliJsonData("distribute.plan", report, 0, "plan");
+      else printDistributionPlan(report);
       return;
     }
     throw new Error("skillset: expected distribute subcommand plan");
@@ -481,7 +495,7 @@ export async function runCli(
         ...(marketplaceName === undefined ? {} : { name: marketplaceName }),
       });
       if (jsonOutput) {
-        process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset marketplace check"));
+        printCliJsonData("marketplace.check", report, report.ok ? 0 : 1, "diagnostics");
       } else {
         printMarketplaceCheck(report);
       }
@@ -559,6 +573,17 @@ export async function runCli(
 
   if (command === "check") {
     const result = await lintSkillset(rootPath, options);
+    if (jsonOutput) {
+      const diagnostics = result.issues.map((issue): SkillsetCliDiagnostic => ({
+        code: issue.code,
+        message: issue.message,
+        path: issue.path,
+        severity: issue.severity === "warn" ? "warning" : "error",
+      }));
+      printCliJsonData("check", { checkedSkills: result.checkedSkills }, 0, "diagnostics", diagnostics);
+      await rememberKnownSkillsetWorkspace(rootPath, options);
+      return;
+    }
     for (const issue of result.issues) {
       if (issue.severity !== "warn") continue;
       console.log(`  warn: ${issue.path}: ${issue.code}: ${issue.message}`);
@@ -670,6 +695,10 @@ export async function runCli(
 
   if (command === "diff") {
     const result = await diffSkillsetResult(rootPath, options);
+    if (jsonOutput) {
+      printCliJsonData("diff", result.data);
+      return;
+    }
     printDiagnostics(result.diagnostics);
     const { data: diff } = result;
     const total = diff.added.length + diff.changed.length + diff.missing.length + diff.removed.length;
@@ -690,6 +719,10 @@ export async function runCli(
 
   if (command === "list") {
     const entries = await listGeneratedEntries(rootPath, options);
+    if (jsonOutput) {
+      printCliJsonData("list", { entries });
+      return;
+    }
     for (const entry of entries) {
       const feature = entry.feature === undefined ? "" : ` ${entry.feature}`;
       const origin = entry.origin === undefined ? "" : ` (${entry.origin})`;
@@ -705,8 +738,9 @@ export async function runCli(
   if (command === "features") {
     const features = listFeatureCapabilities(importPath);
     if (jsonOutput) {
-      process.stdout.write(renderValidatedJson({ features } as unknown as JsonRecord, "skillset features"));
-      if (importPath !== undefined && features.length === 0) process.exitCode = 1;
+      const exitCode = importPath !== undefined && features.length === 0 ? 1 : 0;
+      printCliJsonData("lookup.features", { features }, exitCode);
+      if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }
     if (features.length === 0) {
@@ -739,8 +773,9 @@ export async function runCli(
     }
     const result = await explainPath(rootPath, importPath, options);
     if (jsonOutput) {
-      process.stdout.write(renderValidatedJson(result as unknown as JsonRecord, "skillset explain"));
-      if (result.kind === "unknown") process.exitCode = 1;
+      const exitCode = result.kind === "unknown" ? 1 : 0;
+      printCliJsonData("explain", result, exitCode, "diagnostics");
+      if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }
     console.log(`skillset: ${result.path} (${result.kind})`);
@@ -814,8 +849,9 @@ export async function runCli(
     // renders them below instead of relying on core operations to print.
     const report = await doctorSkillset(rootPath, options);
     if (jsonOutput) {
-      process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset doctor"));
-      if (!report.ok) process.exitCode = 1;
+      const exitCode = report.ok ? 0 : 1;
+      printCliJsonData("check.doctor", report, exitCode, "diagnostics");
+      if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }
     for (const issue of report.lintIssues) {
@@ -876,6 +912,23 @@ export function reportCliError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
   process.exitCode = 1;
+}
+
+function printCliJsonData(
+  command: string,
+  data: unknown,
+  exitCode = 0,
+  kind = "data",
+  diagnostics: readonly SkillsetCliDiagnostic[] = []
+): void {
+  process.stdout.write(renderCliDataResult({
+    command,
+    data: data as SchemaJsonRecord,
+    diagnostics,
+    exitCode,
+    kind,
+  }));
+  if (exitCode !== 0) process.exitCode = exitCode;
 }
 
 async function rememberKnownSkillsetWorkspace(rootPath: string, options: SkillsetOptions): Promise<void> {
@@ -2130,7 +2183,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(tryTimeoutMs === undefined ? {} : { timeoutMs: tryTimeoutMs }),
     yes,
   });
-  validateJsonFlags(command, jsonOutput);
+  validateJsonFlags(command, jsonOutput, {
+    ...(changeSubcommand === undefined ? {} : { changeSubcommand }),
+    ciFix,
+    ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
+  });
   if (jsonlOutput) throw new Error("skillset: --jsonl is not supported until a streaming route is enabled");
   validateLookupFlags(command, {
     ...(lookupField === undefined ? {} : { field: lookupField }),
@@ -2920,10 +2977,21 @@ function validateAdoptFlags(
   }
 }
 
-function validateJsonFlags(command: Command, jsonOutput: boolean): void {
+function validateJsonFlags(
+  command: Command,
+  jsonOutput: boolean,
+  route: {
+    readonly changeSubcommand?: ChangeSubcommand;
+    readonly ciFix: boolean;
+    readonly distributionSubcommand?: DistributionSubcommand;
+  }
+): void {
   if (!jsonOutput) return;
-  if (command === "doctor" || command === "explain" || command === "features" || command === "lookup" || command === "marketplace" || command === "try") return;
-  throw new Error("skillset: --json is only supported with doctor, explain, features, lookup, marketplace, or try");
+  if (command === "check" && !route.ciFix) return;
+  if (command === "change" && (route.changeSubcommand === "check" || route.changeSubcommand === "history" || route.changeSubcommand === "list" || route.changeSubcommand === "show" || route.changeSubcommand === "status")) return;
+  if (command === "diff" || command === "doctor" || command === "explain" || command === "features" || command === "list" || command === "lookup" || command === "marketplace" || command === "try") return;
+  if (command === "distribute" && route.distributionSubcommand === "plan") return;
+  throw new Error("skillset: --json is not supported for this command route");
 }
 
 function validateLookupFlags(

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -500,7 +500,7 @@ export async function runCli(
         ...options,
         ...(distributionName === undefined ? {} : { name: distributionName }),
       });
-      if (jsonOutput) printCliJsonData("distribute.plan", report, 0, "plan");
+      if (jsonOutput) printCliJsonData("distribute.plan", { plans: report.plans }, 0, "plan");
       else printDistributionPlan(report);
       return;
     }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -815,7 +815,15 @@ export async function runCli(
     const result = await explainPath(rootPath, importPath, options);
     if (jsonOutput) {
       const exitCode = result.kind === "unknown" ? 1 : 0;
-      printCliJsonData("explain", result, exitCode, "diagnostics");
+      const diagnostics = result.kind === "unknown"
+        ? result.notes.map((message): SkillsetCliDiagnostic => ({
+            code: "explain.path-unknown",
+            message,
+            path: result.path,
+            severity: "error",
+          }))
+        : [];
+      printCliJsonData("explain", result, exitCode, "diagnostics", diagnostics);
       if (exitCode !== 0) process.exitCode = exitCode;
       return;
     }

--- a/apps/skillset/src/cli-output.ts
+++ b/apps/skillset/src/cli-output.ts
@@ -96,6 +96,22 @@ export function renderCliResult(result: SkillsetCliResult): string {
   return `${JSON.stringify(result)}\n`;
 }
 
+export function renderCliDataResult(input: {
+  readonly command: string;
+  readonly data: SchemaJsonRecord;
+  readonly diagnostics?: readonly SkillsetCliDiagnostic[];
+  readonly exitCode?: number;
+  readonly kind?: string;
+}): string {
+  return renderCliResult(createCliResult({
+    command: input.command,
+    data: input.data,
+    ...(input.diagnostics === undefined ? {} : { diagnostics: input.diagnostics }),
+    ...(input.exitCode === undefined ? {} : { exitCode: input.exitCode }),
+    kind: input.kind ?? "data",
+  }));
+}
+
 export function renderCliEvent(event: SkillsetCliEvent): string {
   assertValid(validateCliEvent(event));
   return `${JSON.stringify(event)}\n`;

--- a/apps/skillset/src/lookup-cli.ts
+++ b/apps/skillset/src/lookup-cli.ts
@@ -33,6 +33,7 @@ export function runLookupCommand(options: LookupCommandOptions): void {
     process.stdout.write(renderCliDataResult({
       command: "lookup",
       data: report as unknown as SchemaJsonRecord,
+      ...(failed ? { diagnostics: report.diagnostics, kind: "diagnostics" } : {}),
       exitCode: failed ? 1 : 0,
     }));
   } else {

--- a/apps/skillset/src/lookup-cli.ts
+++ b/apps/skillset/src/lookup-cli.ts
@@ -7,8 +7,9 @@ import {
   type LookupView,
 } from "@skillset/core";
 
-import { renderValidatedJson } from "@skillset/core/internal/structured-output";
-import type { JsonRecord, TargetName } from "@skillset/core/internal/types";
+import type { TargetName } from "@skillset/core/internal/types";
+import type { SchemaJsonRecord } from "@skillset/schema";
+import { renderCliDataResult } from "./cli-output";
 
 export interface LookupCommandOptions {
   readonly aspects: readonly string[];
@@ -28,7 +29,12 @@ export function runLookupCommand(options: LookupCommandOptions): void {
     ...(options.views.length === 0 ? {} : { views: options.views }),
   });
   if (options.json) {
-    process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset lookup"));
+    const failed = report.diagnostics.some((diagnostic) => diagnostic.severity === "error");
+    process.stdout.write(renderCliDataResult({
+      command: "lookup",
+      data: report as unknown as SchemaJsonRecord,
+      exitCode: failed ? 1 : 0,
+    }));
   } else {
     printLookupReport(report);
   }

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -95,6 +95,12 @@ The entries below are the complete final public flag set. Positional arguments a
 | `--claude`, `--codex`, `--cursor` lookup aliases | Removed; use `--compat <providers>`. |
 | command-local `--json` | Standardized as one finite versioned result document by SET-284. |
 
+## Structured-output migration coverage
+
+SET-287 moves the available finite read-only routes onto `skillset.cli.result@1`: `check`, `diff`, `list`, `explain`, `lookup`, `change status|check|show|list|history`, `marketplace check`, and `distribute plan`. Transitional `doctor` and `features` reads use the same envelope until their command-family cutovers remove them.
+
+The final top-level `status` route is intentionally pending SET-280 because it does not exist before that command-family cutover. Plan and mutation routes remain assigned to SET-288; `dev` and continuous test output remain assigned to SET-289. `marketplace update` and the current test/try family therefore still have legacy command-local JSON on this slice and are explicitly outside SET-287.
+
 ## Environment contract
 
 Environment overrides exist only for explicit runtime-test and installed-hook integration boundaries. Ordinary source, check, build, update, and reconcile behavior has no environment-variable compatibility layer.


### PR DESCRIPTION
## Context

#265 defines the structured-output kernel. This applies it to finite read-oriented commands so automation receives one consistent, schema-valid result envelope.

## What changed

- migrates finite `--json` routes including check, diff, list, explain, lookup, change reads/checks, distribution planning, and marketplace checks
- promotes lint, drift, lookup, readiness, ledger, and unknown-path failures into structured diagnostics
- preserves route-specific source hashes, render evidence, provider readiness, and change-ledger data
- keeps machine routes stderr-clean and removes checkout-specific paths from portable JSON
- documents the standalone finite-result contract and adds positive and negative route coverage

## Verification

- required GitHub checks: `changeset`, `check`, and `skillset-ci`
- focused finite-route schema, exit-code, diagnostic, and stderr-cleanliness coverage

## Tracking

Closes SET-287. Stacked on #265.

## Risks / rollout

This intentionally changes the JSON shape of migrated routes before 1.0. Consumers must read the versioned envelope rather than the former command-local top-level shape. Human-readable output is unaffected.
