### PR TITLE
feat(cli): add mutation json results

### DIFF
--- a/.changeset/mutation-json-results.md
+++ b/.changeset/mutation-json-results.md
@@ -1,0 +1,5 @@
+---
+"skillset": minor
+---
+
+Emit versioned structured results for plan-first and mutating CLI routes, with explicit planned versus written state and actual write paths without changing confirmation authority.

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -418,6 +418,21 @@ test("blocked adoption reports its persisted audit artifacts", async () => {
   expect(await exists(cachePath(root, join(ADOPT_REPORT_DIR, "report.json")))).toBe(true);
 });
 
+test("failed instruction adoption reports its partial copied destination", async () => {
+  const root = await fixture({
+    "AGENTS.md": "---\ninvalid: [\n---\n\nHandwritten guidance.\n",
+  });
+
+  const report = await adoptSkillset(root, { write: true });
+  const imported = report.imports.find((result) => result.candidate.kind === "instructions");
+
+  expect(report.ok).toBe(false);
+  expect(imported?.ok).toBe(false);
+  expect(imported?.destination).toBe(".skillset/rules/agents.md");
+  expect(report.writtenPaths).toContain(".skillset/rules/agents.md");
+  expect(await exists(join(root, ".skillset/rules/agents.md"))).toBe(true);
+});
+
 test("adopt elevates a root Cursor native plugin", async () => {
   const root = await fixture({
     ".cursor-plugin/plugin.json": JSON.stringify({

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -565,6 +565,24 @@ test("adopt records an instructions collision as a failed import without throwin
   expect(renderAdoptReportMarkdown(report, { rootPath: root })).toContain("## Failed imports");
 });
 
+test("adopt reports source written before a later batch import fails", async () => {
+  const root = await fixture({
+    ".agents/skills/first/SKILL.md": "---\nname: duplicate\ndescription: First.\n---\n\nFirst.\n",
+    ".agents/skills/second/SKILL.md": "---\nname: duplicate\ndescription: Second.\n---\n\nSecond.\n",
+  });
+
+  const report = await adoptSkillset(root, { write: true });
+
+  expect(report.ok).toBe(false);
+  const failed = report.imports.find((result) => result.candidate.path === ".agents/skills");
+  expect(failed?.ok).toBe(false);
+  expect(failed?.units).toEqual([
+    expect.objectContaining({ kind: "skill", name: "duplicate" }),
+  ]);
+  expect(report.writtenPaths).toContain(".skillset/skills/duplicate");
+  expect(await exists(join(root, ".skillset/skills/duplicate/SKILL.md"))).toBe(true);
+});
+
 test("adopt fails on lint errors and the CLI exits nonzero", async () => {
   const files = {
     ".claude/skills/bad/SKILL.md":

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -400,6 +400,24 @@ test("adopt elevates a root native plugin without copying workspace config into 
   expect(await exists(join(root, ".skillset/plugins/root-native/skills/helper/SKILL.md"))).toBe(true);
 });
 
+test("blocked adoption reports its persisted audit artifacts", async () => {
+  const root = await fixture({
+    ".claude-plugin/plugin.json": JSON.stringify({ name: "claude-name", version: "1.0.0" }),
+    ".codex-plugin/plugin.json": JSON.stringify({ name: "codex-name", version: "1.0.0" }),
+  });
+
+  const report = await adoptSkillset(root, { write: true });
+
+  expect(report.ok).toBe(false);
+  expect(report.write).toBe(false);
+  expect(report.writtenPaths).toEqual([
+    `${ADOPT_REPORT_DIR}/report.md`,
+    `${ADOPT_REPORT_DIR}/report.json`,
+  ]);
+  expect(await exists(cachePath(root, join(ADOPT_REPORT_DIR, "report.md")))).toBe(true);
+  expect(await exists(cachePath(root, join(ADOPT_REPORT_DIR, "report.json")))).toBe(true);
+});
+
 test("adopt elevates a root Cursor native plugin", async () => {
   const root = await fixture({
     ".cursor-plugin/plugin.json": JSON.stringify({

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -6088,6 +6088,15 @@ codex: true
   expect(preview.stdout).toContain("restore preview 1 file");
   expect(await readFile(join(root, "AGENTS.md"), "utf8")).toContain("# Generated Instructions");
 
+  const structuredPreview = await runSkillsetCli("restore", backupId, "--root", root, "--json");
+  expect(structuredPreview.exitCode).toBe(0);
+  expect(structuredPreview.stderr).toBe("");
+  expect(JSON.parse(structuredPreview.stdout)).toMatchObject({
+    command: "restore",
+    data: { state: "planned", writes: [] },
+    ok: true,
+  });
+
   const restored = await runSkillsetCli("restore", backupId, "--root", root, "--yes");
   expect(restored.exitCode).toBe(0);
   expect(restored.stdout).toContain("restored 1 file");

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5473,7 +5473,17 @@ version: 0.1.0
 
 Body.
 `,
+    ".skillset/skills/untouched/SKILL.md": `
+---
+name: untouched
+description: Unchanged release neighbor.
+version: 0.1.0
+---
+
+Unchanged body.
+`,
   });
+  await buildSkillset(root);
   await commitFixture(root);
 
   await Bun.write(
@@ -5507,9 +5517,11 @@ Release the standalone skill body update with a patch version and generated chan
   expect(dryRun.stdout).toContain("dry run wrote no files");
   expect(await Bun.file(join(root, ".skillset/changes/state.json")).exists()).toBe(false);
 
-  const applied = await runSkillsetCli("release", "apply", "--yes", "--root", root);
+  const applied = await runSkillsetCli("release", "apply", "--yes", "--json", "--root", root);
   expect(applied.exitCode).toBe(0);
-  expect(applied.stdout).toContain("skillset: applied release");
+  const appliedEnvelope = JSON.parse(applied.stdout) as { data: { writes: string[] } };
+  expect(appliedEnvelope.data.writes).toContain(".claude/skills/demo/SKILL.md");
+  expect(appliedEnvelope.data.writes).not.toContain(".claude/skills/untouched/SKILL.md");
   expect(await Bun.file(join(root, ".skillset/changes/demo.md")).exists()).toBe(false);
 
   const state = JSON.parse(await readFile(join(root, ".skillset/changes/state.json"), "utf8")) as {

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5511,17 +5511,34 @@ Release the standalone skill body update with a patch version and generated chan
   expect(plan.stdout).toContain("@aaaabb pending patch skill: demo");
   expect(plan.stdout).toContain("skill: demo: 0.1.0 -> 0.1.1 (patch)");
   expect(await Bun.file(join(root, ".skillset/changes/state.json")).exists()).toBe(false);
+  const planJson = await runSkillsetCli("release", "plan", "--json", "--root", root);
+  expect(planJson.exitCode).toBe(0);
+  expect(JSON.parse(planJson.stdout)).toMatchObject({
+    command: "release.plan",
+    data: { entries: [expect.objectContaining({ id: "aaaabbbbcccc" })] },
+    schemaVersion: "skillset.cli.result@1",
+  });
 
   const dryRun = await runSkillsetCli("release", "apply", "--dry-run", "--root", root);
   expect(dryRun.exitCode).toBe(0);
   expect(dryRun.stdout).toContain("dry run wrote no files");
   expect(await Bun.file(join(root, ".skillset/changes/state.json")).exists()).toBe(false);
 
+  await writeFile(join(root, ".claude/skills/demo/SKILL.md"), "hand edit\n", "utf8");
+
   const applied = await runSkillsetCli("release", "apply", "--yes", "--json", "--root", root);
   expect(applied.exitCode).toBe(0);
-  const appliedEnvelope = JSON.parse(applied.stdout) as { data: { writes: string[] } };
+  const appliedEnvelope = JSON.parse(applied.stdout) as {
+    data: { result: { files: string[] }; writes: string[] };
+  };
   expect(appliedEnvelope.data.writes).toContain(".claude/skills/demo/SKILL.md");
   expect(appliedEnvelope.data.writes).not.toContain(".claude/skills/untouched/SKILL.md");
+  const backupManifest = appliedEnvelope.data.writes.find((path) =>
+    /^\.skillset\/snapshots\/[^/]+\/manifest\.json$/u.test(path)
+  );
+  expect(backupManifest).toBeDefined();
+  expect(appliedEnvelope.data.result.files).toContain(backupManifest!);
+  expect(await Bun.file(join(root, backupManifest!)).exists()).toBe(true);
   expect(await Bun.file(join(root, ".skillset/changes/demo.md")).exists()).toBe(false);
 
   const state = JSON.parse(await readFile(join(root, ".skillset/changes/state.json"), "utf8")) as {
@@ -5623,13 +5640,22 @@ Release the standalone skill body update before correcting release-event notes.
     "--root",
     root,
     "--reason",
-    "Corrected release-event notes after reviewing the generated changelog projection."
+    "Corrected release-event notes after reviewing the generated changelog projection.",
+    "--json"
   );
   expect(amended.exitCode).toBe(0);
-  expect(amended.stdout).toContain(`skillset: amended release ${ref}`);
-  expect(amended.stdout).toContain("changes/release-amendments.jsonl");
-  expect(amended.stdout).toContain("Corrected release-event notes");
-  expect(amended.stdout).toContain("scope: skill: demo");
+  expect(JSON.parse(amended.stdout)).toMatchObject({
+    command: "release.amend",
+    data: {
+      report: {
+        amendmentPath: ".skillset/changes/release-amendments.jsonl",
+        release: { ref },
+      },
+      state: "written",
+      writes: [".skillset/changes/release-amendments.jsonl"],
+    },
+    schemaVersion: "skillset.cli.result@1",
+  });
 
   const amendments = await readFile(join(root, ".skillset/changes/release-amendments.jsonl"), "utf8");
   expect(amendments).toContain(releaseRecord!.id);
@@ -5688,6 +5714,13 @@ Body.
   expect(clean.stdout).toContain("skillset: version audit passed");
   expect(clean.stdout).toContain("in-sync: [codex] plugin:alpha");
   expect(clean.stdout).toContain("expected 1.2.3");
+  const cleanJson = await runSkillsetCli("release", "audit", "--json", "--root", root);
+  expect(cleanJson.exitCode).toBe(0);
+  expect(JSON.parse(cleanJson.stdout)).toMatchObject({
+    command: "release.audit",
+    data: { issues: [] },
+    schemaVersion: "skillset.cli.result@1",
+  });
 
   const manifestPath = join(root, "plugins/alpha/codex/.codex-plugin/plugin.json");
   await rm(manifestPath);

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4226,13 +4226,30 @@ Body.
   );
   expect(structuredAdd.exitCode).toBe(0);
   const structuredData = (JSON.parse(structuredAdd.stdout) as {
-    data: { report: { entry: { path: string }; ledgerPath: string }; writes: string[] };
+    data: { report: { entry: { path: string; ref: string; sourceHashes: Record<string, string[]> }; ledgerPath: string }; writes: string[] };
   }).data;
   expect(structuredData.writes).toEqual([
     structuredData.report.entry.path,
     structuredData.report.ledgerPath,
   ]);
   expect(structuredData.report.ledgerPath).toBe(".skillset/changes/ledger.jsonl");
+  expect(Object.keys(structuredData.report.entry.sourceHashes)).not.toHaveLength(0);
+
+  const structuredReason = await runSkillsetCli(
+    "change",
+    "reason",
+    structuredData.report.entry.ref,
+    "--root",
+    root,
+    "--reason",
+    "Clarified the structured change reason while preserving a complete mutation path audit.",
+    "--json"
+  );
+  expect(structuredReason.exitCode).toBe(0);
+  expect((JSON.parse(structuredReason.stdout) as { data: { writes: string[] } }).data.writes).toEqual([
+    structuredData.report.entry.path,
+    ".skillset/changes/ledger.jsonl",
+  ]);
 
   const checked = await runSkillsetCli("change", "check", "--root", root, "--since", "HEAD");
   expect(checked.exitCode).toBe(0);

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4209,6 +4209,31 @@ Body.
   expect(ledger).toContain('"type":"change.covered"');
   expect(ledger).toContain('"hashSchema":"skillset-source-unit-v2"');
 
+  const structuredAdd = await runSkillsetCli(
+    "change",
+    "add",
+    "--root",
+    root,
+    "--since",
+    "HEAD",
+    "--scope",
+    "skill:demo",
+    "--bump",
+    "patch",
+    "--reason",
+    "Recorded the structured mutation paths so automation can audit both files written by change add.",
+    "--json"
+  );
+  expect(structuredAdd.exitCode).toBe(0);
+  const structuredData = (JSON.parse(structuredAdd.stdout) as {
+    data: { report: { entry: { path: string }; ledgerPath: string }; writes: string[] };
+  }).data;
+  expect(structuredData.writes).toEqual([
+    structuredData.report.entry.path,
+    structuredData.report.ledgerPath,
+  ]);
+  expect(structuredData.report.ledgerPath).toBe(".skillset/changes/ledger.jsonl");
+
   const checked = await runSkillsetCli("change", "check", "--root", root, "--since", "HEAD");
   expect(checked.exitCode).toBe(0);
 });

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -4908,8 +4908,12 @@ test("SET-282: reconcile applies source-wins with output backup safety", async (
   expect(structured.stderr).toBe("");
   expect(JSON.parse(structured.stdout)).toMatchObject({
     command: "reconcile",
-    data: { generatedPath, sourceResolutionAvailable: true },
-    kind: "plan",
+    data: {
+      report: { generatedPath, sourceResolutionAvailable: true },
+      state: "planned",
+      writes: [],
+    },
+    kind: "data",
     ok: true,
   });
 });

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -5563,6 +5563,18 @@ Release the standalone skill body update with a patch version and generated chan
   expect(second.stdout).toContain("no pending changes to release");
   expect(await readFile(join(root, ".skillset/changes/history.jsonl"), "utf8")).toBe(history);
 
+  const noOpJson = await runSkillsetCli("release", "apply", "--yes", "--json", "--root", root);
+  expect(noOpJson.exitCode).toBe(0);
+  expect(JSON.parse(noOpJson.stdout)).toMatchObject({
+    command: "release.apply",
+    data: {
+      result: { files: [] },
+      state: "planned",
+      writes: [],
+    },
+    schemaVersion: "skillset.cli.result@1",
+  });
+
   await writeFile(join(root, ".skillset/changes/state.json"), "{nope\n", "utf8");
   const derivedState = await readReleaseState(root);
   expect(derivedState.scopes["skill:demo"]?.version).toBe("0.1.1");

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -7620,13 +7620,13 @@ Audit body.
     }),
   ]);
 
-  const misplacedJson = await runSkillsetCli("build", "--json");
-  expect(misplacedJson.exitCode).toBe(2);
-  expect(misplacedJson.stderr).toBe("");
-  expect(JSON.parse(misplacedJson.stdout)).toMatchObject({
-    diagnostics: [{ message: expect.stringContaining("--json is not supported for this command route") }],
-    exitCode: 2,
-    ok: false,
+  const buildJson = await runSkillsetCli("build", "--root", root, "--json");
+  expect(buildJson.exitCode).toBe(0);
+  expect(buildJson.stderr).toBe("");
+  expect(JSON.parse(buildJson.stdout)).toMatchObject({
+    data: { state: "planned", writes: [] },
+    exitCode: 0,
+    ok: true,
     schemaVersion: "skillset.cli.result@1",
   });
 });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -32,6 +32,19 @@ describe("SET-287 finite read-only JSON", () => {
       }
     });
   }
+
+  test("init JSON preserves preview versus confirmed write authority", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-init-"));
+    const preview = await runJsonRoute("init", "--root", root);
+    const previewEnvelope = JSON.parse(preview.stdout) as SkillsetCliResult & { data: { state: string; writes: unknown[] } };
+    expect(previewEnvelope.data).toMatchObject({ state: "planned", writes: [] });
+    expect(await readdir(root)).toEqual([]);
+
+    const written = await runJsonRoute("init", "--root", root, "--yes");
+    const writtenEnvelope = JSON.parse(written.stdout) as SkillsetCliResult & { data: { state: string; writes: unknown[] } };
+    expect(writtenEnvelope.data.state).toBe("written");
+    expect(writtenEnvelope.data.writes.length).toBeGreaterThan(0);
+  });
 
   for (const route of [
     ["change", "status", "--root", repoRoot],
@@ -198,6 +211,20 @@ describe("SET-287 finite read-only JSON", () => {
     expect(stderr).toBe("");
     expect(validateCliResult(JSON.parse(stdout))).toEqual({ diagnostics: [], ok: true });
   });
+
+  for (const route of [
+    ["build", "--root", fixtureRoot],
+    ["update", "--root", fixtureRoot],
+  ] as const) {
+    test(`${route[0]} preview emits a versioned plan without writes`, async () => {
+      const result = await runJsonRoute(...route);
+      expect(result.stderr).toBe("");
+      const envelope = JSON.parse(result.stdout) as SkillsetCliResult & { data: { state: string; writes: unknown[] } };
+      expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+      expect(envelope.data.state).toBe("planned");
+      expect(envelope.data.writes).toEqual([]);
+    });
+  }
 });
 
 async function runJsonRoute(...args: readonly string[]): Promise<{ exitCode: number; stderr: string; stdout: string }> {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -151,6 +151,31 @@ describe("SET-287 finite read-only JSON", () => {
     expect(envelope.data.writes).toContain(".skillset/changes/state.json");
     expect(envelope.data.writes).toContain(".skillset/cache/adopt/report.md");
     expect(envelope.data.writes).toContain(".skillset/cache/adopt/report.json");
+    expect(envelope.data.writes.some((write) => write.startsWith(".skillset/cache/latest/"))).toBe(true);
+  });
+
+  test("blocked init adoption JSON reports persisted audit writes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-adopt-blocked-"));
+    await mkdir(path.join(root, ".claude-plugin"), { recursive: true });
+    await mkdir(path.join(root, ".codex-plugin"), { recursive: true });
+    await writeFile(
+      path.join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "claude-name", version: "1.0.0" })
+    );
+    await writeFile(
+      path.join(root, ".codex-plugin", "plugin.json"),
+      JSON.stringify({ name: "codex-name", version: "1.0.0" })
+    );
+
+    const blocked = await runJsonRoute("init", "--adopt", "all", "--yes", "--root", root);
+    const envelope = JSON.parse(blocked.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+
+    expect(blocked.exitCode).toBe(1);
+    expect(blocked.stderr).toBe("");
+    expect(envelope.data.writes).toEqual([
+      ".skillset/cache/adopt/report.md",
+      ".skillset/cache/adopt/report.json",
+    ]);
   });
 
   test("build apply emits a finite summary and every changed path", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -121,6 +121,8 @@ describe("SET-287 finite read-only JSON", () => {
 
     expect(envelope.data.writes).toContain(".skillset/skills/one");
     expect(envelope.data.writes).toContain(".skillset/changes/state.json");
+    expect(envelope.data.writes).toContain(".skillset/cache/adopt/report.md");
+    expect(envelope.data.writes).toContain(".skillset/cache/adopt/report.json");
   });
 
   test("build apply emits a finite summary and every changed path", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -51,6 +51,35 @@ describe("SET-287 finite read-only JSON", () => {
     expect(unchangedEnvelope.data.writes).toEqual([]);
   });
 
+  test("init JSON reports a seeded release-state write", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-init-baseline-"));
+    await mkdir(path.join(root, ".skillset", "skills", "demo"), { recursive: true });
+    await writeFile(
+      path.join(root, ".skillset", "skills", "demo", "SKILL.md"),
+      "---\nname: demo\ndescription: Demo.\n---\n\nBody.\n"
+    );
+
+    const written = await runJsonRoute("init", "--root", root, "--yes");
+    const envelope = JSON.parse(written.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+
+    expect(envelope.data.writes).toContain(".skillset/changes/state.json");
+  });
+
+  test("import JSON reports the imported source and seeded release state", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-import-baseline-"));
+    const source = path.join(root, "incoming", "SKILL.md");
+    await mkdir(path.join(root, ".skillset"), { recursive: true });
+    await mkdir(path.dirname(source), { recursive: true });
+    await writeFile(path.join(root, "skillset.yaml"), "skillset:\n  name: import-json\n");
+    await writeFile(source, "---\nname: demo\ndescription: Demo.\n---\n\nBody.\n");
+
+    const imported = await runJsonRoute("import", source, "--kind", "skill", "--root", root);
+    const envelope = JSON.parse(imported.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+
+    expect(envelope.data.writes.some((write) => write.endsWith("/.skillset/skills/demo"))).toBe(true);
+    expect(envelope.data.writes).toContain(".skillset/changes/state.json");
+  });
+
   test("build apply emits a finite summary and every changed path", async () => {
     const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-build-"));
     const root = path.join(parent, "workspace");

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -131,8 +131,10 @@ describe("SET-287 finite read-only JSON", () => {
     const imported = await runJsonRoute("import", source, "--kind", "skill", "--root", root);
     const envelope = JSON.parse(imported.stdout) as SkillsetCliResult & { data: { writes: string[] } };
 
-    expect(envelope.data.writes.some((write) => write.endsWith("/.skillset/skills/demo"))).toBe(true);
-    expect(envelope.data.writes).toContain(".skillset/changes/state.json");
+    expect(envelope.data.writes).toEqual([
+      ".skillset/skills/demo",
+      ".skillset/changes/state.json",
+    ]);
   });
 
   test("init adoption JSON reports imported units and release state", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -120,6 +120,32 @@ describe("SET-287 finite read-only JSON", () => {
     expect(envelope.data.writes).toEqual(envelope.data.report.writes.paths);
   });
 
+  test("build JSON stays stderr-clean when the known-workspace index is unwritable", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-build-xdg-"));
+    const root = path.join(parent, "workspace");
+    const configHome = path.join(parent, "not-a-directory");
+    await cp(fixtureRoot, root, { recursive: true });
+    await writeFile(configHome, "occupied\n");
+    const proc = Bun.spawn(
+      [process.execPath, cli, "build", "--root", root, "--yes", "--json"],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, NODE_ENV: "test", XDG_CONFIG_HOME: configHome },
+        stderr: "pipe",
+        stdout: "pipe",
+      }
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(validateCliResult(JSON.parse(stdout))).toEqual({ diagnostics: [], ok: true });
+  });
+
   test("build JSON normalizes output-safety diagnostics", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-json-build-diagnostics-"));
     await mkdir(path.join(root, ".skillset", "rules"), { recursive: true });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -44,6 +44,41 @@ describe("SET-287 finite read-only JSON", () => {
     const writtenEnvelope = JSON.parse(written.stdout) as SkillsetCliResult & { data: { state: string; writes: unknown[] } };
     expect(writtenEnvelope.data.state).toBe("written");
     expect(writtenEnvelope.data.writes.length).toBeGreaterThan(0);
+    expect(writtenEnvelope.data.writes.every((entry) => typeof entry === "string")).toBe(true);
+
+    const unchanged = await runJsonRoute("init", "--root", root, "--yes");
+    const unchangedEnvelope = JSON.parse(unchanged.stdout) as SkillsetCliResult & { data: { writes: unknown[] } };
+    expect(unchangedEnvelope.data.writes).toEqual([]);
+  });
+
+  test("build apply emits a finite summary and every changed path", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-build-"));
+    const root = path.join(parent, "workspace");
+    await cp(fixtureRoot, root, { recursive: true });
+
+    const result = await runJsonRoute("build", "--root", root, "--yes");
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult & {
+      data: {
+        report: { data?: unknown; renderedFiles: number; writes: { paths: string[] } };
+        writes: string[];
+      };
+    };
+    expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+    expect(envelope.data.report.data).toBeUndefined();
+    expect(envelope.data.report.renderedFiles).toBeGreaterThan(0);
+    expect(envelope.data.writes).toEqual(envelope.data.report.writes.paths);
+  });
+
+  test("change migrate does not report a ledger write for a no-op", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-migrate-"));
+    await mkdir(path.join(root, ".skillset"), { recursive: true });
+    await writeFile(path.join(root, "skillset.yaml"), "skillset:\n  name: migrate-json\n");
+
+    const result = await runJsonRoute("change", "migrate", "--root", root, "--yes");
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+    expect(envelope.data.writes).toEqual([]);
   });
 
   for (const route of [

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -70,6 +70,25 @@ describe("SET-287 finite read-only JSON", () => {
     expect(envelope.data.writes).toEqual(envelope.data.report.writes.paths);
   });
 
+  test("build JSON normalizes output-safety diagnostics", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-build-diagnostics-"));
+    await mkdir(path.join(root, ".skillset", "rules"), { recursive: true });
+    await writeFile(
+      path.join(root, "skillset.yaml"),
+      "skillset:\n  name: build-diagnostics-json\nclaude: false\ncodex: true\n"
+    );
+    await writeFile(path.join(root, ".skillset", "rules", "guide.md"), "# Managed guidance\n");
+    await writeFile(path.join(root, "AGENTS.md"), "# Unmanaged guidance\n");
+
+    const result = await runJsonRoute("build", "--root", root, "--yes");
+    expect(result.stderr).toBe("");
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
+    expect(envelope.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "AGENTS.md", severity: "warning" }),
+    ]));
+  });
+
   test("change migrate does not report a ledger write for a no-op", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-json-migrate-"));
     await mkdir(path.join(root, ".skillset"), { recursive: true });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmod, cp, mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -54,6 +54,34 @@ describe("SET-287 finite read-only JSON", () => {
     const unchanged = await runJsonRoute("init", "--root", root, "--yes");
     const unchangedEnvelope = JSON.parse(unchanged.stdout) as SkillsetCliResult & { data: { writes: unknown[] } };
     expect(unchangedEnvelope.data.writes).toEqual([]);
+  });
+
+  test("init JSON resolves a relative --root once from the invocation cwd", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-relative-root-"));
+    const proc = Bun.spawn(
+      [process.execPath, cli, "init", "--root", "workspace", "--yes", "--json"],
+      {
+        cwd: parent,
+        env: { ...process.env, NODE_ENV: "test" },
+        stderr: "pipe",
+        stdout: "pipe",
+      }
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(validateCliResult(JSON.parse(stdout))).toEqual({ diagnostics: [], ok: true });
+    await expect(readFile(path.join(parent, "workspace", "skillset.yaml"), "utf8")).resolves.toContain(
+      "skillset:"
+    );
+    await expect(
+      readFile(path.join(parent, "workspace", "workspace", "skillset.yaml"), "utf8")
+    ).rejects.toThrow();
   });
 
   test("init JSON stays stderr-clean when the known-workspace index is unwritable", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -137,6 +137,30 @@ describe("SET-287 finite read-only JSON", () => {
     ]);
   });
 
+  test("import JSON reports writes completed before a batch failure", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-import-partial-"));
+    const source = path.join(root, "incoming");
+    await mkdir(path.join(root, ".skillset"), { recursive: true });
+    await mkdir(path.join(source, "first"), { recursive: true });
+    await mkdir(path.join(source, "second"), { recursive: true });
+    await writeFile(path.join(root, "skillset.yaml"), "skillset:\n  name: import-json-partial\n");
+    await writeFile(path.join(source, "first", "SKILL.md"), "---\nname: duplicate\ndescription: First.\n---\n\nFirst.\n");
+    await writeFile(path.join(source, "second", "SKILL.md"), "---\nname: duplicate\ndescription: Second.\n---\n\nSecond.\n");
+
+    const imported = await runJsonRoute("import", source, "--kind", "skills", "--root", root);
+    const envelope = JSON.parse(imported.stdout) as SkillsetCliResult & {
+      data: { state: string; writes: string[] };
+    };
+
+    expect(imported.exitCode).toBe(1);
+    expect(envelope.kind).toBe("diagnostics");
+    expect(envelope.data.state).toBe("written");
+    expect(envelope.data.writes).toEqual([
+      ".skillset/skills/duplicate",
+      ".skillset/changes/state.json",
+    ]);
+  });
+
   test("init adoption JSON reports imported units and release state", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-json-adopt-writes-"));
     await runJsonRoute("init", "--yes", "--root", root);

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -52,8 +52,10 @@ describe("SET-287 finite read-only JSON", () => {
     expect(seededEnvelope.data.writes).toEqual([".skillset/changes/state.json"]);
 
     const unchanged = await runJsonRoute("init", "--root", root, "--yes");
-    const unchangedEnvelope = JSON.parse(unchanged.stdout) as SkillsetCliResult & { data: { writes: unknown[] } };
-    expect(unchangedEnvelope.data.writes).toEqual([]);
+    const unchangedEnvelope = JSON.parse(unchanged.stdout) as SkillsetCliResult & {
+      data: { state: string; writes: unknown[] };
+    };
+    expect(unchangedEnvelope.data).toMatchObject({ state: "planned", writes: [] });
   });
 
   test("init JSON resolves a relative --root once from the invocation cwd", async () => {
@@ -233,10 +235,18 @@ describe("SET-287 finite read-only JSON", () => {
     await cp(fixtureRoot, root, { recursive: true });
 
     const preview = JSON.parse((await runJsonRoute("build", "--root", root)).stdout) as SkillsetCliResult;
-    const applied = JSON.parse((await runJsonRoute("build", "--root", root, "--yes")).stdout) as SkillsetCliResult;
+    const applied = JSON.parse((await runJsonRoute("build", "--root", root, "--yes")).stdout) as SkillsetCliResult & {
+      data: { state: string; writes: string[] };
+    };
+    const unchanged = JSON.parse((await runJsonRoute("build", "--root", root, "--yes")).stdout) as SkillsetCliResult & {
+      data: { state: string; writes: string[] };
+    };
 
     expect(preview.kind).toBe("plan");
     expect(applied.kind).toBe("mutation");
+    expect(applied.data.state).toBe("written");
+    expect(applied.data.writes.length).toBeGreaterThan(0);
+    expect(unchanged.data).toMatchObject({ state: "planned", writes: [] });
   });
 
   test("build apply emits a finite summary and every changed path", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -296,11 +296,23 @@ describe("SET-287 finite read-only JSON", () => {
 
     const result = await runJsonRoute("build", "--root", root, "--yes");
     expect(result.stderr).toBe("");
-    const envelope = JSON.parse(result.stdout) as SkillsetCliResult;
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult & {
+      data: {
+        report: { writes: { backupManifestPath?: string; paths: string[] } };
+        writes: string[];
+      };
+    };
     expect(validateCliResult(envelope)).toEqual({ diagnostics: [], ok: true });
     expect(envelope.diagnostics).toEqual(expect.arrayContaining([
       expect.objectContaining({ path: "AGENTS.md", severity: "warning" }),
     ]));
+    const backupManifestPath = envelope.data.report.writes.backupManifestPath;
+    expect(backupManifestPath).toMatch(/^\.skillset\/snapshots\/[^/]+\/manifest\.json$/u);
+    if (backupManifestPath === undefined) throw new Error("missing build backup manifest path");
+    expect(envelope.data.writes).toEqual([
+      ...envelope.data.report.writes.paths,
+      backupManifestPath,
+    ]);
   });
 
   test("change migrate does not report a ledger write for a no-op", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -156,6 +156,28 @@ describe("SET-287 finite read-only JSON", () => {
     expect(envelope.data.writes.some((write) => write.startsWith(".skillset/cache/latest/"))).toBe(true);
   });
 
+  test("destination adoption JSON reports acquired source files", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-adopt-destination-"));
+    const source = path.join(parent, "source");
+    const destination = path.join(parent, "destination");
+    await mkdir(path.join(source, ".agents", "skills", "one"), { recursive: true });
+    await writeFile(path.join(source, "README.md"), "# Acquired repo\n");
+    await writeFile(
+      path.join(source, ".agents", "skills", "one", "SKILL.md"),
+      "---\nname: one\ndescription: One.\n---\n\nBody.\n"
+    );
+
+    const adopted = await runJsonRoute(
+      "init", destination, "--from", source, "--adopt", "all", "--yes"
+    );
+    const envelope = JSON.parse(adopted.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+
+    expect(adopted.exitCode).toBe(0);
+    expect(envelope.data.writes).toContain("README.md");
+    expect(envelope.data.writes).toContain(".agents/skills/one/SKILL.md");
+    expect(envelope.data.writes).toContain(".git");
+  });
+
   test("blocked init adoption JSON reports persisted audit writes", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-json-adopt-blocked-"));
     await mkdir(path.join(root, ".claude-plugin"), { recursive: true });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -45,6 +45,11 @@ describe("SET-287 finite read-only JSON", () => {
     expect(writtenEnvelope.data.state).toBe("written");
     expect(writtenEnvelope.data.writes.length).toBeGreaterThan(0);
     expect(writtenEnvelope.data.writes.every((entry) => typeof entry === "string")).toBe(true);
+    expect(writtenEnvelope.data.writes).toContain(".git");
+
+    const seeded = await runJsonRoute("init", "--root", root, "--yes");
+    const seededEnvelope = JSON.parse(seeded.stdout) as SkillsetCliResult & { data: { writes: unknown[] } };
+    expect(seededEnvelope.data.writes).toEqual([".skillset/changes/state.json"]);
 
     const unchanged = await runJsonRoute("init", "--root", root, "--yes");
     const unchangedEnvelope = JSON.parse(unchanged.stdout) as SkillsetCliResult & { data: { writes: unknown[] } };

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -286,7 +286,10 @@ describe("SET-287 finite read-only JSON", () => {
 
     const result = await runJsonRoute("change", "migrate", "--root", root, "--yes");
     expect(result.stderr).toBe("");
-    const envelope = JSON.parse(result.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+    const envelope = JSON.parse(result.stdout) as SkillsetCliResult & {
+      data: { state: string; writes: string[] };
+    };
+    expect(envelope.data.state).toBe("planned");
     expect(envelope.data.writes).toEqual([]);
   });
 

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -56,6 +56,28 @@ describe("SET-287 finite read-only JSON", () => {
     expect(unchangedEnvelope.data.writes).toEqual([]);
   });
 
+  test("init JSON stays stderr-clean when the known-workspace index is unwritable", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-init-xdg-"));
+    const root = path.join(parent, "workspace");
+    const configHome = path.join(parent, "not-a-directory");
+    await writeFile(configHome, "occupied\n");
+    const proc = Bun.spawn([process.execPath, cli, "init", "--root", root, "--yes", "--json"], {
+      cwd: repoRoot,
+      env: { ...process.env, NODE_ENV: "test", XDG_CONFIG_HOME: configHome },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(validateCliResult(JSON.parse(stdout))).toEqual({ diagnostics: [], ok: true });
+  });
+
   test("init JSON reports a seeded release-state write", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-json-init-baseline-"));
     await mkdir(path.join(root, ".skillset", "skills", "demo"), { recursive: true });

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -80,6 +80,21 @@ describe("SET-287 finite read-only JSON", () => {
     expect(envelope.data.writes).toContain(".skillset/changes/state.json");
   });
 
+  test("init adoption JSON reports imported units and release state", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skillset-json-adopt-writes-"));
+    await mkdir(path.join(root, ".agents", "skills", "one"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agents", "skills", "one", "SKILL.md"),
+      "---\nname: one\ndescription: One.\n---\n\nBody.\n"
+    );
+
+    const adopted = await runJsonRoute("init", "--adopt", "all", "--yes", "--root", root);
+    const envelope = JSON.parse(adopted.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+
+    expect(envelope.data.writes).toContain(".skillset/skills/one");
+    expect(envelope.data.writes).toContain(".skillset/changes/state.json");
+  });
+
   test("build apply emits a finite summary and every changed path", async () => {
     const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-build-"));
     const root = path.join(parent, "workspace");

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -170,7 +170,7 @@ describe("SET-287 finite read-only JSON", () => {
     );
 
     const blocked = await runJsonRoute("init", "--adopt", "all", "--yes", "--root", root);
-    const envelope = JSON.parse(blocked.stdout) as SkillsetCliResult & { data: { writes: string[] } };
+    const envelope = JSON.parse(blocked.stdout) as SkillsetCliResult & { data: { state: string; writes: string[] } };
 
     expect(blocked.exitCode).toBe(1);
     expect(blocked.stderr).toBe("");
@@ -178,6 +178,19 @@ describe("SET-287 finite read-only JSON", () => {
       ".skillset/cache/adopt/report.md",
       ".skillset/cache/adopt/report.json",
     ]);
+    expect(envelope.data.state).toBe("written");
+  });
+
+  test("build JSON distinguishes plans from mutations", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "skillset-json-build-kinds-"));
+    const root = path.join(parent, "workspace");
+    await cp(fixtureRoot, root, { recursive: true });
+
+    const preview = JSON.parse((await runJsonRoute("build", "--root", root)).stdout) as SkillsetCliResult;
+    const applied = JSON.parse((await runJsonRoute("build", "--root", root, "--yes")).stdout) as SkillsetCliResult;
+
+    expect(preview.kind).toBe("plan");
+    expect(applied.kind).toBe("mutation");
   });
 
   test("build apply emits a finite summary and every changed path", async () => {

--- a/apps/skillset/src/__tests__/finite-read-json.test.ts
+++ b/apps/skillset/src/__tests__/finite-read-json.test.ts
@@ -87,6 +87,7 @@ describe("SET-287 finite read-only JSON", () => {
 
   test("init adoption JSON reports imported units and release state", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skillset-json-adopt-writes-"));
+    await runJsonRoute("init", "--yes", "--root", root);
     await mkdir(path.join(root, ".agents", "skills", "one"), { recursive: true });
     await writeFile(
       path.join(root, ".agents", "skills", "one", "SKILL.md"),

--- a/apps/skillset/src/__tests__/known-skillsets-cli.test.ts
+++ b/apps/skillset/src/__tests__/known-skillsets-cli.test.ts
@@ -51,6 +51,30 @@ test("SET-233: check records the workspace in the managed known-Skillsets index"
   }]);
 });
 
+test("SET-288: JSON build records the workspace in the managed index", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-known-json-build-"));
+  const xdgConfigHome = join(root, "xdg-config");
+  const workspace = join(root, "workspace");
+  await writeWorkspace(workspace);
+  await runGit(workspace, "init", "-q");
+  await runGit(workspace, "remote", "add", "origin", "git@github.com:Acme/docs-cli.git");
+
+  const built = await runSkillsetCli(
+    { GIT_DIR: ".git", GIT_WORK_TREE: process.cwd(), XDG_CONFIG_HOME: xdgConfigHome },
+    "build",
+    "--yes",
+    "--json",
+    "--root",
+    workspace
+  );
+
+  expect(built.exitCode).toBe(0);
+  const index = JSON.parse(await readFile(join(xdgConfigHome, "skillset", "skillsets.json"), "utf8")) as {
+    readonly skillsets: readonly { readonly path: string }[];
+  };
+  expect(index.skillsets.map((entry) => entry.path)).toEqual([await realpath(workspace)]);
+});
+
 async function writeWorkspace(root: string): Promise<void> {
   await mkdir(join(root, ".skillset/skills/demo"), { recursive: true });
   await writeFile(join(root, "skillset.yaml"), `

--- a/apps/skillset/src/__tests__/known-skillsets-cli.test.ts
+++ b/apps/skillset/src/__tests__/known-skillsets-cli.test.ts
@@ -75,6 +75,29 @@ test("SET-288: JSON build records the workspace in the managed index", async () 
   expect(index.skillsets.map((entry) => entry.path)).toEqual([await realpath(workspace)]);
 });
 
+test("SET-288: JSON build preview records the workspace in the managed index", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-known-json-preview-"));
+  const xdgConfigHome = join(root, "xdg-config");
+  const workspace = join(root, "workspace");
+  await writeWorkspace(workspace);
+  await runGit(workspace, "init", "-q");
+  await runGit(workspace, "remote", "add", "origin", "git@github.com:Acme/docs-cli.git");
+
+  const preview = await runSkillsetCli(
+    { GIT_DIR: ".git", GIT_WORK_TREE: process.cwd(), XDG_CONFIG_HOME: xdgConfigHome },
+    "build",
+    "--json",
+    "--root",
+    workspace
+  );
+
+  expect(preview.exitCode).toBe(0);
+  const index = JSON.parse(await readFile(join(xdgConfigHome, "skillset", "skillsets.json"), "utf8")) as {
+    readonly skillsets: readonly { readonly path: string }[];
+  };
+  expect(index.skillsets.map((entry) => entry.path)).toEqual([await realpath(workspace)]);
+});
+
 async function writeWorkspace(root: string): Promise<void> {
   await mkdir(join(root, ".skillset/skills/demo"), { recursive: true });
   await writeFile(join(root, "skillset.yaml"), `

--- a/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
+++ b/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
@@ -208,9 +208,13 @@ Use this demo skill.
   const checkedReport = (JSON.parse(checkedJson.stdout) as {
     readonly data: { readonly entries: readonly { readonly provenance: unknown }[] };
   }).data;
-  const updateReport = JSON.parse(updateJson.stdout) as {
-    readonly check: { readonly entries: readonly { readonly provenance: unknown }[] };
-  };
+  const updateReport = (JSON.parse(updateJson.stdout) as {
+    readonly data: {
+      readonly report: {
+        readonly check: { readonly entries: readonly { readonly provenance: unknown }[] };
+      };
+    };
+  }).data.report;
   expect(checkedReport.entries[0]?.provenance).toEqual(updateReport.check.entries[0]?.provenance);
   expect(checkedJson.stdout).not.toContain(parent);
   expect(updateJson.stdout).not.toContain(parent);

--- a/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
+++ b/apps/skillset/src/__tests__/marketplace-check-cli.test.ts
@@ -366,14 +366,17 @@ Use this demo skill.
     "update",
     "outfitter",
     "--yes",
+    "--json",
     "--root",
     marketplace
   );
 
   expect(updated.exitCode).toBe(1);
   expect(updated.stderr).toBe("");
-  expect(updated.stdout).toContain("skillset: marketplace update failed");
-  expect(updated.stdout).toContain("remote repository could not be reached");
+  const envelope = JSON.parse(updated.stdout) as {
+    readonly data: { readonly state: string; readonly writes: readonly string[] };
+  };
+  expect(envelope.data).toEqual(expect.objectContaining({ state: "planned", writes: [] }));
   await expect(readdir(marketplace)).resolves.not.toContain("plugins-claude");
 }, 15_000);
 

--- a/apps/skillset/src/__tests__/new-source.test.ts
+++ b/apps/skillset/src/__tests__/new-source.test.ts
@@ -25,6 +25,12 @@ test("SET-165: new skill previews by default and writes ordinary repo source wit
   expect(skill).toContain('title: "Docs CLI Expert"');
   expect(skill).toContain('description: "Use when working with Docs CLI Expert workflows."');
 
+  const jsonWritten = await runSkillsetCli("new", "skill", "JSON Skill", "--root", root, "--yes", "--json");
+  expect(jsonWritten.exitCode).toBe(0);
+  const jsonWrites = (JSON.parse(jsonWritten.stdout) as { data: { writes: unknown[] } }).data.writes;
+  expect(jsonWrites).toEqual([".skillset/skills/json-skill/SKILL.md"]);
+  expect(jsonWrites.every((path) => typeof path === "string")).toBe(true);
+
   await expect(runSkillsetCli("build", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
   const check = await runSkillsetCli("check", "--root", root);
   expect(check.exitCode).toBe(0);

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -246,7 +246,7 @@ async function listAcquisitionFiles(rootPath: string, currentPath = rootPath): P
   for (const entry of entries) {
     const path = join(currentPath, entry.name);
     if (entry.isDirectory()) paths.push(...await listAcquisitionFiles(rootPath, path));
-    else paths.push(relative(rootPath, path));
+    else paths.push(relative(rootPath, path).replaceAll("\\", "/"));
   }
   return paths;
 }

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -62,6 +62,7 @@ export interface AdoptImportedUnit {
 }
 
 export interface AdoptImportResult {
+  readonly baselinePaths: readonly string[];
   readonly candidate: SetupImportCandidate;
   /** Instructions destination relative to the root (e.g. `.skillset/rules/agents.md`). */
   readonly destination?: string;
@@ -100,6 +101,7 @@ export interface AdoptReport {
   readonly acquisition: AdoptAcquisition;
   readonly alreadyAdopted: boolean;
   readonly baselinePath?: string;
+  readonly baselinePaths: readonly string[];
   readonly baselines: readonly ReleaseBaselineEntry[];
   readonly buildError?: string;
   readonly builtFiles: number;
@@ -261,6 +263,7 @@ async function adoptResolvedRoot(
     return {
       acquisition,
       alreadyAdopted,
+      baselinePaths: [],
       baselines: survey.baselines,
       builtFiles: 0,
       candidates,
@@ -282,6 +285,7 @@ async function adoptResolvedRoot(
     const report: AdoptReport = {
       acquisition,
       alreadyAdopted,
+      baselinePaths: [],
       baselines: survey.baselines,
       builtFiles: 0,
       candidates,
@@ -359,10 +363,15 @@ async function adoptResolvedRoot(
   }
 
   const lintErrors = lintIssues.filter((issue) => issue.severity === "error");
+  const baselinePaths = [...new Set([
+    ...(init.baselinePath === undefined ? [] : [init.baselinePath]),
+    ...imports.flatMap((result) => result.baselinePaths),
+  ])];
   const report: AdoptReport = {
     acquisition,
     alreadyAdopted,
     ...(init.baselinePath === undefined ? {} : { baselinePath: init.baselinePath }),
+    baselinePaths,
     baselines: init.baselines,
     ...(buildError === undefined ? {} : { buildError }),
     builtFiles,
@@ -490,9 +499,9 @@ async function importCandidate(
       // protection, so it belongs on the cutover list.
       cutover.push(candidate.path);
       previewSources.push(destination);
-      return { candidate, destination, detail: destination, renderResults: [], ok: true, units: [] };
+      return { baselinePaths: [], candidate, destination, detail: destination, renderResults: [], ok: true, units: [] };
     } catch (error) {
-      return { candidate, detail: errorMessage(error), renderResults: [], ok: false, units: [] };
+      return { baselinePaths: [], candidate, detail: errorMessage(error), renderResults: [], ok: false, units: [] };
     }
   }
 
@@ -518,6 +527,9 @@ async function importCandidate(
       }
     }
     return {
+      baselinePaths: [...new Set(batch.imports.flatMap((report) =>
+        report.baselinePath === undefined ? [] : [report.baselinePath]
+      ))],
       candidate,
       detail: `${units.map((unit) => `${unit.kind} ${unit.name}`).join(", ")} (${batch.files} files)`,
       renderResults: batch.renderResults,
@@ -525,7 +537,7 @@ async function importCandidate(
       units,
     };
   } catch (error) {
-    return { candidate, detail: errorMessage(error), renderResults: [], ok: false, units: [] };
+    return { baselinePaths: [], candidate, detail: errorMessage(error), renderResults: [], ok: false, units: [] };
   }
 }
 

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -529,6 +529,8 @@ async function importCandidate(
   previewSources: string[]
 ): Promise<AdoptImportResult> {
   if (candidate.kind === "instructions") {
+    const expectedDestination = instructionDestination(candidate.path);
+    const destinationExisted = await exists(join(rootPath, expectedDestination));
     try {
       const destination = await importInstructionFile(rootPath, candidate.path);
       await writeMarkdownSourceOrigin(
@@ -543,7 +545,16 @@ async function importCandidate(
       previewSources.push(destination);
       return { baselinePaths: [], candidate, destination, detail: destination, renderResults: [], ok: true, units: [] };
     } catch (error) {
-      return { baselinePaths: [], candidate, detail: errorMessage(error), renderResults: [], ok: false, units: [] };
+      const copiedBeforeFailure = !destinationExisted && await exists(join(rootPath, expectedDestination));
+      return {
+        baselinePaths: [],
+        candidate,
+        ...(copiedBeforeFailure ? { destination: expectedDestination } : {}),
+        detail: errorMessage(error),
+        renderResults: [],
+        ok: false,
+        units: [],
+      };
     }
   }
 
@@ -646,7 +657,7 @@ async function importCandidateSources(
  * destination.
  */
 async function importInstructionFile(rootPath: string, sourceName: string): Promise<string> {
-  const destinationRelative = `${INSTRUCTIONS_DIR}/${sourceName.toLowerCase()}`;
+  const destinationRelative = instructionDestination(sourceName);
   const destination = join(rootPath, destinationRelative);
   if (await exists(destination)) {
     throw new Error(
@@ -658,6 +669,10 @@ async function importInstructionFile(rootPath: string, sourceName: string): Prom
   await mkdir(dirname(destination), { recursive: true });
   await writeFile(destination, content);
   return destinationRelative;
+}
+
+function instructionDestination(sourceName: string): string {
+  return `${INSTRUCTIONS_DIR}/${sourceName.toLowerCase()}`;
 }
 
 function sourceOriginFor(acquisition: AdoptAcquisition, path: string): SourceOrigin {

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -129,10 +129,16 @@ export interface AdoptReport {
    */
   readonly transformPreviews: readonly TransformPreview[];
   readonly write: boolean;
+  /** Logical paths actually written by this adoption attempt, including audit artifacts. */
+  readonly writtenPaths: readonly string[];
 }
 
 /** Where write-mode adoption persists its migration report. */
 export const ADOPT_REPORT_DIR = ".skillset/cache/adopt";
+const ADOPT_REPORT_PATHS = [
+  `${ADOPT_REPORT_DIR}/report.md`,
+  `${ADOPT_REPORT_DIR}/report.json`,
+] as const;
 
 const INSTRUCTIONS_DIR = ".skillset/rules";
 
@@ -278,6 +284,7 @@ async function adoptResolvedRoot(
       surveySkips: survey.surveySkips,
       transformPreviews: [],
       write: false,
+      writtenPaths: [],
     };
   }
 
@@ -300,6 +307,7 @@ async function adoptResolvedRoot(
       surveySkips: survey.surveySkips,
       transformPreviews: [],
       write: false,
+      writtenPaths: ADOPT_REPORT_PATHS,
     };
     await persistAdoptReport(report);
     return report;
@@ -345,6 +353,7 @@ async function adoptResolvedRoot(
   }
 
   let builtFiles = 0;
+  let buildWritePaths: readonly string[] = [];
   let renderResults: readonly SkillsetRenderResult[] = [
     ...surveySkipRenderResults(survey.surveySkips),
     ...imports.flatMap((result) => result.renderResults),
@@ -353,6 +362,7 @@ async function adoptResolvedRoot(
     try {
       const build = await buildSkillsetResult(init.rootPath, { ...buildOptions, isolated: true });
       builtFiles = build.data.length;
+      buildWritePaths = build.writes.paths;
       renderResults = [
         ...renderResults,
         ...build.renderResults,
@@ -366,6 +376,16 @@ async function adoptResolvedRoot(
   const baselinePaths = [...new Set([
     ...(init.baselinePath === undefined ? [] : [init.baselinePath]),
     ...imports.flatMap((result) => result.baselinePaths),
+  ])];
+  const writtenPaths = [...new Set([
+    ...init.files.filter((file) => file.status === "create").map((file) => file.path),
+    ...imports.flatMap((entry) => [
+      ...(entry.destination === undefined ? [] : [entry.destination]),
+      ...entry.units.map((unit) => `.skillset/${unit.kind === "skill" ? "skills" : "plugins"}/${unit.name}`),
+    ]),
+    ...baselinePaths,
+    ...buildWritePaths,
+    ...ADOPT_REPORT_PATHS,
   ])];
   const report: AdoptReport = {
     acquisition,
@@ -390,6 +410,7 @@ async function adoptResolvedRoot(
     surveySkips: survey.surveySkips,
     transformPreviews,
     write: true,
+    writtenPaths,
   };
 
   await persistAdoptReport(report, workspaceCacheKey);

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -16,7 +16,7 @@ import {
 import type { ReleaseBaselineEntry } from "./adoption";
 import { buildSkillsetResult, ISOLATED_OUT_ROOT } from "@skillset/core";
 import { gitSafeEnv } from "./git-env";
-import { importSources } from "./import";
+import { ImportBatchError, type ImportReport, importSources } from "./import";
 import { inspectSkillset } from "@skillset/core";
 import { loadBuildGraph } from "@skillset/core/internal/resolver";
 import { initSkillset, type SetupFile, type SetupImportCandidate, type SetupInclude, type SurveySkip } from "./setup";
@@ -549,16 +549,7 @@ async function importCandidate(
 
   try {
     const batch = await importCandidateSources(rootPath, acquisition, candidate, allCandidates);
-    const units = batch.imports.map((report) => {
-      const sourcePath = candidate.kind === "plugin"
-        ? candidate.path
-        : relative(rootPath, report.sourcePath).replaceAll("\\", "/");
-      return {
-        kind: report.kind,
-        name: report.name,
-        sourcePath: sourcePath.length === 0 ? "." : sourcePath,
-      };
-    });
+    const units = adoptedUnits(rootPath, candidate, batch.imports);
     for (const report of batch.imports) {
       for (const file of report.copiedFiles) {
         if (basename(file) !== "SKILL.md") continue;
@@ -579,8 +570,35 @@ async function importCandidate(
       units,
     };
   } catch (error) {
-    return { baselinePaths: [], candidate, detail: errorMessage(error), renderResults: [], ok: false, units: [] };
+    const partialImports = error instanceof ImportBatchError ? error.imports : [];
+    return {
+      baselinePaths: [...new Set(partialImports.flatMap((report) =>
+        report.baselinePath === undefined ? [] : [report.baselinePath]
+      ))],
+      candidate,
+      detail: errorMessage(error),
+      renderResults: partialImports.flatMap((report) => report.renderResults),
+      ok: false,
+      units: adoptedUnits(rootPath, candidate, partialImports),
+    };
   }
+}
+
+function adoptedUnits(
+  rootPath: string,
+  candidate: SetupImportCandidate,
+  imports: readonly ImportReport[]
+): readonly AdoptImportedUnit[] {
+  return imports.map((report) => {
+    const sourcePath = candidate.kind === "plugin"
+      ? candidate.path
+      : relative(rootPath, report.sourcePath).replaceAll("\\", "/");
+    return {
+      kind: report.kind,
+      name: report.name,
+      sourcePath: sourcePath.length === 0 ? "." : sourcePath,
+    };
+  });
 }
 
 async function importCandidateSources(

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -99,6 +99,7 @@ export interface TransformPreview {
 export interface AdoptReport {
   readonly acquisition: AdoptAcquisition;
   readonly alreadyAdopted: boolean;
+  readonly baselinePath?: string;
   readonly baselines: readonly ReleaseBaselineEntry[];
   readonly buildError?: string;
   readonly builtFiles: number;
@@ -361,6 +362,7 @@ async function adoptResolvedRoot(
   const report: AdoptReport = {
     acquisition,
     alreadyAdopted,
+    ...(init.baselinePath === undefined ? {} : { baselinePath: init.baselinePath }),
     baselines: init.baselines,
     ...(buildError === undefined ? {} : { buildError }),
     builtFiles,

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -184,17 +184,20 @@ export async function adoptSkillset(
     });
     if (!preflight.ok) return preflight;
   }
-  const acquisition = destination === undefined || write !== true
-    ? acquired
+  const copied = destination === undefined || write !== true
+    ? { acquisition: acquired, writtenPaths: [] }
     : await copyAdoptAcquisition(acquired, resolve(basePath, destination));
-  return adoptResolvedRoot(acquisition, {
+  return adoptResolvedRoot(copied.acquisition, {
     ...buildOptions,
     ...(targets === undefined ? {} : { targets }),
     ...(write === undefined ? {} : { write }),
-  });
+  }, copied.writtenPaths);
 }
 
-async function copyAdoptAcquisition(acquisition: AdoptAcquisition, destination: string): Promise<AdoptAcquisition> {
+async function copyAdoptAcquisition(
+  acquisition: AdoptAcquisition,
+  destination: string
+): Promise<{ readonly acquisition: AdoptAcquisition; readonly writtenPaths: readonly string[] }> {
   const rootPath = resolve(destination);
   try {
     if ((await readdir(rootPath)).length > 0) throw new Error(`skillset: init acquisition destination must be empty: ${rootPath}`);
@@ -228,8 +231,24 @@ async function copyAdoptAcquisition(acquisition: AdoptAcquisition, destination: 
   } finally {
     if (stagedRoot !== undefined) await rm(stagedRoot, { force: true, recursive: true });
   }
+  const writtenPaths = await listAcquisitionFiles(rootPath);
   await initializeAdoptGit(rootPath);
-  return { ...acquisition, rootPath };
+  return {
+    acquisition: { ...acquisition, rootPath },
+    writtenPaths: [...writtenPaths, ".git"],
+  };
+}
+
+async function listAcquisitionFiles(rootPath: string, currentPath = rootPath): Promise<readonly string[]> {
+  const paths: string[] = [];
+  const entries = (await readdir(currentPath, { withFileTypes: true }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    const path = join(currentPath, entry.name);
+    if (entry.isDirectory()) paths.push(...await listAcquisitionFiles(rootPath, path));
+    else paths.push(relative(rootPath, path));
+  }
+  return paths;
 }
 
 async function initializeAdoptGit(rootPath: string): Promise<void> {
@@ -245,7 +264,8 @@ async function initializeAdoptGit(rootPath: string): Promise<void> {
 
 async function adoptResolvedRoot(
   acquisition: AdoptAcquisition,
-  options: AdoptOptions = {}
+  options: AdoptOptions = {},
+  acquisitionWrittenPaths: readonly string[] = []
 ): Promise<AdoptReport> {
   const { candidates: selectedCandidates, include, name, targets, write, ...buildOptions } = options;
   const writeMode = write === true;
@@ -307,7 +327,7 @@ async function adoptResolvedRoot(
       surveySkips: survey.surveySkips,
       transformPreviews: [],
       write: false,
-      writtenPaths: ADOPT_REPORT_PATHS,
+      writtenPaths: [...new Set([...acquisitionWrittenPaths, ...ADOPT_REPORT_PATHS])],
     };
     await persistAdoptReport(report);
     return report;
@@ -378,6 +398,7 @@ async function adoptResolvedRoot(
     ...imports.flatMap((result) => result.baselinePaths),
   ])];
   const writtenPaths = [...new Set([
+    ...acquisitionWrittenPaths,
     ...init.files.filter((file) => file.status === "create").map((file) => file.path),
     ...imports.flatMap((entry) => [
       ...(entry.destination === undefined ? [] : [entry.destination]),

--- a/apps/skillset/src/change-workflow.ts
+++ b/apps/skillset/src/change-workflow.ts
@@ -91,6 +91,7 @@ export interface ChangeAddReport {
 
 export interface ChangeReasonReport {
   readonly entry: ChangeEntryView;
+  readonly ledgerPath?: string;
 }
 
 export interface ChangeAmendReport {
@@ -235,7 +236,12 @@ export async function updateChangeReason(rootPath: string, options: ChangeReason
   }
   const updated = resolvePendingChangeRef(await readPendingChangeEntries(rootPath, storageOptions), entry.id ?? options.ref);
   const refs = refIndex([updated], await readHistoryEntries(rootPath, storageOptions));
-  return { entry: pendingView(updated, refs) };
+  return {
+    entry: pendingView(updated, refs),
+    ...(entry.format === "reason"
+      ? { ledgerPath: workspaceChangeFile(storageOptions.sourceDir, "ledger.jsonl") }
+      : {}),
+  };
 }
 
 export async function amendAppliedChange(rootPath: string, options: ChangeAmendOptions): Promise<ChangeAmendReport> {

--- a/apps/skillset/src/change-workflow.ts
+++ b/apps/skillset/src/change-workflow.ts
@@ -86,6 +86,7 @@ export interface ChangeEntryView {
 
 export interface ChangeAddReport {
   readonly entry: ChangeEntryView;
+  readonly ledgerPath: string;
 }
 
 export interface ChangeReasonReport {
@@ -193,7 +194,10 @@ export async function addChangeEntry(rootPath: string, options: ChangeAddOptions
   const [entry] = await readPendingChangeEntries(rootPath, statusOptions).then((entries) => entries.filter((item) => item.id === id));
   if (entry === undefined) throw new Error(`skillset: failed to read created change entry ${id}`);
   const refs = refIndex([entry], await readHistoryEntries(rootPath, statusOptions));
-  return { entry: pendingView(entry, refs) };
+  return {
+    entry: pendingView(entry, refs),
+    ledgerPath: workspaceChangeFile(statusOptions.sourceDir, "ledger.jsonl"),
+  };
 }
 
 export async function updateChangeReason(rootPath: string, options: ChangeReasonOptions): Promise<ChangeReasonReport> {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -665,20 +665,23 @@ export async function runCli(
   }
 
   if (command === "init") {
+    const initCwd = resolve(rootPath);
+    const explicitInitRootPath = rootExplicit ? initCwd : undefined;
+    const setupRootPath = importPath ?? explicitInitRootPath;
     if (initAdopt !== undefined || initFrom !== undefined) {
       const writeMode = initAdopt !== undefined && yes && !dryRun;
       const inferredRoot = initFrom === undefined
         ? (await initSkillset({
-            cwd: rootPath,
-            ...(rootExplicit ? { rootPath } : {}),
+            cwd: initCwd,
+            ...(explicitInitRootPath === undefined ? {} : { rootPath: explicitInitRootPath }),
             useGitRoot: !rootExplicit,
             write: false,
           })).rootPath
         : rootPath;
       const report = await adoptSkillset(initFrom ?? inferredRoot, {
-        cwd: rootPath,
+        cwd: initCwd,
         ...(initAdopt === undefined ? {} : { candidates: initAdopt }),
-        ...(importPath === undefined ? {} : { destination: resolve(rootPath, importPath) }),
+        ...(importPath === undefined ? {} : { destination: resolve(initCwd, importPath) }),
         ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
         ...(importName === undefined ? {} : { name: importName }),
         ...(setupTargets === undefined ? {} : { targets: setupTargets }),
@@ -712,11 +715,11 @@ export async function runCli(
     }
     if (!jsonOutput && !yes && !dryRun && process.stdin.isTTY && process.stdout.isTTY) {
       const survey = await initSkillset({
-        cwd: rootPath,
-        ...(importPath === undefined ? rootExplicit ? { rootPath } : {} : { rootPath: importPath }),
+        cwd: initCwd,
+        ...(setupRootPath === undefined ? {} : { rootPath: setupRootPath }),
         ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
         ...(setupTargets === undefined ? {} : { targets: setupTargets }),
-        useGitRoot: !rootExplicit && importPath === undefined,
+        useGitRoot: setupRootPath === undefined,
         write: false,
       });
       if (survey.importCandidates.length > 0) {
@@ -725,7 +728,7 @@ export async function runCli(
         if (selection.confirmed && selection.candidates.length > 0) {
           const report = await adoptSkillset(importPath ?? survey.rootPath, {
             candidates: selection.candidates,
-            cwd: rootPath,
+            cwd: initCwd,
             ...(importName === undefined ? {} : { name: importName }),
             ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
             ...(setupTargets === undefined ? {} : { targets: setupTargets }),
@@ -741,12 +744,12 @@ export async function runCli(
           return;
         }
         const setup = await initSkillset({
-          cwd: rootPath,
-          ...(importPath === undefined ? rootExplicit ? { rootPath } : {} : { rootPath: importPath }),
+          cwd: initCwd,
+          ...(setupRootPath === undefined ? {} : { rootPath: setupRootPath }),
           ...(importName === undefined ? {} : { name: importName }),
           ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
           ...(setupTargets === undefined ? {} : { targets: setupTargets }),
-          useGitRoot: !rootExplicit && importPath === undefined,
+          useGitRoot: setupRootPath === undefined,
           write: true,
         });
         printSetupReport(setup, "written");
@@ -755,12 +758,12 @@ export async function runCli(
       }
     }
     const setup = await initSkillset({
-      cwd: rootPath,
-      ...(importPath === undefined ? rootExplicit ? { rootPath } : {} : { rootPath: importPath }),
+      cwd: initCwd,
+      ...(setupRootPath === undefined ? {} : { rootPath: setupRootPath }),
       ...(importName === undefined ? {} : { name: importName }),
       ...(setupTargets === undefined ? {} : { targets: setupTargets }),
       ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
-      useGitRoot: !rootExplicit && importPath === undefined,
+      useGitRoot: setupRootPath === undefined,
       write: yes && !dryRun,
     });
     if (jsonOutput && yes && !dryRun) {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -107,10 +107,9 @@ import {
 } from "./try-cli";
 import { initSkillset, type SetupInclude, type SetupReport } from "./setup";
 import { sourceUnitDisplay, sourceUnitDisplays, sourceUnitSelector } from "@skillset/core/internal/source-unit-selector";
-import { renderValidatedJson } from "@skillset/core/internal/structured-output";
 import { renderCliDataResult } from "./cli-output";
 import { runSkillsetTest, type SkillsetTestReport } from "./test-runner";
-import type { BuildScope, CompileBuildMode, JsonRecord, SkillsetOptions, SourceOrigin, TargetName } from "@skillset/core/internal/types";
+import type { BuildScope, CompileBuildMode, SkillsetOptions, SourceOrigin, TargetName } from "@skillset/core/internal/types";
 import type { SchemaJsonRecord, SkillsetCliDiagnostic } from "@skillset/schema";
 
 type Command = CliCommand;
@@ -245,9 +244,14 @@ export async function runCli(
   } = parseCliArgs(args);
 
   if (command === "build") {
-    console.log("skillset: build projects source to generated output");
     if (dryRun || !yes) {
       const result = await diffSkillsetResult(rootPath, options);
+      if (jsonOutput) {
+        printCliJsonData("build.plan", { changes: result.data, state: "planned", writes: [] }, result.ok ? 0 : 1, "diagnostics", result.diagnostics);
+        if (!result.ok) process.exitCode = 1;
+        return;
+      }
+      console.log("skillset: build projects source to generated output");
       printDiagnostics(result.diagnostics);
       const { data: diff } = result;
       printDiffPlan(diff, dryRun ? "dry run" : "write confirmation required");
@@ -256,6 +260,12 @@ export async function runCli(
       return;
     }
     const result = await buildSkillsetResult(rootPath, options);
+    if (jsonOutput) {
+      printCliJsonData("build.apply", { result, state: "written", writes: result.writes.writtenPaths }, result.ok ? 0 : 1, "diagnostics", result.diagnostics);
+      if (!result.ok) process.exitCode = 1;
+      return;
+    }
+    console.log("skillset: build projects source to generated output");
     printDiagnostics(result.diagnostics);
     console.log(`skillset: wrote ${result.writes.writtenPaths.length} generated files`);
     if (result.writes.deletedPaths.length > 0) {
@@ -307,23 +317,27 @@ export async function runCli(
       return;
     }
     if (changeSubcommand === "add") {
-      printChangeEntry("added", (await addChangeEntry(rootPath, {
+      const report = await addChangeEntry(rootPath, {
         ...changeOptions,
         ...(changeBump === undefined ? {} : { bump: changeBump }),
         ...(changeGroup === undefined ? {} : { group: changeGroup }),
         reason: changeReason ?? { kind: "auto" },
         scopes: changeScopes ?? [],
-      })).entry);
+      });
+      if (jsonOutput) printCliJsonData("change.add", { report, state: "written", writes: [report.entry.path, report.ledgerPath] });
+      else printChangeEntry("added", report.entry);
       return;
     }
     if (changeSubcommand === "reason") {
       if (changeRef === undefined) throw new Error("skillset: change reason requires @ref");
-      printChangeEntry("updated", (await updateChangeReason(rootPath, {
+      const report = await updateChangeReason(rootPath, {
         ...changeOptions,
         append: changeAppend,
         reason: changeReason ?? { kind: "auto" },
         ref: changeRef,
-      })).entry);
+      });
+      if (jsonOutput) printCliJsonData("change.reason", { report, state: "written", writes: [report.entry.path] });
+      else printChangeEntry("updated", report.entry);
       return;
     }
     if (changeSubcommand === "amend") {
@@ -333,8 +347,11 @@ export async function runCli(
         reason: changeReason ?? { kind: "auto" },
         ref: changeRef,
       });
-      printChangeEntry("amended", report.entry);
-      console.log(`  amendment: ${report.path}`);
+      if (jsonOutput) printCliJsonData("change.amend", { report, state: "written", writes: [report.path] });
+      else {
+        printChangeEntry("amended", report.entry);
+        console.log(`  amendment: ${report.path}`);
+      }
       return;
     }
     if (changeSubcommand === "show") {
@@ -376,8 +393,11 @@ export async function runCli(
         ...changeOptions,
         write: yes && !dryRun,
       });
-      printChangeMigration(report);
-      if ((!yes || dryRun) && report.entries.length > 0) console.log("skillset: rerun change migrate with --yes to rewrite pending entries");
+      if (jsonOutput) printCliJsonData("change.migrate", { report, state: report.written ? "written" : "planned", writes: report.written ? [report.ledgerPath] : [] });
+      else {
+        printChangeMigration(report);
+        if ((!yes || dryRun) && report.entries.length > 0) console.log("skillset: rerun change migrate with --yes to rewrite pending entries");
+      }
       return;
     }
     throw new Error("skillset: expected change subcommand add, amend, check, history, list, migrate, reason, show, or status");
@@ -396,7 +416,12 @@ export async function runCli(
     }
     if (releaseSubcommand === "apply") {
       if (dryRun || !yes) {
-        printReleasePlan(await planRelease(rootPath, options));
+        const plan = await planRelease(rootPath, options);
+        if (jsonOutput) {
+          printCliJsonData("release.apply", { plan, state: "planned", writes: [] });
+          return;
+        }
+        printReleasePlan(plan);
         if (dryRun) {
           console.log("skillset: release apply dry run wrote no files");
         } else {
@@ -405,7 +430,8 @@ export async function runCli(
         return;
       }
       const result = await applyRelease(rootPath, options);
-      printReleaseApply(result.plan, result.files, result.renderedFiles);
+      if (jsonOutput) printCliJsonData("release.apply", { result, state: "written", writes: result.files });
+      else printReleaseApply(result.plan, result.files, result.renderedFiles);
       return;
     }
     if (releaseSubcommand === "amend") {
@@ -425,8 +451,11 @@ export async function runCli(
       ...options,
       write: yes && !dryRun,
     });
-    process.stdout.write(renderProviderFormatUpdateReport(report));
-    if (!yes || dryRun) console.log("skillset: update preview wrote no files");
+    if (jsonOutput) printCliJsonData("update", { report, state: report.wrote ? "written" : "planned", writes: report.writtenPaths }, report.ok && !report.blocked ? 0 : 1);
+    else {
+      process.stdout.write(renderProviderFormatUpdateReport(report));
+      if (!yes || dryRun) console.log("skillset: update preview wrote no files");
+    }
     if (!report.ok || report.blocked) process.exitCode = 1;
     return;
   }
@@ -434,8 +463,11 @@ export async function runCli(
   if (command === "restore") {
     if (importPath === undefined) throw new Error("skillset: expected backup id to restore");
     const report = await restoreOutputBackup(rootPath, importPath, { write: yes && !dryRun });
-    printRestoreReport(report);
-    if (!yes || dryRun) console.log("skillset: rerun restore with --yes to write restored files");
+    if (jsonOutput) printCliJsonData("restore", { report, state: report.write ? "written" : "planned", writes: report.restoredPaths });
+    else {
+      printRestoreReport(report);
+      if (!yes || dryRun) console.log("skillset: rerun restore with --yes to write restored files");
+    }
     return;
   }
 
@@ -481,7 +513,7 @@ export async function runCli(
         write: yes && !dryRun,
       });
       if (jsonOutput) {
-        process.stdout.write(renderValidatedJson(report as unknown as JsonRecord, "skillset marketplace update"));
+        printCliJsonData("marketplace.update", { report, state: report.write ? "written" : "planned", writes: report.writtenPaths }, report.ok ? 0 : 1);
       } else {
         printMarketplaceUpdate(report);
       }
@@ -607,8 +639,11 @@ export async function runCli(
         write: writeMode,
       });
       const reason = writeMode ? report.write ? "written" : "blocked before write" : "write confirmation required";
-      printAdoptReport(report, reason);
-      if (!writeMode && report.ok && initAdopt !== undefined) console.log("skillset: rerun init with --adopt and --yes to write adopted source");
+      if (jsonOutput) printCliJsonData("init.adopt", { report, state: report.write ? "written" : "planned", writes: report.write ? [...report.setupFiles.map((file) => file.path), ...report.imports.flatMap((entry) => entry.destination === undefined ? [] : [entry.destination])] : [] }, report.ok ? 0 : 1);
+      else {
+        printAdoptReport(report, reason);
+        if (!writeMode && report.ok && initAdopt !== undefined) console.log("skillset: rerun init with --adopt and --yes to write adopted source");
+      }
       if (!report.ok) process.exitCode = 1;
       if (writeMode && report.ok) await rememberKnownSkillsetWorkspace(report.rootPath, options);
       return;
@@ -666,8 +701,11 @@ export async function runCli(
       useGitRoot: !rootExplicit && importPath === undefined,
       write: yes && !dryRun,
     });
-    printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
-    if (!yes || dryRun) console.log("skillset: rerun init with --yes to write setup files");
+    if (jsonOutput) printCliJsonData("init", { report: setup, state: yes && !dryRun ? "written" : "planned", writes: yes && !dryRun ? setup.files : [] });
+    else {
+      printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
+      if (!yes || dryRun) console.log("skillset: rerun init with --yes to write setup files");
+    }
     if (yes && !dryRun) await rememberKnownSkillsetWorkspace(setup.rootPath, options);
     return;
   }
@@ -681,7 +719,9 @@ export async function runCli(
       rootPath,
       ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
     });
-    if (result.imports.length === 1) {
+    if (jsonOutput) {
+      printCliJsonData("import", { result, state: "written", writes: result.imports.flatMap((entry) => [entry.targetPath]) });
+    } else if (result.imports.length === 1) {
       const [single] = result.imports;
       if (single !== undefined) printImportReport(single);
     } else {
@@ -691,7 +731,7 @@ export async function runCli(
         console.log(`  - ${imported.kind} ${imported.name}: ${imported.targetPath} (${imported.files} files)`);
       }
     }
-    for (const warning of result.warnings) console.warn(`  warning: ${warning}`);
+    if (!jsonOutput) for (const warning of result.warnings) console.warn(`  warning: ${warning}`);
     return;
   }
 
@@ -708,8 +748,15 @@ export async function runCli(
       skillsetOptions: options,
       write: yes && !dryRun,
     });
-    printNewSourceReport(report, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
-    if (!yes || dryRun) console.log("skillset: rerun new with --yes to write source files");
+    if (jsonOutput) printCliJsonData("new", {
+      report,
+      state: report.write ? "written" : "planned",
+      writes: report.write ? report.files.map((file) => file.path) : [],
+    });
+    else {
+      printNewSourceReport(report, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
+      if (!yes || dryRun) console.log("skillset: rerun new with --yes to write source files");
+    }
     return;
   }
 
@@ -881,11 +928,8 @@ export async function runCli(
       ...(reconcileChoice === undefined ? {} : { choice: reconcileChoice }),
       write: reconcileChoice !== undefined && yes,
     });
-    if (jsonOutput) {
-      printCliJsonData("reconcile", report, 0, report.applied ? "mutation" : "plan");
-    } else {
-      process.stdout.write(renderReconcileReport(report));
-    }
+    if (jsonOutput) printCliJsonData("reconcile", { report, state: report.applied ? "written" : "planned", writes: report.writtenPaths });
+    else process.stdout.write(renderReconcileReport(report));
     return;
   }
 
@@ -2315,6 +2359,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   validateJsonFlags(command, jsonOutput, {
     ...(changeSubcommand === undefined ? {} : { changeSubcommand }),
     ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
+    ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
   });
   if (jsonlOutput) throw new Error("skillset: --jsonl is not supported until a streaming route is enabled");
   validateLookupFlags(command, args, {
@@ -3084,12 +3129,16 @@ function validateJsonFlags(
   route: {
     readonly changeSubcommand?: ChangeSubcommand;
     readonly distributionSubcommand?: DistributionSubcommand;
+    readonly releaseSubcommand?: ReleaseSubcommand;
   }
 ): void {
   if (!jsonOutput) return;
+  if (command === "build" || command === "import" || command === "init" || command === "new" || command === "reconcile" || command === "restore" || command === "update") return;
   if (command === "check") return;
   if (command === "change" && (route.changeSubcommand === "check" || route.changeSubcommand === "history" || route.changeSubcommand === "list" || route.changeSubcommand === "show" || route.changeSubcommand === "status")) return;
-  if (command === "diff" || command === "status" || command === "explain" || command === "list" || command === "lookup" || command === "marketplace" || command === "reconcile" || command === "test") return;
+  if (command === "change" && (route.changeSubcommand === "add" || route.changeSubcommand === "amend" || route.changeSubcommand === "migrate" || route.changeSubcommand === "reason")) return;
+  if (command === "release" && route.releaseSubcommand === "apply") return;
+  if (command === "diff" || command === "status" || command === "explain" || command === "list" || command === "lookup" || command === "marketplace" || command === "test") return;
   if (command === "distribute" && route.distributionSubcommand === "plan") return;
   throw new Error("skillset: --json is not supported for this command route");
 }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -273,6 +273,7 @@ export async function runCli(
         writes: result.writes.paths,
       }, result.ok ? 0 : 1, "diagnostics", serializeDiagnostics(result.diagnostics));
       if (!result.ok) process.exitCode = 1;
+      else await rememberKnownSkillsetWorkspace(rootPath, options);
       return;
     }
     console.log("skillset: build projects source to generated output");
@@ -675,7 +676,18 @@ export async function runCli(
         write: writeMode,
       });
       const reason = writeMode ? report.write ? "written" : "blocked before write" : "write confirmation required";
-      if (jsonOutput) printCliJsonData("init.adopt", { report, state: report.write ? "written" : "planned", writes: report.write ? [...report.setupFiles.filter((file) => file.status === "create").map((file) => file.path), ...report.imports.flatMap((entry) => entry.destination === undefined ? [] : [entry.destination])] : [] }, report.ok ? 0 : 1);
+      if (jsonOutput) printCliJsonData("init.adopt", {
+        report,
+        state: report.write ? "written" : "planned",
+        writes: report.write ? [...new Set([
+          ...report.setupFiles.filter((file) => file.status === "create").map((file) => file.path),
+          ...report.imports.flatMap((entry) => [
+            ...(entry.destination === undefined ? [] : [entry.destination]),
+            ...entry.units.map((unit) => `.skillset/${unit.kind === "skill" ? "skills" : "plugins"}/${unit.name}`),
+          ]),
+          ...(report.baselinePath === undefined ? [] : [report.baselinePath]),
+        ])] : [],
+      }, report.ok ? 0 : 1);
       else {
         printAdoptReport(report, reason);
         if (!writeMode && report.ok && initAdopt !== undefined) console.log("skillset: rerun init with --adopt and --yes to write adopted source");

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -247,7 +247,7 @@ export async function runCli(
     if (dryRun || !yes) {
       const result = await diffSkillsetResult(rootPath, options);
       if (jsonOutput) {
-        printCliJsonData("build.plan", { changes: result.data, state: "planned", writes: [] }, result.ok ? 0 : 1, "diagnostics", serializeDiagnostics(result.diagnostics));
+        printCliJsonData("build.plan", { changes: result.data, state: "planned", writes: [] }, result.ok ? 0 : 1, "plan", serializeDiagnostics(result.diagnostics));
         if (!result.ok) process.exitCode = 1;
         return;
       }
@@ -272,7 +272,7 @@ export async function runCli(
         },
         state: "written",
         writes: result.writes.paths,
-      }, result.ok ? 0 : 1, "diagnostics", serializeDiagnostics(result.diagnostics));
+      }, result.ok ? 0 : 1, "mutation", serializeDiagnostics(result.diagnostics));
       if (!result.ok) process.exitCode = 1;
       return;
     }
@@ -693,7 +693,7 @@ export async function runCli(
       }
       if (jsonOutput) printCliJsonData("init.adopt", {
         report,
-        state: report.write ? "written" : "planned",
+        state: report.writtenPaths.length > 0 ? "written" : "planned",
         writes: report.writtenPaths,
       }, report.ok ? 0 : 1);
       else {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -698,6 +698,8 @@ export async function runCli(
             ...entry.units.map((unit) => `.skillset/${unit.kind === "skill" ? "skills" : "plugins"}/${unit.name}`),
           ]),
           ...report.baselinePaths,
+          `${ADOPT_REPORT_DIR}/report.md`,
+          `${ADOPT_REPORT_DIR}/report.json`,
         ])] : [],
       }, report.ok ? 0 : 1);
       else {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -261,7 +261,17 @@ export async function runCli(
     }
     const result = await buildSkillsetResult(rootPath, options);
     if (jsonOutput) {
-      printCliJsonData("build.apply", { result, state: "written", writes: result.writes.writtenPaths }, result.ok ? 0 : 1, "diagnostics", result.diagnostics);
+      printCliJsonData("build.apply", {
+        report: {
+          ok: result.ok,
+          operation: result.operation,
+          renderedFiles: result.data.length,
+          renderResults: result.renderResults.length,
+          writes: result.writes,
+        },
+        state: "written",
+        writes: result.writes.paths,
+      }, result.ok ? 0 : 1, "diagnostics", result.diagnostics);
       if (!result.ok) process.exitCode = 1;
       return;
     }
@@ -393,7 +403,21 @@ export async function runCli(
         ...changeOptions,
         write: yes && !dryRun,
       });
-      if (jsonOutput) printCliJsonData("change.migrate", { report, state: report.written ? "written" : "planned", writes: report.written ? [report.ledgerPath] : [] });
+      if (jsonOutput) {
+        const writes = report.written && report.entries.length > 0
+          ? [...new Set([
+              ...report.entries.flatMap((entry) => entry.fromPath === entry.toPath
+                ? [entry.toPath]
+                : [entry.fromPath, entry.toPath]),
+              report.ledgerPath,
+            ])].sort()
+          : [];
+        printCliJsonData("change.migrate", {
+          report: { ...report, entries: report.entries.map(serializeChangeEntry) },
+          state: report.written ? "written" : "planned",
+          writes,
+        });
+      }
       else {
         printChangeMigration(report);
         if ((!yes || dryRun) && report.entries.length > 0) console.log("skillset: rerun change migrate with --yes to rewrite pending entries");
@@ -639,7 +663,7 @@ export async function runCli(
         write: writeMode,
       });
       const reason = writeMode ? report.write ? "written" : "blocked before write" : "write confirmation required";
-      if (jsonOutput) printCliJsonData("init.adopt", { report, state: report.write ? "written" : "planned", writes: report.write ? [...report.setupFiles.map((file) => file.path), ...report.imports.flatMap((entry) => entry.destination === undefined ? [] : [entry.destination])] : [] }, report.ok ? 0 : 1);
+      if (jsonOutput) printCliJsonData("init.adopt", { report, state: report.write ? "written" : "planned", writes: report.write ? [...report.setupFiles.filter((file) => file.status === "create").map((file) => file.path), ...report.imports.flatMap((entry) => entry.destination === undefined ? [] : [entry.destination])] : [] }, report.ok ? 0 : 1);
       else {
         printAdoptReport(report, reason);
         if (!writeMode && report.ok && initAdopt !== undefined) console.log("skillset: rerun init with --adopt and --yes to write adopted source");
@@ -701,7 +725,7 @@ export async function runCli(
       useGitRoot: !rootExplicit && importPath === undefined,
       write: yes && !dryRun,
     });
-    if (jsonOutput) printCliJsonData("init", { report: setup, state: yes && !dryRun ? "written" : "planned", writes: yes && !dryRun ? setup.files : [] });
+    if (jsonOutput) printCliJsonData("init", { report: setup, state: yes && !dryRun ? "written" : "planned", writes: yes && !dryRun ? setup.files.filter((file) => file.status === "create").map((file) => file.path) : [] });
     else {
       printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
       if (!yes || dryRun) console.log("skillset: rerun init with --yes to write setup files");

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -694,7 +694,7 @@ export async function runCli(
             ...(entry.destination === undefined ? [] : [entry.destination]),
             ...entry.units.map((unit) => `.skillset/${unit.kind === "skill" ? "skills" : "plugins"}/${unit.name}`),
           ]),
-          ...(report.baselinePath === undefined ? [] : [report.baselinePath]),
+          ...report.baselinePaths,
         ])] : [],
       }, report.ok ? 0 : 1);
       else {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -428,7 +428,7 @@ export async function runCli(
           : [];
         printCliJsonData("change.migrate", {
           report: { ...report, entries: report.entries.map(serializeChangeEntry) },
-          state: report.written ? "written" : "planned",
+          state: writes.length > 0 ? "written" : "planned",
           writes,
         });
       }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -463,7 +463,7 @@ export async function runCli(
   if (command === "restore") {
     if (importPath === undefined) throw new Error("skillset: expected backup id to restore");
     const report = await restoreOutputBackup(rootPath, importPath, { write: yes && !dryRun });
-    if (jsonOutput) printCliJsonData("restore", { report, state: report.write ? "written" : "planned", writes: report.restoredPaths });
+    if (jsonOutput) printCliJsonData("restore", { report, state: report.write ? "written" : "planned", writes: report.write ? report.restoredPaths : [] });
     else {
       printRestoreReport(report);
       if (!yes || dryRun) console.log("skillset: rerun restore with --yes to write restored files");
@@ -648,7 +648,7 @@ export async function runCli(
       if (writeMode && report.ok) await rememberKnownSkillsetWorkspace(report.rootPath, options);
       return;
     }
-    if (!yes && !dryRun && process.stdin.isTTY && process.stdout.isTTY) {
+    if (!jsonOutput && !yes && !dryRun && process.stdin.isTTY && process.stdout.isTTY) {
       const survey = await initSkillset({
         cwd: rootPath,
         ...(importPath === undefined ? {} : { rootPath: importPath }),

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -694,16 +694,7 @@ export async function runCli(
       if (jsonOutput) printCliJsonData("init.adopt", {
         report,
         state: report.write ? "written" : "planned",
-        writes: report.write ? [...new Set([
-          ...report.setupFiles.filter((file) => file.status === "create").map((file) => file.path),
-          ...report.imports.flatMap((entry) => [
-            ...(entry.destination === undefined ? [] : [entry.destination]),
-            ...entry.units.map((unit) => `.skillset/${unit.kind === "skill" ? "skills" : "plugins"}/${unit.name}`),
-          ]),
-          ...report.baselinePaths,
-          `${ADOPT_REPORT_DIR}/report.md`,
-          `${ADOPT_REPORT_DIR}/report.json`,
-        ])] : [],
+        writes: report.writtenPaths,
       }, report.ok ? 0 : 1);
       else {
         printAdoptReport(report, reason);

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -263,6 +263,9 @@ export async function runCli(
     const result = await buildSkillsetResult(rootPath, options);
     if (jsonOutput) {
       if (result.ok) await rememberKnownSkillsetWorkspace(rootPath, options, true);
+      const writes = result.writes.backupManifestPath === undefined
+        ? result.writes.paths
+        : [...result.writes.paths, result.writes.backupManifestPath];
       printCliJsonData("build.apply", {
         report: {
           ok: result.ok,
@@ -272,7 +275,7 @@ export async function runCli(
           writes: result.writes,
         },
         state: "written",
-        writes: result.writes.paths,
+        writes,
       }, result.ok ? 0 : 1, "mutation", serializeDiagnostics(result.diagnostics));
       if (!result.ok) process.exitCode = 1;
       return;

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -550,7 +550,11 @@ export async function runCli(
         write: yes && !dryRun,
       });
       if (jsonOutput) {
-        printCliJsonData("marketplace.update", { report, state: report.write ? "written" : "planned", writes: report.writtenPaths }, report.ok ? 0 : 1);
+        printCliJsonData("marketplace.update", {
+          report,
+          state: report.ok && report.writtenPaths.length > 0 ? "written" : "planned",
+          writes: report.writtenPaths,
+        }, report.ok ? 0 : 1);
       } else {
         printMarketplaceUpdate(report);
       }
@@ -664,7 +668,12 @@ export async function runCli(
     if (initAdopt !== undefined || initFrom !== undefined) {
       const writeMode = initAdopt !== undefined && yes && !dryRun;
       const inferredRoot = initFrom === undefined
-        ? (await initSkillset({ cwd: rootPath, useGitRoot: !rootExplicit, write: false })).rootPath
+        ? (await initSkillset({
+            cwd: rootPath,
+            ...(rootExplicit ? { rootPath } : {}),
+            useGitRoot: !rootExplicit,
+            write: false,
+          })).rootPath
         : rootPath;
       const report = await adoptSkillset(initFrom ?? inferredRoot, {
         cwd: rootPath,
@@ -699,7 +708,7 @@ export async function runCli(
     if (!jsonOutput && !yes && !dryRun && process.stdin.isTTY && process.stdout.isTTY) {
       const survey = await initSkillset({
         cwd: rootPath,
-        ...(importPath === undefined ? {} : { rootPath: importPath }),
+        ...(importPath === undefined ? rootExplicit ? { rootPath } : {} : { rootPath: importPath }),
         ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
         ...(setupTargets === undefined ? {} : { targets: setupTargets }),
         useGitRoot: !rootExplicit && importPath === undefined,
@@ -728,7 +737,7 @@ export async function runCli(
         }
         const setup = await initSkillset({
           cwd: rootPath,
-          ...(importPath === undefined ? {} : { rootPath: importPath }),
+          ...(importPath === undefined ? rootExplicit ? { rootPath } : {} : { rootPath: importPath }),
           ...(importName === undefined ? {} : { name: importName }),
           ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
           ...(setupTargets === undefined ? {} : { targets: setupTargets }),
@@ -742,7 +751,7 @@ export async function runCli(
     }
     const setup = await initSkillset({
       cwd: rootPath,
-      ...(importPath === undefined ? {} : { rootPath: importPath }),
+      ...(importPath === undefined ? rootExplicit ? { rootPath } : {} : { rootPath: importPath }),
       ...(importName === undefined ? {} : { name: importName }),
       ...(setupTargets === undefined ? {} : { targets: setupTargets }),
       ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
@@ -755,6 +764,7 @@ export async function runCli(
       writes: yes && !dryRun
         ? [
             ...setup.files.filter((file) => file.status === "create").map((file) => file.path),
+            ...(setup.git?.status === "create" ? [setup.git.path] : []),
             ...(setup.baselinePath === undefined ? [] : [setup.baselinePath]),
           ]
         : [],

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -444,12 +444,17 @@ export async function runCli(
   if (command === "release") {
     if (releaseSubcommand === "audit") {
       const report = await auditVersions(rootPath, options);
-      printVersionAudit(report);
-      if (report.issues.length > 0) process.exitCode = 1;
+      if (jsonOutput) printCliJsonData("release.audit", report, report.issues.length > 0 ? 1 : 0);
+      else {
+        printVersionAudit(report);
+        if (report.issues.length > 0) process.exitCode = 1;
+      }
       return;
     }
     if (releaseSubcommand === "plan") {
-      printReleasePlan(await planRelease(rootPath, options));
+      const report = await planRelease(rootPath, options);
+      if (jsonOutput) printCliJsonData("release.plan", report);
+      else printReleasePlan(report);
       return;
     }
     if (releaseSubcommand === "apply") {
@@ -474,11 +479,18 @@ export async function runCli(
     }
     if (releaseSubcommand === "amend") {
       if (releaseRef === undefined) throw new Error("skillset: release amend requires @ref");
-      printReleaseAmend(await amendReleaseRecord(rootPath, {
+      const report = await amendReleaseRecord(rootPath, {
         ...options,
         reason: releaseReason ?? { kind: "auto" },
         ref: releaseRef,
-      }));
+      });
+      if (jsonOutput) {
+        printCliJsonData("release.amend", {
+          report,
+          state: "written",
+          writes: [report.amendmentPath],
+        });
+      } else printReleaseAmend(report);
       return;
     }
     throw new Error("skillset: expected release subcommand amend, apply, audit, or plan");
@@ -3245,7 +3257,7 @@ function validateJsonFlags(
   if (command === "check") return;
   if (command === "change" && (route.changeSubcommand === "check" || route.changeSubcommand === "history" || route.changeSubcommand === "list" || route.changeSubcommand === "show" || route.changeSubcommand === "status")) return;
   if (command === "change" && (route.changeSubcommand === "add" || route.changeSubcommand === "amend" || route.changeSubcommand === "migrate" || route.changeSubcommand === "reason")) return;
-  if (command === "release" && route.releaseSubcommand === "apply") return;
+  if (command === "release" && route.releaseSubcommand !== undefined) return;
   if (command === "diff" || command === "status" || command === "explain" || command === "list" || command === "lookup" || command === "marketplace" || command === "test") return;
   if (command === "distribute" && route.distributionSubcommand === "plan") return;
   throw new Error("skillset: --json is not supported for this command route");

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -274,7 +274,7 @@ export async function runCli(
           renderResults: result.renderResults.length,
           writes: result.writes,
         },
-        state: "written",
+        state: writes.length > 0 ? "written" : "planned",
         writes,
       }, result.ok ? 0 : 1, "mutation", serializeDiagnostics(result.diagnostics));
       if (!result.ok) process.exitCode = 1;
@@ -782,17 +782,20 @@ export async function runCli(
     if (jsonOutput && yes && !dryRun) {
       await rememberKnownSkillsetWorkspace(setup.rootPath, options, true);
     }
-    if (jsonOutput) printCliJsonData("init", {
-      report: setup,
-      state: yes && !dryRun ? "written" : "planned",
-      writes: yes && !dryRun
+    if (jsonOutput) {
+      const writes = yes && !dryRun
         ? [
             ...setup.files.filter((file) => file.status === "create").map((file) => file.path),
             ...(setup.git?.status === "create" ? [setup.git.path] : []),
             ...(setup.baselinePath === undefined ? [] : [setup.baselinePath]),
           ]
-        : [],
-    });
+        : [];
+      printCliJsonData("init", {
+        report: setup,
+        state: writes.length > 0 ? "written" : "planned",
+        writes,
+      });
+    }
     else {
       printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
       if (!yes || dryRun) console.log("skillset: rerun init with --yes to write setup files");

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -737,7 +737,16 @@ export async function runCli(
       useGitRoot: !rootExplicit && importPath === undefined,
       write: yes && !dryRun,
     });
-    if (jsonOutput) printCliJsonData("init", { report: setup, state: yes && !dryRun ? "written" : "planned", writes: yes && !dryRun ? setup.files.filter((file) => file.status === "create").map((file) => file.path) : [] });
+    if (jsonOutput) printCliJsonData("init", {
+      report: setup,
+      state: yes && !dryRun ? "written" : "planned",
+      writes: yes && !dryRun
+        ? [
+            ...setup.files.filter((file) => file.status === "create").map((file) => file.path),
+            ...(setup.baselinePath === undefined ? [] : [setup.baselinePath]),
+          ]
+        : [],
+    });
     else {
       printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
       if (!yes || dryRun) console.log("skillset: rerun init with --yes to write setup files");
@@ -756,7 +765,14 @@ export async function runCli(
       ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
     });
     if (jsonOutput) {
-      printCliJsonData("import", { result, state: "written", writes: result.imports.flatMap((entry) => [entry.targetPath]) });
+      printCliJsonData("import", {
+        result,
+        state: "written",
+        writes: [...new Set(result.imports.flatMap((entry) => [
+          entry.targetPath,
+          ...(entry.baselinePath === undefined ? [] : [entry.baselinePath]),
+        ]))],
+      });
     } else if (result.imports.length === 1) {
       const [single] = result.imports;
       if (single !== undefined) printImportReport(single);

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -685,6 +685,9 @@ export async function runCli(
         write: writeMode,
       });
       const reason = writeMode ? report.write ? "written" : "blocked before write" : "write confirmation required";
+      if (jsonOutput && writeMode && report.ok) {
+        await rememberKnownSkillsetWorkspace(report.rootPath, options, true);
+      }
       if (jsonOutput) printCliJsonData("init.adopt", {
         report,
         state: report.write ? "written" : "planned",
@@ -702,7 +705,7 @@ export async function runCli(
         if (!writeMode && report.ok && initAdopt !== undefined) console.log("skillset: rerun init with --adopt and --yes to write adopted source");
       }
       if (!report.ok) process.exitCode = 1;
-      if (writeMode && report.ok) await rememberKnownSkillsetWorkspace(report.rootPath, options);
+      if (!jsonOutput && writeMode && report.ok) await rememberKnownSkillsetWorkspace(report.rootPath, options);
       return;
     }
     if (!jsonOutput && !yes && !dryRun && process.stdin.isTTY && process.stdout.isTTY) {
@@ -758,6 +761,9 @@ export async function runCli(
       useGitRoot: !rootExplicit && importPath === undefined,
       write: yes && !dryRun,
     });
+    if (jsonOutput && yes && !dryRun) {
+      await rememberKnownSkillsetWorkspace(setup.rootPath, options, true);
+    }
     if (jsonOutput) printCliJsonData("init", {
       report: setup,
       state: yes && !dryRun ? "written" : "planned",
@@ -773,7 +779,7 @@ export async function runCli(
       printSetupReport(setup, dryRun ? "dry run" : yes ? "written" : "write confirmation required");
       if (!yes || dryRun) console.log("skillset: rerun init with --yes to write setup files");
     }
-    if (yes && !dryRun) await rememberKnownSkillsetWorkspace(setup.rootPath, options);
+    if (!jsonOutput && yes && !dryRun) await rememberKnownSkillsetWorkspace(setup.rootPath, options);
     return;
   }
 

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -247,7 +247,7 @@ export async function runCli(
     if (dryRun || !yes) {
       const result = await diffSkillsetResult(rootPath, options);
       if (jsonOutput) {
-        printCliJsonData("build.plan", { changes: result.data, state: "planned", writes: [] }, result.ok ? 0 : 1, "diagnostics", result.diagnostics);
+        printCliJsonData("build.plan", { changes: result.data, state: "planned", writes: [] }, result.ok ? 0 : 1, "diagnostics", serializeDiagnostics(result.diagnostics));
         if (!result.ok) process.exitCode = 1;
         return;
       }
@@ -271,7 +271,7 @@ export async function runCli(
         },
         state: "written",
         writes: result.writes.paths,
-      }, result.ok ? 0 : 1, "diagnostics", result.diagnostics);
+      }, result.ok ? 0 : 1, "diagnostics", serializeDiagnostics(result.diagnostics));
       if (!result.ok) process.exitCode = 1;
       return;
     }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -261,6 +261,7 @@ export async function runCli(
     }
     const result = await buildSkillsetResult(rootPath, options);
     if (jsonOutput) {
+      if (result.ok) await rememberKnownSkillsetWorkspace(rootPath, options, true);
       printCliJsonData("build.apply", {
         report: {
           ok: result.ok,
@@ -273,7 +274,6 @@ export async function runCli(
         writes: result.writes.paths,
       }, result.ok ? 0 : 1, "diagnostics", serializeDiagnostics(result.diagnostics));
       if (!result.ok) process.exitCode = 1;
-      else await rememberKnownSkillsetWorkspace(rootPath, options);
       return;
     }
     console.log("skillset: build projects source to generated output");
@@ -1181,11 +1181,16 @@ function ciReportDiagnostics(report: CiReport): readonly SkillsetCliDiagnostic[]
   return diagnostics;
 }
 
-async function rememberKnownSkillsetWorkspace(rootPath: string, options: SkillsetOptions): Promise<void> {
+async function rememberKnownSkillsetWorkspace(
+  rootPath: string,
+  options: SkillsetOptions,
+  quiet = false
+): Promise<void> {
   if (process.env.NODE_ENV === "test" && process.env.XDG_CONFIG_HOME === undefined) return;
   try {
     await recordKnownSkillsetWorkspace(rootPath, options.xdg);
   } catch (error) {
+    if (quiet) return;
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`  warning: could not update known Skillsets index: ${message}`);
   }

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { basename, dirname, resolve } from "node:path";
+import { basename, dirname, relative, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
 import {
@@ -793,8 +793,10 @@ export async function runCli(
         result,
         state: "written",
         writes: [...new Set(result.imports.flatMap((entry) => [
-          entry.targetPath,
-          ...(entry.baselinePath === undefined ? [] : [entry.baselinePath]),
+          workspaceRelativePath(rootPath, entry.targetPath),
+          ...(entry.baselinePath === undefined
+            ? []
+            : [workspaceRelativePath(rootPath, entry.baselinePath)]),
         ]))],
       });
     } else if (result.imports.length === 1) {
@@ -1064,6 +1066,10 @@ export async function runCli(
   }
 
   throw new Error(`skillset: unhandled command ${command}`);
+}
+
+function workspaceRelativePath(rootPath: string, path: string): string {
+  return relative(resolve(rootPath), resolve(rootPath, path)).replaceAll("\\", "/");
 }
 
 export function readInitAdoptionSelection(

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -70,7 +70,7 @@ import {
   type HookRunner,
   type HookSubcommand,
 } from "./runtime-hooks";
-import { importSources, type ImportKind, type ImportProvider, type ImportReport } from "./import";
+import { ImportBatchError, importSources, type ImportKind, type ImportProvider, type ImportReport } from "./import";
 import {
   addLookupTarget,
   addLookupTargets,
@@ -781,24 +781,35 @@ export async function runCli(
   }
 
   if (command === "import") {
-    const result = await importSources({
-      ...(importKind === undefined ? {} : { kind: importKind }),
-      ...(importName === undefined ? {} : { name: importName }),
-      ...(importPath === undefined ? {} : { sourcePath: importPath }),
-      ...(importProvider === undefined ? {} : { provider: importProvider }),
-      rootPath,
-      ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
-    });
+    let result;
+    try {
+      result = await importSources({
+        ...(importKind === undefined ? {} : { kind: importKind }),
+        ...(importName === undefined ? {} : { name: importName }),
+        ...(importPath === undefined ? {} : { sourcePath: importPath }),
+        ...(importProvider === undefined ? {} : { provider: importProvider }),
+        rootPath,
+        ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
+      });
+    } catch (error) {
+      if (!jsonOutput || !(error instanceof ImportBatchError)) throw error;
+      const writes = importWritePaths(rootPath, error.imports);
+      printCliJsonData("import", {
+        imports: error.imports,
+        state: writes.length > 0 ? "written" : "planned",
+        writes,
+      }, 1, "diagnostics", [{
+        code: "import.partial",
+        message: error.message,
+        severity: "error",
+      }]);
+      return;
+    }
     if (jsonOutput) {
       printCliJsonData("import", {
         result,
         state: "written",
-        writes: [...new Set(result.imports.flatMap((entry) => [
-          workspaceRelativePath(rootPath, entry.targetPath),
-          ...(entry.baselinePath === undefined
-            ? []
-            : [workspaceRelativePath(rootPath, entry.baselinePath)]),
-        ]))],
+        writes: importWritePaths(rootPath, result.imports),
       });
     } else if (result.imports.length === 1) {
       const [single] = result.imports;
@@ -1067,6 +1078,15 @@ export async function runCli(
   }
 
   throw new Error(`skillset: unhandled command ${command}`);
+}
+
+function importWritePaths(rootPath: string, imports: readonly ImportReport[]): readonly string[] {
+  return [...new Set(imports.flatMap((entry) => [
+    workspaceRelativePath(rootPath, entry.targetPath),
+    ...(entry.baselinePath === undefined
+      ? []
+      : [workspaceRelativePath(rootPath, entry.baselinePath)]),
+  ]))];
 }
 
 function workspaceRelativePath(rootPath: string, path: string): string {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -334,7 +334,11 @@ export async function runCli(
         reason: changeReason ?? { kind: "auto" },
         scopes: changeScopes ?? [],
       });
-      if (jsonOutput) printCliJsonData("change.add", { report, state: "written", writes: [report.entry.path, report.ledgerPath] });
+      if (jsonOutput) printCliJsonData("change.add", {
+        report: { ...report, entry: serializeChangeEntry(report.entry) },
+        state: "written",
+        writes: [report.entry.path, report.ledgerPath],
+      });
       else printChangeEntry("added", report.entry);
       return;
     }
@@ -346,7 +350,11 @@ export async function runCli(
         reason: changeReason ?? { kind: "auto" },
         ref: changeRef,
       });
-      if (jsonOutput) printCliJsonData("change.reason", { report, state: "written", writes: [report.entry.path] });
+      if (jsonOutput) printCliJsonData("change.reason", {
+        report: { ...report, entry: serializeChangeEntry(report.entry) },
+        state: "written",
+        writes: [report.entry.path, ...(report.ledgerPath === undefined ? [] : [report.ledgerPath])],
+      });
       else printChangeEntry("updated", report.entry);
       return;
     }
@@ -357,7 +365,11 @@ export async function runCli(
         reason: changeReason ?? { kind: "auto" },
         ref: changeRef,
       });
-      if (jsonOutput) printCliJsonData("change.amend", { report, state: "written", writes: [report.path] });
+      if (jsonOutput) printCliJsonData("change.amend", {
+        report: { ...report, entry: serializeChangeEntry(report.entry) },
+        state: "written",
+        writes: [report.path],
+      });
       else {
         printChangeEntry("amended", report.entry);
         console.log(`  amendment: ${report.path}`);

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -247,6 +247,7 @@ export async function runCli(
     if (dryRun || !yes) {
       const result = await diffSkillsetResult(rootPath, options);
       if (jsonOutput) {
+        if (result.ok) await rememberKnownSkillsetWorkspace(rootPath, options, true);
         printCliJsonData("build.plan", { changes: result.data, state: "planned", writes: [] }, result.ok ? 0 : 1, "plan", serializeDiagnostics(result.diagnostics));
         if (!result.ok) process.exitCode = 1;
         return;

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -473,7 +473,13 @@ export async function runCli(
         return;
       }
       const result = await applyRelease(rootPath, options);
-      if (jsonOutput) printCliJsonData("release.apply", { result, state: "written", writes: result.files });
+      if (jsonOutput) {
+        printCliJsonData("release.apply", {
+          result,
+          state: result.files.length > 0 ? "written" : "planned",
+          writes: result.files,
+        });
+      }
       else printReleaseApply(result.plan, result.files, result.renderedFiles);
       return;
     }

--- a/apps/skillset/src/import.ts
+++ b/apps/skillset/src/import.ts
@@ -123,6 +123,16 @@ export interface ImportBatchReport {
   readonly warnings: readonly string[];
 }
 
+export class ImportBatchError extends Error {
+  readonly imports: readonly ImportReport[];
+
+  constructor(message: string, imports: readonly ImportReport[]) {
+    super(message);
+    this.name = "ImportBatchError";
+    this.imports = imports;
+  }
+}
+
 export async function importSources(options: ImportSourcesOptions): Promise<ImportBatchReport> {
   const sourcePath = resolveImportSourcePath(options);
   const plan = await planImports(sourcePath, options.kind);
@@ -132,16 +142,18 @@ export async function importSources(options: ImportSourcesOptions): Promise<Impo
 
   const imports: ImportReport[] = [];
   for (const item of plan.items) {
-    imports.push(
-      await importSource({
+    try {
+      imports.push(await importSource({
         kind: item.kind,
         rootPath: options.rootPath,
         sourcePath: item.sourcePath,
         ...(options.name === undefined ? {} : { name: options.name }),
         ...(options.sourceDir === undefined ? {} : { sourceDir: options.sourceDir }),
         ...(options.sourceOrigin === undefined ? {} : { sourceOrigin: options.sourceOrigin }),
-      })
-    );
+      }));
+    } catch (error) {
+      throw new ImportBatchError(errorMessage(error), imports);
+    }
   }
 
   return {

--- a/apps/skillset/src/import.ts
+++ b/apps/skillset/src/import.ts
@@ -97,6 +97,7 @@ export interface ImportSourcesOptions {
 }
 
 export interface ImportReport {
+  readonly baselinePath?: string;
   readonly baselines: readonly ReleaseBaselineEntry[];
   readonly copiedFiles: readonly string[];
   readonly files: number;
@@ -199,7 +200,7 @@ export async function importSource(options: ImportOptions): Promise<ImportReport
 
     await rename(stagingPath, targetPath);
     committed = true;
-    let baselineReport: { readonly entries: readonly ReleaseBaselineEntry[] };
+    let baselineReport: { readonly entries: readonly ReleaseBaselineEntry[]; readonly path?: string };
     try {
       baselineReport = await seedImportedBaselines(options.rootPath, {
         kind: options.kind,
@@ -221,6 +222,7 @@ export async function importSource(options: ImportOptions): Promise<ImportReport
     });
 
     return {
+      ...(baselineReport.path === undefined ? {} : { baselinePath: baselineReport.path }),
       baselines: baselineReport.entries,
       copiedFiles,
       files: copiedFiles.length,
@@ -276,7 +278,7 @@ async function seedImportedBaselines(
     readonly name: string;
     readonly sourceDir: string;
   }
-): Promise<{ readonly entries: readonly ReleaseBaselineEntry[] }> {
+): Promise<{ readonly entries: readonly ReleaseBaselineEntry[]; readonly path?: string }> {
   const includeScope = (scope: string): boolean => {
     if (options.kind === "skill") return scope === `skill:${options.name}`;
     return scope === `plugin:${options.name}` || scope.startsWith(`plugin.${options.name}.`);
@@ -286,7 +288,10 @@ async function seedImportedBaselines(
     { sourceDir: options.sourceDir },
     { includeScope, write: true }
   );
-  return { entries: report.entries };
+  return {
+    entries: report.entries,
+    ...(report.path === undefined ? {} : { path: report.path }),
+  };
 }
 
 interface FrontmatterClassification {

--- a/apps/skillset/src/release.ts
+++ b/apps/skillset/src/release.ts
@@ -174,6 +174,9 @@ export async function applyRelease(
     const build = await buildSkillsetResult(rootPath, releaseOptions);
     renderedFiles = build.data.length;
     for (const path of build.writes.paths) files.add(path);
+    if (build.writes.backupManifestPath !== undefined) {
+      files.add(build.writes.backupManifestPath);
+    }
   } catch (error) {
     await restoreSnapshots(rootPath, snapshots);
     throw error;

--- a/apps/skillset/src/release.ts
+++ b/apps/skillset/src/release.ts
@@ -2,7 +2,7 @@ import { appendFile, mkdir, readFile, rm, stat, writeFile } from "node:fs/promis
 import { createHash, randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 
-import { buildSkillset } from "@skillset/core";
+import { buildSkillsetResult } from "@skillset/core";
 import { changeCheck, readPendingChangeEntries, type ChangeBump, type PendingChangeEntry } from "./change-entries";
 import { resolveChangeReason, type ChangeReasonInput } from "./change-workflow";
 import { detectWorkspaceOptions, SOURCE_HASH_SCHEMA } from "./change-status";
@@ -171,9 +171,9 @@ export async function applyRelease(
       await appendReleaseRecord(rootPath, releaseOptions.sourceDir, plan, now, files);
     }
 
-    const rendered = await buildSkillset(rootPath, releaseOptions);
-    renderedFiles = rendered.length;
-    for (const file of rendered) files.add(file.path);
+    const build = await buildSkillsetResult(rootPath, releaseOptions);
+    renderedFiles = build.data.length;
+    for (const path of build.writes.paths) files.add(path);
   } catch (error) {
     await restoreSnapshots(rootPath, snapshots);
     throw error;

--- a/apps/skillset/src/setup.ts
+++ b/apps/skillset/src/setup.ts
@@ -68,6 +68,7 @@ export interface SetupGit {
 }
 
 export interface SetupReport {
+  readonly baselinePath?: string;
   readonly baselines: readonly ReleaseBaselineEntry[];
   readonly files: readonly SetupFile[];
   readonly git?: SetupGit;
@@ -192,15 +193,17 @@ async function applySetupPlan(
     if (git?.status === "create") await initializeGit(rootPath);
   }
 
-  const baselines = kind === "init"
-    ? (await seedReleaseBaselines(rootPath, {}, { write: options.write === true })).entries
-    : [];
+  const baselineReport = kind === "init"
+    ? await seedReleaseBaselines(rootPath, {}, { write: options.write === true })
+    : undefined;
+  const baselines = baselineReport?.entries ?? [];
   const importSurvey = kind === "init"
     ? await detectImportCandidates(rootPath, alreadyAdopted)
     : { candidates: [], diagnostics: [] };
   const surveySkips = kind === "init" ? await detectSurveySkips(rootPath) : [];
 
   return {
+    ...(baselineReport?.path === undefined ? {} : { baselinePath: baselineReport.path }),
     baselines,
     files,
     ...(git === undefined ? {} : { git }),


### PR DESCRIPTION
## Context

Plan-first and mutating routes need the same stable machine contract as finite read routes. Automation must distinguish previews from writes and see every path actually changed.

## What changed

- adds versioned JSON results to plan-first and mutating routes
- reports explicit `planned` versus `written` state and actual write paths
- preserves `--yes` as write authority; machine output does not imply permission
- reports audit artifacts, release evidence, baselines, generated output, deletions, and acquisitions
- preserves completed work in partial adoption/import failures
- normalizes reported paths and workspace indexing for deterministic automation

## Verification

- required GitHub checks: `changeset`, `check`, and `skillset-ci`
- focused mutation-envelope, adopt/import, reconcile, ledger, and partial-write coverage

## Tracking

Closes SET-288. Stacked on #273.

## Risks / rollout

Partial failures may legitimately return non-empty `writes`; consumers must treat those as completed side effects. Write authority remains explicit and unchanged.
