### PR TITLE
feat(cli): add two-direction reconcile workflow

### DIFF
--- a/.changeset/reconcile-managed-output.md
+++ b/.changeset/reconcile-managed-output.md
@@ -1,0 +1,5 @@
+---
+"skillset": minor
+---
+
+Replace `suggest-source` with a two-direction `reconcile` workflow that previews managed conflicts and applies an explicit source-wins or output-wins plan with one confirmation.

--- a/apps/skillset/src/__tests__/ci.test.ts
+++ b/apps/skillset/src/__tests__/ci.test.ts
@@ -65,6 +65,33 @@ test("ci reports generated drift without writing when fix is off", async () => {
   expect(markdown).toContain("skillset build --yes");
 });
 
+test("ci does not recommend output reconciliation that reconcile would refuse", async () => {
+  const root = await fixture({
+    ...DEMO_FIXTURE,
+    ".skillset/skills/other/SKILL.md": `
+---
+name: other
+description: Other.
+---
+
+Other body.
+`,
+  });
+  await commitFixture(root);
+  await buildSkillset(root);
+  const otherPath = ".claude/skills/other/SKILL.md";
+  await writeFile(join(root, GENERATED_SKILL), "---\nname: demo\n---\n\nDemo output edit.\n");
+  await writeFile(join(root, otherPath), "---\nname: other\n---\n\nOther output edit.\n");
+
+  const report = await ciSkillset(root, { since: "HEAD" });
+
+  expect(report.sourceSuggestions).toHaveLength(2);
+  expect(report.sourceSuggestions?.every((suggestion) => suggestion.status === "refused")).toBe(true);
+  expect(report.sourceSuggestions?.every((suggestion) =>
+    suggestion.message.includes("unrelated generated drift exists")
+  )).toBe(true);
+});
+
 test("check JSON promotes readiness failures to envelope diagnostics", async () => {
   const root = await builtFixture();
   await writeFile(join(root, GENERATED_SKILL), "stale\n");

--- a/apps/skillset/src/__tests__/ci.test.ts
+++ b/apps/skillset/src/__tests__/ci.test.ts
@@ -60,7 +60,7 @@ test("ci reports generated drift without writing when fix is off", async () => {
   expect(await readFile(generatedPath, "utf8")).toBe(edited);
   const markdown = renderCiReportMarkdown(report);
   expect(markdown).toContain("### Stale generated output");
-  expect(markdown).toContain("### Source suggestions");
+  expect(markdown).toContain("### Reconciliation");
   expect(markdown).toContain("Generated Markdown body can be moved back to the source file");
   expect(markdown).toContain("skillset build --yes");
 });
@@ -167,7 +167,7 @@ test("check --write refuses target-side generated edits", async () => {
   const markdown = renderCiReportMarkdown(report);
   expect(markdown).toContain("### Target-side generated edits");
   expect(markdown).toContain("will not overwrite");
-  expect(markdown).toContain("### Source suggestions");
+  expect(markdown).toContain("### Reconciliation");
 });
 
 test("check --write refuses unmanaged output collisions", async () => {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4843,6 +4843,7 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
 
   expect(result.exitCode).toBe(0);
   expect(result.stdout).toContain("reconciled using source");
+  expect(result.stdout).toContain("recovery: skillset restore ");
   expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
   expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).not.toContain("Output edit.");
 

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5016,6 +5016,11 @@ Body.
   ]);
   await buildSkillset(root);
 
+  const preview = await runSkillsetCli("reconcile", ".skillset/skills/demo/CHANGELOG.md", "--use", "output", "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).not.toContain("rerun with --use output --yes");
+
   const refused = await runSkillsetCli("reconcile", ".skillset/skills/demo/CHANGELOG.md", "--use", "output", "--yes", "--root", root);
   expect(refused.exitCode).toBe(1);
   expect(refused.stderr).toContain("Generated changelogs are managed projections");

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5217,6 +5217,8 @@ Body.
   const preview = await runSkillsetCli("reconcile", ".skillset/skills/demo/CHANGELOG.md", "--use", "output", "--root", root);
   expect(preview.exitCode).toBe(0);
   expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).toContain("rerun with --use source --yes to apply");
+  expect(preview.stdout).not.toContain("choose --use source or --use output");
   expect(preview.stdout).not.toContain("rerun with --use output --yes");
 
   const refused = await runSkillsetCli("reconcile", ".skillset/skills/demo/CHANGELOG.md", "--use", "output", "--yes", "--root", root);

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4939,6 +4939,39 @@ test("SET-282: reconcile refuses sibling target drift from the same source", asy
   expect(await readFile(join(root, codexPath), "utf8")).toContain("Codex edit.");
 });
 
+test("SET-282: reconcile refuses sibling resource drift from the same output", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-resources\nclaude: true\ncodex: false\n",
+    ".skillset/shared/references/guide.md": "# Source guide\n",
+    ".skillset/skills/demo/SKILL.md": `---
+name: demo
+description: Demo.
+resources:
+  references:
+    - shared:references/guide.md
+---
+
+Source body.
+`,
+  });
+  await buildSkillset(root);
+  const skillPath = ".claude/skills/demo/SKILL.md";
+  const guidePath = ".claude/skills/demo/references/guide.md";
+  await writeFile(join(root, skillPath), "---\nname: demo\n---\n\nOutput edit.\n", "utf8");
+  await writeFile(join(root, guidePath), "# Output guide edit\n", "utf8");
+
+  const result = await runSkillsetCli(
+    "reconcile", skillPath, "--use", "output", "--yes", "--root", root
+  );
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("unrelated generated drift exists");
+  expect(result.stderr).toContain(guidePath);
+  expect(await readFile(join(root, skillPath), "utf8")).toContain("Output edit.");
+  expect(await readFile(join(root, guidePath), "utf8")).toBe("# Output guide edit\n");
+  expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).toContain("Source body.");
+});
+
 test("SET-282: reconcile accepts a selected secondary lock file", async () => {
   const root = await contractFixture({
     "skillset.yaml": "skillset:\n  name: reconcile-secondary\nclaude: true\ncodex: false\n",

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4911,6 +4911,68 @@ test("SET-282: reconcile refuses to overwrite unrelated generated drift", async 
   expect(await readFile(join(root, betaPath), "utf8")).toContain("Beta output edit.");
 });
 
+test("SET-282: reconcile refuses sibling target drift from the same source", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-siblings\nclaude: true\ncodex: true\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nSource body.\n",
+  });
+  await buildSkillset(root);
+  const claudePath = ".claude/skills/demo/SKILL.md";
+  const codexPath = ".agents/skills/demo/SKILL.md";
+  await writeFile(join(root, claudePath), "---\nname: demo\n---\n\nClaude edit.\n", "utf8");
+  await writeFile(join(root, codexPath), "---\nname: demo\n---\n\nCodex edit.\n", "utf8");
+
+  const result = await runSkillsetCli(
+    "reconcile", claudePath, "--use", "output", "--yes", "--root", root
+  );
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain(codexPath);
+  expect(await readFile(join(root, claudePath), "utf8")).toContain("Claude edit.");
+  expect(await readFile(join(root, codexPath), "utf8")).toContain("Codex edit.");
+});
+
+test("SET-282: reconcile accepts a selected secondary lock file", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-secondary\nclaude: true\ncodex: false\n",
+    ".skillset/shared/references/guide.md": "# Source guide\n",
+    ".skillset/skills/demo/SKILL.md": `---
+name: demo
+description: Demo.
+resources:
+  references:
+    - shared:references/guide.md
+---
+
+Read the guide.
+`,
+  });
+  await buildSkillset(root);
+  const secondaryPath = ".claude/skills/demo/references/guide.md";
+  await writeFile(join(root, secondaryPath), "# Edited guide\n", "utf8");
+
+  const result = await runSkillsetCli(
+    "reconcile", secondaryPath, "--use", "source", "--yes", "--root", root
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(await readFile(join(root, secondaryPath), "utf8")).toBe("# Source guide\n");
+});
+
+test("SET-282: --write is rejected outside check", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: write-route\nclaude: true\ncodex: false\n",
+  });
+  for (const args of [
+    ["build", "--write", "--root", root],
+    ["reconcile", "missing", "--write", "--root", root],
+  ]) {
+    const result = await runSkillsetCli(...args);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--write is only supported with check");
+  }
+});
+
 test("SET-282: reconcile refuses output-wins generated changelog edits", async () => {
   const root = await contractFixture({
     "skillset.yaml": `

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4823,6 +4823,7 @@ Original source body.
   const written = await runSkillsetCli("reconcile", generatedPath, "--use", "output", "--yes", "--root", root);
   expect(written.exitCode).toBe(0);
   expect(written.stdout).toContain("reconciled using output");
+  expect(written.stdout).not.toContain("recovery: skillset restore");
   const source = await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8");
   expect(source).toContain("Edited generated body.");
   expect(source).not.toContain("metadata:");

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4852,6 +4852,23 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
   expect(rebuilt.stdout).toContain("reconciled using source");
   expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
 
+  await writeFile(
+    join(root, generatedPath),
+    "---\nname: demo\ndescription: Broken output without a closing fence.\n",
+    "utf8"
+  );
+  const recovered = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "source",
+    "--yes",
+    "--root",
+    root
+  );
+  expect(recovered.exitCode).toBe(0);
+  expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
+
   const structured = await runSkillsetCli("reconcile", generatedPath, "--root", root, "--json");
   expect(structured.exitCode).toBe(0);
   expect(structured.stderr).toBe("");
@@ -4861,6 +4878,37 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
     kind: "plan",
     ok: true,
   });
+});
+
+test("SET-282: reconcile refuses to overwrite unrelated generated drift", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-scope\nclaude: true\ncodex: false\n",
+    ".skillset/skills/alpha/SKILL.md":
+      "---\nname: alpha\ndescription: Alpha.\n---\n\nAlpha source.\n",
+    ".skillset/skills/beta/SKILL.md":
+      "---\nname: beta\ndescription: Beta.\n---\n\nBeta source.\n",
+  });
+  await buildSkillset(root);
+  const alphaPath = ".claude/skills/alpha/SKILL.md";
+  const betaPath = ".claude/skills/beta/SKILL.md";
+  await writeFile(join(root, alphaPath), "---\nname: alpha\n---\n\nAlpha output edit.\n", "utf8");
+  await writeFile(join(root, betaPath), "---\nname: beta\n---\n\nBeta output edit.\n", "utf8");
+
+  const result = await runSkillsetCli(
+    "reconcile",
+    alphaPath,
+    "--use",
+    "source",
+    "--yes",
+    "--root",
+    root
+  );
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("unrelated generated drift exists");
+  expect(result.stderr).toContain(betaPath);
+  expect(await readFile(join(root, alphaPath), "utf8")).toContain("Alpha output edit.");
+  expect(await readFile(join(root, betaPath), "utf8")).toContain("Beta output edit.");
 });
 
 test("SET-282: reconcile refuses output-wins generated changelog edits", async () => {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4839,7 +4839,7 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
   const generatedPath = ".claude/skills/demo/SKILL.md";
   await writeFile(join(root, generatedPath), "---\nname: demo\ndescription: Demo.\n---\n\nOutput edit.\n", "utf8");
 
-  const result = await runSkillsetCli("reconcile", generatedPath, "--use", "source", "--yes", "--root", root);
+  const result = await runSkillsetCli("reconcile", `./${generatedPath}`, "--use", "source", "--yes", "--root", root);
 
   expect(result.exitCode).toBe(0);
   expect(result.stdout).toContain("reconciled using source");

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5008,6 +5008,10 @@ test("SET-282: source-wins rebuilds sibling target drift", async () => {
   await writeFile(join(root, ".skillset/skills/demo/SKILL.md"), "---\nname: demo\ndescription: Demo.\n---\n\nUpdated source.\n", "utf8");
   await writeFile(join(root, claudePath), "---\nname: demo\n---\n\nClaude edit.\n", "utf8");
 
+  const preview = await runSkillsetCli("reconcile", claudePath, "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("source wins: available");
+
   const result = await runSkillsetCli(
     "reconcile", claudePath, "--use", "source", "--yes", "--root", root
   );

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5107,6 +5107,13 @@ Source body.
   await writeFile(join(root, skillPath), "---\nname: demo\n---\n\nOutput edit.\n", "utf8");
   await writeFile(join(root, guidePath), "# Output guide edit\n", "utf8");
 
+  const preview = await runSkillsetCli(
+    "reconcile", skillPath, "--use", "output", "--root", root
+  );
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).toContain(guidePath);
+
   const result = await runSkillsetCli(
     "reconcile", skillPath, "--use", "output", "--yes", "--root", root
   );

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4785,7 +4785,7 @@ Body.
   expect(diff.stdout).toContain("generated CHANGELOG.md files are managed projections");
 });
 
-test("SET-151: suggest-source previews and writes clean generated skill body edits", async () => {
+test("SET-282: reconcile previews and applies output-wins skill edits", async () => {
   const root = await contractFixture({
     "skillset.yaml": `
 skillset:
@@ -4811,28 +4811,43 @@ Original source body.
     "utf8"
   );
 
-  const preview = await runSkillsetCli("suggest-source", generatedPath, "--root", root);
+  const preview = await runSkillsetCli("reconcile", generatedPath, "--root", root);
   expect(preview.exitCode).toBe(0);
-  expect(preview.stdout).toContain("skillset: source suggestion suggestible");
+  expect(preview.stdout).toContain("output wins: available");
+  expect(preview.stdout).toContain("source wins: available");
   expect(preview.stdout).toContain("source: .skillset/skills/demo/SKILL.md");
-  expect(preview.stdout).toContain("write: preview");
-  expect(preview.stdout).toContain("rerun with `--write --yes`");
   await expect(readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).resolves.toContain("Original source body.");
 
-  const writeAttempt = await runSkillsetCli("suggest-source", generatedPath, "--write", "--root", root);
-  expect(writeAttempt.exitCode).toBe(1);
-  expect(writeAttempt.stderr).toContain("suggest-source --write requires --yes");
-
-  const written = await runSkillsetCli("suggest-source", generatedPath, "--write", "--yes", "--root", root);
+  const written = await runSkillsetCli("reconcile", generatedPath, "--use", "output", "--yes", "--root", root);
   expect(written.exitCode).toBe(0);
-  expect(written.stdout).toContain("skillset: source suggestion written");
-  expect(written.stdout).toContain("write: applied");
+  expect(written.stdout).toContain("reconciled using output");
   const source = await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8");
   expect(source).toContain("Edited generated body.");
   expect(source).not.toContain("metadata:");
+
+  const removed = await runSkillsetCli("suggest-source", generatedPath, "--root", root);
+  expect(removed.exitCode).toBe(1);
+  expect(removed.stderr).toContain("expected command");
 });
 
-test("SET-151: suggest-source refuses generated changelog edits", async () => {
+test("SET-282: reconcile applies source-wins with output backup safety", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-source\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nSource body.\n",
+  });
+  await buildSkillset(root);
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  await writeFile(join(root, generatedPath), "---\nname: demo\ndescription: Demo.\n---\n\nOutput edit.\n", "utf8");
+
+  const result = await runSkillsetCli("reconcile", generatedPath, "--use", "source", "--yes", "--root", root);
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("reconciled using source");
+  expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
+  expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).not.toContain("Output edit.");
+});
+
+test("SET-282: reconcile refuses output-wins generated changelog edits", async () => {
   const root = await contractFixture({
     "skillset.yaml": `
 skillset:
@@ -4860,12 +4875,9 @@ Body.
   ]);
   await buildSkillset(root);
 
-  const refused = await runSkillsetCli("suggest-source", ".skillset/skills/demo/CHANGELOG.md", "--root", root);
+  const refused = await runSkillsetCli("reconcile", ".skillset/skills/demo/CHANGELOG.md", "--use", "output", "--yes", "--root", root);
   expect(refused.exitCode).toBe(1);
-  expect(refused.stdout).toContain("source suggestion refused");
-  expect(refused.stdout).toContain("Generated changelogs are managed projections");
-  expect(refused.stdout).toContain("skillset change amend <@ref>");
-  expect(refused.stdout).toContain("skillset release amend <@ref>");
+  expect(refused.stderr).toContain("Generated changelogs are managed projections");
 });
 
 test("SET-37: plugin changelog aggregates child skill applied records", async () => {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4816,6 +4816,8 @@ Original source body.
   expect(preview.stdout).toContain("output wins: available");
   expect(preview.stdout).toContain("source wins: available");
   expect(preview.stdout).toContain("source: .skillset/skills/demo/SKILL.md");
+  expect(preview.stdout).toContain("rerun with --use output --yes to apply");
+  expect(preview.stdout).not.toContain("--use undefined");
   await expect(readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).resolves.toContain("Original source body.");
 
   const written = await runSkillsetCli("reconcile", generatedPath, "--use", "output", "--yes", "--root", root);

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4989,6 +4989,40 @@ test("SET-282: source-wins rebuilds sibling target drift", async () => {
   expect(await readFile(join(root, codexPath), "utf8")).toContain("Updated source.");
 });
 
+test("SET-282: source-wins deletes stale sibling outputs", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-stale-sibling\nclaude: true\ncodex: false\n",
+    ".skillset/shared/references/guide.md": "# Guide\n",
+    ".skillset/skills/demo/SKILL.md": `---
+name: demo
+description: Demo.
+resources:
+  references:
+    - shared:references/guide.md
+---
+
+Source body.
+`,
+  });
+  await buildSkillset(root);
+  const sourcePath = join(root, ".skillset/skills/demo/SKILL.md");
+  const skillPath = ".claude/skills/demo/SKILL.md";
+  const staleSiblingPath = ".claude/skills/demo/references/guide.md";
+  await writeFile(
+    sourcePath,
+    "---\nname: demo\ndescription: Demo.\n---\n\nSource body without the reference.\n",
+    "utf8"
+  );
+
+  const result = await runSkillsetCli(
+    "reconcile", skillPath, "--use", "source", "--yes", "--root", root
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(await Bun.file(join(root, staleSiblingPath)).exists()).toBe(false);
+  expect(await readFile(join(root, skillPath), "utf8")).toContain("without the reference");
+});
+
 test("SET-282: reconcile refuses sibling resource drift from the same output", async () => {
   const root = await contractFixture({
     "skillset.yaml": "skillset:\n  name: reconcile-resources\nclaude: true\ncodex: false\n",

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4845,6 +4845,22 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
   expect(result.stdout).toContain("reconciled using source");
   expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
   expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).not.toContain("Output edit.");
+
+  await rm(join(root, generatedPath));
+  const rebuilt = await runSkillsetCli("reconcile", generatedPath, "--use", "source", "--yes", "--root", root);
+  expect(rebuilt.exitCode).toBe(0);
+  expect(rebuilt.stdout).toContain("reconciled using source");
+  expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
+
+  const structured = await runSkillsetCli("reconcile", generatedPath, "--root", root, "--json");
+  expect(structured.exitCode).toBe(0);
+  expect(structured.stderr).toBe("");
+  expect(JSON.parse(structured.stdout)).toMatchObject({
+    command: "reconcile",
+    data: { generatedPath, sourceResolutionAvailable: true },
+    kind: "plan",
+    ok: true,
+  });
 });
 
 test("SET-282: reconcile refuses output-wins generated changelog edits", async () => {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5073,6 +5073,14 @@ test("SET-282: --write is rejected outside check", async () => {
   }
 });
 
+test("SET-282: reconcile rejects source and output root overrides", async () => {
+  for (const flag of ["--source", "--dist"]) {
+    const result = await runSkillsetCli("reconcile", "missing", flag, "alternate");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("reconcile does not support --source or --dist overrides");
+  }
+});
+
 test("SET-282: reconcile refuses output-wins generated changelog edits", async () => {
   const root = await contractFixture({
     "skillset.yaml": `

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4883,6 +4883,36 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
   });
 });
 
+test("SET-282: failed output-wins reconciliation restores source", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-invalid-output\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nOriginal source body.\n",
+  });
+  await buildSkillset(root);
+  const sourcePath = join(root, ".skillset/skills/demo/SKILL.md");
+  const originalSource = await readFile(sourcePath, "utf8");
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  await writeFile(
+    join(root, generatedPath),
+    "---\nname: demo\ndescription: Demo.\n---\n\nSee [missing](shared:references/missing.md).\n",
+    "utf8"
+  );
+
+  const result = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("links to undeclared shared resource");
+  expect(await readFile(sourcePath, "utf8")).toBe(originalSource);
+});
+
 test("SET-282: reconcile refuses to overwrite unrelated generated drift", async () => {
   const root = await contractFixture({
     "skillset.yaml": "skillset:\n  name: reconcile-scope\nclaude: true\ncodex: false\n",

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4833,6 +4833,29 @@ Original source body.
   expect(removed.stderr).toContain("expected command");
 });
 
+test("SET-282: reconcile rejects adaptive source paths before writing", async () => {
+  const sourcePath = ".skillset/skills/demo/SKILL.md";
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-source-path\nclaude: true\ncodex: false\n",
+    [sourcePath]: "---\nname: demo\ndescription: Demo.\n---\n\nSource body.\n",
+  });
+  await buildSkillset(root);
+
+  const result = await runSkillsetCli(
+    "reconcile",
+    sourcePath,
+    "--use",
+    "source",
+    "--yes",
+    "--root",
+    root
+  );
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("reconcile requires a managed generated path");
+  expect(result.stderr).toContain(`${sourcePath} is source`);
+});
+
 test("SET-282: reconcile applies source-wins with output backup safety", async () => {
   const root = await contractFixture({
     "skillset.yaml": "skillset:\n  name: reconcile-source\nclaude: true\ncodex: false\n",

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4894,6 +4894,10 @@ test("SET-282: reconcile refuses to overwrite unrelated generated drift", async 
   await writeFile(join(root, alphaPath), "---\nname: alpha\n---\n\nAlpha output edit.\n", "utf8");
   await writeFile(join(root, betaPath), "---\nname: beta\n---\n\nBeta output edit.\n", "utf8");
 
+  const preview = await runSkillsetCli("reconcile", alphaPath, "--root", root);
+  expect(preview.exitCode).toBe(1);
+  expect(preview.stderr).toContain(betaPath);
+
   const result = await runSkillsetCli(
     "reconcile",
     alphaPath,

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1,5 +1,5 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 import { expect, test } from "bun:test";
@@ -4987,6 +4987,13 @@ test("SET-282: reconcile refuses sibling target drift from the same source", asy
   await writeFile(join(root, claudePath), "---\nname: demo\n---\n\nClaude edit.\n", "utf8");
   await writeFile(join(root, codexPath), "---\nname: demo\n---\n\nCodex edit.\n", "utf8");
 
+  const preview = await runSkillsetCli("reconcile", claudePath, "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("source wins: available");
+  expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).toContain(codexPath);
+  expect(preview.stdout).not.toContain("rerun with --use output --yes");
+
   const result = await runSkillsetCli(
     "reconcile", claudePath, "--use", "output", "--yes", "--root", root
   );
@@ -4995,6 +5002,30 @@ test("SET-282: reconcile refuses sibling target drift from the same source", asy
   expect(result.stderr).toContain(codexPath);
   expect(await readFile(join(root, claudePath), "utf8")).toContain("Claude edit.");
   expect(await readFile(join(root, codexPath), "utf8")).toContain("Codex edit.");
+});
+
+test("SET-282: output-wins normalizes equivalent selected paths", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-normalized\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nSource body.\n",
+  });
+  await buildSkillset(root);
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  await writeFile(join(root, generatedPath), "---\nname: demo\n---\n\nOutput edit.\n", "utf8");
+
+  const result = await runSkillsetCli(
+    "reconcile",
+    resolve(root, generatedPath),
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("reconciled using output");
+  expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).toContain("Output edit.");
 });
 
 test("SET-282: source-wins rebuilds sibling target drift", async () => {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4939,6 +4939,26 @@ test("SET-282: reconcile refuses sibling target drift from the same source", asy
   expect(await readFile(join(root, codexPath), "utf8")).toContain("Codex edit.");
 });
 
+test("SET-282: source-wins rebuilds sibling target drift", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-source-siblings\nclaude: true\ncodex: true\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nInitial source.\n",
+  });
+  await buildSkillset(root);
+  const claudePath = ".claude/skills/demo/SKILL.md";
+  const codexPath = ".agents/skills/demo/SKILL.md";
+  await writeFile(join(root, ".skillset/skills/demo/SKILL.md"), "---\nname: demo\ndescription: Demo.\n---\n\nUpdated source.\n", "utf8");
+  await writeFile(join(root, claudePath), "---\nname: demo\n---\n\nClaude edit.\n", "utf8");
+
+  const result = await runSkillsetCli(
+    "reconcile", claudePath, "--use", "source", "--yes", "--root", root
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(await readFile(join(root, claudePath), "utf8")).toContain("Updated source.");
+  expect(await readFile(join(root, codexPath), "utf8")).toContain("Updated source.");
+});
+
 test("SET-282: reconcile refuses sibling resource drift from the same output", async () => {
   const root = await contractFixture({
     "skillset.yaml": "skillset:\n  name: reconcile-resources\nclaude: true\ncodex: false\n",

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4845,6 +4845,7 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
 
   expect(result.exitCode).toBe(0);
   expect(result.stdout).toContain("reconciled using source");
+  expect(result.stdout).not.toContain("output next:");
   expect(result.stdout).toContain("recovery: skillset restore ");
   expect(await readFile(join(root, generatedPath), "utf8")).toContain("Source body.");
   expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).not.toContain("Output edit.");
@@ -4911,6 +4912,33 @@ test("SET-282: failed output-wins reconciliation restores source", async () => {
   expect(result.exitCode).toBe(1);
   expect(result.stderr).toContain("links to undeclared shared resource");
   expect(await readFile(sourcePath, "utf8")).toBe(originalSource);
+});
+
+test("SET-282: source-wins removes edited output after its source is deleted", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": "skillset:\n  name: reconcile-removed-source\nclaude: true\ncodex: false\n",
+    ".skillset/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\n---\n\nSource body.\n",
+    ".skillset/skills/keep/SKILL.md": "---\nname: keep\ndescription: Keep.\n---\n\nKeep body.\n",
+  });
+  await buildSkillset(root);
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  await writeFile(join(root, generatedPath), "Edited managed output.\n", "utf8");
+  await rm(join(root, ".skillset/skills/demo"), { recursive: true });
+
+  const result = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "source",
+    "--yes",
+    "--root",
+    root
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("reconciled using source");
+  expect(result.stdout).not.toContain("output next:");
+  expect(await Bun.file(join(root, generatedPath)).exists()).toBe(false);
 });
 
 test("SET-282: reconcile refuses to overwrite unrelated generated drift", async () => {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4957,6 +4957,16 @@ Read the guide.
 
   expect(result.exitCode).toBe(0);
   expect(await readFile(join(root, secondaryPath), "utf8")).toBe("# Source guide\n");
+
+  await writeFile(join(root, secondaryPath), "# Edited guide again\n", "utf8");
+  const refused = await runSkillsetCli(
+    "reconcile", secondaryPath, "--use", "output", "--yes", "--root", root
+  );
+
+  expect(refused.exitCode).toBe(1);
+  expect(refused.stderr).toContain("Auxiliary skill outputs cannot replace the owning SKILL.md source body");
+  expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).toContain("Read the guide.");
+  expect(await readFile(join(root, ".skillset/shared/references/guide.md"), "utf8")).toBe("# Source guide\n");
 });
 
 test("SET-282: --write is rejected outside check", async () => {

--- a/apps/skillset/src/ci.ts
+++ b/apps/skillset/src/ci.ts
@@ -16,12 +16,13 @@ import {
   type SkillsetDiagnostic,
   type SkillsetDiff,
 } from "@skillset/core";
-import { suggestSource, type SourceSuggestionReport } from "@skillset/core/internal/authoring";
+import type { SourceSuggestionReport } from "@skillset/core/internal/authoring";
 import { inspectSkillset } from "@skillset/core";
 import { readManagedOutputState } from "@skillset/core/internal/output-safety";
 import { loadBuildGraph } from "@skillset/core/internal/resolver";
 import type { LintIssue, SkillsetOptions } from "@skillset/core/internal/types";
 import { runProviderFormatUpdates } from "./provider-format-updates";
+import { reconcileManagedPath } from "./reconcile";
 
 export interface CiOptions extends SkillsetOptions {
   /** Include branch-aware source and package change gates. */
@@ -440,7 +441,8 @@ async function sourceSuggestionsForDrift(
   const reports: SourceSuggestionReport[] = [];
   for (const path of paths) {
     try {
-      reports.push(await suggestSource(rootPath, path, options));
+      const preview = await reconcileManagedPath(rootPath, path, options);
+      reports.push(preview.outputResolution);
     } catch (error) {
       reports.push({
         entries: [],

--- a/apps/skillset/src/ci.ts
+++ b/apps/skillset/src/ci.ts
@@ -356,7 +356,7 @@ export function renderCiReportMarkdown(report: CiReport): string {
   }
 
   if (report.sourceSuggestions !== undefined && report.sourceSuggestions.length > 0) {
-    lines.push("### Source suggestions", "");
+    lines.push("### Reconciliation", "");
     for (const suggestion of report.sourceSuggestions) {
       const source = suggestion.sourcePath === undefined ? "" : ` source \`${suggestion.sourcePath}\``;
       lines.push(`- ${suggestion.status}: \`${suggestion.generatedPath}\`${source}: ${suggestion.message}`);

--- a/apps/skillset/src/cli-commands.ts
+++ b/apps/skillset/src/cli-commands.ts
@@ -2,7 +2,7 @@ export const CLI_COMMANDS = [
   "build", "change", "check", "dev", "diff",
   "distribute", "doctor", "explain", "features", "hooks", "import", "init",
   "list", "lookup", "marketplace", "new", "release",
-  "restore", "suggest-source", "test", "update",
+  "reconcile", "restore", "test", "update",
 ] as const;
 
 export type CliCommand = (typeof CLI_COMMANDS)[number];

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -2086,7 +2086,10 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       if (flag === "--agent-runtime") hookAgentRuntime = true;
       if (flag === "--pre-commit") hookPreCommit = true;
       if (flag === "--pre-push") hookPrePush = true;
-      if (flag === "--write" && command === "check") checkWrite = true;
+      if (flag === "--write") {
+        if (command !== "check") throw new Error("skillset: --write is only supported with check");
+        checkWrite = true;
+      }
       if (flag === "--watch") devWatch = true;
       if (flag === "--frontmatter") lookupViews = addLookupView(lookupViews, "frontmatter");
       if (flag === "--fields") lookupViews = addLookupView(lookupViews, "fields");

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -880,7 +880,11 @@ export async function runCli(
       ...(reconcileChoice === undefined ? {} : { choice: reconcileChoice }),
       write: reconcileChoice !== undefined && yes,
     });
-    process.stdout.write(renderReconcileReport(report));
+    if (jsonOutput) {
+      printCliJsonData("reconcile", report, 0, report.applied ? "mutation" : "plan");
+    } else {
+      process.stdout.write(renderReconcileReport(report));
+    }
     return;
   }
 
@@ -3049,7 +3053,7 @@ function validateJsonFlags(
   if (!jsonOutput) return;
   if (command === "check") return;
   if (command === "change" && (route.changeSubcommand === "check" || route.changeSubcommand === "history" || route.changeSubcommand === "list" || route.changeSubcommand === "show" || route.changeSubcommand === "status")) return;
-  if (command === "diff" || command === "doctor" || command === "explain" || command === "features" || command === "list" || command === "lookup" || command === "marketplace" || command === "test") return;
+  if (command === "diff" || command === "doctor" || command === "explain" || command === "features" || command === "list" || command === "lookup" || command === "marketplace" || command === "reconcile" || command === "test") return;
   if (command === "distribute" && route.distributionSubcommand === "plan") return;
   throw new Error("skillset: --json is not supported for this command route");
 }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -2370,9 +2370,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   validateReconcileFlags(command, {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(changeSince === undefined ? {} : { changeSince }),
+    ...(distDir === undefined ? {} : { distDir }),
     dryRun,
     ...(scopes === undefined ? {} : { scopes }),
     ...(reconcileChoice === undefined ? {} : { choice: reconcileChoice }),
+    ...(sourceDir === undefined ? {} : { sourceDir }),
     yes,
   });
   validateNewSourceFlags(command, {
@@ -2814,9 +2816,11 @@ function validateReconcileFlags(
   reconcile: {
     readonly buildMode?: CompileBuildMode;
     readonly changeSince?: string;
+    readonly distDir?: string;
     readonly dryRun: boolean;
     readonly scopes?: readonly BuildScope[];
     readonly choice?: ReconcileChoice;
+    readonly sourceDir?: string;
     readonly yes: boolean;
   }
 ): void {
@@ -2824,6 +2828,9 @@ function validateReconcileFlags(
   if (command !== "reconcile") return;
   if (reconcile.buildMode !== undefined) throw new Error("skillset: --updated and --all are not supported with reconcile");
   if (reconcile.changeSince !== undefined) throw new Error("skillset: --since is not supported with reconcile");
+  if (reconcile.distDir !== undefined || reconcile.sourceDir !== undefined) {
+    throw new Error("skillset: reconcile does not support --source or --dist overrides");
+  }
   if (reconcile.dryRun) throw new Error("skillset: --dry-run is redundant for reconcile preview mode");
   if (reconcile.scopes !== undefined) throw new Error("skillset: --scope is not supported with reconcile");
   if (reconcile.yes && reconcile.choice === undefined) throw new Error("skillset: reconcile --yes requires --use source or --use output");

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -49,9 +49,7 @@ import {
   explainPath,
   listFeatureCapabilities,
   listGeneratedEntries,
-  suggestSource,
   type FeatureCapability,
-  type SourceSuggestionReport,
 } from "@skillset/core/internal/authoring";
 import { ciSkillset, hasDrift, renderCiReportMarkdown, type CiReport } from "./ci";
 import { printDiagnostics, printDiffPlan, printGeneratedChangelogDriftHint, printGeneratedChangelogPathHint } from "./cli-renderers";
@@ -100,6 +98,7 @@ import {
   renderProviderFormatUpdateReport,
   runProviderFormatUpdates,
 } from "./provider-format-updates";
+import { reconcileManagedPath, renderReconcileReport, type ReconcileChoice } from "./reconcile";
 import { readClaudeSettingSources, type TryClaudeSettingSources, type TrySubcommand } from "./try";
 import {
   isTrySubcommand,
@@ -139,7 +138,7 @@ const USAGE = [
   "       skillset release apply [--yes|--dry-run] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset release amend <@ref> [--reason <text>|--reason-file <path>|--reason -] [--root <path>]",
   "       skillset restore <backup-id> [--yes|--dry-run] [--root <path>]",
-  "       skillset suggest-source <generated-path> [--write --yes] [--root <path>] [--source <dir>] [--dist <dir>]",
+  "       skillset reconcile <managed-path> [--use <source|output> --yes] [--root <path>]",
   "       skillset distribute plan [name] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset marketplace check [name] [--json] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset marketplace update [name] [--yes|--dry-run] [--json] [--root <path>] [--source <dir>] [--dist <dir>]",
@@ -239,12 +238,13 @@ export async function runCli(
     tryTimeoutMs,
     setupIncludes,
     setupTargets,
-    sourceSuggestionWrite,
+    reconcileChoice,
     testName,
     yes,
   } = parseCliArgs(args);
 
   if (command === "build") {
+    console.log("skillset: build projects source to generated output");
     if (dryRun || !yes) {
       const result = await diffSkillsetResult(rootPath, options);
       printDiagnostics(result.diagnostics);
@@ -871,16 +871,16 @@ export async function runCli(
     return;
   }
 
-  if (command === "suggest-source") {
+  if (command === "reconcile") {
     if (importPath === undefined) {
-      throw new Error("skillset: expected a generated path to suggest source");
+      throw new Error("skillset: expected a managed path to reconcile");
     }
-    const report = await suggestSource(rootPath, importPath, {
+    const report = await reconcileManagedPath(rootPath, importPath, {
       ...options,
-      write: sourceSuggestionWrite && yes,
+      ...(reconcileChoice === undefined ? {} : { choice: reconcileChoice }),
+      write: reconcileChoice !== undefined && yes,
     });
-    printSourceSuggestion(report);
-    if (report.status === "refused") process.exitCode = 1;
+    process.stdout.write(renderReconcileReport(report));
     return;
   }
 
@@ -1139,7 +1139,7 @@ interface ParsedArgs {
   readonly rootPath: string;
   readonly setupIncludes?: readonly SetupInclude[];
   readonly setupTargets?: readonly TargetName[];
-  readonly sourceSuggestionWrite: boolean;
+  readonly reconcileChoice?: ReconcileChoice;
   readonly testName?: string;
   readonly yes: boolean;
 }
@@ -1210,21 +1210,6 @@ function printChangeCheck(report: ChangeCheckReport): void {
   process.exitCode = 1;
 }
 
-function printSourceSuggestion(report: SourceSuggestionReport): void {
-  console.log(`skillset: source suggestion ${report.status} ${report.generatedPath}`);
-  if (report.sourcePath !== undefined) console.log(`  source: ${report.sourcePath}`);
-  if (report.lockPath !== undefined) console.log(`  lock: ${report.lockPath}`);
-  console.log(`  message: ${report.message}`);
-  if (report.wouldWrite) console.log(`  write: ${report.wrote ? "applied" : "preview"}`);
-  for (const entry of report.entries) {
-    console.log(`  owner: [${entry.target}] ${entry.kind ?? "generated"} ${entry.sourcePath} -> ${entry.outputPath}`);
-  }
-  if (report.nextSteps.length > 0) {
-    console.log("  next:");
-    for (const step of report.nextSteps) console.log(`    ${step}`);
-  }
-}
-
 function printChangeStatus(report: ChangeStatusReport): void {
   const baseline =
     report.baseline.kind === "git-ref"
@@ -1288,7 +1273,7 @@ function printCiReport(report: CiReport): void {
   for (const path of drift.removed) console.log(`  generated - ${path}`);
   printGeneratedChangelogDriftHint(drift);
   for (const suggestion of report.sourceSuggestions ?? []) {
-    console.log(`  source suggestion ${suggestion.status}: ${suggestion.generatedPath}`);
+    console.log(`  reconcile output ${suggestion.status}: ${suggestion.generatedPath}`);
     if (suggestion.sourcePath !== undefined) console.log(`    source: ${suggestion.sourcePath}`);
     console.log(`    ${suggestion.message}`);
   }
@@ -1787,7 +1772,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let scopes: readonly BuildScope[] | undefined;
   let setupIncludes: readonly SetupInclude[] | undefined;
   let setupTargets: readonly TargetName[] | undefined;
-  let sourceSuggestionWrite = false;
+  let reconcileChoice: ReconcileChoice | undefined;
   let testName: string | undefined;
   let yes = false;
   let index = 1;
@@ -1903,7 +1888,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     }
   }
 
-  if (command === "explain" || command === "suggest-source") {
+  if (command === "explain" || command === "reconcile") {
     const rawPath = args[index];
     if (rawPath === undefined || rawPath.startsWith("--")) {
       throw new Error(`skillset: expected a path to ${command}`);
@@ -2000,6 +1985,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag !== "--fix" &&
       flag !== "--ci" &&
       flag !== "--only" &&
+      flag !== "--use" &&
       flag !== "--report" &&
       flag !== "--json" &&
       flag !== "--jsonl" &&
@@ -2096,10 +2082,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       if (flag === "--agent-runtime") hookAgentRuntime = true;
       if (flag === "--pre-commit") hookPreCommit = true;
       if (flag === "--pre-push") hookPrePush = true;
-      if (flag === "--write") {
-        if (command === "check") checkWrite = true;
-        else sourceSuggestionWrite = true;
-      }
+      if (flag === "--write" && command === "check") checkWrite = true;
       if (flag === "--watch") devWatch = true;
       if (flag === "--frontmatter") lookupViews = addLookupView(lookupViews, "frontmatter");
       if (flag === "--fields") lookupViews = addLookupView(lookupViews, "fields");
@@ -2160,6 +2143,10 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     if (flag === "--only") {
       if (value !== "outputs") throw new Error("skillset: expected --only outputs");
       checkOnly = value;
+    }
+    if (flag === "--use") {
+      if (value !== "source" && value !== "output") throw new Error("skillset: --use expects source or output");
+      reconcileChoice = value;
     }
     if (flag === "--field") lookupField = setLookupField(lookupField, value);
     if (flag === "--runner") hookRunner = readHookRunner(value);
@@ -2373,12 +2360,12 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(scopes === undefined ? {} : { scopes }),
     ...(sourceDir === undefined ? {} : { sourceDir }),
   });
-  validateSuggestSourceFlags(command, {
+  validateReconcileFlags(command, {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(changeSince === undefined ? {} : { changeSince }),
     dryRun,
     ...(scopes === undefined ? {} : { scopes }),
-    write: sourceSuggestionWrite,
+    ...(reconcileChoice === undefined ? {} : { choice: reconcileChoice }),
     yes,
   });
   validateNewSourceFlags(command, {
@@ -2472,7 +2459,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     rootPath: resolve(rootPath),
     ...(setupIncludes === undefined ? {} : { setupIncludes }),
     ...(setupTargets === undefined ? {} : { setupTargets }),
-    sourceSuggestionWrite,
+    ...(reconcileChoice === undefined ? {} : { reconcileChoice }),
     ...(testName === undefined ? {} : { testName }),
     yes,
   };
@@ -2815,27 +2802,24 @@ function validateRestoreFlags(
   }
 }
 
-function validateSuggestSourceFlags(
+function validateReconcileFlags(
   command: Command,
-  suggestion: {
+  reconcile: {
     readonly buildMode?: CompileBuildMode;
     readonly changeSince?: string;
     readonly dryRun: boolean;
     readonly scopes?: readonly BuildScope[];
-    readonly write: boolean;
+    readonly choice?: ReconcileChoice;
     readonly yes: boolean;
   }
 ): void {
-  if (suggestion.write && command !== "suggest-source") {
-    throw new Error("skillset: --write is only supported with suggest-source");
-  }
-  if (command !== "suggest-source") return;
-  if (suggestion.buildMode !== undefined) throw new Error("skillset: --updated and --all are not supported with suggest-source");
-  if (suggestion.changeSince !== undefined) throw new Error("skillset: --since is not supported with suggest-source");
-  if (suggestion.dryRun) throw new Error("skillset: --dry-run is redundant for suggest-source preview mode");
-  if (suggestion.scopes !== undefined) throw new Error("skillset: --scope is not supported with suggest-source");
-  if (suggestion.yes && !suggestion.write) throw new Error("skillset: --yes is only supported with suggest-source --write");
-  if (suggestion.write && !suggestion.yes) throw new Error("skillset: suggest-source --write requires --yes");
+  if (reconcile.choice !== undefined && command !== "reconcile") throw new Error("skillset: --use is only supported with reconcile");
+  if (command !== "reconcile") return;
+  if (reconcile.buildMode !== undefined) throw new Error("skillset: --updated and --all are not supported with reconcile");
+  if (reconcile.changeSince !== undefined) throw new Error("skillset: --since is not supported with reconcile");
+  if (reconcile.dryRun) throw new Error("skillset: --dry-run is redundant for reconcile preview mode");
+  if (reconcile.scopes !== undefined) throw new Error("skillset: --scope is not supported with reconcile");
+  if (reconcile.yes && reconcile.choice === undefined) throw new Error("skillset: reconcile --yes requires --use source or --use output");
 }
 
 function validateNewSourceFlags(

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -41,14 +41,12 @@ export async function reconcileManagedPath(
     entry.outputPath !== explanation.path &&
     entry.files?.includes(explanation.path) === true
   );
-  if (write) {
-    await assertReconcileDriftIsScoped(
-      rootPath,
-      explanation.path,
-      sourcePaths,
-      skillsetOptions
-    );
-  }
+  await assertReconcileDriftIsScoped(
+    rootPath,
+    explanation.path,
+    sourcePaths,
+    skillsetOptions
+  );
   const outputResolution = choice === "source"
     ? {
         entries: explanation.entries,

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -125,12 +125,8 @@ async function assertReconcileDriftIsScoped(
   const entries = (await listGeneratedEntries(rootPath, options)).filter((entry) =>
     sourcePaths.includes(entry.sourcePath)
   );
-  const owningEntries = entries.filter((entry) =>
-    entry.outputPath === managedPath || entry.files?.includes(managedPath) === true
-  );
   const allowedPaths = new Set([
     managedPath,
-    ...owningEntries.flatMap((entry) => [entry.outputPath, ...(entry.files ?? [])]),
     ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
   ].map(normalizeReconcilePath));
   const preview = await diffSkillsetResult(rootPath, options);

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { buildSkillsetResult, diffSkillsetResult } from "@skillset/core";
@@ -50,7 +50,7 @@ export async function reconcileManagedPath(
     choice === "source",
     skillsetOptions
   );
-  const outputResolution = choice === "source"
+  let outputResolution = choice === "source"
     ? {
         entries: explanation.entries,
         generatedPath: explanation.path,
@@ -75,7 +75,7 @@ export async function reconcileManagedPath(
     : outputExists
     ? await suggestSource(rootPath, managedPath, {
         ...skillsetOptions,
-        write: write && choice === "output",
+        write: false,
       })
     : {
         entries: explanation.entries,
@@ -91,17 +91,38 @@ export async function reconcileManagedPath(
   let backupManifestPath: string | undefined;
   let backupRunId: string | undefined;
   if (write && choice !== undefined) {
-    if (choice === "output" && !outputResolution.wrote) {
-      throw new Error(`skillset: output cannot win for ${managedPath}: ${outputResolution.message}`);
+    const applyBuild = async (): Promise<void> => {
+      const built = await buildSkillsetResult(rootPath, skillsetOptions);
+      if (!built.ok) {
+        const reason = built.diagnostics.map((diagnostic) => diagnostic.message).join("; ");
+        throw new Error(`skillset: reconcile build failed${reason.length === 0 ? "" : `: ${reason}`}`);
+      }
+      writtenPaths = built.writes.paths;
+      backupManifestPath = built.writes.backupManifestPath;
+      backupRunId = built.writes.backupRunId;
+    };
+    if (choice === "output") {
+      if (!outputResolution.wouldWrite || sourcePath === undefined) {
+        throw new Error(`skillset: output cannot win for ${managedPath}: ${outputResolution.message}`);
+      }
+      const sourceAbsolute = resolve(rootPath, sourcePath);
+      const originalSource = await readFile(sourceAbsolute, "utf8");
+      try {
+        outputResolution = await suggestSource(rootPath, managedPath, {
+          ...skillsetOptions,
+          write: true,
+        });
+        if (!outputResolution.wrote) {
+          throw new Error(`skillset: output cannot win for ${managedPath}: ${outputResolution.message}`);
+        }
+        await applyBuild();
+      } catch (error) {
+        await writeFile(sourceAbsolute, originalSource, "utf8");
+        throw error;
+      }
+    } else {
+      await applyBuild();
     }
-    const built = await buildSkillsetResult(rootPath, skillsetOptions);
-    if (!built.ok) {
-      const reason = built.diagnostics.map((diagnostic) => diagnostic.message).join("; ");
-      throw new Error(`skillset: reconcile build failed${reason.length === 0 ? "" : `: ${reason}`}`);
-    }
-    writtenPaths = built.writes.paths;
-    backupManifestPath = built.writes.backupManifestPath;
-    backupRunId = built.writes.backupRunId;
   }
 
   return {

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -36,6 +36,11 @@ export async function reconcileManagedPath(
   const outputExists = await stat(resolve(rootPath, explanation.path)).then(() => true, () => false);
   const sourcePaths = [...new Set(explanation.entries.map((entry) => entry.sourcePath))];
   const sourcePath = sourcePaths.length === 1 ? sourcePaths[0] : undefined;
+  const auxiliarySkillOutput = explanation.entries.some((entry) =>
+    (entry.kind === "standalone-skill" || entry.kind === "plugin-skill") &&
+    entry.outputPath !== explanation.path &&
+    entry.files?.includes(explanation.path) === true
+  );
   if (write) {
     await assertReconcileDriftIsScoped(
       rootPath,
@@ -50,6 +55,17 @@ export async function reconcileManagedPath(
         generatedPath: explanation.path,
         message: "Source selected; output reverse-patch analysis was skipped.",
         nextSteps: ["Rebuild the managed output from its source."],
+        ...(sourcePath === undefined ? {} : { sourcePath }),
+        status: "refused" as const,
+        wouldWrite: false,
+        wrote: false,
+      }
+    : outputExists && auxiliarySkillOutput
+    ? {
+        entries: explanation.entries,
+        generatedPath: explanation.path,
+        message: "Auxiliary skill outputs cannot replace the owning SKILL.md source body.",
+        nextSteps: ["Update the auxiliary source resource directly, or use source resolution to restore its generated copy."],
         ...(sourcePath === undefined ? {} : { sourcePath }),
         status: "refused" as const,
         wouldWrite: false,

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -1,3 +1,6 @@
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+
 import { buildSkillsetResult } from "@skillset/core";
 import { explainPath, suggestSource, type SourceSuggestionReport } from "@skillset/core/internal/authoring";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
@@ -25,10 +28,24 @@ export async function reconcileManagedPath(
     throw new Error(`skillset: reconcile requires a managed generated path; ${managedPath} has no generated owner`);
   }
 
-  const outputResolution = await suggestSource(rootPath, managedPath, {
-    ...skillsetOptions,
-    write: write && choice === "output",
-  });
+  const outputExists = await stat(resolve(rootPath, explanation.path)).then(() => true, () => false);
+  const sourcePaths = [...new Set(explanation.entries.map((entry) => entry.sourcePath))];
+  const sourcePath = sourcePaths.length === 1 ? sourcePaths[0] : undefined;
+  const outputResolution = outputExists
+    ? await suggestSource(rootPath, managedPath, {
+        ...skillsetOptions,
+        write: write && choice === "output",
+      })
+    : {
+        entries: explanation.entries,
+        generatedPath: explanation.path,
+        message: "Generated output is missing; output cannot win.",
+        nextSteps: ["Use source resolution to rebuild the missing managed output."],
+        ...(sourcePath === undefined ? {} : { sourcePath }),
+        status: "refused" as const,
+        wouldWrite: false,
+        wrote: false,
+      };
   let writtenPaths: readonly string[] = [];
   if (write && choice !== undefined) {
     if (choice === "output" && !outputResolution.wrote) {
@@ -47,7 +64,7 @@ export async function reconcileManagedPath(
     ...(choice === undefined ? {} : { choice }),
     generatedPath: explanation.path,
     outputResolution,
-    ...(outputResolution.sourcePath === undefined ? {} : { sourcePath: outputResolution.sourcePath }),
+    ...(sourcePath === undefined ? {} : { sourcePath }),
     sourceResolutionAvailable: true,
     writtenPaths,
   };

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -336,7 +336,7 @@ export function renderReconcileReport(report: ReconcileReport): string {
   ];
   if (report.applied) {
     lines.push(`skillset: reconciled using ${report.choice} (${report.writtenPaths.length} generated file${report.writtenPaths.length === 1 ? "" : "s"} refreshed)`);
-    if (report.backupRunId !== undefined) {
+    if (report.choice === "source" && report.backupRunId !== undefined) {
       lines.push(`  recovery: skillset restore ${report.backupRunId} --yes`);
     }
   } else if (report.choice === "source") {

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -1,0 +1,72 @@
+import { buildSkillsetResult } from "@skillset/core";
+import { explainPath, suggestSource, type SourceSuggestionReport } from "@skillset/core/internal/authoring";
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+export type ReconcileChoice = "output" | "source";
+
+export interface ReconcileReport {
+  readonly applied: boolean;
+  readonly choice?: ReconcileChoice;
+  readonly generatedPath: string;
+  readonly outputResolution: SourceSuggestionReport;
+  readonly sourcePath?: string;
+  readonly sourceResolutionAvailable: boolean;
+  readonly writtenPaths: readonly string[];
+}
+
+export async function reconcileManagedPath(
+  rootPath: string,
+  managedPath: string,
+  options: SkillsetOptions & { readonly choice?: ReconcileChoice; readonly write?: boolean } = {}
+): Promise<ReconcileReport> {
+  const { choice, write = false, ...skillsetOptions } = options;
+  const explanation = await explainPath(rootPath, managedPath, skillsetOptions);
+  if (explanation.kind !== "generated" || explanation.entries.length === 0) {
+    throw new Error(`skillset: reconcile requires a managed generated path; ${managedPath} has no generated owner`);
+  }
+
+  const outputResolution = await suggestSource(rootPath, managedPath, {
+    ...skillsetOptions,
+    write: write && choice === "output",
+  });
+  let writtenPaths: readonly string[] = [];
+  if (write && choice !== undefined) {
+    if (choice === "output" && !outputResolution.wrote) {
+      throw new Error(`skillset: output cannot win for ${managedPath}: ${outputResolution.message}`);
+    }
+    const built = await buildSkillsetResult(rootPath, skillsetOptions);
+    if (!built.ok) {
+      const reason = built.diagnostics.map((diagnostic) => diagnostic.message).join("; ");
+      throw new Error(`skillset: reconcile build failed${reason.length === 0 ? "" : `: ${reason}`}`);
+    }
+    writtenPaths = built.writes.paths;
+  }
+
+  return {
+    applied: write && choice !== undefined,
+    ...(choice === undefined ? {} : { choice }),
+    generatedPath: explanation.path,
+    outputResolution,
+    ...(outputResolution.sourcePath === undefined ? {} : { sourcePath: outputResolution.sourcePath }),
+    sourceResolutionAvailable: true,
+    writtenPaths,
+  };
+}
+
+export function renderReconcileReport(report: ReconcileReport): string {
+  const lines = [
+    `skillset: reconcile ${report.generatedPath}`,
+    `  source: ${report.sourcePath ?? "unknown"}`,
+    "  source wins: available; re-render managed output from source",
+    `  output wins: ${report.outputResolution.wouldWrite ? "available" : "refused"}; ${report.outputResolution.message}`,
+  ];
+  if (report.applied) {
+    lines.push(`skillset: reconciled using ${report.choice} (${report.writtenPaths.length} generated file${report.writtenPaths.length === 1 ? "" : "s"} refreshed)`);
+  } else if (report.choice !== undefined) {
+    lines.push(`skillset: preview only; rerun with --use ${report.choice} --yes to apply`);
+  } else {
+    lines.push("skillset: choose --use source or --use output, then pass --yes to apply");
+  }
+  for (const step of report.outputResolution.nextSteps) lines.push(`  output next: ${step}`);
+  return `${lines.join("\n")}\n`;
+}

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -1,5 +1,5 @@
 import { readFile, stat, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { buildSkillsetResult, diffSkillsetResult } from "@skillset/core";
 import {
@@ -9,6 +9,7 @@ import {
   type SourceSuggestionReport,
 } from "@skillset/core/internal/authoring";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
+import type { GeneratedEntry } from "@skillset/core/internal/types";
 
 export type ReconcileChoice = "output" | "source";
 
@@ -31,29 +32,35 @@ export async function reconcileManagedPath(
 ): Promise<ReconcileReport> {
   const { choice, write = false, ...skillsetOptions } = options;
   const explanation = await explainPath(rootPath, managedPath, skillsetOptions);
-  if (explanation.kind !== "generated" || explanation.entries.length === 0) {
+  const liveEntry = explanation.kind === "generated" && explanation.entries.length > 0
+    ? undefined
+    : await findLiveLockEntry(rootPath, managedPath);
+  const generatedPath = liveEntry?.generatedPath ?? explanation.path;
+  const ownershipEntries = liveEntry === undefined ? explanation.entries : [liveEntry.entry];
+  if (ownershipEntries.length === 0) {
     throw new Error(`skillset: reconcile requires a managed generated path; ${managedPath} has no generated owner`);
   }
 
-  const outputExists = await stat(resolve(rootPath, explanation.path)).then(() => true, () => false);
-  const sourcePaths = [...new Set(explanation.entries.map((entry) => entry.sourcePath))];
+  const outputExists = await stat(resolve(rootPath, generatedPath)).then(() => true, () => false);
+  const sourcePaths = [...new Set(ownershipEntries.map((entry) => entry.sourcePath))];
   const sourcePath = sourcePaths.length === 1 ? sourcePaths[0] : undefined;
-  const auxiliarySkillOutput = explanation.entries.some((entry) =>
+  const auxiliarySkillOutput = ownershipEntries.some((entry) =>
     (entry.kind === "standalone-skill" || entry.kind === "plugin-skill") &&
-    entry.outputPath !== explanation.path &&
-    entry.files?.includes(explanation.path) === true
+    entry.outputPath !== generatedPath &&
+    entry.files?.includes(generatedPath) === true
   );
   await assertReconcileDriftIsScoped(
     rootPath,
-    explanation.path,
+    generatedPath,
     sourcePaths,
     choice === "source",
-    skillsetOptions
+    skillsetOptions,
+    ownershipEntries
   );
   let outputResolution = choice === "source"
     ? {
-        entries: explanation.entries,
-        generatedPath: explanation.path,
+        entries: ownershipEntries,
+        generatedPath,
         message: "Source selected; output reverse-patch analysis was skipped.",
         nextSteps: ["Rebuild the managed output from its source."],
         ...(sourcePath === undefined ? {} : { sourcePath }),
@@ -63,8 +70,8 @@ export async function reconcileManagedPath(
       }
     : outputExists && auxiliarySkillOutput
     ? {
-        entries: explanation.entries,
-        generatedPath: explanation.path,
+        entries: ownershipEntries,
+        generatedPath,
         message: "Auxiliary skill outputs cannot replace the owning SKILL.md source body.",
         nextSteps: ["Update the auxiliary source resource directly, or use source resolution to restore its generated copy."],
         ...(sourcePath === undefined ? {} : { sourcePath }),
@@ -78,8 +85,8 @@ export async function reconcileManagedPath(
         write: false,
       })
     : {
-        entries: explanation.entries,
-        generatedPath: explanation.path,
+        entries: ownershipEntries,
+        generatedPath,
         message: "Generated output is missing; output cannot win.",
         nextSteps: ["Use source resolution to rebuild the missing managed output."],
         ...(sourcePath === undefined ? {} : { sourcePath }),
@@ -123,6 +130,7 @@ export async function reconcileManagedPath(
     } else {
       await applyBuild();
     }
+    outputResolution = { ...outputResolution, nextSteps: [] };
   }
 
   return {
@@ -130,7 +138,7 @@ export async function reconcileManagedPath(
     ...(backupManifestPath === undefined ? {} : { backupManifestPath }),
     ...(backupRunId === undefined ? {} : { backupRunId }),
     ...(choice === undefined ? {} : { choice }),
-    generatedPath: explanation.path,
+    generatedPath,
     outputResolution,
     ...(sourcePath === undefined ? {} : { sourcePath }),
     sourceResolutionAvailable: true,
@@ -143,10 +151,31 @@ async function assertReconcileDriftIsScoped(
   managedPath: string,
   sourcePaths: readonly string[],
   allowSourceSiblings: boolean,
-  options: SkillsetOptions
+  options: SkillsetOptions,
+  ownershipEntries: readonly GeneratedEntry[]
 ): Promise<void> {
-  const entries = (await listGeneratedEntries(rootPath, options)).filter((entry) =>
-    sourcePaths.includes(entry.sourcePath)
+  const preview = await diffSkillsetResult(rootPath, options);
+  const driftPaths = [
+    ...preview.data.added,
+    ...preview.data.changed,
+    ...preview.data.missing,
+    ...preview.data.removed,
+  ];
+  const liveSiblingEntries = (await Promise.all(
+    driftPaths.map((path) => findLiveLockEntry(rootPath, path))
+  )).flatMap((match) =>
+    match !== undefined && sourcePaths.includes(match.entry.sourcePath) ? [match.entry] : []
+  );
+  const entries = [
+    ...(await listGeneratedEntries(rootPath, options)).filter((entry) =>
+      sourcePaths.includes(entry.sourcePath)
+    ),
+    ...ownershipEntries,
+    ...liveSiblingEntries,
+  ].filter((entry, index, all) =>
+    all.findIndex((candidate) =>
+      candidate.outputRoot === entry.outputRoot && candidate.outputPath === entry.outputPath
+    ) === index
   );
   const lockedSiblingPaths = allowSourceSiblings
     ? await listLockedSiblingPaths(rootPath, entries, sourcePaths)
@@ -159,19 +188,72 @@ async function assertReconcileDriftIsScoped(
     ...lockedSiblingPaths,
     ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
   ].map(normalizeReconcilePath));
-  const preview = await diffSkillsetResult(rootPath, options);
-  const driftPaths = [
-    ...preview.data.added,
-    ...preview.data.changed,
-    ...preview.data.missing,
-    ...preview.data.removed,
-  ];
   const unrelated = driftPaths.filter((path) => !allowedPaths.has(normalizeReconcilePath(path)));
   if (unrelated.length > 0) {
     throw new Error(
       `skillset: reconcile ${managedPath} refuses to write while unrelated generated drift exists: ${unrelated.join(", ")}`
     );
   }
+}
+
+async function findLiveLockEntry(
+  rootPath: string,
+  managedPath: string
+): Promise<{ readonly entry: GeneratedEntry; readonly generatedPath: string } | undefined> {
+  const generatedPath = normalizeManagedPath(rootPath, managedPath);
+  for (const lockPath of lockCandidates(generatedPath)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(resolve(rootPath, lockPath), "utf8")) as unknown;
+    } catch {
+      continue;
+    }
+    if (!isRecord(parsed) || typeof parsed.outputRoot !== "string" || !Array.isArray(parsed.items)) continue;
+    const outputRoot = normalizeReconcilePath(parsed.outputRoot);
+    for (const item of parsed.items) {
+      if (!isRecord(item) || typeof item.outputPath !== "string" || typeof item.sourcePath !== "string") continue;
+      const files = Array.isArray(item.files)
+        ? item.files.filter((file): file is string => typeof file === "string")
+        : [];
+      const ownedPaths = [item.outputPath, ...files].map((path) =>
+        normalizeReconcilePath(outputRoot === "." ? path : join(outputRoot, path))
+      );
+      if (!ownedPaths.includes(generatedPath)) continue;
+      return {
+        entry: {
+          files: ownedPaths,
+          ...(typeof item.kind === "string" ? { kind: item.kind } : {}),
+          outputPath: normalizeReconcilePath(outputRoot === "." ? item.outputPath : join(outputRoot, item.outputPath)),
+          outputRoot,
+          sourcePath: item.sourcePath,
+          target: "live-lock",
+        },
+        generatedPath,
+      };
+    }
+  }
+  return undefined;
+}
+
+function lockCandidates(outputPath: string): readonly string[] {
+  const candidates: string[] = [];
+  let current = dirname(outputPath);
+  while (current !== "." && current !== "") {
+    candidates.push(`${current}/skillset.lock`);
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  candidates.push("skillset.lock");
+  return candidates;
+}
+
+function normalizeManagedPath(rootPath: string, path: string): string {
+  const normalized = normalizeReconcilePath(relative(resolve(rootPath), resolve(rootPath, path)));
+  if (normalized === "" || normalized.startsWith("../") || isAbsolute(normalized)) {
+    throw new Error(`skillset: reconcile path escapes root: ${path}`);
+  }
+  return normalized;
 }
 
 async function listLockedSiblingPaths(

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -53,7 +53,7 @@ export async function reconcileManagedPath(
     rootPath,
     generatedPath,
     sourcePaths,
-    choice === "source",
+    choice !== "output",
     skillsetOptions,
     ownershipEntries
   );

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -344,7 +344,9 @@ export function renderReconcileReport(report: ReconcileReport): string {
   } else if (report.outputResolution.wouldWrite) {
     lines.push("skillset: preview only; rerun with --use output --yes to apply");
   } else {
-    lines.push("skillset: choose --use source or --use output, then pass --yes to apply");
+    lines.push(
+      "skillset: preview only; rerun with --use source --yes to apply, or address the output refusal manually"
+    );
   }
   for (const step of report.outputResolution.nextSteps) lines.push(`  output next: ${step}`);
   return `${lines.join("\n")}\n`;

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -14,6 +14,8 @@ export type ReconcileChoice = "output" | "source";
 
 export interface ReconcileReport {
   readonly applied: boolean;
+  readonly backupManifestPath?: string;
+  readonly backupRunId?: string;
   readonly choice?: ReconcileChoice;
   readonly generatedPath: string;
   readonly outputResolution: SourceSuggestionReport;
@@ -85,6 +87,8 @@ export async function reconcileManagedPath(
         wrote: false,
       };
   let writtenPaths: readonly string[] = [];
+  let backupManifestPath: string | undefined;
+  let backupRunId: string | undefined;
   if (write && choice !== undefined) {
     if (choice === "output" && !outputResolution.wrote) {
       throw new Error(`skillset: output cannot win for ${managedPath}: ${outputResolution.message}`);
@@ -95,10 +99,14 @@ export async function reconcileManagedPath(
       throw new Error(`skillset: reconcile build failed${reason.length === 0 ? "" : `: ${reason}`}`);
     }
     writtenPaths = built.writes.paths;
+    backupManifestPath = built.writes.backupManifestPath;
+    backupRunId = built.writes.backupRunId;
   }
 
   return {
     applied: write && choice !== undefined,
+    ...(backupManifestPath === undefined ? {} : { backupManifestPath }),
+    ...(backupRunId === undefined ? {} : { backupRunId }),
     ...(choice === undefined ? {} : { choice }),
     generatedPath: explanation.path,
     outputResolution,
@@ -149,6 +157,9 @@ export function renderReconcileReport(report: ReconcileReport): string {
   ];
   if (report.applied) {
     lines.push(`skillset: reconciled using ${report.choice} (${report.writtenPaths.length} generated file${report.writtenPaths.length === 1 ? "" : "s"} refreshed)`);
+    if (report.backupRunId !== undefined) {
+      lines.push(`  recovery: skillset restore ${report.backupRunId} --yes`);
+    }
   } else if (report.choice !== undefined) {
     lines.push(`skillset: preview only; rerun with --use ${report.choice} --yes to apply`);
   } else {

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -47,6 +47,7 @@ export async function reconcileManagedPath(
     rootPath,
     explanation.path,
     sourcePaths,
+    choice === "source",
     skillsetOptions
   );
   const outputResolution = choice === "source"
@@ -120,6 +121,7 @@ async function assertReconcileDriftIsScoped(
   rootPath: string,
   managedPath: string,
   sourcePaths: readonly string[],
+  allowSourceSiblings: boolean,
   options: SkillsetOptions
 ): Promise<void> {
   const entries = (await listGeneratedEntries(rootPath, options)).filter((entry) =>
@@ -127,6 +129,9 @@ async function assertReconcileDriftIsScoped(
   );
   const allowedPaths = new Set([
     managedPath,
+    ...(allowSourceSiblings
+      ? entries.flatMap((entry) => [entry.outputPath, ...(entry.files ?? [])])
+      : []),
     ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
   ].map(normalizeReconcilePath));
   const preview = await diffSkillsetResult(rootPath, options);

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -32,6 +32,9 @@ export async function reconcileManagedPath(
 ): Promise<ReconcileReport> {
   const { choice, write = false, ...skillsetOptions } = options;
   const explanation = await explainPath(rootPath, managedPath, skillsetOptions);
+  if (explanation.kind.startsWith("source-")) {
+    throw new Error(`skillset: reconcile requires a managed generated path; ${managedPath} is source`);
+  }
   const liveEntry = explanation.kind === "generated" && explanation.entries.length > 0
     ? undefined
     : await findLiveLockEntry(rootPath, managedPath);

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -35,7 +35,10 @@ export async function reconcileManagedPath(
   const liveEntry = explanation.kind === "generated" && explanation.entries.length > 0
     ? undefined
     : await findLiveLockEntry(rootPath, managedPath);
-  const generatedPath = liveEntry?.generatedPath ?? explanation.path;
+  const generatedPath = normalizeManagedPath(
+    rootPath,
+    liveEntry?.generatedPath ?? explanation.path
+  );
   const ownershipEntries = liveEntry === undefined ? explanation.entries : [liveEntry.entry];
   if (ownershipEntries.length === 0) {
     throw new Error(`skillset: reconcile requires a managed generated path; ${managedPath} has no generated owner`);
@@ -57,12 +60,32 @@ export async function reconcileManagedPath(
     skillsetOptions,
     ownershipEntries
   );
+  const outputScopeError = choice === undefined
+    ? await readReconcileScopeError(
+        rootPath,
+        generatedPath,
+        sourcePaths,
+        skillsetOptions,
+        ownershipEntries
+      )
+    : undefined;
   let outputResolution = choice === "source"
     ? {
         entries: ownershipEntries,
         generatedPath,
         message: "Source selected; output reverse-patch analysis was skipped.",
         nextSteps: ["Rebuild the managed output from its source."],
+        ...(sourcePath === undefined ? {} : { sourcePath }),
+        status: "refused" as const,
+        wouldWrite: false,
+        wrote: false,
+      }
+    : outputScopeError !== undefined
+    ? {
+        entries: ownershipEntries,
+        generatedPath,
+        message: outputScopeError,
+        nextSteps: ["Resolve sibling generated drift before letting this output replace its source."],
         ...(sourcePath === undefined ? {} : { sourcePath }),
         status: "refused" as const,
         wouldWrite: false,
@@ -144,6 +167,28 @@ export async function reconcileManagedPath(
     sourceResolutionAvailable: true,
     writtenPaths,
   };
+}
+
+async function readReconcileScopeError(
+  rootPath: string,
+  managedPath: string,
+  sourcePaths: readonly string[],
+  options: SkillsetOptions,
+  ownershipEntries: readonly GeneratedEntry[]
+): Promise<string | undefined> {
+  try {
+    await assertReconcileDriftIsScoped(
+      rootPath,
+      managedPath,
+      sourcePaths,
+      false,
+      options,
+      ownershipEntries
+    );
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
 }
 
 async function assertReconcileDriftIsScoped(

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -148,11 +148,15 @@ async function assertReconcileDriftIsScoped(
   const entries = (await listGeneratedEntries(rootPath, options)).filter((entry) =>
     sourcePaths.includes(entry.sourcePath)
   );
+  const lockedSiblingPaths = allowSourceSiblings
+    ? await listLockedSiblingPaths(rootPath, entries, sourcePaths)
+    : [];
   const allowedPaths = new Set([
     managedPath,
     ...(allowSourceSiblings
       ? entries.flatMap((entry) => [entry.outputPath, ...(entry.files ?? [])])
       : []),
+    ...lockedSiblingPaths,
     ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
   ].map(normalizeReconcilePath));
   const preview = await diffSkillsetResult(rootPath, options);
@@ -168,6 +172,32 @@ async function assertReconcileDriftIsScoped(
       `skillset: reconcile ${managedPath} refuses to write while unrelated generated drift exists: ${unrelated.join(", ")}`
     );
   }
+}
+
+async function listLockedSiblingPaths(
+  rootPath: string,
+  entries: readonly { readonly outputRoot: string }[],
+  sourcePaths: readonly string[]
+): Promise<readonly string[]> {
+  const siblings = new Set<string>();
+  for (const outputRoot of new Set(entries.map((entry) => entry.outputRoot))) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(resolve(rootPath, outputRoot, "skillset.lock"), "utf8")) as unknown;
+    } catch {
+      continue;
+    }
+    if (!isRecord(parsed) || !Array.isArray(parsed.items)) continue;
+    for (const item of parsed.items) {
+      if (!isRecord(item) || !sourcePaths.includes(readString(item.sourcePath))) continue;
+      if (typeof item.outputPath === "string") siblings.add(join(outputRoot, item.outputPath));
+      if (!Array.isArray(item.files)) continue;
+      for (const file of item.files) {
+        if (typeof file === "string") siblings.add(join(outputRoot, file));
+      }
+    }
+  }
+  return [...siblings].sort();
 }
 
 export function renderReconcileReport(report: ReconcileReport): string {
@@ -195,4 +225,12 @@ export function renderReconcileReport(report: ReconcileReport): string {
 
 function normalizeReconcilePath(path: string): string {
   return path.replaceAll("\\", "/");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -39,7 +39,7 @@ export async function reconcileManagedPath(
   if (write) {
     await assertReconcileDriftIsScoped(
       rootPath,
-      managedPath,
+      explanation.path,
       sourcePaths,
       skillsetOptions
     );

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -132,7 +132,7 @@ async function assertReconcileDriftIsScoped(
     managedPath,
     ...owningEntries.flatMap((entry) => [entry.outputPath, ...(entry.files ?? [])]),
     ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
-  ]);
+  ].map(normalizeReconcilePath));
   const preview = await diffSkillsetResult(rootPath, options);
   const driftPaths = [
     ...preview.data.added,
@@ -140,7 +140,7 @@ async function assertReconcileDriftIsScoped(
     ...preview.data.missing,
     ...preview.data.removed,
   ];
-  const unrelated = driftPaths.filter((path) => !allowedPaths.has(path));
+  const unrelated = driftPaths.filter((path) => !allowedPaths.has(normalizeReconcilePath(path)));
   if (unrelated.length > 0) {
     throw new Error(
       `skillset: reconcile ${managedPath} refuses to write while unrelated generated drift exists: ${unrelated.join(", ")}`
@@ -160,11 +160,17 @@ export function renderReconcileReport(report: ReconcileReport): string {
     if (report.backupRunId !== undefined) {
       lines.push(`  recovery: skillset restore ${report.backupRunId} --yes`);
     }
-  } else if (report.choice === "source" || report.outputResolution.wouldWrite) {
-    lines.push(`skillset: preview only; rerun with --use ${report.choice} --yes to apply`);
+  } else if (report.choice === "source") {
+    lines.push("skillset: preview only; rerun with --use source --yes to apply");
+  } else if (report.outputResolution.wouldWrite) {
+    lines.push("skillset: preview only; rerun with --use output --yes to apply");
   } else {
     lines.push("skillset: choose --use source or --use output, then pass --yes to apply");
   }
   for (const step of report.outputResolution.nextSteps) lines.push(`  output next: ${step}`);
   return `${lines.join("\n")}\n`;
+}
+
+function normalizeReconcilePath(path: string): string {
+  return path.replaceAll("\\", "/");
 }

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -107,7 +107,7 @@ async function assertReconcileDriftIsScoped(
     entry.outputPath === managedPath || entry.files?.includes(managedPath) === true
   );
   const allowedPaths = new Set([
-    ...entries.map((entry) => entry.outputPath),
+    managedPath,
     ...owningEntries.flatMap((entry) => [entry.outputPath, ...(entry.files ?? [])]),
     ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
   ]);

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -1,8 +1,13 @@
 import { stat } from "node:fs/promises";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 
-import { buildSkillsetResult } from "@skillset/core";
-import { explainPath, suggestSource, type SourceSuggestionReport } from "@skillset/core/internal/authoring";
+import { buildSkillsetResult, diffSkillsetResult } from "@skillset/core";
+import {
+  explainPath,
+  listGeneratedEntries,
+  suggestSource,
+  type SourceSuggestionReport,
+} from "@skillset/core/internal/authoring";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
 
 export type ReconcileChoice = "output" | "source";
@@ -31,7 +36,26 @@ export async function reconcileManagedPath(
   const outputExists = await stat(resolve(rootPath, explanation.path)).then(() => true, () => false);
   const sourcePaths = [...new Set(explanation.entries.map((entry) => entry.sourcePath))];
   const sourcePath = sourcePaths.length === 1 ? sourcePaths[0] : undefined;
-  const outputResolution = outputExists
+  if (write) {
+    await assertReconcileDriftIsScoped(
+      rootPath,
+      managedPath,
+      sourcePaths,
+      skillsetOptions
+    );
+  }
+  const outputResolution = choice === "source"
+    ? {
+        entries: explanation.entries,
+        generatedPath: explanation.path,
+        message: "Source selected; output reverse-patch analysis was skipped.",
+        nextSteps: ["Rebuild the managed output from its source."],
+        ...(sourcePath === undefined ? {} : { sourcePath }),
+        status: "refused" as const,
+        wouldWrite: false,
+        wrote: false,
+      }
+    : outputExists
     ? await suggestSource(rootPath, managedPath, {
         ...skillsetOptions,
         write: write && choice === "output",
@@ -68,6 +92,38 @@ export async function reconcileManagedPath(
     sourceResolutionAvailable: true,
     writtenPaths,
   };
+}
+
+async function assertReconcileDriftIsScoped(
+  rootPath: string,
+  managedPath: string,
+  sourcePaths: readonly string[],
+  options: SkillsetOptions
+): Promise<void> {
+  const entries = (await listGeneratedEntries(rootPath, options)).filter((entry) =>
+    sourcePaths.includes(entry.sourcePath)
+  );
+  const owningEntries = entries.filter((entry) =>
+    entry.outputPath === managedPath || entry.files?.includes(managedPath) === true
+  );
+  const allowedPaths = new Set([
+    ...entries.map((entry) => entry.outputPath),
+    ...owningEntries.flatMap((entry) => [entry.outputPath, ...(entry.files ?? [])]),
+    ...entries.map((entry) => join(entry.outputRoot, "skillset.lock")),
+  ]);
+  const preview = await diffSkillsetResult(rootPath, options);
+  const driftPaths = [
+    ...preview.data.added,
+    ...preview.data.changed,
+    ...preview.data.missing,
+    ...preview.data.removed,
+  ];
+  const unrelated = driftPaths.filter((path) => !allowedPaths.has(path));
+  if (unrelated.length > 0) {
+    throw new Error(
+      `skillset: reconcile ${managedPath} refuses to write while unrelated generated drift exists: ${unrelated.join(", ")}`
+    );
+  }
 }
 
 export function renderReconcileReport(report: ReconcileReport): string {

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -56,11 +56,11 @@ export async function reconcileManagedPath(
     rootPath,
     generatedPath,
     sourcePaths,
-    choice !== "output",
+    choice !== "output" || !write,
     skillsetOptions,
     ownershipEntries
   );
-  const outputScopeError = choice === undefined
+  const outputScopeError = choice === undefined || (choice === "output" && !write)
     ? await readReconcileScopeError(
         rootPath,
         generatedPath,

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -160,7 +160,7 @@ export function renderReconcileReport(report: ReconcileReport): string {
     if (report.backupRunId !== undefined) {
       lines.push(`  recovery: skillset restore ${report.backupRunId} --yes`);
     }
-  } else if (report.choice !== undefined) {
+  } else if (report.choice === "source" || report.outputResolution.wouldWrite) {
     lines.push(`skillset: preview only; rerun with --use ${report.choice} --yes to apply`);
   } else {
     lines.push("skillset: choose --use source or --use output, then pass --yes to apply");

--- a/docs/features/ci.md
+++ b/docs/features/ci.md
@@ -24,7 +24,7 @@ Skillset uses two separate change ledgers. `.skillset/changes/` records source-u
 
 Generated entity `CHANGELOG.md` files are managed projections. When one has been edited directly, `--fix` refuses to overwrite it and the report points to `skillset change reason <@ref>`, `skillset change amend <@ref>`, or `skillset release amend <@ref>` as appropriate.
 
-For added or changed generated paths, CI also runs the same read-only classification used by `skillset suggest-source`. Reports include the generated path, owning source path when known, whether the edit is suggestible or refused, and the next manual command. CI does not perform source writeback in v1; contributors accept clean suggestions locally with `skillset suggest-source <path> --write --yes`, then rebuild generated output and add the required change entry.
+For added or changed generated paths, CI runs the same read-only ownership and safety classification used by `skillset reconcile`. Reports include the generated path, owning source path when known, whether output-wins is available or refused, and the next manual command. CI never chooses a conflict direction automatically.
 
 [Source Suggestions](source-suggestions.md) is the future recovery path for managed generated-output edits that should become source changes. CI writeback remains future-only until the local suggestion command can classify clean source patches, refusal cases, and stale lock/conflict risks.
 

--- a/docs/features/source-suggestions.md
+++ b/docs/features/source-suggestions.md
@@ -4,7 +4,7 @@ Feature id: `source-suggestions`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)
 
-Source suggestions are the recovery workflow for managed generated-output edits. They help a contributor who changed a file recorded in `skillset.lock` understand which source unit owns that file, whether the edit can be safely moved back to source, and what command or manual action should happen next. The v1 local command is diagnostics-first and only writes clean generated skill Markdown body edits when explicitly confirmed.
+Reconciliation are the recovery workflow for managed generated-output edits. They help a contributor who changed a file recorded in `skillset.lock` understand which source unit owns that file, whether the edit can be safely moved back to source, and what command or manual action should happen next. The v1 local command is diagnostics-first and only writes clean generated skill Markdown body edits when explicitly confirmed.
 
 ## Source Shape
 
@@ -13,19 +13,19 @@ There is no author-facing source key in v1. The source of truth remains the exis
 The intended local command shape is:
 
 ```bash
-skillset suggest-source <generated-path>
-skillset suggest-source <generated-path> --write --yes
+skillset reconcile <generated-path>
+skillset reconcile <generated-path> --use output --yes
 ```
 
-Preview mode is read-only. Write mode is allowed only for clean, single-source cases where the generated Markdown body can be mapped back to one source path without losing meaning, and it requires `--write --yes`. The command reuses `skillset.lock` ownership and `skillset explain` provenance so "which source owns this generated file?" has one answer across the CLI.
+Preview mode is read-only. Write mode is allowed only for clean, single-source cases where the generated Markdown body can be mapped back to one source path without losing meaning, and it requires `--use output --yes`. The command reuses `skillset.lock` ownership and `skillset explain` provenance so "which source owns this generated file?" has one answer across the CLI.
 
 ## Target Support
 
 | Case | Behavior | Status |
 | --- | --- | --- |
-| Managed generated skill body edit | Preview source `SKILL.md` body replacement, optionally write with `--write --yes` when clean | `implemented` |
+| Managed generated skill body edit | Preview source `SKILL.md` body replacement, optionally write with `--use output --yes` when clean | `implemented` |
 | Pending changelog wording before release | Do not reverse-patch from generated output; point to `skillset change reason <@ref>` because pending entries are not rendered into committed changelogs | `implemented` |
-| Generated changelog edit after release | Refuse source suggestion and point to `skillset change amend` for applied-history wording or `skillset release amend` for release-event metadata | `implemented` |
+| Generated changelog edit after release | Refuse reconciliation and point to `skillset change amend` for applied-history wording or `skillset release amend` for release-event metadata | `implemented` |
 | Generated metadata, lock files, manifests, or version fields | Refuse; source ownership is not a safe text patch | `planned` |
 | Output from partials, shared resources, or multiple source files | Refuse with diagnostics until a richer mapping exists | `implemented` |
 | Provider-native output with no adaptive round trip | Refuse and explain the provider-specific source or manual path | `planned` |
@@ -45,28 +45,28 @@ The first implementation should make diagnostics useful before attempting writes
 
 ## Provenance
 
-Source suggestions should not create a second source of truth. Accepted source suggestions change the real source file or pending reason, then normal build/release machinery updates generated outputs and locks and `skillset check --only outputs` checks the result.
+Reconciliation should not create a second source of truth. Accepted reconciliation changes the real source file or pending reason, then normal build/release machinery updates generated outputs and locks and `skillset check --only outputs` checks the result.
 
 When CI suggestions arrive later, they should record enough evidence to avoid noisy repeat comments: suggestion id, generated path, owning source path, lock hash or source hash reviewed, suggested action, accepted/rejected/skipped status, and whether a writeback commit was attempted. That evidence belongs to suggestion workflow state, not generated target files.
 
 ## Relationship To Settings Suggestions
 
-Source suggestions and reviewed settings suggestions solve different problems:
+Reconciliation and reviewed settings suggestions solve different problems:
 
-- Source suggestions recover edits made to files Skillset already owns as generated output.
+- Reconciliation recover edits made to files Skillset already owns as generated output.
 - Settings suggestions propose changes to live runtime configuration that Skillset intentionally does not own or mutate during build.
 
-Both need reviewable previews, stable ids, conflict checks, and refusal paths, but they must stay separate. A source suggestion should never mutate `~/.claude`, `~/.codex`, trust settings, marketplace activation, or project runtime settings. A settings suggestion should never pretend a generated output edit can be recovered into adaptive source.
+Both need reviewable previews, stable ids, conflict checks, and refusal paths, but they must stay separate. A reconciliation should never mutate `~/.claude`, `~/.codex`, trust settings, marketplace activation, or project runtime settings. A settings suggestion should never pretend a generated output edit can be recovered into adaptive source.
 
 ## CI Path
 
-[SET-152](https://linear.app/outfitter/issue/SET-152/design-ci-source-suggestion-writeback-for-managed-generated-edits) adds CI-side source suggestion diagnostics and keeps automated writeback as a future permissioned step. The intended path is:
+[SET-152](https://linear.app/outfitter/issue/SET-152/design-ci-source-suggestion-writeback-for-managed-generated-edits) adds CI-side reconciliation diagnostics and keeps automated writeback as a future permissioned step. The intended path is:
 
 1. `skillset check --ci` detects a PR edit to a managed generated path.
 2. CI resolves the owning source unit from `skillset.lock`.
-3. CI runs the same safety classification as `skillset suggest-source` for added and changed generated paths.
+3. CI runs the same safety classification as `skillset reconcile` for added and changed generated paths.
 4. For unsafe or ambiguous cases, CI reports the source path, reason for refusal, and manual command in the job summary or PR comment.
-5. For clean cases, CI reports the suggested source path and local `skillset suggest-source <path> --write --yes` recovery command; it does not write source automatically in v1.
+5. For clean cases, CI reports the owning source path and local `skillset reconcile <path> --use output --yes` recovery command; it does not choose a direction automatically.
 6. Future safe same-repo writeback may commit a source update plus regenerated output back to the PR branch only after permission, branch freshness, and conflict checks pass.
 7. Meaningful source edits still require normal change coverage.
 

--- a/docs/features/workbench.md
+++ b/docs/features/workbench.md
@@ -100,7 +100,7 @@ These fixtures are internal compiler fixtures, not public source-root `tests.yam
 - Run `skillset check` before `skillset build --yes` when editing source that is covered by current authoring diagnostics.
 - Run `skillset check --only outputs` after building or when checking whether generated output is stale.
 - Run `skillset change check` for pending change coverage.
-- Keep generated-output edits out of source truth; use `skillset explain`, `skillset diff`, `skillset restore`, and source suggestions when a generated file was edited directly.
+- Keep generated-output edits out of source truth; use `skillset reconcile` to choose source-wins or output-wins explicitly.
 - Treat `strict` rules as opt-in until a repo explicitly chooses them.
 - Do not add rule backends that execute source scripts during checks. Workbench may inspect files and parse source, but runtime execution belongs to explicit tests, harnesses, or user-approved hooks.
 

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -90,7 +90,6 @@ The entries below are the complete final public flag set. Positional arguments a
 | `--global` | Removed with top-level `create`; external destination uses `init [destination]`. |
 | `--dry-run` | Removed; preview is already the default. |
 | `dev --watch --apply` | Becomes bare `dev` and explicit `dev --write`. |
-| `suggest-source --write --yes` | Becomes `reconcile --use output --yes`. |
 | `check --fix` | Becomes local `check --write`; `--fix` remains CI-only. |
 | `--claude`, `--codex`, `--cursor` lookup aliases | Removed; use `--compat <providers>`. |
 | command-local `--json` | Standardized as one finite versioned result document by SET-284. |

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -574,6 +574,7 @@ function collectLockItems(rendered: Awaited<ReturnType<typeof renderBuildGraph>>
           outputPath: joinOutputRoot(outputRoot, outputPath),
           ...(dependencies === undefined ? {} : { dependencies }),
           ...(typeof rawItem.feature === "string" ? { feature: rawItem.feature } : {}),
+          ...(files.length === 0 ? {} : { files: files.map((file) => joinOutputRoot(outputRoot, file)) }),
           ...(typeof rawItem.kind === "string" ? { kind: rawItem.kind } : {}),
           ...(typeof rawItem.origin === "string" ? { origin: rawItem.origin } : {}),
           ...(typeof rawItem.outputHash === "string" ? { outputHash: rawItem.outputHash } : {}),

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -334,7 +334,7 @@ export async function suggestSource(
       : "Generated Markdown body can be moved back to the source file.",
     nextSteps: write
       ? ["Run `skillset build --yes` to refresh generated output.", "Run `skillset change add` or `skillset change check` if the source edit needs change coverage."]
-      : ["Review the body change, then rerun with `--write --yes` to update source.", "After accepting, run `skillset build --yes`."],
+      : [`Review the body change, then run \`skillset reconcile ${generatedPath} --use output --yes\`.`],
     sourcePath,
     status: write ? "written" : "suggestible",
     wouldWrite: true,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -304,6 +304,7 @@ export interface SourceOrigin {
 export interface GeneratedEntry {
   readonly dependencies?: readonly string[];
   readonly feature?: string;
+  readonly files?: readonly string[];
   readonly origin?: string;
   readonly kind?: string;
   readonly outputHash?: string;


### PR DESCRIPTION
## Context

`suggest-source` described only one recovery direction. Reconciliation should let a contributor inspect a managed conflict and explicitly choose whether source or output wins.

## What changed

- replaces `skillset suggest-source` with read-only-by-default `skillset reconcile <managed-path>`
- adds explicit `--use source --yes` and narrow `--use output --yes` write paths
- resolves ownership through current generated entries and live lock evidence
- refuses root escapes, ambiguous ownership, auxiliary outputs, unrelated drift, and unsafe siblings
- restores original source if output-wins writeback is followed by a failed build
- reports appropriate backup/recovery evidence and versioned JSON plans/results
- reuses the read-only classification in CI guidance without letting CI choose a direction

## Verification

- required GitHub checks: `changeset`, `check`, and `skillset-ci`
- broad preview/apply, ownership, sibling, path, rollback, backup, JSON, and flag-validation coverage

## Tracking

Closes SET-282. Stacked on #271.

## Risks / rollout

This is an intentional hard cutover. Output-wins remains deliberately narrow; source-wins may refresh sibling outputs owned by the same source and records generated backup evidence.
