### PR TITLE
refactor(cli): extract projection route parsers

### DIFF
--- a/.changeset/cli-projection-route-parsers.md
+++ b/.changeset/cli-projection-route-parsers.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Move build, diff, check, dev, and update argument handling into typed command-owned parsers without changing their public CLI contracts.

--- a/apps/skillset/src/__tests__/projection-args.test.ts
+++ b/apps/skillset/src/__tests__/projection-args.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseBuildCommandRequest,
+  parseDiffCommandRequest,
+} from "../build-args";
+import { parseCheckCommandRequest } from "../check-args";
+import { parseCliRequest } from "../cli-args";
+import { parseDevCommandRequest } from "../dev-args";
+import { parseUpdateCommandRequest } from "../update-args";
+
+const CONTEXT = { cwd: "/workspace/repo" } as const;
+
+describe("SET-301 projection and readiness route parsers", () => {
+  test("build owns projection options and request construction", () => {
+    expect(
+      parseBuildCommandRequest(
+        [
+          "build",
+          "--root",
+          "nested",
+          "--scope",
+          "repo,plugins",
+          "--updated",
+          "--isolated",
+          "--json",
+          "--yes",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      options: {
+        buildMode: "updated",
+        isolated: true,
+        scopes: ["repo", "plugins"],
+      },
+      rootPath: "/workspace/repo/nested",
+      yes: true,
+    });
+  });
+
+  test("diff owns projection options while preserving ignored confirmation", () => {
+    expect(
+      parseDiffCommandRequest(
+        ["diff", "--all", "--scope=all", "--isolated", "--json", "--yes"],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      options: {
+        buildMode: "all",
+        isolated: true,
+        scopes: ["repo", "plugins", "project", "user"],
+      },
+      rootPath: "/workspace/repo",
+    });
+  });
+
+  test("check owns CI and narrow-output request construction", () => {
+    expect(
+      parseCheckCommandRequest(
+        [
+          "check",
+          "--ci",
+          "--fix",
+          "--since",
+          "HEAD",
+          "--report=report.md",
+          "--json",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      changeSince: "HEAD",
+      checkOnly: undefined,
+      checkWrite: false,
+      ciFix: true,
+      ciMode: true,
+      ciReportPath: "report.md",
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo",
+    });
+    expect(
+      parseCheckCommandRequest(
+        [
+          "check",
+          "--only",
+          "outputs",
+          "--updated",
+          "--scope",
+          "repo",
+          "--isolated",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({
+      checkOnly: "outputs",
+      options: { buildMode: "updated", isolated: true, scopes: ["repo"] },
+    });
+  });
+
+  test("dev and update own their write and machine modes", () => {
+    expect(
+      parseDevCommandRequest(
+        ["dev", "--root=watch", "--write", "--jsonl"],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonlOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/watch",
+      write: true,
+    });
+    expect(
+      parseUpdateCommandRequest(
+        ["update", "--root", "target", "--json", "--yes"],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/target",
+      yes: true,
+    });
+  });
+
+  test("preserves representative validation order and diagnostics", () => {
+    const cases = [
+      {
+        args: ["check", "--fix", "--scope", "repo"],
+        message: "skillset: check --fix requires --ci",
+      },
+      {
+        args: ["check", "--jsonl", "--updated"],
+        message: "skillset: --jsonl is only supported with dev",
+      },
+      {
+        args: ["dev", "--fix", "--updated"],
+        message: "skillset: readiness flags are only supported with check",
+      },
+      {
+        args: ["dev", "--json", "--isolated"],
+        message: "skillset: --json is not supported for this command route",
+      },
+      {
+        args: ["update", "--scope", "plugins", "--isolated"],
+        message:
+          "skillset: update does not support --scope; provider format updates require a whole-workspace safety preflight",
+      },
+      {
+        args: ["build", "--include", "ci"],
+        message: "skillset: setup options are only supported with init",
+      },
+    ] as const;
+
+    for (const { args, message } of cases) {
+      expect(() => parseCliRequest(args, CONTEXT)).toThrow(message);
+    }
+  });
+
+  test("preserves known cross-route ownership and lexical diagnostics", () => {
+    const routes = ["build", "check", "dev", "diff", "update"] as const;
+    const cases = [
+      {
+        args: ["--append"],
+        message:
+          "skillset: change options are only supported with change commands",
+      },
+      {
+        args: ["--runner", "git"],
+        message: "skillset: hook options are only supported with hooks print",
+      },
+      {
+        args: ["--event", "SessionStart"],
+        message:
+          "skillset: hook context options are only supported with hooks context",
+      },
+      {
+        args: ["--frontmatter"],
+        message: "skillset: lookup flags are only supported with lookup",
+      },
+      {
+        args: ["--background"],
+        message: "skillset: ad hoc test options are only supported with test",
+      },
+      {
+        args: ["--adopt", "demo"],
+        message:
+          "skillset: --adopt and init acquisition --from are only supported with init",
+      },
+      {
+        args: ["--id", "demo"],
+        message: "skillset: new options are only supported with new",
+      },
+      {
+        args: ["--use", "source"],
+        message: "skillset: --use is only supported with reconcile",
+      },
+      {
+        args: ["--include", "invalid"],
+        message: "skillset: expected --include ci",
+      },
+      {
+        args: ["--targets", "invalid"],
+        message: "skillset: expected --targets",
+      },
+      {
+        args: ["--only", "invalid"],
+        message: "skillset: expected --only outputs",
+      },
+      {
+        args: ["--kind", "invalid"],
+        message: "skillset: expected --kind skill, skills, plugin, or plugins",
+      },
+      {
+        args: ["--from", "invalid"],
+        message:
+          "skillset: expected --from claude, codex, cursor, agents, or skillset",
+      },
+    ] as const;
+
+    for (const route of routes) {
+      for (const { args, message } of cases) {
+        expect(() => parseCliRequest([route, ...args], CONTEXT)).toThrow(
+          message
+        );
+      }
+    }
+    for (const route of ["build", "check", "dev", "diff", "update"] as const) {
+      expect(() =>
+        parseCliRequest(
+          [route, "--from", "claude", "--kind", "skill", "--name", "demo"],
+          CONTEXT
+        )
+      ).not.toThrow();
+    }
+    expect(() => parseCliRequest(["diff", "--yes"], CONTEXT)).not.toThrow();
+    expect(() => parseCliRequest(["dev", "--since", "HEAD"], CONTEXT)).toThrow(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  });
+});

--- a/apps/skillset/src/build-args.ts
+++ b/apps/skillset/src/build-args.ts
@@ -1,0 +1,150 @@
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import type { BuildCommandRequest, DiffCommandRequest } from "./build-cli";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+
+export const parseBuildCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): BuildCommandRequest => {
+  const parsed = parseProjectionArgs(args, context);
+  return {
+    jsonOutput: parsed.jsonOutput,
+    options: parsed.options,
+    rootPath: parsed.rootPath,
+    yes: parsed.yes,
+  };
+};
+
+export const parseDiffCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): DiffCommandRequest => {
+  const parsed = parseProjectionArgs(args, context);
+  return {
+    jsonOutput: parsed.jsonOutput,
+    options: parsed.options,
+    rootPath: parsed.rootPath,
+  };
+};
+
+interface ProjectionArgs {
+  readonly jsonOutput: boolean;
+  readonly options: SkillsetOptions;
+  readonly rootPath: string;
+  readonly yes: boolean;
+}
+
+const parseProjectionArgs = (
+  args: readonly string[],
+  context: CliParseContext
+): ProjectionArgs => {
+  let buildMode: "all" | "updated" | undefined;
+  let isolated = false;
+  let jsonOutput = false;
+  let rootPath: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let yes = false;
+  let readinessFlag = false;
+  let sinceFlag = false;
+  let jsonlOutput = false;
+  const reader = new CliArgReader(args, 1);
+
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--updated":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(buildMode, "updated");
+        break;
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(buildMode, "all");
+        break;
+      case "--isolated":
+        assertBooleanOption(option);
+        isolated = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--from":
+      case "--kind":
+      case "--name":
+        reader.readRequiredOptionValue(option);
+        break;
+      case "--fix":
+      case "--ci":
+        assertBooleanOption(option);
+        readinessFlag = true;
+        break;
+      case "--only":
+      case "--report":
+        reader.readRequiredOptionValue(option);
+        readinessFlag = true;
+        break;
+      case "--since":
+        reader.readRequiredOptionValue(option);
+        sinceFlag = true;
+        break;
+      case "--include":
+      case "--targets":
+        reader.readRequiredOptionValue(option);
+        throw new Error("skillset: setup options are only supported with init");
+      case "--write":
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --write is only supported with check or dev"
+        );
+      case "--jsonl":
+        assertBooleanOption(option);
+        jsonlOutput = true;
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  if (readinessFlag) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (sinceFlag) {
+    throw new Error(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  }
+  if (jsonlOutput) {
+    throw new Error("skillset: --jsonl is only supported with dev");
+  }
+
+  return {
+    jsonOutput,
+    options: {
+      ...(buildMode === undefined ? {} : { buildMode }),
+      ...(scopes === undefined ? {} : { scopes }),
+      ...(isolated ? { isolated: true } : {}),
+    },
+    rootPath: resolveCliRoot(context, rootPath),
+    yes,
+  };
+};

--- a/apps/skillset/src/check-args.ts
+++ b/apps/skillset/src/check-args.ts
@@ -1,0 +1,168 @@
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import type { CheckCommandRequest } from "./check-cli";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+
+export const parseCheckCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): CheckCommandRequest => {
+  let buildMode: "all" | "updated" | undefined;
+  let changeSince: string | undefined;
+  let checkOnly: "outputs" | undefined;
+  let checkWrite = false;
+  let ciFix = false;
+  let ciMode = false;
+  let ciReportPath: string | undefined;
+  let isolated = false;
+  let jsonOutput = false;
+  let jsonlOutput = false;
+  let rootPath: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let yes = false;
+  const reader = new CliArgReader(args, 1);
+
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--since":
+        changeSince = reader.readRequiredOptionValue(option);
+        break;
+      case "--report":
+        ciReportPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--only": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "outputs") {
+          throw new Error("skillset: expected --only outputs");
+        }
+        checkOnly = value;
+        break;
+      }
+      case "--ci":
+        assertBooleanOption(option);
+        ciMode = true;
+        break;
+      case "--fix":
+        assertBooleanOption(option);
+        ciFix = true;
+        break;
+      case "--write":
+        assertBooleanOption(option);
+        checkWrite = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--jsonl":
+        assertBooleanOption(option);
+        jsonlOutput = true;
+        break;
+      case "--isolated":
+        assertBooleanOption(option);
+        isolated = true;
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--from":
+      case "--kind":
+      case "--name":
+        reader.readRequiredOptionValue(option);
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--include":
+      case "--targets":
+        reader.readRequiredOptionValue(option);
+        throw new Error("skillset: setup options are only supported with init");
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  if (yes) {
+    throw new Error(
+      "skillset: check does not take mutation confirmation flags"
+    );
+  }
+  if (ciFix && !ciMode) {
+    throw new Error("skillset: check --fix requires --ci");
+  }
+  if (checkWrite && ciMode) {
+    throw new Error("skillset: check --ci uses --fix instead of --write");
+  }
+  if ((ciReportPath !== undefined || changeSince !== undefined) && !ciMode) {
+    throw new Error("skillset: --report and --since require check --ci");
+  }
+  if (
+    checkOnly !== undefined &&
+    (ciMode ||
+      ciFix ||
+      checkWrite ||
+      ciReportPath !== undefined ||
+      changeSince !== undefined)
+  ) {
+    throw new Error(
+      "skillset: check --only outputs cannot be combined with CI or write flags"
+    );
+  }
+  if (jsonlOutput) {
+    throw new Error("skillset: --jsonl is only supported with dev");
+  }
+  if (checkOnly !== "outputs" && buildMode !== undefined) {
+    throw new Error(
+      "skillset check does not support --updated or --all; it checks source diagnostics"
+    );
+  }
+  if (checkOnly !== "outputs" && scopes !== undefined) {
+    throw new Error(
+      "skillset check does not support --scope; it checks source diagnostics"
+    );
+  }
+  if (isolated && checkOnly !== "outputs") {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+  return {
+    changeSince,
+    checkOnly,
+    checkWrite,
+    ciFix,
+    ciMode,
+    ciReportPath,
+    jsonOutput,
+    options: {
+      ...(checkOnly === "outputs" && buildMode !== undefined
+        ? { buildMode }
+        : {}),
+      ...(checkOnly === "outputs" && scopes !== undefined ? { scopes } : {}),
+      ...(isolated ? { isolated: true } : {}),
+    },
+    rootPath: resolveCliRoot(context, rootPath),
+  };
+};

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -7,8 +7,13 @@ import type {
   TargetName,
 } from "@skillset/core/internal/types";
 
+import {
+  parseBuildCommandRequest,
+  parseDiffCommandRequest,
+} from "./build-args";
 import type { ChangeBump } from "./change-entries";
 import type { ChangeReasonInput, ChangeSubcommand } from "./change-workflow";
+import { parseCheckCommandRequest } from "./check-args";
 import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
 import {
   mergeBuildMode,
@@ -25,6 +30,7 @@ import type { CliCommand } from "./cli-commands";
 import { CliOutputError, readCliCommand } from "./cli-output";
 import type { CliRequest } from "./cli-request";
 import { USAGE } from "./cli-usage";
+import { parseDevCommandRequest } from "./dev-args";
 import type { ImportKind, ImportProvider } from "./import";
 import {
   addLookupTarget,
@@ -52,6 +58,7 @@ import type { SetupInclude } from "./setup";
 import { readClaudeSettingSources } from "./try";
 import type { TryClaudeSettingSources, TrySubcommand } from "./try";
 import { isTrySubcommand, validateTryFlags } from "./try-cli";
+import { parseUpdateCommandRequest } from "./update-args";
 
 type Command = CliCommand;
 type DistributionSubcommand = "plan";
@@ -68,12 +75,6 @@ interface ParsedArgs {
   readonly changeStaged: boolean;
   readonly changeScopes?: readonly string[];
   readonly changeSubcommand?: ChangeSubcommand;
-  readonly ciFix: boolean;
-  readonly ciMode: boolean;
-  readonly ciReportPath?: string;
-  readonly checkOnly?: "outputs";
-  readonly checkWrite: boolean;
-  readonly devWrite: boolean;
   readonly distributionName?: string;
   readonly distributionSubcommand?: DistributionSubcommand;
   readonly hookAgentRuntime: boolean;
@@ -93,7 +94,6 @@ interface ParsedArgs {
   readonly initAdopt?: readonly string[];
   readonly initFrom?: string;
   readonly jsonOutput: boolean;
-  readonly jsonlOutput: boolean;
   readonly lookupAspects: readonly string[];
   readonly lookupField?: string;
   readonly lookupFeatures: boolean;
@@ -133,16 +133,10 @@ interface ParsedArgs {
 }
 
 function parseArgs(
+  command: Command,
   args: readonly string[],
   context: CliParseContext
 ): ParsedArgs {
-  const command = args[0];
-  if (!isCliCommand(command)) {
-    throw new Error(
-      `skillset: expected command ${renderExpectedCliCommands()}\n${USAGE}`
-    );
-  }
-
   let changeSubcommand: ChangeSubcommand | undefined;
   let distributionName: string | undefined;
   let distributionSubcommand: DistributionSubcommand | undefined;
@@ -168,12 +162,6 @@ function parseArgs(
   let changeSince: string | undefined;
   let changeStaged = false;
   let changeScopes: readonly string[] | undefined;
-  let ciFix = false;
-  let ciMode = false;
-  let ciReportPath: string | undefined;
-  let checkOnly: "outputs" | undefined;
-  let checkWrite = false;
-  let devWrite = false;
   let hookAgentRuntime = false;
   let hookContextEvent: string | undefined;
   let hookContextFields: readonly HookRuntimeContextField[] | undefined;
@@ -191,7 +179,6 @@ function parseArgs(
   let initAdopt: readonly string[] | undefined;
   let initFrom: string | undefined;
   let jsonOutput = false;
-  let jsonlOutput = false;
   let lookupAspects: string[] = [];
   let lookupField: string | undefined;
   let lookupFeatures = false;
@@ -540,17 +527,8 @@ function parseArgs(
       if (flag === "--staged") {
         changeStaged = true;
       }
-      if (flag === "--fix") {
-        ciFix = true;
-      }
-      if (flag === "--ci") {
-        ciMode = true;
-      }
       if (flag === "--json") {
         jsonOutput = true;
-      }
-      if (flag === "--jsonl") {
-        jsonlOutput = true;
       }
       if (flag === "--agent-runtime") {
         hookAgentRuntime = true;
@@ -562,11 +540,7 @@ function parseArgs(
         hookPrePush = true;
       }
       if (flag === "--write") {
-        if (command === "check") {
-          checkWrite = true;
-        } else if (command === "dev") {
-          devWrite = true;
-        } else {
+        if (command !== "check" && command !== "dev") {
           throw new Error(
             "skillset: --write is only supported with check or dev"
           );
@@ -657,14 +631,10 @@ function parseArgs(
     if (flag === "--bump") {
       changeBump = readChangeBump(value);
     }
-    if (flag === "--report") {
-      ciReportPath = value;
-    }
     if (flag === "--only") {
       if (value !== "outputs") {
         throw new Error("skillset: expected --only outputs");
       }
-      checkOnly = value;
     }
     if (flag === "--use") {
       if (value !== "source" && value !== "output") {
@@ -820,26 +790,7 @@ function parseArgs(
     );
   }
 
-  validateCiFlags(command, {
-    ci: ciMode,
-    fix: ciFix,
-    ...(checkOnly === undefined ? {} : { only: checkOnly }),
-    ...(ciReportPath === undefined ? {} : { reportPath: ciReportPath }),
-    ...(changeSince === undefined ? {} : { since: changeSince }),
-    write: checkWrite,
-    yes,
-  });
-  validateDevFlags(command, {
-    write: devWrite,
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(scopes === undefined ? {} : { scopes }),
-    yes,
-  });
-  validateUpdateFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(scopes === undefined ? {} : { scopes }),
-    yes,
-  });
+  validateLegacyReadinessFlags(command, args);
 
   validateAdoptFlags(command, {
     ...(buildMode === undefined ? {} : { buildMode }),
@@ -882,7 +833,14 @@ function parseArgs(
     ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
     ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
   });
-  if (jsonlOutput && command !== "dev") {
+  if (
+    hasCliFlag(args, "--jsonl") &&
+    command !== "build" &&
+    command !== "check" &&
+    command !== "dev" &&
+    command !== "diff" &&
+    command !== "update"
+  ) {
     throw new Error("skillset: unknown option --jsonl");
   }
   validateLookupFlags(
@@ -896,15 +854,9 @@ function parseArgs(
     },
     rootExplicit
   );
-  validateSourceDiagnosticFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(checkOnly === undefined ? {} : { only: checkOnly }),
-    ...(scopes === undefined ? {} : { scopes }),
-    yes,
-  });
   validateListFlags(command, buildMode);
 
-  validateIsolatedFlag(command, isolated, checkOnly);
+  validateLegacyIsolatedFlag(command, isolated);
   validateDistributionFlags(command, {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(distributionName === undefined ? {} : { name: distributionName }),
@@ -1020,12 +972,6 @@ function parseArgs(
     changeStaged,
     ...(changeScopes === undefined ? {} : { changeScopes }),
     ...(changeSubcommand === undefined ? {} : { changeSubcommand }),
-    ciFix,
-    ciMode,
-    ...(ciReportPath === undefined ? {} : { ciReportPath }),
-    ...(checkOnly === undefined ? {} : { checkOnly }),
-    checkWrite,
-    devWrite,
     ...(distributionName === undefined ? {} : { distributionName }),
     ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
     hookAgentRuntime,
@@ -1045,7 +991,6 @@ function parseArgs(
     ...(initAdopt === undefined ? {} : { initAdopt }),
     ...(initFrom === undefined ? {} : { initFrom }),
     jsonOutput,
-    jsonlOutput,
     lookupAspects,
     ...(lookupField === undefined ? {} : { lookupField }),
     lookupFeatures,
@@ -1089,20 +1034,6 @@ function parseArgs(
 
 function createCliRequest(parsed: ParsedArgs): CliRequest {
   const { command, jsonOutput, options, rootPath, yes } = parsed;
-  if (command === "build")
-    return { command, request: { jsonOutput, options, rootPath, yes } };
-  if (command === "diff")
-    return { command, request: { jsonOutput, options, rootPath } };
-  if (command === "dev")
-    return {
-      command,
-      request: {
-        jsonlOutput: parsed.jsonlOutput,
-        options,
-        rootPath,
-        write: parsed.devWrite,
-      },
-    };
   if (command === "change")
     return {
       command,
@@ -1135,8 +1066,6 @@ function createCliRequest(parsed: ParsedArgs): CliRequest {
         yes,
       },
     };
-  if (command === "update")
-    return { command, request: { jsonOutput, options, rootPath, yes } };
   if (command === "restore")
     return {
       command,
@@ -1207,21 +1136,6 @@ function createCliRequest(parsed: ParsedArgs): CliRequest {
         trySubcommand: parsed.trySubcommand,
         tryTarget: parsed.tryTarget,
         tryTimeoutMs: parsed.tryTimeoutMs,
-      },
-    };
-  if (command === "check")
-    return {
-      command,
-      request: {
-        changeSince: parsed.changeSince,
-        checkOnly: parsed.checkOnly,
-        checkWrite: parsed.checkWrite,
-        ciFix: parsed.ciFix,
-        ciMode: parsed.ciMode,
-        ciReportPath: parsed.ciReportPath,
-        jsonOutput,
-        options,
-        rootPath,
       },
     };
   if (command === "init")
@@ -1320,7 +1234,29 @@ export function parseCliRequest(
   context: CliParseContext = { cwd: process.cwd() }
 ): CliRequest {
   try {
-    return createCliRequest(parseArgs(args, context));
+    const command = args[0];
+    if (!isCliCommand(command)) {
+      throw new Error(
+        `skillset: expected command ${renderExpectedCliCommands()}\n${USAGE}`
+      );
+    }
+    const parsed = parseArgs(command, args, context);
+    if (command === "build") {
+      return { command, request: parseBuildCommandRequest(args, context) };
+    }
+    if (command === "check") {
+      return { command, request: parseCheckCommandRequest(args, context) };
+    }
+    if (command === "dev") {
+      return { command, request: parseDevCommandRequest(args, context) };
+    }
+    if (command === "diff") {
+      return { command, request: parseDiffCommandRequest(args, context) };
+    }
+    if (command === "update") {
+      return { command, request: parseUpdateCommandRequest(args, context) };
+    }
+    return createCliRequest(parsed);
   } catch (error) {
     if (error instanceof CliOutputError) {
       throw error;
@@ -1729,42 +1665,6 @@ function validateTestFlags(
   }
 }
 
-function validateSourceDiagnosticFlags(
-  command: Command,
-  sourceCheck: {
-    readonly buildMode?: CompileBuildMode;
-    readonly only?: "outputs";
-    readonly scopes?: readonly BuildScope[];
-    readonly yes: boolean;
-  }
-): void {
-  if (command !== "check") {
-    return;
-  }
-  const label = `skillset ${command}`;
-  if (sourceCheck.only === "outputs") {
-    if (sourceCheck.yes) {
-      throw new Error(
-        `${label} --only outputs is read-only and does not support --yes`
-      );
-    }
-    return;
-  }
-  if (sourceCheck.buildMode !== undefined) {
-    throw new Error(
-      `${label} does not support --updated or --all; it checks source diagnostics`
-    );
-  }
-  if (sourceCheck.scopes !== undefined) {
-    throw new Error(
-      `${label} does not support --scope; it checks source diagnostics`
-    );
-  }
-  if (sourceCheck.yes) {
-    throw new Error(`${label} is read-only and does not support --yes`);
-  }
-}
-
 function validateListFlags(
   command: Command,
   buildMode: CompileBuildMode | undefined
@@ -1944,18 +1844,16 @@ function mergeSetupIncludes(
   return [...seen];
 }
 
-function validateIsolatedFlag(
-  command: Command,
-  isolated: boolean,
-  checkOnly?: "outputs"
-): void {
+function validateLegacyIsolatedFlag(command: Command, isolated: boolean): void {
   if (!isolated) {
     return;
   }
   if (
     command === "build" ||
+    command === "check" ||
+    command === "dev" ||
     command === "diff" ||
-    (command === "check" && checkOnly === "outputs")
+    command === "update"
   ) {
     return;
   }
@@ -1964,112 +1862,34 @@ function validateIsolatedFlag(
   );
 }
 
-function validateCiFlags(
+function validateLegacyReadinessFlags(
   command: Command,
-  ci: {
-    readonly ci: boolean;
-    readonly fix: boolean;
-    readonly only?: "outputs";
-    readonly reportPath?: string;
-    readonly since?: string;
-    readonly write: boolean;
-    readonly yes: boolean;
-  }
+  args: readonly string[]
 ): void {
-  if (command !== "check") {
-    if (
-      ci.ci ||
-      ci.fix ||
-      ci.only !== undefined ||
-      ci.reportPath !== undefined ||
-      ci.write
-    ) {
-      throw new Error(
-        "skillset: readiness flags are only supported with check"
-      );
-    }
-    if (ci.since !== undefined && command !== "change" && command !== "hooks") {
-      throw new Error(
-        "skillset: --since is only supported with check --ci or change commands"
-      );
-    }
+  if (command === "check") {
     return;
-  }
-  if (ci.yes) {
-    throw new Error(
-      "skillset: check does not take mutation confirmation flags"
-    );
-  }
-  if (ci.fix && !ci.ci) {
-    throw new Error("skillset: check --fix requires --ci");
-  }
-  if (ci.write && ci.ci) {
-    throw new Error("skillset: check --ci uses --fix instead of --write");
-  }
-  if ((ci.reportPath !== undefined || ci.since !== undefined) && !ci.ci) {
-    throw new Error("skillset: --report and --since require check --ci");
   }
   if (
-    ci.only !== undefined &&
-    (ci.ci ||
-      ci.fix ||
-      ci.write ||
-      ci.reportPath !== undefined ||
-      ci.since !== undefined)
+    hasCliFlag(args, "--ci") ||
+    hasCliFlag(args, "--fix") ||
+    hasCliFlag(args, "--only") ||
+    hasCliFlag(args, "--report")
+  ) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (
+    hasCliFlag(args, "--since") &&
+    command !== "change" &&
+    command !== "hooks"
   ) {
     throw new Error(
-      "skillset: check --only outputs cannot be combined with CI or write flags"
+      "skillset: --since is only supported with check --ci or change commands"
     );
   }
 }
 
-function validateDevFlags(
-  command: Command,
-  dev: {
-    readonly write: boolean;
-    readonly buildMode?: CompileBuildMode;
-    readonly scopes?: readonly BuildScope[];
-    readonly yes: boolean;
-  }
-): void {
-  if (dev.write && command !== "dev") {
-    throw new Error("skillset: dev write mode is only supported with dev");
-  }
-  if (command !== "dev") {
-    return;
-  }
-  if (dev.buildMode !== undefined) {
-    throw new Error("skillset: dev does not support --updated or --all");
-  }
-  if (dev.scopes !== undefined) {
-    throw new Error("skillset: dev does not support --scope yet");
-  }
-  if (dev.yes) {
-    throw new Error(
-      "skillset: dev uses preview mode by default or write mode with --write; it does not support --yes"
-    );
-  }
-}
-
-function validateUpdateFlags(
-  command: Command,
-  update: {
-    readonly buildMode?: CompileBuildMode;
-    readonly scopes?: readonly BuildScope[];
-    readonly yes: boolean;
-  }
-): void {
-  if (command !== "update") {
-    return;
-  }
-  if (update.buildMode !== undefined) {
-    throw new Error("skillset: update does not support --updated or --all");
-  }
-  if (update.scopes !== undefined) {
-    throw new Error(
-      "skillset: update does not support --scope; provider format updates require a whole-workspace safety preflight"
-    );
-  }
+function hasCliFlag(args: readonly string[], expected: string): boolean {
+  return args.some((argument) => argument.split("=", 1)[0] === expected);
 }
 
 function validateSetupFlags(
@@ -2115,8 +1935,12 @@ function validateJsonFlags(
   if (!jsonOutput) {
     return;
   }
+  if (command === "dev") {
+    return;
+  }
   if (
     command === "build" ||
+    command === "check" ||
     command === "import" ||
     command === "init" ||
     command === "new" ||
@@ -2124,9 +1948,6 @@ function validateJsonFlags(
     command === "restore" ||
     command === "update"
   ) {
-    return;
-  }
-  if (command === "check") {
     return;
   }
   if (

--- a/apps/skillset/src/dev-args.ts
+++ b/apps/skillset/src/dev-args.ts
@@ -1,0 +1,119 @@
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { DevCommandRequest } from "./dev-cli";
+
+export const parseDevCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): DevCommandRequest => {
+  let buildMode: "all" | "updated" | undefined;
+  let isolated = false;
+  let jsonOutput = false;
+  let jsonlOutput = false;
+  let readinessFlag = false;
+  let rootPath: string | undefined;
+  let scopes: readonly string[] | undefined;
+  let yes = false;
+  let write = false;
+  const reader = new CliArgReader(args, 1);
+
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--write":
+        assertBooleanOption(option);
+        write = true;
+        break;
+      case "--jsonl":
+        assertBooleanOption(option);
+        jsonlOutput = true;
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--from":
+      case "--kind":
+      case "--name":
+        reader.readRequiredOptionValue(option);
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--fix":
+      case "--ci":
+        assertBooleanOption(option);
+        readinessFlag = true;
+        break;
+      case "--only":
+      case "--report":
+      case "--since":
+        reader.readRequiredOptionValue(option);
+        readinessFlag = true;
+        break;
+      case "--include":
+      case "--targets":
+        reader.readRequiredOptionValue(option);
+        throw new Error("skillset: setup options are only supported with init");
+      case "--isolated":
+        assertBooleanOption(option);
+        isolated = true;
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  if (readinessFlag) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (buildMode !== undefined) {
+    throw new Error("skillset: dev does not support --updated or --all");
+  }
+  if (scopes !== undefined) {
+    throw new Error("skillset: dev does not support --scope yet");
+  }
+  if (yes) {
+    throw new Error(
+      "skillset: dev uses preview mode by default or write mode with --write; it does not support --yes"
+    );
+  }
+  if (jsonOutput) {
+    throw new Error("skillset: --json is not supported for this command route");
+  }
+  if (isolated) {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+
+  return {
+    jsonlOutput,
+    options: {},
+    rootPath: resolveCliRoot(context, rootPath),
+    write,
+  };
+};

--- a/apps/skillset/src/update-args.ts
+++ b/apps/skillset/src/update-args.ts
@@ -1,0 +1,116 @@
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { UpdateCommandRequest } from "./update-cli";
+
+export const parseUpdateCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): UpdateCommandRequest => {
+  let buildMode: "all" | "updated" | undefined;
+  let isolated = false;
+  let jsonOutput = false;
+  let jsonlOutput = false;
+  let readinessFlag = false;
+  let rootPath: string | undefined;
+  let scopes: readonly string[] | undefined;
+  let yes = false;
+  const reader = new CliArgReader(args, 1);
+
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--from":
+      case "--kind":
+      case "--name":
+        reader.readRequiredOptionValue(option);
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--fix":
+      case "--ci":
+        assertBooleanOption(option);
+        readinessFlag = true;
+        break;
+      case "--only":
+      case "--report":
+      case "--since":
+        reader.readRequiredOptionValue(option);
+        readinessFlag = true;
+        break;
+      case "--include":
+      case "--targets":
+        reader.readRequiredOptionValue(option);
+        throw new Error("skillset: setup options are only supported with init");
+      case "--write":
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --write is only supported with check or dev"
+        );
+      case "--isolated":
+        assertBooleanOption(option);
+        isolated = true;
+        break;
+      case "--jsonl":
+        assertBooleanOption(option);
+        jsonlOutput = true;
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  if (readinessFlag) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (buildMode !== undefined) {
+    throw new Error("skillset: update does not support --updated or --all");
+  }
+  if (scopes !== undefined) {
+    throw new Error(
+      "skillset: update does not support --scope; provider format updates require a whole-workspace safety preflight"
+    );
+  }
+  if (jsonlOutput) {
+    throw new Error("skillset: --jsonl is only supported with dev");
+  }
+  if (isolated) {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+
+  return {
+    jsonOutput,
+    options: {},
+    rootPath: resolveCliRoot(context, rootPath),
+    yes,
+  };
+};


### PR DESCRIPTION
## Context

SET-301 moves projection and readiness grammar into typed command owners.

## What changed

- Added route parsers for build, diff, check, dev, and update.
- Moved defaults, validation, repeats, and typed request construction out of the global bag.
- Preserved legacy lexical/ownership precedence during the staged migration.

## Verification

- Focused projection/parser/output/contract suites
- Exact-parent differential with zero request or error differences for the characterized matrix
- Typecheck, guards, whitespace, and `bun run check`

## Risk

No parser IO, prompts, handler changes, or write-timing changes; compatibility scaffolding is deliberately removed only at SET-305.

Linear: SET-301