### PR TITLE
feat(cli): unify declared and ad hoc tests

### DIFF
--- a/.changeset/unify-test-runs.md
+++ b/.changeset/unify-test-runs.md
@@ -1,0 +1,5 @@
+---
+"skillset": minor
+---
+
+Unify declared and ad hoc provider runs under `skillset test`, move retained ad hoc evidence beneath `.skillset/cache/tests/ad-hoc`, rename runtime overrides to `SKILLSET_TEST_*`, and remove top-level `try` without aliases.

--- a/.envrc.example
+++ b/.envrc.example
@@ -9,7 +9,7 @@ export NPM_TOKEN="npm_REPLACE_ME"
 # `claude setup-token` prints this export line for subscription-backed CLI use.
 export CLAUDE_CODE_OAUTH_TOKEN="REPLACE_WITH_CLAUDE_SETUP_TOKEN"
 # Optional: isolated is the default; alternatives are user, project, or local.
-# export SKILLSET_TRY_CLAUDE_SETTING_SOURCES="isolated"
+# export SKILLSET_TEST_CLAUDE_SETTING_SOURCES="isolated"
 
 # API-key fallback for Claude SDK/API workflows. Usually leave unset when using
 # CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ skillset explain <path>     # explain a source or generated path (rendering, loc
 skillset features [id]      # inspect registry feature capabilities and target support; add --json for records
 skillset restore <backup>   # preview restoring a generated-output backup; write with --yes
 skillset doctor             # aggregate lint issues, drift, warnings, and render result advisories; add --json for records
-skillset test [name]        # run an isolated deterministic projection test
+skillset test [name]        # run a committed deterministic/runtime declaration
+skillset test --target codex --prompt "..." # run an ad hoc provider test
+skillset test status        # inspect the retained ad hoc test lifecycle (also: tail, list)
 ```
 
 `init` and `build` are plan-first: they print pending filesystem changes and write only with `--yes`; `--dry-run` always prevents writes, even when paired with `--yes`. `skillset check` is read-only by default and combines source diagnostics with generated-output readiness. `check --only outputs` is the narrow freshness check. `check --write` repairs only source-driven drift: it refuses managed target-side edits and provider-format migrations, which must be reconciled or applied through `skillset update`. `check --ci` adds branch-aware Skillset change-entry and package Changesets gates; CI uses `--fix`, not `--write`, and may also emit a Markdown report with `--report`. The retired top-level `lint`, `verify`, and `ci` commands have no compatibility aliases. `skillset init --include ci` scaffolds the corresponding workflow (see [CI](docs/features/ci.md)).

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1969,6 +1969,21 @@ Demo body.
   expect(firstReport.schemaVersion).toBe(3);
   expect(firstReport.targets).toEqual(["claude"]);
 
+  const structured = await runSkillsetCli("test", "self", "--root", root, "--json");
+  expect(structured.exitCode).toBe(0);
+  expect(structured.stderr).toBe("");
+  expect(JSON.parse(structured.stdout)).toMatchObject({
+    command: "test",
+    data: { name: "self", ok: true },
+    exitCode: 0,
+    kind: "test",
+    ok: true,
+  });
+
+  const mixed = await runSkillsetCli("test", "self", "--target", "claude", "--root", root);
+  expect(mixed.exitCode).toBe(1);
+  expect(mixed.stderr).toContain("declared test self cannot be combined with ad hoc test flags");
+
   const second = await runSkillsetCli("test", "self", "--root", root);
   expect(second.exitCode).toBe(0);
   const secondLatest = JSON.parse(await readFile(cachePath(root, ".skillset/cache/tests/latest.json"), "utf8")) as {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1896,6 +1896,19 @@ Demo body.
   expect(result.stderr).toContain("use .skillset/tests.yaml.self.checks");
 });
 
+test("SET-280: test lifecycle words are reserved declaration names", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reserved-test-name\nclaude: true\ncodex: false\n",
+    ".skillset/tests.yaml": "status:\n  select:\n    skills:\n      primary: [demo]\n  checks:\n    projection: true\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nBody.\n",
+  });
+
+  const result = await runSkillsetCli("test", "--root", root);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("test name status is reserved for the retained-run lifecycle");
+});
+
 test("SET-50: skillset test runs an isolated projection and refreshes latest", async () => {
   const root = await contractFixture({
     "skillset.yaml": `

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -266,28 +266,28 @@ Use this skill to answer fixture questions.
     prompt: "Inspect missing plugin.",
     target: "claude",
     xdg,
-  })).rejects.toThrow("unknown try plugin \"missing\"; available plugins: acme, codex-only");
+  })).rejects.toThrow("unknown test plugin \"missing\"; available plugins: acme, codex-only");
 
   await expect(startTryRun(root, {
     plugins: ["acme", "acme"],
     prompt: "Inspect duplicate plugin.",
     target: "claude",
     xdg,
-  })).rejects.toThrow("duplicate try plugin \"acme\"");
+  })).rejects.toThrow("duplicate test plugin \"acme\"");
 
   await expect(startTryRun(root, {
     plugins: ["codex-only"],
     prompt: "Inspect disabled plugin.",
     target: "claude",
     xdg,
-  })).rejects.toThrow("try plugin \"codex-only\" is not enabled for claude");
+  })).rejects.toThrow("test plugin \"codex-only\" is not enabled for claude");
 
   await expect(startTryRun(root, {
     plugins: ["acme"],
     prompt: "Inspect Codex plugin selection.",
     target: "codex",
     xdg,
-  })).rejects.toThrow("try --plugin is only supported for targets with local plugin-dir support: claude, cursor");
+  })).rejects.toThrow("test --plugin is only supported for targets with local plugin-dir support: claude, cursor");
 });
 
 test("SET-272: try CLI starts directly and supports status, tail, and list", async () => {
@@ -327,6 +327,8 @@ CLI fixture body.
   const tail = await runSkillsetCli(env, "test", "tail", report.runId, "--lines", "10", "--json", "--root", root);
   expect(tail.exitCode).toBe(0);
   expect(tail.stdout).toContain("Inspect CLI fixture.");
+  expect(tail.stdout).toContain("test passed");
+  expect(tail.stdout).not.toContain("try passed");
 
   const list = await runSkillsetCli(env, "test", "list", "--json", "--root", root);
   expect(list.exitCode).toBe(0);
@@ -816,7 +818,10 @@ Runtime failure body.
     timeoutMs: 10,
     xdg,
   });
-  expect((await readTryStatus(root, timeout.runId, { xdg })).failureClass).toBe("timeout");
+  const timeoutStatus = await readTryStatus(root, timeout.runId, { xdg });
+  expect(timeoutStatus.failureClass).toBe("timeout");
+  expect(timeoutStatus.error).toContain("test command timed out");
+  expect(timeoutStatus.error).not.toContain("try command");
 });
 
 async function fixture(files: Record<string, string>): Promise<string> {

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 
 import { expect, test } from "bun:test";
 import { createOperationalPathContext, resolveOperationalPath } from "@skillset/core";
+import { validateCliResult, type SkillsetCliResult } from "@skillset/schema";
 
 import {
   listTryRuns,
@@ -315,24 +316,37 @@ CLI fixture body.
 
   const run = await runSkillsetCli(env, "test", "--target", "codex", "--prompt", "Inspect CLI fixture.", "--json", "--root", root);
   expect(run.exitCode).toBe(0);
-  const report = JSON.parse(run.stdout) as { kind: string; runId: string; runPath: string; state: string };
+  const runEnvelope = JSON.parse(run.stdout) as SkillsetCliResult;
+  expect(validateCliResult(runEnvelope)).toEqual({ diagnostics: [], ok: true });
+  expect(runEnvelope.command).toBe("test");
+  expect(runEnvelope.kind).toBe("test");
+  const report = runEnvelope.data as { kind: string; runId: string; runPath: string; state: string };
   expect(report.kind).toBe("ad-hoc");
   expect(report.state).toBe("passed");
   expect(report.runPath).toStartWith(".skillset/cache/tests/ad-hoc/runs/");
 
   const status = await runSkillsetCli(env, "test", "status", report.runId, "--json", "--root", root);
   expect(status.exitCode).toBe(0);
-  expect(JSON.parse(status.stdout)).toEqual(expect.objectContaining({ runId: report.runId, state: "passed" }));
+  const statusEnvelope = JSON.parse(status.stdout) as SkillsetCliResult;
+  expect(validateCliResult(statusEnvelope)).toEqual({ diagnostics: [], ok: true });
+  expect(statusEnvelope.command).toBe("test status");
+  expect(statusEnvelope.data).toEqual(expect.objectContaining({ runId: report.runId, state: "passed" }));
 
   const tail = await runSkillsetCli(env, "test", "tail", report.runId, "--lines", "10", "--json", "--root", root);
   expect(tail.exitCode).toBe(0);
-  expect(tail.stdout).toContain("Inspect CLI fixture.");
-  expect(tail.stdout).toContain("test passed");
+  const tailEnvelope = JSON.parse(tail.stdout) as SkillsetCliResult;
+  expect(validateCliResult(tailEnvelope)).toEqual({ diagnostics: [], ok: true });
+  expect(tailEnvelope.command).toBe("test tail");
+  expect(JSON.stringify(tailEnvelope.data)).toContain("Inspect CLI fixture.");
+  expect(JSON.stringify(tailEnvelope.data)).toContain("test passed");
   expect(tail.stdout).not.toContain("try passed");
 
   const list = await runSkillsetCli(env, "test", "list", "--json", "--root", root);
   expect(list.exitCode).toBe(0);
-  expect(list.stdout).toContain(report.runId);
+  const listEnvelope = JSON.parse(list.stdout) as SkillsetCliResult;
+  expect(validateCliResult(listEnvelope)).toEqual({ diagnostics: [], ok: true });
+  expect(listEnvelope.command).toBe("test list");
+  expect(JSON.stringify(listEnvelope.data)).toContain(report.runId);
 
   const oldTry = await runSkillsetCli(env, "try", "--target", "codex", "--prompt", "Old command.", "--root", root);
   expect(oldTry.exitCode).toBe(1);
@@ -380,12 +394,13 @@ CLI Claude fixture body.
     root
   );
   expect(run.exitCode).toBe(0);
-  const report = JSON.parse(run.stdout) as { runId: string; state: string };
+  const report = (JSON.parse(run.stdout) as SkillsetCliResult).data as { runId: string; state: string };
   expect(report.state).toBe("passed");
 
   const status = await runSkillsetCli(env, "test", "status", report.runId, "--json", "--root", root);
   expect(status.exitCode).toBe(0);
-  expect(JSON.parse(status.stdout).command.join(" ")).toContain("--setting-sources local");
+  const statusData = (JSON.parse(status.stdout) as SkillsetCliResult).data as { command: string[] };
+  expect(statusData.command.join(" ")).toContain("--setting-sources local");
 });
 
 test("SET-272: background tries complete through the renamed worker command", async () => {
@@ -424,7 +439,7 @@ Background fixture body.
     root
   );
   expect(started.exitCode).toBe(0);
-  const report = JSON.parse(started.stdout) as { runId: string; state: string };
+  const report = (JSON.parse(started.stdout) as SkillsetCliResult).data as { runId: string; state: string };
   expect(report.state).toBe("queued");
 
   let state = report.state;

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -33,7 +33,7 @@ Use this skill to answer fixture questions.
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
   const report = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CODEX_BIN: bin },
+    env: { ...process.env, SKILLSET_TEST_CODEX_BIN: bin },
     prompt: "List the available fixture skills.",
     target: "codex",
     xdg,
@@ -41,7 +41,7 @@ Use this skill to answer fixture questions.
 
   expect(report.ok).toBe(true);
   expect(report.state).toBe("passed");
-  expect(report.runPath).toStartWith(".skillset/cache/runtime-tests/runs/");
+  expect(report.runPath).toStartWith(".skillset/cache/tests/ad-hoc/runs/");
   expect(await exists(cachePath(root, xdg, report.tailPath))).toBe(true);
   expect(await readFile(cachePath(root, xdg, report.reportPath), "utf8")).toContain("fake codex final");
 
@@ -86,7 +86,7 @@ Use this skill to answer fixture questions.
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
   const report = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CLAUDE_BIN: bin },
+    env: { ...process.env, SKILLSET_TEST_CLAUDE_BIN: bin },
     plugins: ["acme"],
     prompt: "Inspect Claude fixture.",
     target: "claude",
@@ -135,7 +135,7 @@ Use this skill to answer fixture questions.
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
   const report = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CURSOR_BIN: bin },
+    env: { ...process.env, SKILLSET_TEST_CURSOR_BIN: bin },
     plugins: ["acme"],
     prompt: "Inspect Cursor fixture.",
     target: "cursor",
@@ -186,7 +186,7 @@ Use this skill to answer fixture questions.
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
   const fromDefault = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CLAUDE_BIN: bin },
+    env: { ...process.env, SKILLSET_TEST_CLAUDE_BIN: bin },
     prompt: "Inspect Claude default fixture.",
     target: "claude",
     xdg,
@@ -196,8 +196,8 @@ Use this skill to answer fixture questions.
   const fromEnv = await startTryRun(root, {
     env: {
       ...process.env,
-      SKILLSET_TRY_CLAUDE_BIN: bin,
-      SKILLSET_TRY_CLAUDE_SETTING_SOURCES: "user",
+      SKILLSET_TEST_CLAUDE_BIN: bin,
+      SKILLSET_TEST_CLAUDE_SETTING_SOURCES: "user",
     },
     prompt: "Inspect Claude env fixture.",
     target: "claude",
@@ -209,8 +209,8 @@ Use this skill to answer fixture questions.
     claudeSettingSources: "local",
     env: {
       ...process.env,
-      SKILLSET_TRY_CLAUDE_BIN: bin,
-      SKILLSET_TRY_CLAUDE_SETTING_SOURCES: "user",
+      SKILLSET_TEST_CLAUDE_BIN: bin,
+      SKILLSET_TEST_CLAUDE_SETTING_SOURCES: "user",
     },
     prompt: "Inspect Claude option fixture.",
     target: "claude",
@@ -309,27 +309,32 @@ CLI fixture body.
   const bin = await fakeCodexBin(root);
   const env = {
     ...process.env,
-    SKILLSET_TRY_CODEX_BIN: bin,
+    SKILLSET_TEST_CODEX_BIN: bin,
     XDG_CACHE_HOME: join(root, "xdg-cache"),
   };
 
-  const run = await runSkillsetCli(env, "try", "--target", "codex", "--prompt", "Inspect CLI fixture.", "--json", "--root", root);
+  const run = await runSkillsetCli(env, "test", "--target", "codex", "--prompt", "Inspect CLI fixture.", "--json", "--root", root);
   expect(run.exitCode).toBe(0);
-  const report = JSON.parse(run.stdout) as { runId: string; runPath: string; state: string };
+  const report = JSON.parse(run.stdout) as { kind: string; runId: string; runPath: string; state: string };
+  expect(report.kind).toBe("ad-hoc");
   expect(report.state).toBe("passed");
-  expect(report.runPath).toStartWith(".skillset/cache/runtime-tests/runs/");
+  expect(report.runPath).toStartWith(".skillset/cache/tests/ad-hoc/runs/");
 
-  const status = await runSkillsetCli(env, "try", "status", report.runId, "--json", "--root", root);
+  const status = await runSkillsetCli(env, "test", "status", report.runId, "--json", "--root", root);
   expect(status.exitCode).toBe(0);
   expect(JSON.parse(status.stdout)).toEqual(expect.objectContaining({ runId: report.runId, state: "passed" }));
 
-  const tail = await runSkillsetCli(env, "try", "tail", report.runId, "--lines", "10", "--json", "--root", root);
+  const tail = await runSkillsetCli(env, "test", "tail", report.runId, "--lines", "10", "--json", "--root", root);
   expect(tail.exitCode).toBe(0);
   expect(tail.stdout).toContain("Inspect CLI fixture.");
 
-  const list = await runSkillsetCli(env, "try", "list", "--json", "--root", root);
+  const list = await runSkillsetCli(env, "test", "list", "--json", "--root", root);
   expect(list.exitCode).toBe(0);
   expect(list.stdout).toContain(report.runId);
+
+  const oldTry = await runSkillsetCli(env, "try", "--target", "codex", "--prompt", "Old command.", "--root", root);
+  expect(oldTry.exitCode).toBe(1);
+  expect(oldTry.stderr).toContain("expected command");
 
   const retired = await runSkillsetCli(env, "runtime-tester", "run", "--target", "codex", "--prompt", "Old command.", "--root", root);
   expect(retired.exitCode).toBe(1);
@@ -355,13 +360,13 @@ CLI Claude fixture body.
   const bin = await fakeClaudeBin(root);
   const env = {
     ...process.env,
-    SKILLSET_TRY_CLAUDE_BIN: bin,
+    SKILLSET_TEST_CLAUDE_BIN: bin,
     XDG_CACHE_HOME: join(root, "xdg-cache"),
   };
 
   const run = await runSkillsetCli(
     env,
-    "try",
+    "test",
     "--target",
     "claude",
     "--prompt",
@@ -376,7 +381,7 @@ CLI Claude fixture body.
   const report = JSON.parse(run.stdout) as { runId: string; state: string };
   expect(report.state).toBe("passed");
 
-  const status = await runSkillsetCli(env, "try", "status", report.runId, "--json", "--root", root);
+  const status = await runSkillsetCli(env, "test", "status", report.runId, "--json", "--root", root);
   expect(status.exitCode).toBe(0);
   expect(JSON.parse(status.stdout).command.join(" ")).toContain("--setting-sources local");
 });
@@ -399,14 +404,14 @@ Background fixture body.
   });
   const env = {
     ...process.env,
-    SKILLSET_TRY_CODEX_BIN: await fakeCodexBin(root),
+    SKILLSET_TEST_CODEX_BIN: await fakeCodexBin(root),
     XDG_CACHE_HOME: join(root, "xdg-cache"),
   };
   const xdg = { env };
 
   const started = await runSkillsetCli(
     env,
-    "try",
+    "test",
     "--target",
     "codex",
     "--prompt",
@@ -488,9 +493,9 @@ checks:
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
   const runtimeEnv = {
     ...process.env,
-    SKILLSET_TRY_CLAUDE_BIN: await fakeClaudeBin(root),
-    SKILLSET_TRY_CODEX_BIN: await fakeCodexBin(root),
-    SKILLSET_TRY_CURSOR_BIN: await fakeCursorBin(root),
+    SKILLSET_TEST_CLAUDE_BIN: await fakeClaudeBin(root),
+    SKILLSET_TEST_CODEX_BIN: await fakeCodexBin(root),
+    SKILLSET_TEST_CURSOR_BIN: await fakeCursorBin(root),
   };
   const report = await runSkillsetTest(root, "runtime", {
     runtimeEnv,
@@ -507,7 +512,7 @@ checks:
     "inline",
   ]);
   for (const result of report.runtimeTests) {
-    expect(result.runPath).toStartWith(".skillset/cache/runtime-tests/runs/");
+    expect(result.runPath).toStartWith(".skillset/cache/tests/ad-hoc/runs/");
     expect(await exists(cachePath(root, xdg, String(result.reportPath)))).toBe(true);
     expect(await exists(cachePath(root, xdg, String(result.outputPath)))).toBe(true);
     expect(result.assertions.every((assertion) => assertion.ok)).toBe(true);
@@ -563,7 +568,7 @@ checks:
   });
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
   const report = await runSkillsetTest(root, "runtime", {
-    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: await fakeCodexBin(root) },
+    runtimeEnv: { ...process.env, SKILLSET_TEST_CODEX_BIN: await fakeCodexBin(root) },
     xdg,
   });
 
@@ -578,7 +583,7 @@ checks:
 
   const authBin = await fakeFailureBin(root, "declared-auth-codex", "Not logged in. Run setup-token.", 1);
   const authReport = await runSkillsetTest(root, "runtime", {
-    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: authBin },
+    runtimeEnv: { ...process.env, SKILLSET_TEST_CODEX_BIN: authBin },
     xdg,
   });
   expect(authReport.runtimeTests[0]).toEqual(expect.objectContaining({
@@ -622,7 +627,7 @@ checks:
   });
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
   const report = await runSkillsetTest(root, "runtime", {
-    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: join(root, "must-not-run") },
+    runtimeEnv: { ...process.env, SKILLSET_TEST_CODEX_BIN: join(root, "must-not-run") },
     xdg,
   });
 
@@ -635,7 +640,7 @@ checks:
       target: "codex",
     }),
   ]);
-  expect(await exists(cachePath(root, xdg, ".skillset/cache/runtime-tests/latest.json"))).toBe(false);
+  expect(await exists(cachePath(root, xdg, ".skillset/cache/tests/ad-hoc/latest.json"))).toBe(false);
 });
 
 test("SET-273: failed isolated builds produce normalized render failures", async () => {
@@ -675,7 +680,7 @@ checks:
 `,
   });
   const report = await runSkillsetTest(root, "runtime", {
-    runtimeEnv: { ...process.env, SKILLSET_TRY_CODEX_BIN: join(root, "must-not-run") },
+    runtimeEnv: { ...process.env, SKILLSET_TEST_CODEX_BIN: join(root, "must-not-run") },
   });
 
   expect(report.ok).toBe(false);
@@ -784,7 +789,7 @@ Runtime failure body.
   const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
 
   const missing = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CODEX_BIN: join(root, "missing-codex") },
+    env: { ...process.env, SKILLSET_TEST_CODEX_BIN: join(root, "missing-codex") },
     name: "missing-runtime",
     prompt: "Missing runtime.",
     target: "codex",
@@ -794,7 +799,7 @@ Runtime failure body.
 
   const authBin = await fakeFailureBin(root, "auth-claude", "Not logged in. Run setup-token.", 1);
   const auth = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CLAUDE_BIN: authBin },
+    env: { ...process.env, SKILLSET_TEST_CLAUDE_BIN: authBin },
     name: "auth-runtime",
     prompt: "Auth runtime.",
     target: "claude",
@@ -804,7 +809,7 @@ Runtime failure body.
 
   const timeoutBin = await fakeSleepingBin(root);
   const timeout = await startTryRun(root, {
-    env: { ...process.env, SKILLSET_TRY_CODEX_BIN: timeoutBin },
+    env: { ...process.env, SKILLSET_TEST_CODEX_BIN: timeoutBin },
     name: "timeout-runtime",
     prompt: "Timeout runtime.",
     target: "codex",

--- a/apps/skillset/src/cli-commands.ts
+++ b/apps/skillset/src/cli-commands.ts
@@ -2,7 +2,7 @@ export const CLI_COMMANDS = [
   "build", "change", "check", "dev", "diff",
   "distribute", "doctor", "explain", "features", "hooks", "import", "init",
   "list", "lookup", "marketplace", "new", "providers", "release",
-  "restore", "suggest-source", "test", "try", "update",
+  "restore", "suggest-source", "test", "update",
 ] as const;
 
 export type CliCommand = (typeof CLI_COMMANDS)[number];
@@ -15,7 +15,7 @@ export const CLI_LEAF_SUBCOMMANDS: Readonly<Partial<Record<CliCommand, readonly 
   marketplace: ["check", "update"],
   providers: ["check", "diff", "update"],
   release: ["amend", "apply", "audit", "plan"],
-  try: ["list", "status", "tail", "worker"],
+  test: ["list", "status", "tail", "worker"],
 };
 
 const CLI_COMMAND_SET = new Set<string>(CLI_COMMANDS);

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -153,9 +153,9 @@ const USAGE = [
   "       skillset features [feature-id] [--json]",
   "       skillset lookup [subject] [aspect...] [--frontmatter] [--fields] [--field <path>] [--values] [--events] [--compat [claude|codex|cursor...]] [--examples] [--schema] [--claude] [--codex] [--cursor] [--json]",
   "       skillset test [name] [--root <path>] [--source <dir>]",
-  "       skillset try --target <claude|codex|cursor> [--prompt <text>|--prompt-file <path>] [--plugin <id>] [--name <name>] [--timeout-ms <ms>] [--claude-setting-sources <isolated|user|project|local>] [--background] [--json] [--root <path>] [--source <dir>]",
-  "       skillset try <status|tail> [run-id] [--lines <count>] [--json] [--root <path>]",
-  "       skillset try list [--json] [--root <path>]",
+  "       skillset test --target <claude|codex|cursor> [--prompt <text>|--prompt-file <path>] [--plugin <id>] [--name <name>] [--timeout-ms <ms>] [--claude-setting-sources <isolated|user|project|local>] [--background] [--json] [--root <path>] [--source <dir>]",
+  "       skillset test <status|tail> [run-id] [--lines <count>] [--json] [--root <path>]",
+  "       skillset test list [--json] [--root <path>]",
   "       skillset hooks print --runner <lefthook|husky|pre-commit|git> [--pre-commit] [--pre-push]",
   "       skillset hooks print --target <claude|codex> --agent-runtime",
   "       skillset hooks run <post-tool-use|stop> [--root <path>]",
@@ -280,25 +280,6 @@ export async function runCli(
   if (command === "dev") {
     if (!devWatch) throw new Error("skillset: dev currently requires --watch");
     await runDevWatch(rootPath, options, process.stdout, devApply ? "apply" : "preview");
-    return;
-  }
-
-  if (command === "try") {
-    await runTryCommand(rootPath, {
-      background: tryBackground,
-      ...(tryClaudeSettingSources === undefined ? {} : { claudeSettingSources: tryClaudeSettingSources }),
-      json: jsonOutput,
-      ...(tryLines === undefined ? {} : { lines: tryLines }),
-      ...(tryName === undefined ? {} : { name: tryName }),
-      plugins: tryPlugins,
-      ...(tryPrompt === undefined ? {} : { prompt: tryPrompt }),
-      ...(tryPromptFile === undefined ? {} : { promptFile: tryPromptFile }),
-      ...(tryRunId === undefined ? {} : { runId: tryRunId }),
-      skillsetOptions: options,
-      ...(trySubcommand === undefined ? {} : { subcommand: trySubcommand }),
-      ...(tryTarget === undefined ? {} : { target: tryTarget }),
-      ...(tryTimeoutMs === undefined ? {} : { timeoutMs: tryTimeoutMs }),
-    });
     return;
   }
 
@@ -562,6 +543,24 @@ export async function runCli(
   }
 
   if (command === "test") {
+    if (trySubcommand !== undefined || tryTarget !== undefined) {
+      await runTryCommand(rootPath, {
+        background: tryBackground,
+        ...(tryClaudeSettingSources === undefined ? {} : { claudeSettingSources: tryClaudeSettingSources }),
+        json: jsonOutput,
+        ...(tryLines === undefined ? {} : { lines: tryLines }),
+        ...(tryName === undefined ? {} : { name: tryName }),
+        plugins: tryPlugins,
+        ...(tryPrompt === undefined ? {} : { prompt: tryPrompt }),
+        ...(tryPromptFile === undefined ? {} : { promptFile: tryPromptFile }),
+        ...(tryRunId === undefined ? {} : { runId: tryRunId }),
+        skillsetOptions: options,
+        ...(trySubcommand === undefined ? {} : { subcommand: trySubcommand }),
+        ...(tryTarget === undefined ? {} : { target: tryTarget }),
+        ...(tryTimeoutMs === undefined ? {} : { timeoutMs: tryTimeoutMs }),
+      });
+      return;
+    }
     const report = await runSkillsetTest(rootPath, testName, options);
     printSkillsetTest(report);
     if (!report.ok) process.exitCode = 1;
@@ -1889,11 +1888,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     index += 1;
   }
 
-  if (command === "try") {
+  if (command === "test") {
     const subcommand = args[index];
-    if (subcommand !== undefined && !subcommand.startsWith("--") && !isTrySubcommand(subcommand)) {
-      throw new Error("skillset: expected try options or subcommand list, status, or tail");
-    }
     if (isTrySubcommand(subcommand)) {
       trySubcommand = subcommand;
       index += 1;
@@ -1973,7 +1969,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     index += 1;
   }
 
-  if (command === "test") {
+  if (command === "test" && trySubcommand === undefined) {
     const rawName = args[index];
     if (rawName !== undefined && !rawName.startsWith("--")) {
       testName = rawName;
@@ -2198,7 +2194,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--format") hookContextFormat = readHookRuntimeContextFormat(value);
     if (flag === "--context-fields") hookContextFields = readHookRuntimeContextFields(value);
     if (flag === "--target") {
-      if (command === "try") tryTarget = readTargetName(value);
+      if (command === "test") tryTarget = readTargetName(value);
       else hookTarget = readHookTarget(value);
     }
     if (flag === "--prompt") tryPrompt = value;
@@ -2215,7 +2211,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--in") newContainer = value;
     if (flag === "--name") {
       if (command === "new") newName = value;
-      else if (command === "try") tryName = value;
+      else if (command === "test") tryName = value;
       else importName = value;
     }
     if (flag === "--preset") newPresets = [...(newPresets ?? []), value];
@@ -3113,7 +3109,7 @@ function validateJsonFlags(
   if (!jsonOutput) return;
   if (command === "check") return;
   if (command === "change" && (route.changeSubcommand === "check" || route.changeSubcommand === "history" || route.changeSubcommand === "list" || route.changeSubcommand === "show" || route.changeSubcommand === "status")) return;
-  if (command === "diff" || command === "doctor" || command === "explain" || command === "features" || command === "list" || command === "lookup" || command === "marketplace" || command === "try") return;
+  if (command === "diff" || command === "doctor" || command === "explain" || command === "features" || command === "list" || command === "lookup" || command === "marketplace" || command === "test") return;
   if (command === "distribute" && route.distributionSubcommand === "plan") return;
   throw new Error("skillset: --json is not supported for this command route");
 }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -562,7 +562,8 @@ export async function runCli(
       return;
     }
     const report = await runSkillsetTest(rootPath, testName, options);
-    printSkillsetTest(report);
+    if (jsonOutput) printCliJsonData("test", report, report.ok ? 0 : 1, "test");
+    else printSkillsetTest(report);
     if (!report.ok) process.exitCode = 1;
     return;
   }
@@ -2307,6 +2308,21 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(scopes === undefined ? {} : { scopes }),
   });
+  const hasAdHocTestFlags =
+    trySubcommand !== undefined ||
+    tryTarget !== undefined ||
+    tryPrompt !== undefined ||
+    tryPromptFile !== undefined ||
+    tryPlugins.length > 0 ||
+    tryName !== undefined ||
+    tryTimeoutMs !== undefined ||
+    tryClaudeSettingSources !== undefined ||
+    tryBackground;
+  if (command === "test" && testName !== undefined && hasAdHocTestFlags) {
+    throw new Error(
+      `skillset: declared test ${testName} cannot be combined with ad hoc test flags`
+    );
+  }
   validateTryFlags(command, trySubcommand, {
     background: tryBackground,
     ...(buildMode === undefined ? {} : { buildMode }),
@@ -2370,7 +2386,9 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(releaseRef === undefined ? {} : { ref: releaseRef }),
   });
   validateTestFlags(command, {
+    adHoc: hasAdHocTestFlags,
     ...(buildMode === undefined ? {} : { buildMode }),
+    ...(testName === undefined ? {} : { declaredName: testName }),
     ...(distDir === undefined ? {} : { distDir }),
     dryRun,
     ...(scopes === undefined ? {} : { scopes }),
@@ -2763,7 +2781,9 @@ function validateMarketplaceFlags(
 function validateTestFlags(
   command: Command,
   test: {
+    readonly adHoc: boolean;
     readonly buildMode?: CompileBuildMode;
+    readonly declaredName?: string;
     readonly distDir?: string;
     readonly dryRun: boolean;
     readonly scopes?: readonly BuildScope[];
@@ -2771,6 +2791,11 @@ function validateTestFlags(
   }
 ): void {
   if (command !== "test") return;
+  if (test.declaredName !== undefined && test.adHoc) {
+    throw new Error(
+      `skillset: declared test ${test.declaredName} cannot be combined with ad hoc test flags`
+    );
+  }
   if (
     test.buildMode !== undefined ||
     test.distDir !== undefined ||

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -356,6 +356,9 @@ function addTestDeclaration(
   name: string,
   declaration: TestDeclarationRecord
 ): void {
+  if (name === "list" || name === "status" || name === "tail" || name === "worker") {
+    throw new Error(`skillset: test name ${name} is reserved for the retained-run lifecycle`);
+  }
   const existing = declarations[name];
   if (existing !== undefined) {
     throw new Error(`skillset: duplicate test ${name} in ${existing.label} and ${declaration.label}`);

--- a/apps/skillset/src/try-cli.ts
+++ b/apps/skillset/src/try-cli.ts
@@ -46,7 +46,7 @@ export async function runTryCommand(rootPath: string, options: TryCommandOptions
       target: requireTryTarget(options.target),
       ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
     });
-    if (options.json) console.log(renderValidatedJson(report as unknown as JsonRecord, "try run"));
+    if (options.json) console.log(renderValidatedJson(report as unknown as JsonRecord, "test run"));
     else printTryRun(report);
     if (!report.ok) process.exitCode = 1;
     return;
@@ -58,20 +58,20 @@ export async function runTryCommand(rootPath: string, options: TryCommandOptions
   }
   if (options.subcommand === "status") {
     const status = await readTryStatus(rootPath, options.runId);
-    if (options.json) console.log(renderValidatedJson(status as unknown as JsonRecord, "try status"));
+    if (options.json) console.log(renderValidatedJson(status as unknown as JsonRecord, "test status"));
     else printTryStatus(status);
     if (status.state === "failed") process.exitCode = 1;
     return;
   }
   if (options.subcommand === "tail") {
     const lines = await tailTryRun(rootPath, options.runId, options.lines ?? 40);
-    if (options.json) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "try tail"));
+    if (options.json) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "test tail"));
     else printTryTail(lines);
     return;
   }
   if (options.subcommand === "list") {
     const entries = await listTryRuns(rootPath);
-    if (options.json) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "try list"));
+    if (options.json) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "test list"));
     else printTryList(entries);
     return;
   }

--- a/apps/skillset/src/try-cli.ts
+++ b/apps/skillset/src/try-cli.ts
@@ -52,7 +52,7 @@ export async function runTryCommand(rootPath: string, options: TryCommandOptions
     return;
   }
   if (options.subcommand === "worker") {
-    if (options.runId === undefined) throw new Error("skillset: try worker requires run id");
+    if (options.runId === undefined) throw new Error("skillset: test worker requires run id");
     await executeTryRun(rootPath, options.runId);
     return;
   }
@@ -110,25 +110,26 @@ export function validateTryFlags(
     runtime.promptFile !== undefined ||
     runtime.target !== undefined ||
     runtime.timeoutMs !== undefined;
-  if (hasRuntimeFlag && command !== "try") {
-    throw new Error("skillset: try options are only supported with try");
+  if (hasRuntimeFlag && command !== "test") {
+    throw new Error("skillset: ad hoc test options are only supported with test");
   }
-  if (command !== "try") return;
+  if (command !== "test") return;
+  if (!hasRuntimeFlag && subcommand === undefined) return;
   if (runtime.buildMode !== undefined || runtime.distDir !== undefined || runtime.dryRun || runtime.scopes !== undefined || runtime.yes) {
-    throw new Error("skillset: build/write options are not supported with try; try builds an isolated projection under logical .skillset/cache/runtime-tests");
+    throw new Error("skillset: build/write options are not supported with ad hoc test runs; test uses logical .skillset/cache/tests/ad-hoc");
   }
   if (subcommand === undefined) {
-    if (runtime.target === undefined) throw new Error("skillset: try requires --target claude, codex, or cursor");
+    if (runtime.target === undefined) throw new Error("skillset: ad hoc test requires --target claude, codex, or cursor");
     if ((runtime.prompt === undefined && runtime.promptFile === undefined) || (runtime.prompt !== undefined && runtime.promptFile !== undefined)) {
-      throw new Error("skillset: try requires exactly one of --prompt or --prompt-file");
+      throw new Error("skillset: ad hoc test requires exactly one of --prompt or --prompt-file");
     }
     return;
   }
   if (runtime.background || runtime.claudeSettingSources !== undefined || runtime.name !== undefined || runtime.plugins.length > 0 || runtime.prompt !== undefined || runtime.promptFile !== undefined || runtime.target !== undefined || runtime.timeoutMs !== undefined) {
-    throw new Error(`skillset: try execution options are not supported with ${subcommand}`);
+    throw new Error(`skillset: test execution options are not supported with ${subcommand}`);
   }
   if (runtime.lines !== undefined && subcommand !== "tail") {
-    throw new Error("skillset: --lines is only supported with try tail");
+    throw new Error("skillset: --lines is only supported with test tail");
   }
 }
 
@@ -138,17 +139,17 @@ async function readTryPrompt(
   promptFile: string | undefined
 ): Promise<string> {
   if (prompt !== undefined) return prompt;
-  if (promptFile === undefined) throw new Error("skillset: try requires --prompt or --prompt-file");
+  if (promptFile === undefined) throw new Error("skillset: ad hoc test requires --prompt or --prompt-file");
   return readFile(resolve(rootPath, promptFile), "utf8");
 }
 
 function requireTryTarget(target: TargetName | undefined): TargetName {
-  if (target === undefined) throw new Error("skillset: try requires --target claude, codex, or cursor");
+  if (target === undefined) throw new Error("skillset: ad hoc test requires --target claude, codex, or cursor");
   return target;
 }
 
 function printTryRun(report: TryRunReport): void {
-  console.log(`skillset: try ${formatTryState(report.state)}${report.background ? " in background" : ""}`);
+  console.log(`skillset: ad hoc test ${formatTryState(report.state)}${report.background ? " in background" : ""}`);
   console.log(`  run: ${report.runPath}`);
   console.log(`  latest: ${report.latestPath}`);
   console.log(`  status: ${report.statusPath}`);
@@ -157,7 +158,7 @@ function printTryRun(report: TryRunReport): void {
 }
 
 function printTryStatus(status: TryStatus): void {
-  console.log(`skillset: try ${status.runId} ${formatTryState(status.state)}`);
+  console.log(`skillset: test ${status.runId} ${formatTryState(status.state)}`);
   console.log(`  target: ${status.target}`);
   console.log(`  name: ${status.name}`);
   if (status.pid !== undefined) console.log(`  pid: ${status.pid}`);
@@ -184,7 +185,7 @@ function printTryTail(lines: readonly TryTailLine[]): void {
 
 function printTryList(entries: readonly TryListEntry[]): void {
   if (entries.length === 0) {
-    console.log("skillset: no try runs");
+    console.log("skillset: no ad hoc test runs");
     return;
   }
   for (const entry of entries) {

--- a/apps/skillset/src/try-cli.ts
+++ b/apps/skillset/src/try-cli.ts
@@ -15,8 +15,9 @@ import {
   type TrySubcommand,
   type TryTailLine,
 } from "./try";
-import { renderValidatedJson } from "@skillset/core/internal/structured-output";
-import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, TargetName } from "@skillset/core/internal/types";
+import type { SchemaJsonRecord } from "@skillset/schema";
+import type { BuildScope, CompileBuildMode, SkillsetOptions, TargetName } from "@skillset/core/internal/types";
+import { renderCliDataResult } from "./cli-output";
 
 export interface TryCommandOptions {
   readonly background: boolean;
@@ -46,7 +47,7 @@ export async function runTryCommand(rootPath: string, options: TryCommandOptions
       target: requireTryTarget(options.target),
       ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
     });
-    if (options.json) console.log(renderValidatedJson(report as unknown as JsonRecord, "test run"));
+    if (options.json) printTryJson("test", report, report.ok ? 0 : 1);
     else printTryRun(report);
     if (!report.ok) process.exitCode = 1;
     return;
@@ -58,23 +59,32 @@ export async function runTryCommand(rootPath: string, options: TryCommandOptions
   }
   if (options.subcommand === "status") {
     const status = await readTryStatus(rootPath, options.runId);
-    if (options.json) console.log(renderValidatedJson(status as unknown as JsonRecord, "test status"));
+    if (options.json) printTryJson("test status", status, status.state === "failed" ? 1 : 0);
     else printTryStatus(status);
     if (status.state === "failed") process.exitCode = 1;
     return;
   }
   if (options.subcommand === "tail") {
     const lines = await tailTryRun(rootPath, options.runId, options.lines ?? 40);
-    if (options.json) console.log(renderValidatedJson({ lines: lines.map((line) => ({ ...line })), schemaVersion: 1 }, "test tail"));
+    if (options.json) printTryJson("test tail", { lines: lines.map((line) => ({ ...line })) });
     else printTryTail(lines);
     return;
   }
   if (options.subcommand === "list") {
     const entries = await listTryRuns(rootPath);
-    if (options.json) console.log(renderValidatedJson({ runs: entries.map((entry) => ({ ...entry })), schemaVersion: 1 }, "test list"));
+    if (options.json) printTryJson("test list", { runs: entries.map((entry) => ({ ...entry })) });
     else printTryList(entries);
     return;
   }
+}
+
+function printTryJson(command: string, data: unknown, exitCode = 0): void {
+  process.stdout.write(renderCliDataResult({
+    command,
+    data: data as SchemaJsonRecord,
+    exitCode,
+    kind: "test",
+  }));
 }
 
 export function isTrySubcommand(value: string | undefined): value is TrySubcommand {

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -284,10 +284,10 @@ export async function executeTryRun(
     updatedAt: new Date().toISOString(),
     ...(failureClass === undefined ? {} : { failureClass }),
     ...(result.timedOut
-      ? { error: `try command timed out after ${config.timeoutMs}ms` }
-      : result.exitCode === 0 ? {} : { error: stderr.trim() || `try command exited with code ${result.exitCode}` }),
+      ? { error: `test command timed out after ${config.timeoutMs}ms` }
+      : result.exitCode === 0 ? {} : { error: stderr.trim() || `test command exited with code ${result.exitCode}` }),
   });
-  await appendEvent(paths, "status", `try ${nextState}`);
+  await appendEvent(paths, "status", `test ${nextState}`);
 }
 
 export async function readTryEvidence(
@@ -517,21 +517,21 @@ function validateTryPlugins(
 ): readonly string[] {
   if (plugins.length === 0) return [];
   if (target === "codex") {
-    throw new Error("skillset: try --plugin is only supported for targets with local plugin-dir support: claude, cursor");
+    throw new Error("skillset: test --plugin is only supported for targets with local plugin-dir support: claude, cursor");
   }
   const seen = new Set<string>();
   const selected: string[] = [];
   const knownPlugins = graph.plugins.map((plugin) => plugin.id).sort(compareStrings);
   for (const pluginId of plugins) {
-    if (seen.has(pluginId)) throw new Error(`skillset: duplicate try plugin ${JSON.stringify(pluginId)}`);
+    if (seen.has(pluginId)) throw new Error(`skillset: duplicate test plugin ${JSON.stringify(pluginId)}`);
     seen.add(pluginId);
     const plugin = graph.plugins.find((candidate) => candidate.id === pluginId);
     if (plugin === undefined) {
       const available = knownPlugins.length === 0 ? "none configured" : knownPlugins.join(", ");
-      throw new Error(`skillset: unknown try plugin ${JSON.stringify(pluginId)}; available plugins: ${available}`);
+      throw new Error(`skillset: unknown test plugin ${JSON.stringify(pluginId)}; available plugins: ${available}`);
     }
     if (!plugin.targets[target].enabled) {
-      throw new Error(`skillset: try plugin ${JSON.stringify(pluginId)} is not enabled for ${target}`);
+      throw new Error(`skillset: test plugin ${JSON.stringify(pluginId)} is not enabled for ${target}`);
     }
     selected.push(pluginId);
   }
@@ -677,7 +677,7 @@ async function failRun(
     state: "failed",
     updatedAt: endedAt,
   });
-  await appendEvent(paths, "status", `try failed: ${error}`);
+  await appendEvent(paths, "status", `test failed: ${error}`);
 }
 
 function classifyTryFailure(
@@ -728,18 +728,18 @@ async function readLatestRunId(
 ): Promise<string> {
   const latest = await readRetainedRunLatest(rootPath, graph, RUNTIME_TEST_ROOT, xdg);
   if (!isRecord(latest) || typeof latest.runId !== "string") {
-    throw new Error("skillset: try latest run is malformed");
+    throw new Error("skillset: test latest run is malformed");
   }
   return latest.runId;
 }
 
 async function readConfig(path: string): Promise<TryStoredConfig> {
   const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
-  if (!isRecord(raw)) throw new Error("skillset: try config is malformed");
-  if (!isTargetName(raw.target)) throw new Error("skillset: try config target is malformed");
-  if (typeof raw.prompt !== "string") throw new Error("skillset: try config prompt is malformed");
+  if (!isRecord(raw)) throw new Error("skillset: test config is malformed");
+  if (!isTargetName(raw.target)) throw new Error("skillset: test config target is malformed");
+  if (typeof raw.prompt !== "string") throw new Error("skillset: test config prompt is malformed");
   const claudeSettingSources = typeof raw.claudeSettingSources === "string"
-    ? readClaudeSettingSources(raw.claudeSettingSources, "try config claudeSettingSources")
+    ? readClaudeSettingSources(raw.claudeSettingSources, "test config claudeSettingSources")
     : undefined;
   return {
     ...(claudeSettingSources === undefined ? {} : { claudeSettingSources }),
@@ -755,7 +755,7 @@ async function readConfig(path: string): Promise<TryStoredConfig> {
 async function readStatus(path: string): Promise<TryStatus> {
   const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
   if (!isRecord(raw) || typeof raw.runId !== "string" || !isTargetName(raw.target)) {
-    throw new Error("skillset: try status is malformed");
+    throw new Error("skillset: test status is malformed");
   }
   return raw as unknown as TryStatus;
 }

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -48,6 +48,7 @@ export interface TryStatus {
   readonly failureClass?: TryFailureClass;
   readonly finalMessagePath?: string;
   readonly latestRoot: string;
+  readonly kind: "ad-hoc";
   readonly name: string;
   readonly outputPath: string;
   readonly pid?: number;
@@ -74,6 +75,7 @@ export interface TryEvidence {
 
 export interface TryRunReport {
   readonly background: boolean;
+  readonly kind: "ad-hoc";
   readonly latestPath: string;
   readonly ok: boolean;
   readonly reportPath: string;
@@ -87,6 +89,7 @@ export interface TryRunReport {
 export interface TryListEntry {
   readonly endedAt?: string;
   readonly name: string;
+  readonly kind: "ad-hoc";
   readonly runId: string;
   readonly runPath: string;
   readonly startedAt: string;
@@ -133,10 +136,10 @@ interface TryStoredConfig {
   readonly timeoutMs: number;
 }
 
-const RUNTIME_TEST_ROOT = ".skillset/cache/runtime-tests";
+const RUNTIME_TEST_ROOT = ".skillset/cache/tests/ad-hoc";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_CLAUDE_SETTING_SOURCES: TryClaudeSettingSources = "isolated";
-const TRY_CLAUDE_SETTING_SOURCES_ENV = "SKILLSET_TRY_CLAUDE_SETTING_SOURCES";
+const TRY_CLAUDE_SETTING_SOURCES_ENV = "SKILLSET_TEST_CLAUDE_SETTING_SOURCES";
 // Empty --setting-sources keeps Claude probes independent from user/project/local settings while preserving env auth and explicit --plugin-dir inputs.
 const ISOLATED_CLAUDE_SETTING_SOURCES_ARG = "";
 const CLAUDE_SETTING_SOURCES_DISPLAY = "\"\"";
@@ -148,15 +151,15 @@ export async function startTryRun(
   const root = resolve(rootPath);
   const cacheRoot = resolve(options.cacheRootPath ?? root);
   if (options.background === true && cacheRoot !== root) {
-    throw new Error("skillset: background tries cannot use a separate cache root");
+    throw new Error("skillset: background ad hoc tests cannot use a separate cache root");
   }
   const graph = await loadBuildGraph(root, options);
   if (!graph.root.targets[options.target].enabled) {
-    throw new Error(`skillset: try target ${options.target} is not enabled by root target configuration`);
+    throw new Error(`skillset: test target ${options.target} is not enabled by root target configuration`);
   }
-  const name = options.name ?? `try-${options.target}`;
+  const name = options.name ?? `ad-hoc-${options.target}`;
   const plugins = validateTryPlugins(graph, options.target, options.plugins ?? []);
-  const runId = makeRetainedRunId(name, { fallbackName: "try", includeName: true });
+  const runId = makeRetainedRunId(name, { fallbackName: "ad-hoc", includeName: true });
   const paths = tryPaths(cacheRoot, graph, runId, options.xdg);
   await mkdir(paths.absolute.runPath, { recursive: true });
 
@@ -176,6 +179,7 @@ export async function startTryRun(
   );
   await writeFile(paths.absolute.promptPath, options.prompt, "utf8");
   await writeStatus(paths, {
+    kind: "ad-hoc",
     latestRoot: ISOLATED_OUT_ROOT,
     name,
     outputPath: paths.logical.outputPath,
@@ -354,6 +358,7 @@ export async function listTryRuns(
       const status = await readStatus(join(runsRoot, entry.name, "status.json"));
       runs.push({
         ...(status.endedAt === undefined ? {} : { endedAt: status.endedAt }),
+        kind: status.kind,
         name: status.name,
         runId: status.runId,
         runPath: status.runPath,
@@ -397,7 +402,7 @@ function runtimeCommand(
 ): { readonly cmd: readonly string[]; readonly cwd: string; readonly display: readonly string[] } {
   const latestRoot = resolveRetainedRunPath(rootPath, graph, ISOLATED_OUT_ROOT, xdg);
   if (config.target === "claude") {
-    const bin = env.SKILLSET_TRY_CLAUDE_BIN ?? "claude";
+    const bin = env.SKILLSET_TEST_CLAUDE_BIN ?? "claude";
     const pluginArgs = tryPluginDirs(graph, latestRoot, config.target, config.plugins).flatMap((pluginDir) => [
       "--plugin-dir",
       pluginDir,
@@ -424,7 +429,7 @@ function runtimeCommand(
   }
 
   if (config.target === "cursor") {
-    const bin = env.SKILLSET_TRY_CURSOR_BIN ?? "cursor-agent";
+    const bin = env.SKILLSET_TEST_CURSOR_BIN ?? "cursor-agent";
     const pluginArgs = tryPluginDirs(graph, latestRoot, config.target, config.plugins).flatMap((pluginDir) => [
       "--plugin-dir",
       pluginDir,
@@ -445,7 +450,7 @@ function runtimeCommand(
     return { cmd, cwd: latestRoot, display: cmd };
   }
 
-  const bin = env.SKILLSET_TRY_CODEX_BIN ?? "codex";
+  const bin = env.SKILLSET_TEST_CODEX_BIN ?? "codex";
   const cmd = [
     bin,
     "exec",
@@ -590,8 +595,8 @@ function cleanEnv(env: Record<string, string | undefined>): Record<string, strin
 
 function spawnTryWorker(rootPath: string, runId: string): number | undefined {
   const cliPath = process.argv[1];
-  if (cliPath === undefined) throw new Error("skillset: try cannot locate CLI entrypoint for background worker");
-  const child = spawnNode(process.execPath, [cliPath, "try", "worker", runId, "--root", rootPath], {
+  if (cliPath === undefined) throw new Error("skillset: test cannot locate CLI entrypoint for background worker");
+  const child = spawnNode(process.execPath, [cliPath, "test", "worker", runId, "--root", rootPath], {
     cwd: rootPath,
     detached: true,
     env: process.env,
@@ -790,6 +795,7 @@ function runReport(
 ): TryRunReport {
   return {
     background,
+    kind: "ad-hoc",
     latestPath: paths.logical.latestJsonPath,
     ok: state === "passed" || background,
     reportPath: paths.logical.reportPath,

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -9,10 +9,10 @@ Runtime adapters describe how a Skillset rendering can be used by an actual agen
 ## Status
 
 Runtime adapter records describe how a generated provider rendering can be
-smoke-tested or consumed by a concrete runtime. `skillset try` can
+smoke-tested or consumed by a concrete runtime. `skillset test` can
 run non-interactive Claude, Codex, and Cursor prompts against isolated local
 renderings while retaining inspectable run artifacts under the logical
-`.skillset/cache/runtime-tests` path.
+`.skillset/cache/tests/ad-hoc` path.
 
 Cursor is a first-class provider target, not a runtime-only compatibility
 candidate. It participates in the default provider plan alongside Claude and
@@ -59,7 +59,7 @@ Runtime support records live in the feature registry as `runtimeSupport` rows. A
 | Build target | A provider rendering Skillset can render directly. | `claude`, `codex`, `cursor` |
 | Runtime adapter | A concrete runtime or harness that can consume a rendering or compatibility shim. | `claude-code`, `codex-cli`, `codex-app`, `cursor` |
 | Distribution surface | A repo, marketplace, extension root, or package shape a rendering may be synced into. | Implemented `distributions.*` plan config; sync/publish remains future |
-| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Implemented manual activation assets and explicit declared live assertions under `skillset test`; implemented ad hoc live non-interactive prompt runs through `skillset try` |
+| Activation harness | A generated test surface that asks whether a runtime notices or invokes a skill, agent, or plugin. | Declared assertions and ad hoc non-interactive runs share the `skillset test` family. |
 
 The test: adding a runtime must not make `compile.targets` accept a new value. It should add evidence and support records first, then a specific adapter or distribution flow only when the target behavior is proven.
 
@@ -82,7 +82,7 @@ Runtime support diagnostics should name whether behavior is native, pass-through
 
 When behavior is shimmed, diagnostics must identify the mechanism and caveat. For example, a Codex agent can receive an instruction to load skills first, but Skillset should not say Codex has native Claude-style agent `skills` metadata.
 
-`skillset try status` reports live harness state as `queued`, `building`, `running`, `passed`, or `failed`, and `skillset try tail` reads retained output from the logical `.skillset/cache/runtime-tests` path backed by XDG storage.
+`skillset test status` reports live harness state as `queued`, `building`, `running`, `passed`, or `failed`, and `skillset test tail` reads retained output from the logical `.skillset/cache/tests/ad-hoc` path backed by XDG storage.
 
 ## Provenance
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -17,7 +17,7 @@ Skillset currently uses internal compiler fixtures and validation commands:
 | Validation commands | `skillset check`, `skillset check --only outputs`, `doctor`, `diff`, `change check`, `release plan` | `implemented` | Public commands that validate real source and generated output. |
 | Dogfooding | repo scripts, Linear acceptance criteria, real Skillset source changes | internal practice | Proves workflows by using them on this repo. |
 | `skillset test` | `<source-root>/tests.yaml` and `<source-root>/tests/*.yaml` | `implemented` | Deterministic isolated projection and check runner for authored source. |
-| `skillset try` | `.skillset/cache/runtime-tests/` logical reports backed by XDG cache storage | `implemented` / maintainer harness | Runs non-interactive Claude, Codex, or Cursor prompts against an isolated rendering and retains status, output, tail, and report files. |
+| `skillset test --target …` | `.skillset/cache/tests/ad-hoc/` logical reports backed by XDG cache storage | `implemented` | Runs an ad hoc non-interactive provider test and retains status, output, tail, and report files. |
 | `.skillset/evals/` | n/a | `future` | Future adapter-aware behavioral eval declarations or pointers. |
 
 Checked-in internal fixtures use the current workspace layout: `fixtures/<case>/skillset.yaml` as the workspace manifest and `fixtures/<case>/.skillset/` as the source root.
@@ -152,7 +152,7 @@ Edge cases stay explicit: multiple matching skills should be disambiguated in th
 
 ### Declared Runtime Tests
 
-An activation probe becomes a committed live-runtime test when it includes `runtime`. The enclosing `skillset test` declaration still performs its deterministic checks first; only then does Skillset invoke each selected target through the same isolated runner used by `skillset try`.
+An activation probe becomes a committed live-runtime test when it includes `runtime`. The enclosing `skillset test` declaration still performs its deterministic checks first; only then does Skillset invoke each selected target through the same isolated runner used by ad hoc `skillset test`.
 
 ```yaml
 select:
@@ -194,26 +194,26 @@ skillset test docs-activation
 
 The command remains credential-free when the selected declaration has no `runtime` block. Live declarations use provider credentials and binaries already available to the process; they do not install, trust, publish, or edit user-level provider configuration. Claude defaults to isolated setting sources and can explicitly select `isolated`, `user`, `project`, or `local` for a declared probe.
 
-Runtime results distinguish `render`, `binary`, `setup`, `auth`, `timeout`, `runtime`, and `assertion` failures. A provider process can therefore complete successfully while its declared expectation fails as `assertion`; missing generated units fail as `render` before provider launch, while a missing executable fails as `binary`. JSON and Markdown test reports record the target, command context, prompt provenance, normalized assertion results, and logical raw evidence paths. The raw try report, stdout/stderr events, prompt, and final response remain under the repo's XDG-backed `.skillset/cache/runtime-tests/` bucket.
+Runtime results distinguish `render`, `binary`, `setup`, `auth`, `timeout`, `runtime`, and `assertion` failures. A provider process can therefore complete successfully while its declared expectation fails as `assertion`; missing generated units fail as `render` before provider launch, while a missing executable fails as `binary`. JSON and Markdown test reports record the target, command context, prompt provenance, normalized assertion results, and logical raw evidence paths. Raw ad hoc reports, stdout/stderr events, prompts, and final responses remain under the repo's XDG-backed `.skillset/cache/tests/ad-hoc/` bucket.
 
-The promotion path is intentionally direct: use `skillset try` to refine a provider prompt, move the prompt inline or into a source-root file, add the expected rendered unit and literal response assertion to an activation probe, then run it with `skillset test`. Subjective quality evaluation remains separate work under SET-51.
+The promotion path is intentionally direct: use `skillset test` to refine a provider prompt, move the prompt inline or into a source-root file, add the expected rendered unit and literal response assertion to an activation probe, then run it with `skillset test`. Subjective quality evaluation remains separate work under SET-51.
 
-## Runtime Tries
+## Ad Hoc Runtime Tests
 
-`skillset try` is the ad hoc live-runtime harness. It is separate from `skillset test`: deterministic tests prove projection and generated files, while a try builds an isolated latest rendering and asks a real local runtime a non-interactive prompt. A successful try means the runtime process completed; it does not claim that the response satisfied a committed assertion.
+The same `skillset test` family owns ad hoc live-runtime probes. A named test runs a committed declaration; `--target` plus exactly one prompt input starts an ad hoc provider process. Ad hoc success means the provider process completed. Committed runtime blocks retain their stronger declared assertion contract.
 
 ```bash
-skillset try --target codex --prompt "What skills can you see?"
-skillset try --target claude --prompt-file prompts/smoke.md --claude-setting-sources isolated --background
-skillset try status
-skillset try tail --lines 80
-skillset try list
+skillset test --target codex --prompt "What skills can you see?"
+skillset test --target claude --prompt-file prompts/smoke.md --claude-setting-sources isolated --background
+skillset test status
+skillset test tail --lines 80
+skillset test list
 ```
 
 Runs write retained artifacts under the logical repo cache path:
 
 ```text
-.skillset/cache/runtime-tests/
+.skillset/cache/tests/ad-hoc/
   latest.json
   runs/<run-id>/
     config.json
@@ -228,20 +228,20 @@ Runs write retained artifacts under the logical repo cache path:
 
 The physical files live in the repo's XDG-backed Skillset cache bucket. Reports keep logical `.skillset/cache/...` paths so humans, issue comments, and future eval tooling can refer to stable locations without depending on a machine-specific cache root.
 
-`status` reports `queued`, `building`, `running`, `passed`, or `failed`; `tail` streams the retained JSONL output after the fact; and `list` shows recent retained runs. `--background` starts a worker and returns as soon as the queued run is recorded, so long-running probes can be checked later without watching the whole process.
+`status` reports `queued`, `building`, `running`, `passed`, or `failed`; `tail` streams retained JSONL output; and `list` shows recent ad hoc runs. Those lifecycle words are reserved and cannot be declaration names. `--background` starts a worker and returns as soon as the queued run is recorded.
 
 The tester does not install, trust, publish, or enable generated artifacts. It invokes local runtimes against the isolated `latest` rendering. Claude probes default to `--claude-setting-sources isolated`, which passes an explicit empty Claude `--setting-sources` list and loads generated plugins with `--plugin-dir`, so env auth and the rendered plugin directories are the only intended Claude inputs.
 
 Claude setting sources can be overridden for probes that intentionally need more runtime context. Precedence is CLI flag, then env var, then the isolated default:
 
 ```bash
-skillset try --target claude --claude-setting-sources user --prompt "What do you see?"
-SKILLSET_TRY_CLAUDE_SETTING_SOURCES=project skillset try --target claude --prompt "What do you see?"
+skillset test --target claude --claude-setting-sources user --prompt "What do you see?"
+SKILLSET_TEST_CLAUDE_SETTING_SOURCES=project skillset test --target claude --prompt "What do you see?"
 ```
 
-Override runtime binaries with `SKILLSET_TRY_CODEX_BIN`, `SKILLSET_TRY_CLAUDE_BIN`, or `SKILLSET_TRY_CURSOR_BIN` for tests, shims, or machine-specific installs.
+Override runtime binaries with `SKILLSET_TEST_CODEX_BIN`, `SKILLSET_TEST_CLAUDE_BIN`, or `SKILLSET_TEST_CURSOR_BIN` for tests, shims, or machine-specific installs.
 
-For Claude Code non-interactive runs, the CLI process must see a non-interactive credential. If `claude --print` reports `Not logged in`, run `claude setup-token`, put the printed `CLAUDE_CODE_OAUTH_TOKEN` export in the repo-local ignored `.envrc`, and run `direnv allow`. The committed `.envrc.example` shows the expected shape without storing secrets. From shells or automation that do not load the direnv hook, run the try through `direnv exec . skillset try ...`.
+For Claude Code non-interactive runs, the CLI process must see a non-interactive credential. If `claude --print` reports `Not logged in`, run `claude setup-token`, put the printed `CLAUDE_CODE_OAUTH_TOKEN` export in the repo-local ignored `.envrc`, and run `direnv allow`. The committed `.envrc.example` shows the expected shape without storing secrets. From shells or automation that do not load the direnv hook, use `direnv exec . skillset test ...`.
 
 ## Compiler Determinism and Adapter Conformance
 

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -116,6 +116,6 @@ Environment overrides exist only for explicit runtime-test and installed-hook in
 | `SKILLSET_HOOK_EVENT` | Normalized event context carried into an explicit hook command. |
 | `SKILLSET_SESSION_ID` | Normalized provider session id carried into an explicit hook command. |
 
-`SKILLSET_TRY_CLAUDE_BIN`, `SKILLSET_TRY_CODEX_BIN`, `SKILLSET_TRY_CURSOR_BIN`, and `SKILLSET_TRY_CLAUDE_SETTING_SOURCES` are removed without fallback. Standard `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` behavior remains platform context rather than Skillset CLI vocabulary.
+The former `SKILLSET_TRY_*` variables are removed without fallback. Standard `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` behavior remains platform context rather than Skillset CLI vocabulary.
 
 Every implementation issue must update `CLI_ROUTE_FLAGS` with any evidence-backed divergence before changing parser behavior. SET-285 closes the loop by asserting root help, route help, and parser acceptance against this contract.


### PR DESCRIPTION
## Context

Declared projection/runtime tests and ad hoc provider probes are both testing workflows, but the CLI exposed them as separate `test` and `try` families.

## What changed

- keeps named declarations at `skillset test [name]`
- moves ad hoc provider runs to `skillset test --target ... --prompt ...`
- moves retained-run lifecycle commands to `skillset test status`, `tail`, and `list`
- removes top-level `skillset try` without an alias
- moves retained evidence to `.skillset/cache/tests/ad-hoc`
- hard-cuts `SKILLSET_TRY_*` to `SKILLSET_TEST_*` and rejects ambiguous test modes
- emits the shared structured envelope for declared and ad hoc JSON results

## Verification

- required GitHub checks: `changeset`, `check`, and `skillset-ci`
- declared/ad hoc, foreground/background, lifecycle, JSON, cache, flag-conflict, and environment coverage

## Tracking

Closes SET-280. Stacked on #269.

## Risks / rollout

This is an intentional hard cutover. The retired command, cache path, and environment names are not recognized, and existing local ad hoc history is not migrated.
