### PR TITLE
feat(cli): add versioned jsonl streams

### DIFF
--- a/.changeset/stream-cli-events.md
+++ b/.changeset/stream-cli-events.md
@@ -1,0 +1,5 @@
+---
+"skillset": minor
+---
+
+Add validated JSONL event streams for `skillset dev` and align retained runtime-test events with the same versioned event contract.

--- a/apps/skillset/src/__tests__/cli-output.test.ts
+++ b/apps/skillset/src/__tests__/cli-output.test.ts
@@ -4,9 +4,11 @@ import { join } from "node:path";
 import {
   CliOutputError,
   createCliEvent,
+  createCliEventStream,
   createCliResult,
   readCliCommand,
   readCliMachineMode,
+  parseCliEventStream,
   renderCliEvent,
   renderCliResult,
 } from "../cli-output";
@@ -129,24 +131,40 @@ describe("SET-286 CLI output kernel", () => {
     expect(JSON.parse(stdout)).toMatchObject({ command: "cli", exitCode: 2, ok: false });
   });
 
-  test("rejects not-yet-enabled streams through JSONL", async () => {
-    const cli = join(import.meta.dir, "..", "cli.ts");
-    const proc = Bun.spawn([process.execPath, cli, "dev", "--watch", "--jsonl"], {
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
+  test("enforces monotonic streams with exactly one terminal event", () => {
+    let output = "";
+    const stream = createCliEventStream("dev", { write: (chunk) => { output += String(chunk); return true; } });
+    stream.emit("started", {});
+    stream.emit("operation", { ok: true });
+    stream.emit("completed", { reason: "signal" });
+    expect(parseCliEventStream(output).map((event) => [event.sequence, event.event])).toEqual([
+      [1, "started"],
+      [2, "operation"],
+      [3, "completed"],
     ]);
-    expect(exitCode).toBe(2);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toMatchObject({
-      command: "dev",
-      data: { message: "skillset: --jsonl is not supported until a streaming route is enabled" },
-      event: "failed",
-      schemaVersion: "skillset.cli.event@1",
-    });
+    expect(() => stream.emit("operation", {})).toThrow(CliOutputError);
+    expect(() => parseCliEventStream(output.split("\n").slice(0, 2).join("\n"))).toThrow(
+      "ended without exactly one terminal event"
+    );
+  });
+
+  test("rejects unsupported finite and streaming machine routes", async () => {
+    const cli = join(import.meta.dir, "..", "cli.ts");
+    const cases = [
+      ["hooks", "print", "--json"],
+      ["hooks", "run", "post-tool-use", "--jsonl"],
+      ["check", "--jsonl"],
+    ];
+    for (const args of cases) {
+      const proc = Bun.spawn([process.execPath, cli, ...args], { stderr: "pipe", stdout: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(exitCode).toBe(2);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("skillset.cli.");
+    }
   });
 });

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -246,6 +246,26 @@ test("SET-289: JSONL watch setup failures stay in the active sequence", async ()
   expect(events[2]?.data).toMatchObject({ stage: "watch-setup" });
 });
 
+test("SET-289: initial JSONL operation failures stay in the active sequence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-initial-failure-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+
+  await runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: () => {},
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: async () => { throw new Error("initial operation failed"); },
+    scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    watch: () => ({ close: () => {} } as FSWatcher),
+  });
+
+  const events = parseCliEventStream(output);
+  expect(events.map((event) => event.event)).toEqual(["started", "failed"]);
+  expect(events.map((event) => event.sequence)).toEqual([1, 2]);
+  expect(events[1]?.data).toMatchObject({ message: "initial operation failed", stage: "initial-operation" });
+});
+
 test("SET-289: debounced JSONL operation failures terminate the active sequence", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-operation-"));
   await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -344,6 +344,60 @@ test("SET-289: signals do not wait for a stalled initial operation", async () =>
   expect(parseCliEventStream(output).map((event) => event.event)).toEqual(["started", "completed"]);
 });
 
+test("SET-289: apply signals wait for the initial write before completing", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-apply-signal-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+  let signal: (() => void) | undefined;
+  let markStarted: (() => void) | undefined;
+  let finishApply: ((report: DevWatchPreviewReport) => void) | undefined;
+  const started = new Promise<void>((resolvePromise) => {
+    markStarted = resolvePromise;
+  });
+  const apply = new Promise<DevWatchPreviewReport>((resolvePromise) => {
+    finishApply = resolvePromise;
+  });
+
+  const watching = runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "apply", "jsonl", {
+    addSignalListeners: (listener) => { signal = listener; },
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: async () => {
+      markStarted?.();
+      return apply;
+    },
+    scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    watch: () => ({ close: () => {} } as FSWatcher),
+  });
+
+  await started;
+  signal?.();
+  await expect(Promise.race([
+    watching.then(() => "stopped"),
+    Bun.sleep(50).then(() => "pending"),
+  ])).resolves.toBe("pending");
+  finishApply?.({
+    checkedSkills: 1,
+    diagnostics: [],
+    diff: { added: [], changed: [], missing: [], removed: [] },
+    mode: "apply",
+    ok: true,
+    outputRoots: [".claude/skills"],
+    reason: "initial",
+    sourceRoot: ".skillset",
+    warnings: [],
+    writes: {
+      deletedPaths: [],
+      mode: "write",
+      paths: [".claude/skills/demo/SKILL.md"],
+      writtenPaths: [".claude/skills/demo/SKILL.md"],
+    },
+  });
+  await watching;
+
+  expect(parseCliEventStream(output).map((event) => event.event)).toEqual(["started", "operation", "completed"]);
+});
+
 test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-"));
   await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 
 import {
+  createDevWatchJsonlStream,
   createDevWatchDebouncer,
   createDevWatchPlan,
   renderDevWatchPreview,
@@ -13,6 +14,7 @@ import {
   shouldRunDevPreviewForPath,
   type DevWatchScheduler,
 } from "../dev-watch";
+import { parseCliEventStream } from "../cli-output";
 
 test("SET-210: dev watch plan covers ordinary source and ignores generated churn", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-watch-ordinary-"));
@@ -191,6 +193,57 @@ test("SET-210/SET-212: dev command validation keeps writes explicitly opt-in", a
   const wrongCommand = await runSkillsetCli("build", "--watch");
   expect(wrongCommand.exitCode).toBe(1);
   expect(wrongCommand.stderr).toContain("--watch is only supported with dev");
+});
+
+test("SET-289: dev JSONL emits controlled started, operation, and terminal events", () => {
+  let output = "";
+  const stream = createDevWatchJsonlStream({ write: (chunk) => { output += String(chunk); return true; } });
+  stream.started({
+    configPaths: ["skillset.yaml"],
+    ignoredRoots: ["plugins"],
+    outputRoots: ["plugins"],
+    rootPath: "/repo",
+    sourceRoot: ".skillset",
+    watchRoots: [".", ".skillset"],
+  }, "preview");
+  stream.operation({
+    checkedSkills: 1,
+    diagnostics: [],
+    diff: { added: [], changed: [], missing: [], removed: [] },
+    mode: "preview",
+    ok: true,
+    outputRoots: ["plugins"],
+    reason: "initial",
+    sourceRoot: ".skillset",
+    warnings: [],
+  });
+  stream.completed();
+  const events = parseCliEventStream(output);
+  expect(events.map((event) => event.event)).toEqual(["started", "operation", "completed"]);
+  expect(events.map((event) => event.sequence)).toEqual([1, 2, 3]);
+  expect(output).not.toContain("skillset: dev");
+});
+
+test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  const proc = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "..", "cli.ts"), "dev", "--watch", "--jsonl", "--root", root],
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const timer = setTimeout(() => proc.kill("SIGTERM"), 1000);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  clearTimeout(timer);
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+  const events = parseCliEventStream(stdout);
+  expect(events.map((event) => event.event)).toEqual(["started", "operation", "completed"]);
+  expect(stdout).not.toContain("skillset: dev");
 });
 
 async function runSkillsetCli(...args: readonly string[]): Promise<{

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -9,6 +9,7 @@ import {
   createDevWatchDebouncer,
   createDevWatchPlan,
   renderDevWatchPreview,
+  runDevWatch,
   runDevWatchApply,
   runDevWatchPreview,
   shouldRunDevPreviewForPath,
@@ -222,6 +223,26 @@ test("SET-289: dev JSONL emits controlled started, operation, and terminal event
   expect(events.map((event) => event.event)).toEqual(["started", "operation", "completed"]);
   expect(events.map((event) => event.sequence)).toEqual([1, 2, 3]);
   expect(output).not.toContain("skillset: dev");
+});
+
+test("SET-289: JSONL watch setup failures stay in the active sequence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-setup-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+
+  await runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: () => {},
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: runDevWatchPreview,
+    scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    watch: () => { throw new Error("watch setup failed"); },
+  });
+
+  const events = parseCliEventStream(output);
+  expect(events.map((event) => event.event)).toEqual(["started", "operation", "failed"]);
+  expect(events.map((event) => event.sequence)).toEqual([1, 2, 3]);
+  expect(events[2]?.data).toMatchObject({ stage: "watch-setup" });
 });
 
 test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -273,6 +273,24 @@ test("SET-289: debounced JSONL operation failures terminate the active sequence"
   expect(events[2]?.data).toMatchObject({ message: "debounced operation failed", stage: "operation" });
 });
 
+test("SET-289: JSONL signals during the initial operation still terminate the sequence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-initial-signal-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+
+  await runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: (listener) => listener(),
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: runDevWatchPreview,
+    scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    watch: () => ({ close: () => {} } as FSWatcher),
+  });
+
+  const events = parseCliEventStream(output);
+  expect(events.map((event) => event.event)).toEqual(["started", "operation", "completed"]);
+});
+
 test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-"));
   await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -14,6 +14,7 @@ import {
   runDevWatchApply,
   runDevWatchPreview,
   shouldRunDevPreviewForPath,
+  type DevWatchPreviewReport,
   type DevWatchScheduler,
 } from "../dev-watch";
 import { parseCliEventStream } from "../cli-output";
@@ -308,7 +309,39 @@ test("SET-289: JSONL signals during the initial operation still terminate the se
   });
 
   const events = parseCliEventStream(output);
-  expect(events.map((event) => event.event)).toEqual(["started", "operation", "completed"]);
+  expect(events.map((event) => event.event)).toEqual(["started", "completed"]);
+});
+
+test("SET-289: signals do not wait for a stalled initial operation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-stalled-initial-signal-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+  let signal: (() => void) | undefined;
+  let markStarted: (() => void) | undefined;
+  const started = new Promise<void>((resolvePromise) => {
+    markStarted = resolvePromise;
+  });
+  const stalled = new Promise<DevWatchPreviewReport>(() => {});
+
+  const watching = runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: (listener) => { signal = listener; },
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: async () => {
+      markStarted?.();
+      return stalled;
+    },
+    scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    watch: () => ({ close: () => {} } as FSWatcher),
+  });
+
+  await started;
+  signal?.();
+  await expect(Promise.race([
+    watching.then(() => "stopped"),
+    Bun.sleep(100).then(() => "timed-out"),
+  ])).resolves.toBe("stopped");
+  expect(parseCliEventStream(output).map((event) => event.event)).toEqual(["started", "completed"]);
 });
 
 test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -401,6 +401,56 @@ test("SET-289: apply signals wait for the initial write before completing", asyn
   expect(parseCliEventStream(output).map((event) => event.event)).toEqual(["started", "operation", "completed"]);
 });
 
+test("SET-289: shutdown cancels operations queued behind an active run", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-queued-signal-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+  let runs = 0;
+  let signal: (() => void) | undefined;
+  let trigger: ((event: string, filename: string | null) => void) | undefined;
+  let finishChange: ((report: DevWatchPreviewReport) => void) | undefined;
+  let markWatching: (() => void) | undefined;
+  const watchingReady = new Promise<void>((resolvePromise) => {
+    markWatching = resolvePromise;
+  });
+  const activeChange = new Promise<DevWatchPreviewReport>((resolvePromise) => {
+    finishChange = resolvePromise;
+  });
+
+  const watching = runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: (listener) => { signal = listener; },
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: async (runRoot, runOptions, _mode, reason) => {
+      runs += 1;
+      if (runs === 2) return activeChange;
+      return runDevWatchPreview(runRoot, runOptions, reason);
+    },
+    scheduler: { clearTimeout: () => {}, setTimeout: (callback) => { callback(); return 0; } },
+    watch: ((_path: string, callback: (event: string, filename: string | null) => void) => {
+      trigger = callback;
+      markWatching?.();
+      return { close: () => {} } as FSWatcher;
+    }) as typeof import("node:fs").watch,
+  });
+
+  await watchingReady;
+  trigger?.("change", "skillset.yaml");
+  await Promise.resolve();
+  trigger?.("change", ".skillset/skills/demo/SKILL.md");
+  signal?.();
+  finishChange?.(await runDevWatchPreview(root, {}, "skillset.yaml"));
+  await watching;
+
+  expect(runs).toBe(2);
+  expect(parseCliEventStream(output).map((event) => event.event)).toEqual([
+    "started",
+    "operation",
+    "operation",
+    "completed",
+  ]);
+});
+
 test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-"));
   await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -347,6 +347,42 @@ test("SET-289: signals do not wait for a stalled initial operation", async () =>
   expect(parseCliEventStream(output).map((event) => event.event)).toEqual(["started", "completed"]);
 });
 
+test("SET-289: signals do not wait for stalled watch-root collection", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-stalled-roots-signal-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+  let signal: (() => void) | undefined;
+  let markCollecting: (() => void) | undefined;
+  const collecting = new Promise<void>((resolvePromise) => {
+    markCollecting = resolvePromise;
+  });
+  const stalled = new Promise<readonly string[]>(() => {});
+
+  const watching = runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: (listener) => { signal = listener; },
+    collectDirectories: async () => {
+      markCollecting?.();
+      return stalled;
+    },
+    removeSignalListeners: () => {},
+    runOnce: runDevWatchPreview,
+    scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    watch: () => ({ close: () => {} } as FSWatcher),
+  });
+
+  await collecting;
+  signal?.();
+  await expect(Promise.race([
+    watching.then(() => "stopped"),
+    Bun.sleep(100).then(() => "timed-out"),
+  ])).resolves.toBe("stopped");
+  expect(parseCliEventStream(output).map((event) => event.event)).toEqual([
+    "started",
+    "operation",
+    "completed",
+  ]);
+});
+
 test("SET-289: apply signals wait for the initial write before completing", async () => {
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-apply-signal-"));
   await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp } from "node:fs/promises";
+import type { FSWatcher } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -243,6 +244,33 @@ test("SET-289: JSONL watch setup failures stay in the active sequence", async ()
   expect(events.map((event) => event.event)).toEqual(["started", "operation", "failed"]);
   expect(events.map((event) => event.sequence)).toEqual([1, 2, 3]);
   expect(events[2]?.data).toMatchObject({ stage: "watch-setup" });
+});
+
+test("SET-289: debounced JSONL operation failures terminate the active sequence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-operation-"));
+  await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
+  let output = "";
+  let runs = 0;
+
+  await runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
+    addSignalListeners: () => {},
+    collectDirectories: async () => ["."],
+    removeSignalListeners: () => {},
+    runOnce: async (runRoot, runOptions, _mode, reason) => {
+      runs += 1;
+      if (runs > 1) throw new Error("debounced operation failed");
+      return runDevWatchPreview(runRoot, runOptions, reason);
+    },
+    scheduler: { clearTimeout: () => {}, setTimeout: (callback) => { callback(); return 0; } },
+    watch: ((_path: string, callback: (event: string, filename: string | null) => void) => {
+      queueMicrotask(() => callback("change", "skillset.yaml"));
+      return { close: () => {} } as FSWatcher;
+    }) as typeof import("node:fs").watch,
+  });
+
+  const events = parseCliEventStream(output);
+  expect(events.map((event) => event.event)).toEqual(["started", "operation", "failed"]);
+  expect(events[2]?.data).toMatchObject({ message: "debounced operation failed", stage: "operation" });
 });
 
 test("SET-289: dev --jsonl terminates a real controlled stream without human output", async () => {

--- a/apps/skillset/src/__tests__/dev-watch.test.ts
+++ b/apps/skillset/src/__tests__/dev-watch.test.ts
@@ -231,6 +231,7 @@ test("SET-289: JSONL watch setup failures stay in the active sequence", async ()
   const root = await mkdtemp(join(tmpdir(), "skillset-dev-jsonl-setup-"));
   await expect(runSkillsetCli("init", "--root", root, "--yes")).resolves.toMatchObject({ exitCode: 0 });
   let output = "";
+  let exitCode: number | undefined;
 
   await runDevWatch(root, {}, { write: (chunk) => { output += String(chunk); return true; } } as NodeJS.WritableStream, "preview", "jsonl", {
     addSignalListeners: () => {},
@@ -238,6 +239,7 @@ test("SET-289: JSONL watch setup failures stay in the active sequence", async ()
     removeSignalListeners: () => {},
     runOnce: runDevWatchPreview,
     scheduler: { clearTimeout: () => {}, setTimeout: () => 0 },
+    setExitCode: (code) => { exitCode = code; },
     watch: () => { throw new Error("watch setup failed"); },
   });
 
@@ -245,6 +247,7 @@ test("SET-289: JSONL watch setup failures stay in the active sequence", async ()
   expect(events.map((event) => event.event)).toEqual(["started", "operation", "failed"]);
   expect(events.map((event) => event.sequence)).toEqual([1, 2, 3]);
   expect(events[2]?.data).toMatchObject({ stage: "watch-setup" });
+  expect(exitCode).toBe(3);
 });
 
 test("SET-289: initial JSONL operation failures stay in the active sequence", async () => {

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -13,6 +13,7 @@ import {
   tailTryRun,
 } from "../try";
 import { runSkillsetTest } from "../test-runner";
+import { parseCliEventStream } from "../cli-output";
 
 test("try runs a Codex prompt and records inspectable artifacts", async () => {
   const root = await fixture({
@@ -55,6 +56,9 @@ Use this skill to answer fixture questions.
   const tail = await tailTryRun(root, report.runId, 20, { xdg });
   expect(tail.map((line) => line.stream)).toContain("stdout");
   expect(tail.some((line) => line.message.includes("List the available fixture skills."))).toBe(true);
+  const retainedEvents = parseCliEventStream(await readFile(cachePath(root, xdg, report.tailPath), "utf8"));
+  expect(retainedEvents.at(-1)?.event).toBe("completed");
+  expect(retainedEvents.every((event) => event.command === "test")).toBe(true);
 
   const runs = await listTryRuns(root, { xdg });
   expect(runs.map((run) => run.runId)).toContain(report.runId);

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -64,6 +64,38 @@ Use this skill to answer fixture questions.
   expect(runs.map((run) => run.runId)).toContain(report.runId);
 });
 
+test("provider output cannot terminate the retained test event stream", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: provider-status-text-fixture
+codex: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Provider status text fixture.
+---
+
+Body.
+`,
+  });
+  const bin = await fakeCodexStatusTextBin(root);
+  const xdg = { env: { XDG_CACHE_HOME: join(root, "xdg-cache") } };
+  const report = await startTryRun(root, {
+    env: { ...process.env, SKILLSET_TEST_CODEX_BIN: bin },
+    prompt: "Print misleading status text.",
+    target: "codex",
+    xdg,
+  });
+
+  const events = parseCliEventStream(await readFile(cachePath(root, xdg, report.tailPath), "utf8"));
+  expect(events.filter((event) => event.event === "completed")).toHaveLength(1);
+  expect(events.at(-1)?.event).toBe("completed");
+  expect(events.some((event) => event.event === "stdout" && event.data.message === "test passed\n")).toBe(true);
+  expect(events.some((event) => event.event === "stderr" && event.data.message === "test failed: provider text\n")).toBe(true);
+});
+
 test("try runs a Claude prompt with isolated settings and explicit plugin dirs", async () => {
   const root = await fixture({
     "skillset.yaml": `
@@ -873,6 +905,20 @@ if [ -n "$last" ]; then
 fi
 `, "utf8");
   await chmod(bin, 0o755);
+  return bin;
+}
+
+async function fakeCodexStatusTextBin(root: string): Promise<string> {
+  const bin = await fakeCodexBin(root);
+  const script = await readFile(bin, "utf8");
+  await writeFile(
+    bin,
+    script.replace(
+      'echo "fake-codex cwd=$(pwd)"',
+      'printf \'test passed\\n\'\nprintf \'test failed: provider text\\n\' >&2\necho "fake-codex cwd=$(pwd)"'
+    ),
+    "utf8"
+  );
   return bin;
 }
 

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -92,8 +92,8 @@ Body.
   const events = parseCliEventStream(await readFile(cachePath(root, xdg, report.tailPath), "utf8"));
   expect(events.filter((event) => event.event === "completed")).toHaveLength(1);
   expect(events.at(-1)?.event).toBe("completed");
-  expect(events.some((event) => event.event === "stdout" && event.data.message === "test passed\n")).toBe(true);
-  expect(events.some((event) => event.event === "stderr" && event.data.message === "test failed: provider text\n")).toBe(true);
+  expect(events.some((event) => event.event === "stdout" && typeof event.data.message === "string" && event.data.message.includes("test passed"))).toBe(true);
+  expect(events.some((event) => event.event === "stderr" && typeof event.data.message === "string" && event.data.message.includes("test failed: provider text"))).toBe(true);
 });
 
 test("try runs a Claude prompt with isolated settings and explicit plugin dirs", async () => {

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -122,7 +122,7 @@ const USAGE = [
   "       skillset check [--write|--only outputs|--ci [--fix] [--since <ref>] [--report <path>]] [--json] [--root <path>]",
   "       skillset list [--updated|--all] [--scope <scope>] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset status [--json] [--root <path>]",
-  "       skillset dev --watch [--apply] [--root <path>] [--source <dir>] [--dist <dir>]",
+  "       skillset dev --watch [--apply] [--jsonl] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset change status [--since <ref>] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset change check [@ref|--ref <ref>] [--since <ref>] [--root <path>] [--source <dir>] [--dist <dir>]",
   "       skillset change <status|check> --staged [--root <path>] [--source <dir>] [--dist <dir>]",
@@ -205,6 +205,7 @@ export async function runCli(
     initAdopt,
     initFrom,
     jsonOutput,
+    jsonlOutput,
     lookupAspects,
     lookupField,
     lookupFeatures,
@@ -298,7 +299,7 @@ export async function runCli(
 
   if (command === "dev") {
     if (!devWatch) throw new Error("skillset: dev currently requires --watch");
-    await runDevWatch(rootPath, options, process.stdout, devApply ? "apply" : "preview");
+    await runDevWatch(rootPath, options, process.stdout, devApply ? "apply" : "preview", jsonlOutput ? "jsonl" : undefined);
     return;
   }
 
@@ -2493,7 +2494,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
     ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
   });
-  if (jsonlOutput) throw new Error("skillset: --jsonl is not supported until a streaming route is enabled");
+  if (jsonlOutput && command !== "dev") throw new Error("skillset: --jsonl is only supported with dev");
   validateLookupFlags(command, args, {
     features: lookupFeatures,
     ...(lookupField === undefined ? {} : { field: lookupField }),

--- a/apps/skillset/src/cli-entrypoint.ts
+++ b/apps/skillset/src/cli-entrypoint.ts
@@ -1,6 +1,7 @@
 import { reportCliError, runCli } from "./cli-core";
 import {
   CliOutputError,
+  classifyCliFailure,
   createCliEvent,
   createCliResult,
   readCliCommand,
@@ -63,15 +64,4 @@ export async function runCliEntrypoint(
     process.stdout.write(output);
     process.exitCode = exitCode;
   }
-}
-
-function classifyCliFailure(error: unknown): number {
-  if (error instanceof CliOutputError) return error.exitCode;
-  if (
-    error instanceof Error &&
-    (error.message.startsWith("skillset: expected") ||
-      error.message.startsWith("skillset: --"))
-  )
-    return 2;
-  return 3;
 }

--- a/apps/skillset/src/cli-entrypoint.ts
+++ b/apps/skillset/src/cli-entrypoint.ts
@@ -25,7 +25,12 @@ export async function runCliEntrypoint(
     }
     await runCli(args);
   } catch (error) {
-    mode ??= args.includes("--json") ? "json" : undefined;
+    mode ??=
+      args.includes("--jsonl") && !args.includes("--json")
+        ? "jsonl"
+        : args.includes("--json")
+          ? "json"
+          : undefined;
     if (!mode) {
       reportCliError(error);
       return;

--- a/apps/skillset/src/cli-output.ts
+++ b/apps/skillset/src/cli-output.ts
@@ -117,6 +117,50 @@ export function renderCliEvent(event: SkillsetCliEvent): string {
   return `${JSON.stringify(event)}\n`;
 }
 
+const TERMINAL_CLI_EVENTS = new Set(["completed", "failed"]);
+
+export function createCliEventStream(
+  command: string,
+  output: Pick<NodeJS.WritableStream, "write">
+): { readonly emit: (event: string, data: SchemaJsonRecord) => SkillsetCliEvent } {
+  let sequence = 0;
+  let terminal = false;
+  return {
+    emit(event, data) {
+      if (terminal) throw new CliOutputError("skillset: cannot emit an event after a terminal CLI event", 4);
+      const value = createCliEvent({ command, data, event, sequence: sequence + 1 });
+      sequence = value.sequence;
+      terminal = TERMINAL_CLI_EVENTS.has(event);
+      output.write(renderCliEvent(value));
+      return value;
+    },
+  };
+}
+
+export function parseCliEventStream(input: string): readonly SkillsetCliEvent[] {
+  const lines = input.split("\n").filter((line) => line.length > 0);
+  const events = lines.map((line, index) => {
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      throw new CliOutputError(`skillset: invalid JSONL event at line ${index + 1}`, 4);
+    }
+    assertValid(validateCliEvent(value));
+    return value as SkillsetCliEvent;
+  });
+  for (let index = 0; index < events.length; index += 1) {
+    if (events[index]?.sequence !== index + 1) {
+      throw new CliOutputError(`skillset: non-monotonic CLI event sequence at line ${index + 1}`, 4);
+    }
+  }
+  const terminals = events.filter((event) => TERMINAL_CLI_EVENTS.has(event.event));
+  if (terminals.length !== 1 || !TERMINAL_CLI_EVENTS.has(events.at(-1)?.event ?? "")) {
+    throw new CliOutputError("skillset: CLI event stream ended without exactly one terminal event", 4);
+  }
+  return events;
+}
+
 function assertValid(validation: ReturnType<typeof validateCliResult>): void {
   if (validation.ok) return;
   const detail = validation.diagnostics

--- a/apps/skillset/src/cli-output.ts
+++ b/apps/skillset/src/cli-output.ts
@@ -28,6 +28,18 @@ export class CliOutputError extends Error {
   }
 }
 
+export function classifyCliFailure(error: unknown): number {
+  if (error instanceof CliOutputError) return error.exitCode;
+  if (
+    error instanceof Error &&
+    (error.message.startsWith("skillset: expected") ||
+      error.message.startsWith("skillset: --"))
+  ) {
+    return 2;
+  }
+  return 3;
+}
+
 export function readCliCommand(args: readonly string[]): string {
   const command = args[0];
   if (!isCliCommand(command)) return "cli";

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -11,6 +11,9 @@ import {
 import { lintSkillset } from "@skillset/core";
 import { loadBuildGraph } from "@skillset/core/internal/resolver";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
+import type { SchemaJsonRecord } from "@skillset/schema";
+
+import { createCliEventStream } from "./cli-output";
 
 export interface DevWatchPlan {
   readonly configPaths: readonly string[];
@@ -55,6 +58,25 @@ export interface DevWatchDebouncer {
 export interface DevWatchScheduler {
   readonly clearTimeout: (handle: unknown) => void;
   readonly setTimeout: (callback: () => void, delayMs: number) => unknown;
+}
+
+export function createDevWatchJsonlStream(output: Pick<NodeJS.WritableStream, "write">) {
+  const stream = createCliEventStream("dev", output);
+  return {
+    started(plan: DevWatchPlan, mode: DevWatchMode) {
+      return stream.emit("started", {
+        mode,
+        sourceRoot: plan.sourceRoot,
+        watchRoots: [...plan.watchRoots],
+      } as unknown as SchemaJsonRecord);
+    },
+    operation(report: DevWatchPreviewReport) {
+      return stream.emit("operation", report as unknown as SchemaJsonRecord);
+    },
+    completed(reason = "signal") {
+      return stream.emit("completed", { reason });
+    },
+  };
 }
 
 const DEFAULT_DEBOUNCE_MS = 200;
@@ -268,15 +290,23 @@ export async function runDevWatch(
   rootPath: string,
   options: SkillsetOptions = {},
   output: NodeJS.WritableStream = process.stdout,
-  mode: DevWatchMode = "preview"
+  mode: DevWatchMode = "preview",
+  machineMode?: "jsonl"
 ): Promise<void> {
   const plan = await createDevWatchPlan(rootPath, options);
-  output.write(renderDevWatchStart(plan, mode));
-  output.write(renderDevWatchPreview(await runDevWatchOnce(rootPath, options, mode)));
+  const stream = machineMode === "jsonl" ? createDevWatchJsonlStream(output) : undefined;
+  if (stream === undefined) output.write(renderDevWatchStart(plan, mode));
+  else stream.started(plan, mode);
+  const writeOperation = async (reason = "initial") => {
+    const report = await runDevWatchOnce(rootPath, options, mode, reason);
+    if (stream === undefined) output.write(renderDevWatchPreview(report));
+    else stream.operation(report);
+  };
+  await writeOperation();
 
   const watchers: FSWatcher[] = [];
   const debouncer = createDevWatchDebouncer(async (reason) => {
-    output.write(renderDevWatchPreview(await runDevWatchOnce(rootPath, options, mode, reason)));
+    await writeOperation(reason);
   });
 
   for (const watchRoot of await collectDevWatchDirectories(plan)) {
@@ -296,7 +326,8 @@ export async function runDevWatch(
       for (const watcher of watchers) watcher.close();
       process.off("SIGINT", stop);
       process.off("SIGTERM", stop);
-      output.write("skillset: dev watch stopped\n");
+      if (stream === undefined) output.write("skillset: dev watch stopped\n");
+      else stream.completed();
       resolvePromise();
     };
     process.once("SIGINT", stop);

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -337,6 +337,7 @@ export async function runDevWatch(
     else stream.operation(report);
   };
   let activeOperation: Promise<void> | undefined;
+  let stopping = false;
   let pendingOperationError: unknown;
   let pendingSignal = false;
   let initialSignalReceived = false;
@@ -357,7 +358,9 @@ export async function runDevWatch(
   };
   const startOperation = async (reason: string) => {
     const previous = activeOperation;
-    const operation = (previous ?? Promise.resolve()).then(() => writeOperation(reason));
+    const operation = (previous ?? Promise.resolve()).then(() =>
+      stopping ? undefined : writeOperation(reason)
+    );
     activeOperation = operation;
     try {
       await operation;
@@ -413,7 +416,6 @@ export async function runDevWatch(
   }
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
-    let stopping = false;
     const stop = (operationError?: unknown) => {
       if (stopping) return;
       stopping = true;

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -345,9 +345,14 @@ export async function runDevWatch(
   const initialSignal = new Promise<void>((resolvePromise) => {
     resolveInitialSignal = resolvePromise;
   });
+  let resolveWatchSetupSignal: (() => void) | undefined;
+  const watchSetupSignal = new Promise<void>((resolvePromise) => {
+    resolveWatchSetupSignal = resolvePromise;
+  });
   let stopWithError: ((error: unknown) => void) | undefined;
   let stopFromSignal: (() => void) | undefined;
   const signalStop = () => {
+    resolveWatchSetupSignal?.();
     if (stopFromSignal === undefined) {
       pendingSignal = true;
       if (mode === "preview") {
@@ -397,7 +402,17 @@ export async function runDevWatch(
   }, DEFAULT_DEBOUNCE_MS, runtime.scheduler);
 
   try {
-    for (const watchRoot of await runtime.collectDirectories(plan)) {
+    const watchRoots = await Promise.race([
+      runtime.collectDirectories(plan),
+      watchSetupSignal.then(() => undefined),
+    ]);
+    if (watchRoots === undefined) {
+      runtime.removeSignalListeners(signalStop);
+      if (stream === undefined) output.write("skillset: dev watch stopped\n");
+      else stream.completed();
+      return;
+    }
+    for (const watchRoot of watchRoots) {
       watchers.push(runtime.watch(resolve(plan.rootPath, watchRoot), (_event, filename) => {
         const eventPath = filename === null
           ? undefined

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -60,6 +60,15 @@ export interface DevWatchScheduler {
   readonly setTimeout: (callback: () => void, delayMs: number) => unknown;
 }
 
+export interface DevWatchRuntime {
+  readonly addSignalListeners: (listener: () => void) => void;
+  readonly collectDirectories: typeof collectDevWatchDirectories;
+  readonly removeSignalListeners: (listener: () => void) => void;
+  readonly runOnce: typeof runDevWatchOnce;
+  readonly scheduler: DevWatchScheduler;
+  readonly watch: typeof watch;
+}
+
 export function createDevWatchJsonlStream(output: Pick<NodeJS.WritableStream, "write">) {
   const stream = createCliEventStream("dev", output);
   return {
@@ -75,6 +84,9 @@ export function createDevWatchJsonlStream(output: Pick<NodeJS.WritableStream, "w
     },
     completed(reason = "signal") {
       return stream.emit("completed", { reason });
+    },
+    failed(message: string, stage: string) {
+      return stream.emit("failed", { message, stage });
     },
   };
 }
@@ -291,47 +303,93 @@ export async function runDevWatch(
   options: SkillsetOptions = {},
   output: NodeJS.WritableStream = process.stdout,
   mode: DevWatchMode = "preview",
-  machineMode?: "jsonl"
+  machineMode?: "jsonl",
+  runtime: DevWatchRuntime = {
+    addSignalListeners: (listener) => {
+      process.once("SIGINT", listener);
+      process.once("SIGTERM", listener);
+    },
+    collectDirectories: collectDevWatchDirectories,
+    removeSignalListeners: (listener) => {
+      process.off("SIGINT", listener);
+      process.off("SIGTERM", listener);
+    },
+    runOnce: runDevWatchOnce,
+    scheduler: defaultScheduler,
+    watch,
+  }
 ): Promise<void> {
   const plan = await createDevWatchPlan(rootPath, options);
   const stream = machineMode === "jsonl" ? createDevWatchJsonlStream(output) : undefined;
   if (stream === undefined) output.write(renderDevWatchStart(plan, mode));
   else stream.started(plan, mode);
   const writeOperation = async (reason = "initial") => {
-    const report = await runDevWatchOnce(rootPath, options, mode, reason);
+    const report = await runtime.runOnce(rootPath, options, mode, reason);
     if (stream === undefined) output.write(renderDevWatchPreview(report));
     else stream.operation(report);
   };
-  await writeOperation();
+  let activeOperation: Promise<void> | undefined;
+  const startOperation = async (reason: string) => {
+    const previous = activeOperation;
+    const operation = (previous ?? Promise.resolve()).then(() => writeOperation(reason));
+    activeOperation = operation;
+    try {
+      await operation;
+    } finally {
+      if (activeOperation === operation) activeOperation = undefined;
+    }
+  };
+  await startOperation("initial");
 
   const watchers: FSWatcher[] = [];
   const debouncer = createDevWatchDebouncer(async (reason) => {
-    await writeOperation(reason);
-  });
+    await startOperation(reason);
+  }, DEFAULT_DEBOUNCE_MS, runtime.scheduler);
 
-  for (const watchRoot of await collectDevWatchDirectories(plan)) {
-    watchers.push(watch(resolve(plan.rootPath, watchRoot), (_event, filename) => {
-      const eventPath = filename === null
-        ? undefined
-        : normalizeRelativePath(join(watchRoot, filename.toString()));
-      if (shouldRunDevPreviewForPath(plan, eventPath)) {
-        debouncer.trigger(eventPath ?? "change");
-      }
-    }));
+  try {
+    for (const watchRoot of await runtime.collectDirectories(plan)) {
+      watchers.push(runtime.watch(resolve(plan.rootPath, watchRoot), (_event, filename) => {
+        const eventPath = filename === null
+          ? undefined
+          : normalizeRelativePath(join(watchRoot, filename.toString()));
+        if (shouldRunDevPreviewForPath(plan, eventPath)) {
+          debouncer.trigger(eventPath ?? "change");
+        }
+      }));
+    }
+  } catch (error) {
+    for (const watcher of watchers) watcher.close();
+    if (stream === undefined) throw error;
+    stream.failed(error instanceof Error ? error.message : String(error), "watch-setup");
+    if (output === process.stdout) process.exitCode = 1;
+    return;
   }
 
-  await new Promise<void>((resolvePromise) => {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    let stopping = false;
     const stop = () => {
+      if (stopping) return;
+      stopping = true;
       debouncer.cancel();
       for (const watcher of watchers) watcher.close();
-      process.off("SIGINT", stop);
-      process.off("SIGTERM", stop);
-      if (stream === undefined) output.write("skillset: dev watch stopped\n");
-      else stream.completed();
-      resolvePromise();
+      runtime.removeSignalListeners(stop);
+      void (async () => {
+        try {
+          await activeOperation;
+          if (stream === undefined) output.write("skillset: dev watch stopped\n");
+          else stream.completed();
+          resolvePromise();
+        } catch (error) {
+          if (stream === undefined) rejectPromise(error);
+          else {
+            stream.failed(error instanceof Error ? error.message : String(error), "operation");
+            if (output === process.stdout) process.exitCode = 1;
+            resolvePromise();
+          }
+        }
+      })();
     };
-    process.once("SIGINT", stop);
-    process.once("SIGTERM", stop);
+    runtime.addSignalListeners(stop);
   });
 }
 

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -329,6 +329,8 @@ export async function runDevWatch(
     else stream.operation(report);
   };
   let activeOperation: Promise<void> | undefined;
+  let pendingOperationError: unknown;
+  let stopWithError: ((error: unknown) => void) | undefined;
   const startOperation = async (reason: string) => {
     const previous = activeOperation;
     const operation = (previous ?? Promise.resolve()).then(() => writeOperation(reason));
@@ -343,7 +345,12 @@ export async function runDevWatch(
 
   const watchers: FSWatcher[] = [];
   const debouncer = createDevWatchDebouncer(async (reason) => {
-    await startOperation(reason);
+    try {
+      await startOperation(reason);
+    } catch (error) {
+      if (stopWithError === undefined) pendingOperationError = error;
+      else stopWithError(error);
+    }
   }, DEFAULT_DEBOUNCE_MS, runtime.scheduler);
 
   try {
@@ -367,15 +374,16 @@ export async function runDevWatch(
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
     let stopping = false;
-    const stop = () => {
+    const stop = (operationError?: unknown) => {
       if (stopping) return;
       stopping = true;
       debouncer.cancel();
       for (const watcher of watchers) watcher.close();
-      runtime.removeSignalListeners(stop);
+      runtime.removeSignalListeners(signalStop);
       void (async () => {
         try {
           await activeOperation;
+          if (operationError !== undefined) throw operationError;
           if (stream === undefined) output.write("skillset: dev watch stopped\n");
           else stream.completed();
           resolvePromise();
@@ -389,7 +397,10 @@ export async function runDevWatch(
         }
       })();
     };
-    runtime.addSignalListeners(stop);
+    const signalStop = () => stop();
+    stopWithError = (error) => stop(error);
+    runtime.addSignalListeners(signalStop);
+    if (pendingOperationError !== undefined) stop(pendingOperationError);
   });
 }
 

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -13,7 +13,7 @@ import { loadBuildGraph } from "@skillset/core/internal/resolver";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
 import type { SchemaJsonRecord } from "@skillset/schema";
 
-import { createCliEventStream } from "./cli-output";
+import { classifyCliFailure, createCliEventStream } from "./cli-output";
 
 export interface DevWatchPlan {
   readonly configPaths: readonly string[];
@@ -66,6 +66,7 @@ export interface DevWatchRuntime {
   readonly removeSignalListeners: (listener: () => void) => void;
   readonly runOnce: typeof runDevWatchOnce;
   readonly scheduler: DevWatchScheduler;
+  readonly setExitCode?: (exitCode: number) => void;
   readonly watch: typeof watch;
 }
 
@@ -321,6 +322,12 @@ export async function runDevWatch(
 ): Promise<void> {
   const plan = await createDevWatchPlan(rootPath, options);
   const stream = machineMode === "jsonl" ? createDevWatchJsonlStream(output) : undefined;
+  const recordStreamFailure = (error: unknown, stage: string): void => {
+    stream?.failed(error instanceof Error ? error.message : String(error), stage);
+    const exitCode = classifyCliFailure(error);
+    if (runtime.setExitCode !== undefined) runtime.setExitCode(exitCode);
+    else if (output === process.stdout) process.exitCode = exitCode;
+  };
   if (stream === undefined) output.write(renderDevWatchStart(plan, mode));
   else stream.started(plan, mode);
   const writeOperation = async (reason = "initial") => {
@@ -365,8 +372,7 @@ export async function runDevWatch(
   } catch (error) {
     runtime.removeSignalListeners(signalStop);
     if (stream === undefined) throw error;
-    stream.failed(error instanceof Error ? error.message : String(error), "initial-operation");
-    if (output === process.stdout) process.exitCode = 1;
+    recordStreamFailure(error, "initial-operation");
     return;
   }
   if (pendingSignal) {
@@ -402,8 +408,7 @@ export async function runDevWatch(
     for (const watcher of watchers) watcher.close();
     runtime.removeSignalListeners(signalStop);
     if (stream === undefined) throw error;
-    stream.failed(error instanceof Error ? error.message : String(error), "watch-setup");
-    if (output === process.stdout) process.exitCode = 1;
+    recordStreamFailure(error, "watch-setup");
     return;
   }
 
@@ -425,8 +430,7 @@ export async function runDevWatch(
         } catch (error) {
           if (stream === undefined) rejectPromise(error);
           else {
-            stream.failed(error instanceof Error ? error.message : String(error), "operation");
-            if (output === process.stdout) process.exitCode = 1;
+            recordStreamFailure(error, "operation");
             resolvePromise();
           }
         }

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -330,7 +330,13 @@ export async function runDevWatch(
   };
   let activeOperation: Promise<void> | undefined;
   let pendingOperationError: unknown;
+  let pendingSignal = false;
   let stopWithError: ((error: unknown) => void) | undefined;
+  let stopFromSignal: (() => void) | undefined;
+  const signalStop = () => {
+    if (stopFromSignal === undefined) pendingSignal = true;
+    else stopFromSignal();
+  };
   const startOperation = async (reason: string) => {
     const previous = activeOperation;
     const operation = (previous ?? Promise.resolve()).then(() => writeOperation(reason));
@@ -341,7 +347,19 @@ export async function runDevWatch(
       if (activeOperation === operation) activeOperation = undefined;
     }
   };
-  await startOperation("initial");
+  runtime.addSignalListeners(signalStop);
+  try {
+    await startOperation("initial");
+  } catch (error) {
+    runtime.removeSignalListeners(signalStop);
+    throw error;
+  }
+  if (pendingSignal) {
+    runtime.removeSignalListeners(signalStop);
+    if (stream === undefined) output.write("skillset: dev watch stopped\n");
+    else stream.completed();
+    return;
+  }
 
   const watchers: FSWatcher[] = [];
   const debouncer = createDevWatchDebouncer(async (reason) => {
@@ -366,6 +384,7 @@ export async function runDevWatch(
     }
   } catch (error) {
     for (const watcher of watchers) watcher.close();
+    runtime.removeSignalListeners(signalStop);
     if (stream === undefined) throw error;
     stream.failed(error instanceof Error ? error.message : String(error), "watch-setup");
     if (output === process.stdout) process.exitCode = 1;
@@ -397,9 +416,9 @@ export async function runDevWatch(
         }
       })();
     };
-    const signalStop = () => stop();
+    stopFromSignal = () => stop();
     stopWithError = (error) => stop(error);
-    runtime.addSignalListeners(signalStop);
+    if (pendingSignal) stop();
     if (pendingOperationError !== undefined) stop(pendingOperationError);
   });
 }

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -342,8 +342,10 @@ export async function runDevWatch(
   const signalStop = () => {
     if (stopFromSignal === undefined) {
       pendingSignal = true;
-      initialSignalReceived = true;
-      resolveInitialSignal?.();
+      if (mode === "preview") {
+        initialSignalReceived = true;
+        resolveInitialSignal?.();
+      }
     } else stopFromSignal();
   };
   const startOperation = async (reason: string) => {

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -352,7 +352,10 @@ export async function runDevWatch(
     await startOperation("initial");
   } catch (error) {
     runtime.removeSignalListeners(signalStop);
-    throw error;
+    if (stream === undefined) throw error;
+    stream.failed(error instanceof Error ? error.message : String(error), "initial-operation");
+    if (output === process.stdout) process.exitCode = 1;
+    return;
   }
   if (pendingSignal) {
     runtime.removeSignalListeners(signalStop);

--- a/apps/skillset/src/dev-watch.ts
+++ b/apps/skillset/src/dev-watch.ts
@@ -325,17 +325,26 @@ export async function runDevWatch(
   else stream.started(plan, mode);
   const writeOperation = async (reason = "initial") => {
     const report = await runtime.runOnce(rootPath, options, mode, reason);
+    if (initialSignalReceived) return;
     if (stream === undefined) output.write(renderDevWatchPreview(report));
     else stream.operation(report);
   };
   let activeOperation: Promise<void> | undefined;
   let pendingOperationError: unknown;
   let pendingSignal = false;
+  let initialSignalReceived = false;
+  let resolveInitialSignal: (() => void) | undefined;
+  const initialSignal = new Promise<void>((resolvePromise) => {
+    resolveInitialSignal = resolvePromise;
+  });
   let stopWithError: ((error: unknown) => void) | undefined;
   let stopFromSignal: (() => void) | undefined;
   const signalStop = () => {
-    if (stopFromSignal === undefined) pendingSignal = true;
-    else stopFromSignal();
+    if (stopFromSignal === undefined) {
+      pendingSignal = true;
+      initialSignalReceived = true;
+      resolveInitialSignal?.();
+    } else stopFromSignal();
   };
   const startOperation = async (reason: string) => {
     const previous = activeOperation;
@@ -348,8 +357,9 @@ export async function runDevWatch(
     }
   };
   runtime.addSignalListeners(signalStop);
+  const initialOperation = startOperation("initial");
   try {
-    await startOperation("initial");
+    await Promise.race([initialOperation, initialSignal]);
   } catch (error) {
     runtime.removeSignalListeners(signalStop);
     if (stream === undefined) throw error;
@@ -359,6 +369,7 @@ export async function runDevWatch(
   }
   if (pendingSignal) {
     runtime.removeSignalListeners(signalStop);
+    void initialOperation.catch(() => {});
     if (stream === undefined) output.write("skillset: dev watch stopped\n");
     else stream.completed();
     return;

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -727,9 +727,9 @@ async function appendEvent(paths: TryRunPaths, stream: string, message: string):
     };
     const existing = await readOptional(path) ?? "";
     const sequence = existing.split("\n").filter((line) => line.length > 0).length + 1;
-    const event = message === "test passed"
+    const event = stream === "status" && message === "test passed"
       ? "completed"
-      : message.startsWith("test failed")
+      : stream === "status" && message.startsWith("test failed")
         ? "failed"
         : stream;
     await appendFile(path, renderCliEvent(createCliEvent({

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -23,6 +23,8 @@ import { loadBuildGraph } from "@skillset/core/internal/resolver";
 import { renderValidatedJson } from "@skillset/core/internal/structured-output";
 import type { BuildGraph, JsonRecord, SkillsetOptions, TargetName } from "@skillset/core/internal/types";
 
+import { createCliEvent, renderCliEvent } from "./cli-output";
+
 export type TrySubcommand = "list" | "status" | "tail" | "worker";
 export type TryState = "building" | "failed" | "passed" | "queued" | "running";
 export type TryClaudeSettingSources = "isolated" | "local" | "project" | "user";
@@ -39,6 +41,8 @@ export interface TryRunOptions extends SkillsetOptions {
   readonly target: TargetName;
   readonly timeoutMs?: number;
 }
+
+const eventAppendQueues = new Map<string, Promise<void>>();
 
 export interface TryStatus {
   readonly command?: readonly string[];
@@ -713,12 +717,34 @@ async function writeLatest(paths: TryRunPaths, runId: string): Promise<void> {
 }
 
 async function appendEvent(paths: TryRunPaths, stream: string, message: string): Promise<void> {
-  const event = {
-    message,
-    stream,
-    timestamp: new Date().toISOString(),
-  };
-  await appendFile(paths.absolute.outputPath, `${JSON.stringify(event)}\n`, "utf8");
+  const path = paths.absolute.outputPath;
+  const previous = eventAppendQueues.get(path) ?? Promise.resolve();
+  const queued = previous.catch(() => undefined).then(async () => {
+    const data = {
+      message,
+      stream,
+      timestamp: new Date().toISOString(),
+    };
+    const existing = await readOptional(path) ?? "";
+    const sequence = existing.split("\n").filter((line) => line.length > 0).length + 1;
+    const event = message === "try passed"
+      ? "completed"
+      : message.startsWith("try failed")
+        ? "failed"
+        : stream;
+    await appendFile(path, renderCliEvent(createCliEvent({
+      command: "test",
+      data,
+      event,
+      sequence,
+    })), "utf8");
+  });
+  eventAppendQueues.set(path, queued);
+  try {
+    await queued;
+  } finally {
+    if (eventAppendQueues.get(path) === queued) eventAppendQueues.delete(path);
+  }
 }
 
 async function readLatestRunId(
@@ -780,10 +806,11 @@ async function pathExists(path: string): Promise<boolean> {
 function parseTailLine(line: string): TryTailLine {
   const parsed = JSON.parse(line) as unknown;
   if (!isRecord(parsed)) return { message: line, stream: "raw", timestamp: "" };
+  const data = isRecord(parsed.data) ? parsed.data : parsed;
   return {
-    message: typeof parsed.message === "string" ? parsed.message : "",
-    stream: typeof parsed.stream === "string" ? parsed.stream : "raw",
-    timestamp: typeof parsed.timestamp === "string" ? parsed.timestamp : "",
+    message: typeof data.message === "string" ? data.message : "",
+    stream: typeof data.stream === "string" ? data.stream : "raw",
+    timestamp: typeof data.timestamp === "string" ? data.timestamp : "",
   };
 }
 

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -42,7 +42,12 @@ export interface TryRunOptions extends SkillsetOptions {
   readonly timeoutMs?: number;
 }
 
-const eventAppendQueues = new Map<string, Promise<void>>();
+interface EventAppendState {
+  nextSequence?: number;
+  queue: Promise<void>;
+}
+
+const eventAppendStates = new Map<string, EventAppendState>();
 
 export interface TryStatus {
   readonly command?: readonly string[];
@@ -718,32 +723,39 @@ async function writeLatest(paths: TryRunPaths, runId: string): Promise<void> {
 
 async function appendEvent(paths: TryRunPaths, stream: string, message: string): Promise<void> {
   const path = paths.absolute.outputPath;
-  const previous = eventAppendQueues.get(path) ?? Promise.resolve();
-  const queued = previous.catch(() => undefined).then(async () => {
+  const state = eventAppendStates.get(path) ?? { queue: Promise.resolve() };
+  const event = stream === "status" && message === "test passed"
+    ? "completed"
+    : stream === "status" && message.startsWith("test failed")
+      ? "failed"
+      : stream;
+  const queued = state.queue.catch(() => undefined).then(async () => {
     const data = {
       message,
       stream,
       timestamp: new Date().toISOString(),
     };
-    const existing = await readOptional(path) ?? "";
-    const sequence = existing.split("\n").filter((line) => line.length > 0).length + 1;
-    const event = stream === "status" && message === "test passed"
-      ? "completed"
-      : stream === "status" && message.startsWith("test failed")
-        ? "failed"
-        : stream;
+    if (state.nextSequence === undefined) {
+      const existing = await readOptional(path) ?? "";
+      state.nextSequence = existing.split("\n").filter((line) => line.length > 0).length + 1;
+    }
+    const sequence = state.nextSequence;
     await appendFile(path, renderCliEvent(createCliEvent({
       command: "test",
       data,
       event,
       sequence,
     })), "utf8");
+    state.nextSequence = sequence + 1;
   });
-  eventAppendQueues.set(path, queued);
+  state.queue = queued;
+  eventAppendStates.set(path, state);
   try {
     await queued;
   } finally {
-    if (eventAppendQueues.get(path) === queued) eventAppendQueues.delete(path);
+    if ((event === "completed" || event === "failed") && eventAppendStates.get(path)?.queue === queued) {
+      eventAppendStates.delete(path);
+    }
   }
 }
 

--- a/apps/skillset/src/try.ts
+++ b/apps/skillset/src/try.ts
@@ -727,9 +727,9 @@ async function appendEvent(paths: TryRunPaths, stream: string, message: string):
     };
     const existing = await readOptional(path) ?? "";
     const sequence = existing.split("\n").filter((line) => line.length > 0).length + 1;
-    const event = message === "try passed"
+    const event = message === "test passed"
       ? "completed"
-      : message.startsWith("try failed")
+      : message.startsWith("test failed")
         ? "failed"
         : stream;
     await appendFile(path, renderCliEvent(createCliEvent({


### PR DESCRIPTION
## Context

Long-running CLI routes need an event protocol rather than one terminal JSON document, including during failures and signal-driven shutdown.

## What changed

- adds `--jsonl` support to `skillset dev`
- introduces versioned, sequenced events with exactly one terminal completed/failed event
- emits structured started, operation, and terminal events for the watcher
- aligns retained runtime-test events with the same envelope while preserving tail compatibility
- serializes concurrent appends for deterministic ordering
- hardens startup, debounced work, failures, and SIGINT/SIGTERM shutdown

## Verification

- required GitHub checks: `changeset`, `check`, and `skillset-ci`
- focused CLI output, watcher lifecycle, signal, terminal-event, and retained-test stream coverage

## Tracking

Closes SET-289. Stacked on #274.

## Risks / rollout

JSONL consumers must process one versioned event per line and wait for the terminal event. Direct readers of older ad hoc runtime-test records must migrate.
