### PR TITLE
refactor(cli): extract source and distribution parsers

### DIFF
--- a/.changeset/cli-source-distribution-parsers.md
+++ b/.changeset/cli-source-distribution-parsers.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Move source authoring, marketplace, and distribution argument handling into typed command-owned parsers while preserving validation and write timing.

--- a/apps/skillset/src/__tests__/source-distribution-args.test.ts
+++ b/apps/skillset/src/__tests__/source-distribution-args.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseDistributionCommandRequest,
+  parseMarketplaceCommandRequest,
+} from "../distribution-args";
+import { parseInitCommandRequest } from "../init-args";
+import {
+  parseImportCommandRequest,
+  parseNewCommandRequest,
+} from "../source-args";
+
+const CONTEXT = { cwd: "/workspace/repo" } as const;
+
+describe("SET-302 source and distribution route parsers", () => {
+  test("init owns acquisition, adoption, setup, and confirmation inputs", () => {
+    expect(
+      parseInitCommandRequest(
+        [
+          "init",
+          "destination",
+          "--root",
+          "nested",
+          "--from",
+          "source",
+          "--adopt",
+          "first",
+          "--adopt=second",
+          "--name",
+          "Workspace",
+          "--targets",
+          "claude,codex",
+          "--include",
+          "ci",
+          "--include=ci",
+          "--json",
+          "--yes",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      destination: "destination",
+      importName: "Workspace",
+      initAdopt: ["first", "second"],
+      initFrom: "source",
+      jsonOutput: true,
+      options: {},
+      rootExplicit: true,
+      rootPath: "/workspace/repo/nested",
+      setupIncludes: ["ci"],
+      setupTargets: ["claude", "codex"],
+      yes: true,
+    });
+  });
+
+  test("import owns positional inference and explicit source metadata", () => {
+    expect(
+      parseImportCommandRequest(
+        [
+          "import",
+          "claude",
+          "source",
+          "--kind",
+          "skill",
+          "--kind=skill",
+          "--from",
+          "codex",
+          "--name",
+          "portable",
+          "--root=target",
+          "--json",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      importKind: "skill",
+      importName: "portable",
+      importProvider: "codex",
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/target",
+      sourcePath: "source",
+    });
+    expect(
+      parseImportCommandRequest(
+        ["import", "source", "--updated", "--scope", "plugins"],
+        CONTEXT
+      ).options
+    ).toEqual({ buildMode: "updated", scopes: ["plugins"] });
+  });
+
+  test("new owns source placement, presentation, presets, and write policy", () => {
+    expect(
+      parseNewCommandRequest(
+        [
+          "new",
+          "agent",
+          "reviewer",
+          "--id",
+          "review-agent",
+          "--name",
+          "Reviewer",
+          "--in",
+          "quality",
+          "--preset",
+          "base",
+          "--preset=security",
+          "--scope",
+          "repo",
+          "--root",
+          "nested",
+          "--json",
+          "--yes",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      newContainer: "quality",
+      newId: "review-agent",
+      newKind: "agent",
+      newName: "Reviewer",
+      newPresets: ["base", "security"],
+      newScope: "repo",
+      options: {},
+      positionalName: "reviewer",
+      rootPath: "/workspace/repo/nested",
+      yes: true,
+    });
+  });
+
+  test("distribution routes own subcommands, names, machine mode, and writes", () => {
+    expect(
+      parseDistributionCommandRequest(
+        ["distribute", "plan", "release", "--root", "nested", "--json"],
+        CONTEXT
+      )
+    ).toEqual({
+      distributionName: "release",
+      distributionSubcommand: "plan",
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/nested",
+    });
+    expect(
+      parseMarketplaceCommandRequest(
+        ["marketplace", "update", "catalog", "--json", "--yes"],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      marketplaceName: "catalog",
+      marketplaceSubcommand: "update",
+      options: {},
+      rootPath: "/workspace/repo",
+      yes: true,
+    });
+  });
+
+  test("preserves route validation and diagnostic precedence", () => {
+    const cases = [
+      {
+        run: () => parseInitCommandRequest(["init", "--updated"], CONTEXT),
+        message:
+          "skillset: build mode and scope flags are not supported with adopt; adoption always builds the full projection isolated",
+      },
+      {
+        run: () => parseImportCommandRequest(["import", "skill"], CONTEXT),
+        message: "skillset: import kind must be passed with --kind",
+      },
+      {
+        run: () =>
+          parseImportCommandRequest(
+            ["import", "source", "--kind", "skill", "--kind", "plugin"],
+            CONTEXT
+          ),
+        message: "skillset: conflicting import kinds skill and plugin",
+      },
+      {
+        run: () =>
+          parseNewCommandRequest(
+            ["new", "skill", "--from", "claude", "--updated"],
+            CONTEXT
+          ),
+        message: "skillset: --updated and --all are not supported with new",
+      },
+      {
+        run: () =>
+          parseDistributionCommandRequest(
+            ["distribute", "plan", "Not-Lowercase"],
+            CONTEXT
+          ),
+        message: "skillset: expected distribution name to be a lowercase id",
+      },
+      {
+        run: () =>
+          parseMarketplaceCommandRequest(
+            ["marketplace", "check", "--yes"],
+            CONTEXT
+          ),
+        message:
+          "skillset: build/write options are not supported with marketplace check; it is always read-only",
+      },
+    ] as const;
+    for (const { message, run } of cases) {
+      expect(run).toThrow(message);
+    }
+  });
+});

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -31,7 +31,12 @@ import { CliOutputError, readCliCommand } from "./cli-output";
 import type { CliRequest } from "./cli-request";
 import { USAGE } from "./cli-usage";
 import { parseDevCommandRequest } from "./dev-args";
+import {
+  parseDistributionCommandRequest,
+  parseMarketplaceCommandRequest,
+} from "./distribution-args";
 import type { ImportKind, ImportProvider } from "./import";
+import { parseInitCommandRequest } from "./init-args";
 import {
   addLookupTarget,
   addLookupTargets,
@@ -55,6 +60,10 @@ import type {
   HookSubcommand,
 } from "./runtime-hooks";
 import type { SetupInclude } from "./setup";
+import {
+  parseImportCommandRequest,
+  parseNewCommandRequest,
+} from "./source-args";
 import { readClaudeSettingSources } from "./try";
 import type { TryClaudeSettingSources, TrySubcommand } from "./try";
 import { isTrySubcommand, validateTryFlags } from "./try-cli";
@@ -75,8 +84,6 @@ interface ParsedArgs {
   readonly changeStaged: boolean;
   readonly changeScopes?: readonly string[];
   readonly changeSubcommand?: ChangeSubcommand;
-  readonly distributionName?: string;
-  readonly distributionSubcommand?: DistributionSubcommand;
   readonly hookAgentRuntime: boolean;
   readonly hookContextEvent?: string;
   readonly hookContextFields?: readonly HookRuntimeContextField[];
@@ -87,12 +94,7 @@ interface ParsedArgs {
   readonly hookRunEvent?: HookRunEvent;
   readonly hookSubcommand?: HookSubcommand;
   readonly hookTarget?: TargetName;
-  readonly importKind?: ImportKind;
-  readonly importName?: string;
   readonly importPath?: string;
-  readonly importProvider?: ImportProvider;
-  readonly initAdopt?: readonly string[];
-  readonly initFrom?: string;
   readonly jsonOutput: boolean;
   readonly lookupAspects: readonly string[];
   readonly lookupField?: string;
@@ -100,14 +102,6 @@ interface ParsedArgs {
   readonly lookupSubject?: LookupSubject;
   readonly lookupTargets: readonly TargetName[];
   readonly lookupViews: readonly LookupView[];
-  readonly marketplaceName?: string;
-  readonly marketplaceSubcommand?: MarketplaceSubcommand;
-  readonly newContainer?: string;
-  readonly newId?: string;
-  readonly newKind?: NewSourceKind;
-  readonly newName?: string;
-  readonly newPresets?: readonly string[];
-  readonly newScope?: NewSourceScope;
   readonly options: SkillsetOptions;
   readonly releaseSubcommand?: ReleaseSubcommand;
   readonly releaseReason?: ChangeReasonInput;
@@ -125,8 +119,6 @@ interface ParsedArgs {
   readonly tryTimeoutMs?: number;
   readonly rootExplicit: boolean;
   readonly rootPath: string;
-  readonly setupIncludes?: readonly SetupInclude[];
-  readonly setupTargets?: readonly TargetName[];
   readonly reconcileChoice?: ReconcileChoice;
   readonly testName?: string;
   readonly yes: boolean;
@@ -792,10 +784,6 @@ function parseArgs(
 
   validateLegacyReadinessFlags(command, args);
 
-  validateAdoptFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(scopes === undefined ? {} : { scopes }),
-  });
   const hasAdHocTestFlags =
     trySubcommand !== undefined ||
     tryTarget !== undefined ||
@@ -857,24 +845,6 @@ function parseArgs(
   validateListFlags(command, buildMode);
 
   validateLegacyIsolatedFlag(command, isolated);
-  validateDistributionFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(distributionName === undefined ? {} : { name: distributionName }),
-    ...(distributionSubcommand === undefined
-      ? {}
-      : { subcommand: distributionSubcommand }),
-    ...(scopes === undefined ? {} : { scopes }),
-    yes,
-  });
-  validateMarketplaceFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(marketplaceName === undefined ? {} : { name: marketplaceName }),
-    ...(scopes === undefined ? {} : { scopes }),
-    ...(marketplaceSubcommand === undefined
-      ? {}
-      : { subcommand: marketplaceSubcommand }),
-    yes,
-  });
 
   if (command === "release" && scopes !== undefined) {
     throw new Error(
@@ -915,13 +885,9 @@ function parseArgs(
     ...(sourceDir === undefined ? {} : { sourceDir }),
     yes,
   });
-  validateNewSourceFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(distDir === undefined ? {} : { distDir }),
+  validateLegacyNewSourceFlags(command, {
     ...(newContainer === undefined ? {} : { container: newContainer }),
     ...(newId === undefined ? {} : { id: newId }),
-    ...(importKind === undefined ? {} : { importKind }),
-    ...(importProvider === undefined ? {} : { importProvider }),
     ...(newKind === undefined ? {} : { kind: newKind }),
     ...(newName === undefined ? {} : { name: newName }),
     ...(newPresets === undefined ? {} : { presets: newPresets }),
@@ -972,8 +938,6 @@ function parseArgs(
     changeStaged,
     ...(changeScopes === undefined ? {} : { changeScopes }),
     ...(changeSubcommand === undefined ? {} : { changeSubcommand }),
-    ...(distributionName === undefined ? {} : { distributionName }),
-    ...(distributionSubcommand === undefined ? {} : { distributionSubcommand }),
     hookAgentRuntime,
     ...(hookContextEvent === undefined ? {} : { hookContextEvent }),
     ...(hookContextFields === undefined ? {} : { hookContextFields }),
@@ -984,12 +948,7 @@ function parseArgs(
     ...(hookRunEvent === undefined ? {} : { hookRunEvent }),
     ...(hookSubcommand === undefined ? {} : { hookSubcommand }),
     ...(hookTarget === undefined ? {} : { hookTarget }),
-    ...(importKind === undefined ? {} : { importKind }),
-    ...(importName === undefined ? {} : { importName }),
     ...(importPath === undefined ? {} : { importPath }),
-    ...(importProvider === undefined ? {} : { importProvider }),
-    ...(initAdopt === undefined ? {} : { initAdopt }),
-    ...(initFrom === undefined ? {} : { initFrom }),
     jsonOutput,
     lookupAspects,
     ...(lookupField === undefined ? {} : { lookupField }),
@@ -997,14 +956,6 @@ function parseArgs(
     ...(lookupSubject === undefined ? {} : { lookupSubject }),
     lookupTargets,
     lookupViews,
-    ...(marketplaceName === undefined ? {} : { marketplaceName }),
-    ...(marketplaceSubcommand === undefined ? {} : { marketplaceSubcommand }),
-    ...(newContainer === undefined ? {} : { newContainer }),
-    ...(newId === undefined ? {} : { newId }),
-    ...(newKind === undefined ? {} : { newKind }),
-    ...(newName === undefined ? {} : { newName }),
-    ...(newPresets === undefined ? {} : { newPresets }),
-    ...(newScope === undefined ? {} : { newScope }),
     options,
     ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
     ...(releaseReason === undefined ? {} : { releaseReason }),
@@ -1024,8 +975,6 @@ function parseArgs(
     ...(tryTimeoutMs === undefined ? {} : { tryTimeoutMs }),
     rootExplicit,
     rootPath: resolveCliRoot(context, rootPath),
-    ...(setupIncludes === undefined ? {} : { setupIncludes }),
-    ...(setupTargets === undefined ? {} : { setupTargets }),
     ...(reconcileChoice === undefined ? {} : { reconcileChoice }),
     ...(testName === undefined ? {} : { testName }),
     yes,
@@ -1077,29 +1026,6 @@ function createCliRequest(parsed: ParsedArgs): CliRequest {
         yes,
       },
     };
-  if (command === "distribute")
-    return {
-      command,
-      request: {
-        distributionName: parsed.distributionName,
-        distributionSubcommand: parsed.distributionSubcommand,
-        jsonOutput,
-        options,
-        rootPath,
-      },
-    };
-  if (command === "marketplace")
-    return {
-      command,
-      request: {
-        jsonOutput,
-        marketplaceName: parsed.marketplaceName,
-        marketplaceSubcommand: parsed.marketplaceSubcommand,
-        options,
-        rootPath,
-        yes,
-      },
-    };
   if (command === "hooks")
     return {
       command,
@@ -1136,53 +1062,6 @@ function createCliRequest(parsed: ParsedArgs): CliRequest {
         trySubcommand: parsed.trySubcommand,
         tryTarget: parsed.tryTarget,
         tryTimeoutMs: parsed.tryTimeoutMs,
-      },
-    };
-  if (command === "init")
-    return {
-      command,
-      request: {
-        destination: parsed.importPath,
-        importName: parsed.importName,
-        initAdopt: parsed.initAdopt,
-        initFrom: parsed.initFrom,
-        jsonOutput,
-        options,
-        rootExplicit: parsed.rootExplicit,
-        rootPath,
-        setupIncludes: parsed.setupIncludes,
-        setupTargets: parsed.setupTargets,
-        yes,
-      },
-    };
-  if (command === "import")
-    return {
-      command,
-      request: {
-        importKind: parsed.importKind,
-        importName: parsed.importName,
-        importProvider: parsed.importProvider,
-        jsonOutput,
-        options,
-        rootPath,
-        sourcePath: parsed.importPath,
-      },
-    };
-  if (command === "new")
-    return {
-      command,
-      request: {
-        jsonOutput,
-        newContainer: parsed.newContainer,
-        newId: parsed.newId,
-        newKind: parsed.newKind,
-        newName: parsed.newName,
-        newPresets: parsed.newPresets,
-        newScope: parsed.newScope,
-        options,
-        positionalName: parsed.importPath,
-        rootPath,
-        yes,
       },
     };
   if (command === "list")
@@ -1252,6 +1131,27 @@ export function parseCliRequest(
     }
     if (command === "diff") {
       return { command, request: parseDiffCommandRequest(args, context) };
+    }
+    if (command === "distribute") {
+      return {
+        command,
+        request: parseDistributionCommandRequest(args, context),
+      };
+    }
+    if (command === "import") {
+      return { command, request: parseImportCommandRequest(args, context) };
+    }
+    if (command === "init") {
+      return { command, request: parseInitCommandRequest(args, context) };
+    }
+    if (command === "marketplace") {
+      return {
+        command,
+        request: parseMarketplaceCommandRequest(args, context),
+      };
+    }
+    if (command === "new") {
+      return { command, request: parseNewCommandRequest(args, context) };
     }
     if (command === "update") {
       return { command, request: parseUpdateCommandRequest(args, context) };
@@ -1541,80 +1441,6 @@ function validateHookFlags(
   }
 }
 
-function validateDistributionFlags(
-  command: Command,
-  distribution: {
-    readonly buildMode?: CompileBuildMode;
-    readonly name?: string;
-    readonly scopes?: readonly BuildScope[];
-    readonly subcommand?: DistributionSubcommand;
-    readonly yes: boolean;
-  }
-): void {
-  if (command !== "distribute") {
-    return;
-  }
-  if (distribution.subcommand !== "plan") {
-    throw new Error("skillset: expected distribute subcommand plan");
-  }
-  if (
-    distribution.name !== undefined &&
-    !/^[a-z0-9][a-z0-9._-]*$/.test(distribution.name)
-  ) {
-    throw new Error(
-      "skillset: expected distribution name to be a lowercase id"
-    );
-  }
-  if (
-    distribution.buildMode !== undefined ||
-    distribution.scopes !== undefined ||
-    distribution.yes
-  ) {
-    throw new Error(
-      "skillset: build/write options are not supported with distribute plan; it is always read-only"
-    );
-  }
-}
-
-function validateMarketplaceFlags(
-  command: Command,
-  marketplace: {
-    readonly buildMode?: CompileBuildMode;
-    readonly name?: string;
-    readonly scopes?: readonly BuildScope[];
-    readonly subcommand?: MarketplaceSubcommand;
-    readonly yes: boolean;
-  }
-): void {
-  if (command !== "marketplace") {
-    return;
-  }
-  if (
-    marketplace.subcommand !== "check" &&
-    marketplace.subcommand !== "update"
-  ) {
-    throw new Error(
-      "skillset: expected marketplace subcommand check or update"
-    );
-  }
-  if (
-    marketplace.name !== undefined &&
-    !/^[a-z0-9][a-z0-9._-]*$/.test(marketplace.name)
-  ) {
-    throw new Error("skillset: expected marketplace name to be a lowercase id");
-  }
-  if (marketplace.subcommand === "check" && marketplace.yes) {
-    throw new Error(
-      "skillset: build/write options are not supported with marketplace check; it is always read-only"
-    );
-  }
-  if (marketplace.buildMode !== undefined || marketplace.scopes !== undefined) {
-    throw new Error(
-      `skillset: build scope options are not supported with marketplace ${marketplace.subcommand}`
-    );
-  }
-}
-
 function validateTestFlags(
   command: Command,
   args: readonly string[],
@@ -1758,15 +1584,11 @@ function validateReconcileFlags(
   }
 }
 
-function validateNewSourceFlags(
+function validateLegacyNewSourceFlags(
   command: Command,
   source: {
-    readonly buildMode?: CompileBuildMode;
     readonly container?: string;
-    readonly distDir?: string;
     readonly id?: string;
-    readonly importKind?: ImportKind;
-    readonly importProvider?: ImportProvider;
     readonly kind?: NewSourceKind;
     readonly name?: string;
     readonly presets?: readonly string[];
@@ -1782,26 +1604,6 @@ function validateNewSourceFlags(
     source.scope !== undefined;
   if (hasNewFlag && command !== "new") {
     throw new Error("skillset: new options are only supported with new");
-  }
-  if (command !== "new") {
-    return;
-  }
-  if (source.buildMode !== undefined) {
-    throw new Error("skillset: --updated and --all are not supported with new");
-  }
-  if (source.distDir !== undefined) {
-    throw new Error(
-      "skillset: output-root overrides are not supported with new"
-    );
-  }
-  if (source.importKind !== undefined) {
-    throw new Error("skillset: --kind is only supported with import");
-  }
-  if (source.importProvider !== undefined) {
-    throw new Error("skillset: --from is only supported with import");
-  }
-  if (source.kind === undefined) {
-    throw new Error("skillset: expected new kind skill, agent, or hook");
   }
 }
 
@@ -1903,23 +1705,6 @@ function validateSetupFlags(
     setup.includes !== undefined || setup.targets !== undefined;
   if (hasSetupFlag && command !== "init") {
     throw new Error("skillset: setup options are only supported with init");
-  }
-}
-
-function validateAdoptFlags(
-  command: Command,
-  adopt: {
-    readonly buildMode?: CompileBuildMode;
-    readonly scopes?: readonly BuildScope[];
-  }
-): void {
-  if (command !== "init") {
-    return;
-  }
-  if (adopt.buildMode !== undefined || adopt.scopes !== undefined) {
-    throw new Error(
-      "skillset: build mode and scope flags are not supported with adopt; adoption always builds the full projection isolated"
-    );
   }
 }
 

--- a/apps/skillset/src/distribution-args.ts
+++ b/apps/skillset/src/distribution-args.ts
@@ -1,0 +1,160 @@
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type {
+  DistributionCommandRequest,
+  MarketplaceCommandRequest,
+} from "./distribution-cli";
+
+type DistributionSubcommand = "plan";
+type MarketplaceSubcommand = "check" | "update";
+
+export const parseDistributionCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): DistributionCommandRequest => {
+  const subcommand = readDistributionSubcommand(args[1]);
+  let index = 2;
+  let name: string | undefined;
+  const positional = args[index];
+  if (positional !== undefined && !positional.startsWith("--")) {
+    name = positional;
+    index += 1;
+  }
+  const parsed = parseDistributionOptions(args, index, context);
+  validateLowercaseId(name, "distribution");
+  if (parsed.hasBuildOptions || parsed.yes) {
+    throw new Error(
+      "skillset: build/write options are not supported with distribute plan; it is always read-only"
+    );
+  }
+  return {
+    distributionName: name,
+    distributionSubcommand: subcommand,
+    jsonOutput: parsed.jsonOutput,
+    options: {},
+    rootPath: parsed.rootPath,
+  };
+};
+
+export const parseMarketplaceCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): MarketplaceCommandRequest => {
+  const subcommand = readMarketplaceSubcommand(args[1]);
+  let index = 2;
+  let name: string | undefined;
+  const positional = args[index];
+  if (positional !== undefined && !positional.startsWith("--")) {
+    name = positional;
+    index += 1;
+  }
+  const parsed = parseDistributionOptions(args, index, context);
+  validateLowercaseId(name, "marketplace");
+  if (subcommand === "check" && parsed.yes) {
+    throw new Error(
+      "skillset: build/write options are not supported with marketplace check; it is always read-only"
+    );
+  }
+  if (parsed.hasBuildOptions) {
+    throw new Error(
+      `skillset: build scope options are not supported with marketplace ${subcommand}`
+    );
+  }
+  return {
+    jsonOutput: parsed.jsonOutput,
+    marketplaceName: name,
+    marketplaceSubcommand: subcommand,
+    options: {},
+    rootPath: parsed.rootPath,
+    yes: parsed.yes,
+  };
+};
+
+interface DistributionOptions {
+  readonly hasBuildOptions: boolean;
+  readonly jsonOutput: boolean;
+  readonly rootPath: string;
+  readonly yes: boolean;
+}
+
+const parseDistributionOptions = (
+  args: readonly string[],
+  index: number,
+  context: CliParseContext
+): DistributionOptions => {
+  let buildMode: "all" | "updated" | undefined;
+  let jsonOutput = false;
+  let rootPath: string | undefined;
+  let scopes: readonly unknown[] | undefined;
+  let yes = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--name":
+      case "--kind":
+      case "--from":
+        reader.readRequiredOptionValue(option);
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+  return {
+    hasBuildOptions: buildMode !== undefined || scopes !== undefined,
+    jsonOutput,
+    rootPath: resolveCliRoot(context, rootPath),
+    yes,
+  };
+};
+
+const readDistributionSubcommand = (
+  value: string | undefined
+): DistributionSubcommand => {
+  if (value === "plan") return value;
+  throw new Error("skillset: expected distribute subcommand plan");
+};
+
+const readMarketplaceSubcommand = (
+  value: string | undefined
+): MarketplaceSubcommand => {
+  if (value === "check" || value === "update") return value;
+  throw new Error("skillset: expected marketplace subcommand check or update");
+};
+
+const validateLowercaseId = (
+  value: string | undefined,
+  kind: "distribution" | "marketplace"
+): void => {
+  if (value !== undefined && !/^[a-z0-9][a-z0-9._-]*$/.test(value)) {
+    throw new Error(`skillset: expected ${kind} name to be a lowercase id`);
+  }
+};

--- a/apps/skillset/src/init-args.ts
+++ b/apps/skillset/src/init-args.ts
@@ -1,0 +1,174 @@
+import type {
+  SkillsetOptions,
+  TargetName,
+} from "@skillset/core/internal/types";
+
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  readTargetNames,
+  resolveCliRoot,
+  tokenizeCsv,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { ImportKind } from "./import";
+import type { InitCommandRequest } from "./init-cli";
+import type { SetupInclude } from "./setup";
+
+export interface InitExplicitOptions {
+  readonly adopt: readonly string[] | undefined;
+  readonly from: string | undefined;
+  readonly include: readonly SetupInclude[] | undefined;
+  readonly json: boolean;
+  readonly name: string | undefined;
+  readonly root: string | undefined;
+  readonly targets: readonly TargetName[] | undefined;
+  readonly yes: boolean;
+}
+
+export const parseInitCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): InitCommandRequest => {
+  let destination: string | undefined;
+  let index = 1;
+  const positional = args[index];
+  if (positional !== undefined && !positional.startsWith("--")) {
+    destination = positional;
+    index += 1;
+  }
+
+  let adopt: readonly string[] | undefined;
+  let buildMode: "all" | "updated" | undefined;
+  let from: string | undefined;
+  let include: readonly SetupInclude[] | undefined;
+  let json = false;
+  let name: string | undefined;
+  let root: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let targets: readonly TargetName[] | undefined;
+  let yes = false;
+  let ignoredKind: ImportKind | undefined;
+  const reader = new CliArgReader(args, index);
+
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        root = reader.readRequiredOptionValue(option);
+        break;
+      case "--name":
+        name = reader.readRequiredOptionValue(option);
+        break;
+      case "--from":
+        from = reader.readRequiredOptionValue(option);
+        break;
+      case "--adopt":
+        adopt = [...(adopt ?? []), reader.readRequiredOptionValue(option)];
+        break;
+      case "--targets":
+        targets = readTargetNames(reader.readRequiredOptionValue(option));
+        break;
+      case "--include":
+        include = mergeSetupIncludes(
+          include,
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        json = true;
+        break;
+      case "--kind":
+        ignoredKind = readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  void ignoredKind;
+  if (buildMode !== undefined || scopes !== undefined) {
+    throw new Error(
+      "skillset: build mode and scope flags are not supported with adopt; adoption always builds the full projection isolated"
+    );
+  }
+  const explicit: InitExplicitOptions = {
+    adopt,
+    from,
+    include,
+    json,
+    name,
+    root,
+    targets,
+    yes,
+  };
+  return createInitCommandRequest(destination, explicit, context);
+};
+
+const createInitCommandRequest = (
+  destination: string | undefined,
+  explicit: InitExplicitOptions,
+  context: CliParseContext
+): InitCommandRequest => ({
+  destination,
+  importName: explicit.name,
+  initAdopt: explicit.adopt,
+  initFrom: explicit.from,
+  jsonOutput: explicit.json,
+  options: {},
+  rootExplicit: explicit.root !== undefined,
+  rootPath: resolveCliRoot(context, explicit.root),
+  setupIncludes: explicit.include,
+  setupTargets: explicit.targets,
+  yes: explicit.yes,
+});
+
+const mergeSetupIncludes = (
+  current: readonly SetupInclude[] | undefined,
+  value: string
+): readonly SetupInclude[] => {
+  const includes = tokenizeCsv(value);
+  if (includes.length === 0) {
+    throw new Error("skillset: --include requires at least one value");
+  }
+  const seen = new Set<SetupInclude>(current ?? []);
+  for (const include of includes) {
+    if (include !== "ci") {
+      throw new Error("skillset: expected --include ci");
+    }
+    seen.add(include);
+  }
+  return [...seen];
+};
+
+const readImportKind = (value: string): ImportKind => {
+  if (
+    value === "skill" ||
+    value === "skills" ||
+    value === "plugin" ||
+    value === "plugins"
+  ) {
+    return value;
+  }
+  throw new Error(
+    "skillset: expected --kind skill, skills, plugin, or plugins"
+  );
+};

--- a/apps/skillset/src/source-args.ts
+++ b/apps/skillset/src/source-args.ts
@@ -1,0 +1,270 @@
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { ImportKind, ImportProvider } from "./import";
+import type { NewSourceKind, NewSourceScope } from "./new-source";
+import type { ImportCommandRequest, NewCommandRequest } from "./source-cli";
+
+export interface ImportExplicitOptions {
+  readonly from: ImportProvider | undefined;
+  readonly json: boolean;
+  readonly kind: ImportKind | undefined;
+  readonly name: string | undefined;
+  readonly root: string | undefined;
+}
+
+export const parseImportCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): ImportCommandRequest => {
+  let index = 1;
+  let sourcePath: string | undefined;
+  let positionalProvider: ImportProvider | undefined;
+  const first = args[index];
+  if (first !== undefined && !first.startsWith("--")) {
+    if (isImportKind(first)) {
+      throw new Error("skillset: import kind must be passed with --kind");
+    }
+    if (isImportProvider(first)) {
+      positionalProvider = first;
+      index += 1;
+      const path = args[index];
+      if (path !== undefined && !path.startsWith("--")) {
+        sourcePath = path;
+        index += 1;
+      }
+    } else {
+      sourcePath = first;
+      index += 1;
+    }
+  }
+
+  let buildMode: "all" | "updated" | undefined;
+  let from = positionalProvider;
+  let json = false;
+  let kind: ImportKind | undefined;
+  let name: string | undefined;
+  let root: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        root = reader.readRequiredOptionValue(option);
+        break;
+      case "--name":
+        name = reader.readRequiredOptionValue(option);
+        break;
+      case "--kind": {
+        const next = readImportKind(reader.readRequiredOptionValue(option));
+        if (kind !== undefined && kind !== next) {
+          throw new Error(
+            `skillset: conflicting import kinds ${kind} and ${next}`
+          );
+        }
+        kind = next;
+        break;
+      }
+      case "--from":
+        from = readImportProvider(reader.readRequiredOptionValue(option));
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        json = true;
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+  const explicit: ImportExplicitOptions = { from, json, kind, name, root };
+  return {
+    importKind: explicit.kind,
+    importName: explicit.name,
+    importProvider: explicit.from,
+    jsonOutput: explicit.json,
+    options: {
+      ...(buildMode === undefined ? {} : { buildMode }),
+      ...(scopes === undefined ? {} : { scopes }),
+    },
+    rootPath: resolveCliRoot(context, explicit.root),
+    sourcePath,
+  };
+};
+
+export interface NewExplicitOptions {
+  readonly container: string | undefined;
+  readonly displayName: string | undefined;
+  readonly id: string | undefined;
+  readonly json: boolean;
+  readonly presets: readonly string[] | undefined;
+  readonly root: string | undefined;
+  readonly scope: NewSourceScope | undefined;
+  readonly yes: boolean;
+}
+
+export const parseNewCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): NewCommandRequest => {
+  const kind = readNewSourceKind(args[1]);
+  let index = 2;
+  let positionalName: string | undefined;
+  const positional = args[index];
+  if (positional !== undefined && !positional.startsWith("--")) {
+    positionalName = positional;
+    index += 1;
+  }
+  let container: string | undefined;
+  let buildMode: "all" | "updated" | undefined;
+  let displayName: string | undefined;
+  let id: string | undefined;
+  let importKind: ImportKind | undefined;
+  let importProvider: ImportProvider | undefined;
+  let json = false;
+  let presets: readonly string[] | undefined;
+  let root: string | undefined;
+  let scope: NewSourceScope | undefined;
+  let yes = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        root = reader.readRequiredOptionValue(option);
+        break;
+      case "--id":
+        id = reader.readRequiredOptionValue(option);
+        break;
+      case "--name":
+        displayName = reader.readRequiredOptionValue(option);
+        break;
+      case "--in":
+        container = reader.readRequiredOptionValue(option);
+        break;
+      case "--preset":
+        presets = [...(presets ?? []), reader.readRequiredOptionValue(option)];
+        break;
+      case "--scope":
+        scope = readNewSourceScope(reader.readRequiredOptionValue(option));
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        json = true;
+        break;
+      case "--kind":
+        importKind = readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from":
+        importProvider = readImportProvider(
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+  if (buildMode !== undefined) {
+    throw new Error("skillset: --updated and --all are not supported with new");
+  }
+  if (importKind !== undefined) {
+    throw new Error("skillset: --kind is only supported with import");
+  }
+  if (importProvider !== undefined) {
+    throw new Error("skillset: --from is only supported with import");
+  }
+  const explicit: NewExplicitOptions = {
+    container,
+    displayName,
+    id,
+    json,
+    presets,
+    root,
+    scope,
+    yes,
+  };
+  return {
+    jsonOutput: explicit.json,
+    newContainer: explicit.container,
+    newId: explicit.id,
+    newKind: kind,
+    newName: explicit.displayName,
+    newPresets: explicit.presets,
+    newScope: explicit.scope,
+    options: {},
+    positionalName,
+    rootPath: resolveCliRoot(context, explicit.root),
+    yes: explicit.yes,
+  };
+};
+
+const readImportKind = (value: string): ImportKind => {
+  if (isImportKind(value)) return value;
+  throw new Error(
+    "skillset: expected --kind skill, skills, plugin, or plugins"
+  );
+};
+
+const readImportProvider = (value: string): ImportProvider => {
+  if (isImportProvider(value)) return value;
+  throw new Error(
+    "skillset: expected --from claude, codex, cursor, agents, or skillset"
+  );
+};
+
+const isImportKind = (value: string | undefined): value is ImportKind =>
+  value === "skill" ||
+  value === "skills" ||
+  value === "plugin" ||
+  value === "plugins";
+
+const isImportProvider = (value: string | undefined): value is ImportProvider =>
+  value === "agents" ||
+  value === "claude" ||
+  value === "codex" ||
+  value === "cursor" ||
+  value === "skillset";
+
+const readNewSourceKind = (value: string | undefined): NewSourceKind => {
+  if (value === "agent" || value === "hook" || value === "skill") return value;
+  throw new Error("skillset: expected new kind skill, agent, or hook");
+};
+
+const readNewSourceScope = (value: string): NewSourceScope => {
+  if (value === "repo") return value;
+  throw new Error("skillset: new currently supports only --scope repo");
+};


### PR DESCRIPTION
## Context

SET-302 gives source acquisition and distribution routes typed parser ownership.

## What changed

- Added command-owned parsing for init, import, new, marketplace check/update, and distribute plan.
- Moved positionals, repeats, defaults, conflicts, and request construction out of the global parser state.
- Kept parsing synchronous and side-effect free.

## Verification

- Focused source/distribution parser and handler suites
- 1,019-scenario exact-parent differential with zero request or diagnostic differences
- Typecheck, guards, generated-output, Changeset, whitespace, and `bun run check`

## Risk

No acquisition authority, confirmation policy, machine output, handler mutation, or write timing changed.

Linear: SET-302