### PR TITLE
refactor(cli): extract argument reader kernel

### DIFF
--- a/.changeset/cli-argument-reader-kernel.md
+++ b/.changeset/cli-argument-reader-kernel.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Extract the shared policy-free CLI argument reader, scalar value helpers, and injectable parse context while preserving existing command behavior.

--- a/apps/skillset/src/__tests__/cli-arg-reader.test.ts
+++ b/apps/skillset/src/__tests__/cli-arg-reader.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  assertBooleanOption,
+  CliArgReader,
+  splitCliOption,
+} from "../cli-arg-reader";
+import type { CliOptionToken } from "../cli-arg-reader";
+
+const readOption = (reader: CliArgReader): CliOptionToken => {
+  const option = reader.readOption();
+  if (option === undefined) {
+    throw new Error("expected option");
+  }
+  return option;
+};
+
+describe("SET-300 CLI argument reader", () => {
+  test("traverses argv from an injected cursor", () => {
+    const reader = new CliArgReader(["build", "path", "--json"], 1);
+
+    expect(reader.index).toBe(1);
+    expect(reader.peek()).toBe("path");
+    expect(reader.readOptionalPositional()).toBe("path");
+    expect(reader.index).toBe(2);
+    expect(reader.readOptionalPositional()).toBeUndefined();
+    expect(reader.read()).toBe("--json");
+    expect(reader.done).toBe(true);
+  });
+
+  test("splits inline values without losing empty values", () => {
+    expect(splitCliOption("--root=workspace")).toEqual({
+      flag: "--root",
+      inlineValue: "workspace",
+      raw: "--root=workspace",
+    });
+    expect(splitCliOption("--root=")).toEqual({
+      flag: "--root",
+      inlineValue: "",
+      raw: "--root=",
+    });
+    expect(splitCliOption("--json")).toEqual({
+      flag: "--json",
+      raw: "--json",
+    });
+  });
+
+  test("reads required inline and separate option values", () => {
+    const reader = new CliArgReader(["--root", "workspace", "--name=demo"]);
+    const root = readOption(reader);
+    expect(reader.readRequiredOptionValue(root)).toBe("workspace");
+    const name = readOption(reader);
+    expect(reader.readRequiredOptionValue(name)).toBe("demo");
+    expect(reader.done).toBe(true);
+  });
+
+  test("preserves missing-value and boolean diagnostics", () => {
+    const reader = new CliArgReader(["--root", "--json"]);
+    const root = readOption(reader);
+    expect(() => reader.readRequiredOptionValue(root)).toThrow(
+      "skillset: expected value after --root"
+    );
+    const json = readOption(reader);
+    expect(() => assertBooleanOption(json)).not.toThrow();
+    expect(() => assertBooleanOption(splitCliOption("--json=true"))).toThrow(
+      "skillset: --json does not take a value"
+    );
+  });
+
+  test("reads optional inline or repeated positional values", () => {
+    const inline = new CliArgReader(["--compat=claude,codex", "tail"]);
+    expect(inline.readOptionalOptionValues(readOption(inline))).toEqual([
+      "claude,codex",
+    ]);
+    expect(inline.peek()).toBe("tail");
+
+    const separate = new CliArgReader([
+      "--compat",
+      "claude",
+      "codex",
+      "--json",
+    ]);
+    expect(separate.readOptionalOptionValues(readOption(separate))).toEqual([
+      "claude",
+      "codex",
+    ]);
+    expect(separate.peek()).toBe("--json");
+  });
+});

--- a/apps/skillset/src/__tests__/cli-arg-values.test.ts
+++ b/apps/skillset/src/__tests__/cli-arg-values.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  readPositiveInteger,
+  readTargetName,
+  readTargetNames,
+  resolveCliRoot,
+  tokenizeCsv,
+} from "../cli-arg-values";
+
+describe("SET-300 CLI scalar values", () => {
+  test("normalizes roots against the injected cwd", () => {
+    expect(resolveCliRoot({ cwd: "/workspace/repo" })).toBe("/workspace/repo");
+    expect(resolveCliRoot({ cwd: "/workspace/repo" }, "../other")).toBe(
+      "/workspace/other"
+    );
+  });
+
+  test("reads positive integers with stable diagnostics", () => {
+    expect(readPositiveInteger("42", "--lines")).toBe(42);
+    for (const value of ["0", "-1", "1.5", "text"]) {
+      expect(() => readPositiveInteger(value, "--lines")).toThrow(
+        "skillset: expected --lines to be a positive integer"
+      );
+    }
+  });
+
+  test("reads target names and deduplicated target lists", () => {
+    expect(readTargetName("claude")).toBe("claude");
+    expect(readTargetNames("claude, codex,claude")).toEqual([
+      "claude",
+      "codex",
+    ]);
+    expect(() => readTargetName("other")).toThrow(
+      "skillset: expected --target"
+    );
+    expect(() => readTargetNames("")).toThrow(
+      "skillset: --targets requires at least one target"
+    );
+  });
+
+  test("merges build modes and rejects conflicts", () => {
+    expect(mergeBuildMode(undefined, "updated")).toBe("updated");
+    expect(mergeBuildMode("updated", "updated")).toBe("updated");
+    expect(() => mergeBuildMode("updated", "all")).toThrow(
+      "skillset: conflicting build mode flags --updated and --all"
+    );
+  });
+
+  test("reads build scopes with all expansion and stable ordering", () => {
+    expect(readBuildScopes("user, repo,user")).toEqual(["user", "repo"]);
+    expect(readBuildScopes("all")).toEqual([
+      "repo",
+      "plugins",
+      "project",
+      "user",
+    ]);
+    expect(() => readBuildScopes("all,repo")).toThrow(
+      "skillset: --scope all cannot be combined with other scopes"
+    );
+  });
+
+  test("tokenizes comma-separated values without adding policy", () => {
+    expect(tokenizeCsv(" one, two ,,three ")).toEqual(["one", "two", "three"]);
+    expect(tokenizeCsv(" , ")).toEqual([]);
+  });
+});

--- a/apps/skillset/src/__tests__/cli-args.test.ts
+++ b/apps/skillset/src/__tests__/cli-args.test.ts
@@ -927,6 +927,31 @@ describe("SET-299 CLI request characterization", () => {
   });
 });
 
+describe("SET-300 CLI parse context", () => {
+  test("resolves default and relative roots against the injected cwd", () => {
+    expect(canonical(parseCliRequest(["build"], { cwd: ROOT }))).toEqual({
+      command: "build",
+      request: {
+        jsonOutput: false,
+        options: {},
+        rootPath: ROOT,
+        yes: false,
+      },
+    });
+    expect(
+      canonical(parseCliRequest(["build", "--root", "nested"], { cwd: ROOT }))
+    ).toEqual({
+      command: "build",
+      request: {
+        jsonOutput: false,
+        options: {},
+        rootPath: `${ROOT}/nested`,
+        yes: false,
+      },
+    });
+  });
+});
+
 describe("SET-299 parser failure contract", () => {
   const cases = [
     {

--- a/apps/skillset/src/cli-arg-reader.ts
+++ b/apps/skillset/src/cli-arg-reader.ts
@@ -1,0 +1,93 @@
+export interface CliOptionToken {
+  readonly flag: string;
+  readonly inlineValue?: string;
+  readonly raw: string;
+}
+
+export const splitCliOption = (raw: string): CliOptionToken => {
+  const equalsIndex = raw.indexOf("=");
+  if (equalsIndex === -1) {
+    return { flag: raw, raw };
+  }
+  return {
+    flag: raw.slice(0, equalsIndex),
+    inlineValue: raw.slice(equalsIndex + 1),
+    raw,
+  };
+};
+
+export class CliArgReader {
+  readonly #args: readonly string[];
+  #index: number;
+
+  constructor(args: readonly string[], index = 0) {
+    this.#args = args;
+    this.#index = index;
+  }
+
+  get done(): boolean {
+    return this.#index >= this.#args.length;
+  }
+
+  get index(): number {
+    return this.#index;
+  }
+
+  peek(offset = 0): string | undefined {
+    return this.#args[this.#index + offset];
+  }
+
+  read(): string | undefined {
+    const value = this.peek();
+    if (value !== undefined) {
+      this.#index += 1;
+    }
+    return value;
+  }
+
+  readOptionalPositional(): string | undefined {
+    const value = this.peek();
+    if (value === undefined || value.startsWith("--")) {
+      return undefined;
+    }
+    this.#index += 1;
+    return value;
+  }
+
+  readOption(): CliOptionToken | undefined {
+    const raw = this.read();
+    return raw === undefined ? undefined : splitCliOption(raw);
+  }
+
+  readRequiredOptionValue(option: CliOptionToken): string {
+    if (option.inlineValue !== undefined) {
+      return option.inlineValue;
+    }
+    const value = this.peek();
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`skillset: expected value after ${option.flag}`);
+    }
+    this.#index += 1;
+    return value;
+  }
+
+  readOptionalOptionValues(option: CliOptionToken): readonly string[] {
+    if (option.inlineValue !== undefined) {
+      return [option.inlineValue];
+    }
+    const values: string[] = [];
+    while (true) {
+      const value = this.readOptionalPositional();
+      if (value === undefined) {
+        return values;
+      }
+      values.push(value);
+    }
+  }
+}
+
+export const assertBooleanOption = (option: CliOptionToken): void => {
+  if (option.inlineValue !== undefined) {
+    throw new Error(`skillset: ${option.flag} does not take a value`);
+  }
+};

--- a/apps/skillset/src/cli-arg-values.ts
+++ b/apps/skillset/src/cli-arg-values.ts
@@ -1,0 +1,102 @@
+import path from "node:path";
+
+import { isTargetName, targetNames } from "@skillset/core";
+import type {
+  BuildScope,
+  CompileBuildMode,
+  TargetName,
+} from "@skillset/core/internal/types";
+
+export interface CliParseContext {
+  readonly cwd: string;
+}
+
+export const tokenizeCsv = (value: string): readonly string[] =>
+  value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+const isBuildScope = (value: string): value is BuildScope =>
+  value === "repo" ||
+  value === "plugins" ||
+  value === "project" ||
+  value === "user";
+
+export const resolveCliRoot = (
+  context: CliParseContext,
+  rootPath?: string
+): string => path.resolve(context.cwd, rootPath ?? ".");
+
+export const readPositiveInteger = (value: string, flag: string): number => {
+  if (!/^[0-9]+$/u.test(value)) {
+    throw new Error(`skillset: expected ${flag} to be a positive integer`);
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`skillset: expected ${flag} to be a positive integer`);
+  }
+  return parsed;
+};
+
+export const readTargetName = (value: string): TargetName => {
+  if (isTargetName(value)) {
+    return value;
+  }
+  throw new Error(`skillset: expected --target ${targetNames().join(", ")}`);
+};
+
+export const readTargetNames = (
+  value: string,
+  flag = "--targets"
+): readonly TargetName[] => {
+  const targets = tokenizeCsv(value);
+  if (targets.length === 0) {
+    throw new Error(`skillset: ${flag} requires at least one target`);
+  }
+  const seen = new Set<TargetName>();
+  for (const target of targets) {
+    if (!isTargetName(target)) {
+      throw new Error(`skillset: expected ${flag} ${targetNames().join(", ")}`);
+    }
+    seen.add(target);
+  }
+  return [...seen];
+};
+
+export const mergeBuildMode = (
+  current: CompileBuildMode | undefined,
+  next: CompileBuildMode
+): CompileBuildMode => {
+  if (current !== undefined && current !== next) {
+    throw new Error(
+      `skillset: conflicting build mode flags --${current} and --${next}`
+    );
+  }
+  return next;
+};
+
+export const readBuildScopes = (value: string): readonly BuildScope[] => {
+  const scopes = tokenizeCsv(value);
+  if (scopes.length === 0) {
+    throw new Error("skillset: --scope requires at least one scope");
+  }
+  if (scopes.includes("all")) {
+    if (scopes.length > 1) {
+      throw new Error(
+        "skillset: --scope all cannot be combined with other scopes"
+      );
+    }
+    return ["repo", "plugins", "project", "user"];
+  }
+  const seen = new Set<BuildScope>();
+  for (const scope of scopes) {
+    if (!isBuildScope(scope)) {
+      throw new Error(
+        "skillset: expected --scope repo, plugins, project, user, all, or a comma-separated combination"
+      );
+    }
+    seen.add(scope);
+  }
+  return [...seen];
+};

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -1,6 +1,3 @@
-import { resolve } from "node:path";
-
-import { isTargetName, targetNames } from "@skillset/core";
 import type { LookupSubject, LookupView } from "@skillset/core";
 import { sourceUnitSelector } from "@skillset/core/internal/source-unit-selector";
 import type {
@@ -12,6 +9,17 @@ import type {
 
 import type { ChangeBump } from "./change-entries";
 import type { ChangeReasonInput, ChangeSubcommand } from "./change-workflow";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  readPositiveInteger,
+  readTargetName,
+  readTargetNames,
+  resolveCliRoot,
+  tokenizeCsv,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
 import { isCliCommand, renderExpectedCliCommands } from "./cli-commands";
 import type { CliCommand } from "./cli-commands";
 import { CliOutputError, readCliCommand } from "./cli-output";
@@ -124,7 +132,10 @@ interface ParsedArgs {
   readonly yes: boolean;
 }
 
-function parseArgs(args: readonly string[]): ParsedArgs {
+function parseArgs(
+  args: readonly string[],
+  context: CliParseContext
+): ParsedArgs {
   const command = args[0];
   if (!isCliCommand(command)) {
     throw new Error(
@@ -195,7 +206,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let newName: string | undefined;
   let newPresets: readonly string[] | undefined;
   let newScope: NewSourceScope | undefined;
-  let rootPath = process.cwd();
+  let rootPath: string | undefined;
   let rootExplicit = false;
   let sourceDir: string | undefined;
   let distDir: string | undefined;
@@ -413,15 +424,13 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     }
   }
 
-  for (; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === undefined) {
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
       break;
     }
-    const equalsIndex = arg.indexOf("=");
-    const flag = equalsIndex === -1 ? arg : arg.slice(0, equalsIndex);
-    const inlineValue =
-      equalsIndex === -1 ? undefined : arg.slice(equalsIndex + 1);
+    const { flag, raw: arg } = option;
     if (
       flag !== "--root" &&
       flag !== "--id" &&
@@ -483,20 +492,8 @@ function parseArgs(args: readonly string[]): ParsedArgs {
 
     if (flag === "--compat") {
       lookupViews = addLookupView(lookupViews, "compat");
-      if (inlineValue !== undefined) {
-        lookupTargets = addLookupTargets(lookupTargets, inlineValue);
-        continue;
-      }
-      while (
-        args[index + 1] !== undefined &&
-        !args[index + 1]?.startsWith("--")
-      ) {
-        const value = args[index + 1];
-        if (value === undefined) {
-          break;
-        }
+      for (const value of reader.readOptionalOptionValues(option)) {
         lookupTargets = addLookupTargets(lookupTargets, value);
-        index += 1;
       }
       continue;
     }
@@ -524,17 +521,15 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       flag === "--schema" ||
       flag === "--background"
     ) {
-      if (inlineValue !== undefined) {
-        throw new Error(`skillset: ${flag} does not take a value`);
-      }
+      assertBooleanOption(option);
       if (flag === "--yes") {
         yes = true;
       }
       if (flag === "--updated") {
-        buildMode = setBuildMode(buildMode, "updated");
+        buildMode = mergeBuildMode(buildMode, "updated");
       }
       if (flag === "--all") {
-        buildMode = setBuildMode(buildMode, "all");
+        buildMode = mergeBuildMode(buildMode, "all");
       }
       if (flag === "--isolated") {
         isolated = true;
@@ -601,13 +596,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       continue;
     }
 
-    const value = inlineValue ?? args[index + 1];
-    if (value === undefined || value.startsWith("--")) {
-      throw new Error(`skillset: expected value after ${flag}`);
-    }
-    if (inlineValue === undefined) {
-      index += 1;
-    }
+    const value = reader.readRequiredOptionValue(option);
 
     if (flag === "--root") {
       rootPath = value;
@@ -727,7 +716,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       tryLines = readPositiveInteger(value, "--lines");
     }
     if (flag === "--targets") {
-      setupTargets = readSetupTargets(value);
+      setupTargets = readTargetNames(value);
     }
     if (flag === "--include") {
       setupIncludes = mergeSetupIncludes(setupIncludes, value);
@@ -1089,7 +1078,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     ...(tryTarget === undefined ? {} : { tryTarget }),
     ...(tryTimeoutMs === undefined ? {} : { tryTimeoutMs }),
     rootExplicit,
-    rootPath: resolve(rootPath),
+    rootPath: resolveCliRoot(context, rootPath),
     ...(setupIncludes === undefined ? {} : { setupIncludes }),
     ...(setupTargets === undefined ? {} : { setupTargets }),
     ...(reconcileChoice === undefined ? {} : { reconcileChoice }),
@@ -1326,9 +1315,12 @@ function createCliRequest(parsed: ParsedArgs): CliRequest {
   throw new Error(`skillset: unhandled command ${command}`);
 }
 
-export function parseCliRequest(args: readonly string[]): CliRequest {
+export function parseCliRequest(
+  args: readonly string[],
+  context: CliParseContext = { cwd: process.cwd() }
+): CliRequest {
   try {
-    return createCliRequest(parseArgs(args));
+    return createCliRequest(parseArgs(args, context));
   } catch (error) {
     if (error instanceof CliOutputError) {
       throw error;
@@ -1377,10 +1369,7 @@ function readNewSourceScope(value: string): NewSourceScope {
 }
 
 function readChangeScopes(value: string): readonly string[] {
-  const scopes = value
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter((scope) => scope.length > 0);
+  const scopes = tokenizeCsv(value);
   if (scopes.length === 0) {
     throw new Error(
       "skillset: --scope requires at least one source unit scope"
@@ -1392,10 +1381,7 @@ function readChangeScopes(value: string): readonly string[] {
 function readHookRuntimeContextFields(
   value: string
 ): readonly HookRuntimeContextField[] {
-  const fields = value
-    .split(",")
-    .map((field) => field.trim())
-    .filter((field) => field.length > 0);
+  const fields = tokenizeCsv(value);
   if (fields.length === 0) {
     throw new Error("skillset: --context-fields requires at least one field");
   }
@@ -1412,17 +1398,6 @@ function readChangeBump(value: string): ChangeBump {
     return value;
   }
   throw new Error("skillset: expected --bump major, minor, patch, or none");
-}
-
-function readPositiveInteger(value: string, flag: string): number {
-  if (!/^[0-9]+$/u.test(value)) {
-    throw new Error(`skillset: expected ${flag} to be a positive integer`);
-  }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`skillset: expected ${flag} to be a positive integer`);
-  }
-  return parsed;
 }
 
 function setChangeReason(
@@ -1930,55 +1905,6 @@ function validateNewSourceFlags(
   }
 }
 
-function setBuildMode(
-  current: CompileBuildMode | undefined,
-  next: CompileBuildMode
-): CompileBuildMode {
-  if (current !== undefined && current !== next) {
-    throw new Error(
-      `skillset: conflicting build mode flags --${current} and --${next}`
-    );
-  }
-  return next;
-}
-
-function readBuildScopes(value: string): readonly BuildScope[] {
-  const scopes = value
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter((scope) => scope.length > 0);
-  if (scopes.length === 0) {
-    throw new Error("skillset: --scope requires at least one scope");
-  }
-  if (scopes.includes("all")) {
-    if (scopes.length > 1) {
-      throw new Error(
-        "skillset: --scope all cannot be combined with other scopes"
-      );
-    }
-    return ["repo", "plugins", "project", "user"];
-  }
-  const seen = new Set<BuildScope>();
-  for (const scope of scopes) {
-    if (!isBuildScope(scope)) {
-      throw new Error(
-        "skillset: expected --scope repo, plugins, project, user, all, or a comma-separated combination"
-      );
-    }
-    seen.add(scope);
-  }
-  return [...seen];
-}
-
-function isBuildScope(value: string): value is BuildScope {
-  return (
-    value === "repo" ||
-    value === "plugins" ||
-    value === "project" ||
-    value === "user"
-  );
-}
-
 function readHookRunner(value: string): HookRunner {
   if (
     value === "git" ||
@@ -2000,21 +1926,11 @@ function readHookTarget(value: string): TargetName {
   throw new Error("skillset: expected --target claude or codex");
 }
 
-function readTargetName(value: string): TargetName {
-  if (isTargetName(value)) {
-    return value;
-  }
-  throw new Error(`skillset: expected --target ${targetNames().join(", ")}`);
-}
-
 function mergeSetupIncludes(
   current: readonly SetupInclude[] | undefined,
   value: string
 ): readonly SetupInclude[] {
-  const includes = value
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0);
+  const includes = tokenizeCsv(value);
   if (includes.length === 0) {
     throw new Error("skillset: --include requires at least one value");
   }
@@ -2024,26 +1940,6 @@ function mergeSetupIncludes(
       throw new Error("skillset: expected --include ci");
     }
     seen.add(include);
-  }
-  return [...seen];
-}
-
-function readSetupTargets(value: string): readonly TargetName[] {
-  const targets = value
-    .split(",")
-    .map((target) => target.trim())
-    .filter((target) => target.length > 0);
-  if (targets.length === 0) {
-    throw new Error("skillset: --targets requires at least one target");
-  }
-  const seen = new Set<TargetName>();
-  for (const target of targets) {
-    if (!isTargetName(target)) {
-      throw new Error(
-        `skillset: expected --targets ${targetNames().join(", ")}`
-      );
-    }
-    seen.add(target);
   }
   return [...seen];
 }


### PR DESCRIPTION
## Context

SET-300 introduces the policy-free lexical layer used by command-owned parsers above it.

## What changed

- Extracted `CliArgReader` for cursor traversal, inline values, positionals, and boolean tokens.
- Extracted scalar parsing for integers, targets, scopes, CSV values, and roots.
- Injected parse context while preserving `CliRequest`, explicit dispatch, and the single CLI error boundary.

## Verification

- Focused reader, scalar, parser, output, and contract suites
- `bun run typecheck`
- CLI-surface and package-ownership guards
- `bun run check`

## Risk

Mechanical lexical extraction only; command policy and runtime behavior remain on the existing path.

Linear: SET-300