### PR TITLE
refactor(cli): extract lifecycle and recovery parsers

### DIFF
--- a/.changeset/cli-lifecycle-recovery-parsers.md
+++ b/.changeset/cli-lifecycle-recovery-parsers.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Move change, release, reconcile, and restore argument handling into typed command-owned parsers, including parser-owned required operand errors.

--- a/apps/skillset/src/__tests__/lifecycle-args.test.ts
+++ b/apps/skillset/src/__tests__/lifecycle-args.test.ts
@@ -173,6 +173,39 @@ describe("SET-303 lifecycle and recovery route parsers", () => {
         message: "skillset: --use is only supported with reconcile",
       },
       {
+        run: () => parseChangeCommandRequest(["change", "add"], CONTEXT),
+        message: "skillset: change add requires at least one --scope",
+      },
+      {
+        run: () =>
+          parseChangeCommandRequest(
+            ["change", "add", "--scope", "plugin:demo"],
+            CONTEXT
+          ),
+        message:
+          "skillset: change add requires --bump major, minor, patch, or none",
+      },
+      {
+        run: () =>
+          parseChangeCommandRequest(
+            ["change", "reason", "--reason", "why"],
+            CONTEXT
+          ),
+        message: "skillset: change reason requires @ref",
+      },
+      {
+        run: () =>
+          parseChangeCommandRequest(
+            ["change", "amend", "--reason", "why"],
+            CONTEXT
+          ),
+        message: "skillset: change amend requires @ref",
+      },
+      {
+        run: () => parseChangeCommandRequest(["change", "show"], CONTEXT),
+        message: "skillset: change show requires @ref",
+      },
+      {
         run: () =>
           parseReleaseCommandRequest(
             ["release", "plan", "--reason", "why", "--scope", "plugins"],
@@ -214,6 +247,14 @@ describe("SET-303 lifecycle and recovery route parsers", () => {
             CONTEXT
           ),
         message: "skillset: --use is only supported with reconcile",
+      },
+      {
+        run: () =>
+          parseReleaseCommandRequest(
+            ["release", "amend", "--reason", "why"],
+            CONTEXT
+          ),
+        message: "skillset: release amend requires @ref",
       },
       {
         run: () => parseReconcileCommandRequest(["reconcile"], CONTEXT),

--- a/apps/skillset/src/__tests__/lifecycle-args.test.ts
+++ b/apps/skillset/src/__tests__/lifecycle-args.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseChangeCommandRequest } from "../change-args";
+import {
+  parseReconcileCommandRequest,
+  parseRestoreCommandRequest,
+} from "../recovery-args";
+import { parseReleaseCommandRequest } from "../release-args";
+
+const CONTEXT = { cwd: "/workspace/repo" } as const;
+
+describe("SET-303 lifecycle and recovery route parsers", () => {
+  test("change owns subcommands, refs, reasons, scopes, and repeat policy", () => {
+    expect(
+      parseChangeCommandRequest(
+        [
+          "change",
+          "add",
+          "--root",
+          "nested",
+          "--scope",
+          "skills:first",
+          "--scope=plugins:second",
+          "--group",
+          "release",
+          "--reason",
+          "why",
+          "--bump",
+          "minor",
+          "--json",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      changeAppend: false,
+      changeBump: "minor",
+      changeGroup: "release",
+      changeReason: { kind: "inline", value: "why" },
+      changeRef: undefined,
+      changeScopes: ["skills:first", "plugins:second"],
+      changeSince: undefined,
+      changeStaged: false,
+      changeSubcommand: "add",
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/nested",
+      yes: false,
+    });
+
+    expect(
+      parseChangeCommandRequest(
+        [
+          "change",
+          "amend",
+          "first",
+          "--ref=second",
+          "--reason-file",
+          "note.md",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({
+      changeReason: { kind: "file", path: "note.md" },
+      changeRef: "second",
+      changeSubcommand: "amend",
+    });
+  });
+
+  test("release owns amend input and apply confirmation", () => {
+    expect(
+      parseReleaseCommandRequest(
+        [
+          "release",
+          "amend",
+          "first",
+          "--ref",
+          "second",
+          "--reason=-",
+          "--root",
+          "nested",
+          "--json",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      options: {},
+      releaseReason: { kind: "stdin" },
+      releaseRef: "second",
+      releaseSubcommand: "amend",
+      rootPath: "/workspace/repo/nested",
+      yes: false,
+    });
+
+    expect(
+      parseReleaseCommandRequest(
+        ["release", "apply", "--yes", "--updated"],
+        CONTEXT
+      )
+    ).toMatchObject({
+      options: { buildMode: "updated" },
+      releaseSubcommand: "apply",
+      yes: true,
+    });
+  });
+
+  test("recovery routes own required paths, choices, and confirmation", () => {
+    expect(
+      parseReconcileCommandRequest(
+        [
+          "reconcile",
+          "plugins/example/codex",
+          "--use",
+          "source",
+          "--root=nested",
+          "--json",
+          "--yes",
+        ],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      managedPath: "plugins/example/codex",
+      options: {},
+      reconcileChoice: "source",
+      rootPath: "/workspace/repo/nested",
+      yes: true,
+    });
+    expect(
+      parseRestoreCommandRequest(
+        ["restore", "backup-id", "--root", "nested", "--json", "--yes"],
+        CONTEXT
+      )
+    ).toEqual({
+      backupId: "backup-id",
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/nested",
+      yes: true,
+    });
+  });
+
+  test("preserves lifecycle and recovery validation precedence", () => {
+    const cases = [
+      {
+        run: () => parseChangeCommandRequest(["change", "unknown"], CONTEXT),
+        message:
+          "skillset: expected change subcommand add, amend, check, history, list, reason, show, or status",
+      },
+      {
+        run: () =>
+          parseChangeCommandRequest(
+            ["change", "add", "--reason", "one", "--reason-file", "two"],
+            CONTEXT
+          ),
+        message: "skillset: pass only one of --reason or --reason-file",
+      },
+      {
+        run: () =>
+          parseChangeCommandRequest(
+            ["change", "check", "--scope", "skills"],
+            CONTEXT
+          ),
+        message:
+          "skillset: change check is a whole-source command; --scope is not supported",
+      },
+      {
+        run: () =>
+          parseChangeCommandRequest(
+            ["change", "add", "--use", "source"],
+            CONTEXT
+          ),
+        message: "skillset: --use is only supported with reconcile",
+      },
+      {
+        run: () =>
+          parseReleaseCommandRequest(
+            ["release", "plan", "--reason", "why", "--scope", "plugins"],
+            CONTEXT
+          ),
+        message:
+          "skillset: change options are only supported with change commands",
+      },
+      {
+        run: () =>
+          parseReleaseCommandRequest(
+            ["release", "plan", "--ref", "entry", "--yes"],
+            CONTEXT
+          ),
+        message:
+          "skillset: change options are only supported with change commands",
+      },
+      {
+        run: () =>
+          parseReleaseCommandRequest(
+            ["release", "plan", "--since", "origin/main"],
+            CONTEXT
+          ),
+        message:
+          "skillset: --since is only supported with check --ci or change commands",
+      },
+      {
+        run: () =>
+          parseReleaseCommandRequest(
+            ["release", "plan", "--scope", "plugins", "--yes"],
+            CONTEXT
+          ),
+        message: "skillset: --scope is not supported with release commands yet",
+      },
+      {
+        run: () =>
+          parseReleaseCommandRequest(
+            ["release", "plan", "--use", "source"],
+            CONTEXT
+          ),
+        message: "skillset: --use is only supported with reconcile",
+      },
+      {
+        run: () => parseReconcileCommandRequest(["reconcile"], CONTEXT),
+        message: "skillset: expected a path to reconcile",
+      },
+      {
+        run: () => parseRestoreCommandRequest(["restore"], CONTEXT),
+        message: "skillset: expected backup id to restore",
+      },
+      {
+        run: () =>
+          parseReconcileCommandRequest(
+            ["reconcile", "managed", "--ref", "entry"],
+            CONTEXT
+          ),
+        message:
+          "skillset: change options are only supported with change commands",
+      },
+      {
+        run: () =>
+          parseReconcileCommandRequest(
+            ["reconcile", "managed", "--updated", "--since", "origin/main"],
+            CONTEXT
+          ),
+        message:
+          "skillset: --since is only supported with check --ci or change commands",
+      },
+      {
+        run: () =>
+          parseReconcileCommandRequest(
+            ["reconcile", "managed", "--yes"],
+            CONTEXT
+          ),
+        message:
+          "skillset: reconcile --yes requires --use source or --use output",
+      },
+      {
+        run: () =>
+          parseRestoreCommandRequest(
+            ["restore", "backup", "--updated", "--since", "origin/main"],
+            CONTEXT
+          ),
+        message:
+          "skillset: --since is only supported with check --ci or change commands",
+      },
+      {
+        run: () =>
+          parseRestoreCommandRequest(
+            ["restore", "backup", "--use", "source"],
+            CONTEXT
+          ),
+        message: "skillset: --use is only supported with reconcile",
+      },
+      {
+        run: () =>
+          parseRestoreCommandRequest(
+            ["restore", "backup", "--updated", "--use", "source"],
+            CONTEXT
+          ),
+        message: "skillset: restore only supports --root and --yes",
+      },
+      {
+        run: () =>
+          parseRestoreCommandRequest(
+            ["restore", "backup", "--updated", "--scope", "plugins"],
+            CONTEXT
+          ),
+        message: "skillset: restore only supports --root and --yes",
+      },
+    ] as const;
+    for (const { message, run } of cases) {
+      expect(run).toThrow(message);
+    }
+  });
+});

--- a/apps/skillset/src/change-args.ts
+++ b/apps/skillset/src/change-args.ts
@@ -131,6 +131,11 @@ export const parseChangeCommandRequest = (
   if (reconcileChoice !== undefined) {
     throw new Error("skillset: --use is only supported with reconcile");
   }
+  validateRequiredChangeInputs(changeSubcommand, {
+    bump: changeBump,
+    ref: changeRef,
+    scopes: changeScopes,
+  });
   const options: SkillsetOptions = {
     ...(buildMode === undefined ? {} : { buildMode }),
   };
@@ -286,5 +291,31 @@ const validateChangeOptions = (
     throw new Error(
       "skillset: --staged is only supported with change status or change check"
     );
+  }
+};
+
+const validateRequiredChangeInputs = (
+  subcommand: ChangeSubcommand,
+  change: {
+    readonly bump: ChangeBump | undefined;
+    readonly ref: string | undefined;
+    readonly scopes: readonly string[] | undefined;
+  }
+): void => {
+  if (subcommand === "add" && change.scopes === undefined) {
+    throw new Error("skillset: change add requires at least one --scope");
+  }
+  if (subcommand === "add" && change.bump === undefined) {
+    throw new Error(
+      "skillset: change add requires --bump major, minor, patch, or none"
+    );
+  }
+  if (
+    (subcommand === "amend" ||
+      subcommand === "reason" ||
+      subcommand === "show") &&
+    change.ref === undefined
+  ) {
+    throw new Error(`skillset: change ${subcommand} requires @ref`);
   }
 };

--- a/apps/skillset/src/change-args.ts
+++ b/apps/skillset/src/change-args.ts
@@ -1,0 +1,290 @@
+import { sourceUnitSelector } from "@skillset/core/internal/source-unit-selector";
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import type { ChangeCommandRequest } from "./change-cli";
+import type { ChangeBump } from "./change-entries";
+import type { ChangeReasonInput, ChangeSubcommand } from "./change-workflow";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import { mergeBuildMode, resolveCliRoot, tokenizeCsv } from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+
+export const parseChangeCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): ChangeCommandRequest => {
+  const changeSubcommand = readChangeSubcommand(args[1]);
+  let index = 2;
+  let changeRef: string | undefined;
+  const positionalRef = args[index];
+  if (
+    supportsPositionalRef(changeSubcommand) &&
+    positionalRef !== undefined &&
+    !positionalRef.startsWith("--")
+  ) {
+    changeRef = positionalRef;
+    index += 1;
+  }
+
+  let buildMode: "all" | "updated" | undefined;
+  let changeAppend = false;
+  let changeBump: ChangeBump | undefined;
+  let changeGroup: string | undefined;
+  let changeReason: ChangeReasonInput | undefined;
+  let changeScopes: readonly string[] | undefined;
+  let changeSince: string | undefined;
+  let changeStaged = false;
+  let jsonOutput = false;
+  let reconcileChoice: "output" | "source" | undefined;
+  let rootPath: string | undefined;
+  let yes = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--ref":
+        changeRef = reader.readRequiredOptionValue(option);
+        break;
+      case "--since":
+        changeSince = reader.readRequiredOptionValue(option);
+        break;
+      case "--scope":
+        changeScopes = readChangeScopesForSubcommand(
+          changeSubcommand,
+          changeScopes,
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      case "--group":
+        changeGroup = reader.readRequiredOptionValue(option);
+        break;
+      case "--reason":
+        changeReason = setChangeReason(
+          changeReason,
+          readInlineReason(reader.readRequiredOptionValue(option))
+        );
+        break;
+      case "--reason-file":
+        changeReason = setChangeReason(changeReason, {
+          kind: "file",
+          path: reader.readRequiredOptionValue(option),
+        });
+        break;
+      case "--bump":
+        changeBump = readChangeBump(reader.readRequiredOptionValue(option));
+        break;
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        reconcileChoice = value;
+        break;
+      }
+      case "--append":
+        assertBooleanOption(option);
+        changeAppend = true;
+        break;
+      case "--staged":
+        assertBooleanOption(option);
+        changeStaged = true;
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--name":
+      case "--kind":
+      case "--from":
+        reader.readRequiredOptionValue(option);
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  validateChangeOptions(changeSubcommand, {
+    append: changeAppend,
+    bump: changeBump,
+    group: changeGroup,
+    reason: changeReason,
+    ref: changeRef,
+    scopes: changeScopes,
+    staged: changeStaged,
+    yes,
+  });
+  if (reconcileChoice !== undefined) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  const options: SkillsetOptions = {
+    ...(buildMode === undefined ? {} : { buildMode }),
+  };
+  return {
+    changeAppend,
+    changeBump,
+    changeGroup,
+    changeReason,
+    changeRef,
+    changeScopes,
+    changeSince,
+    changeStaged,
+    changeSubcommand,
+    jsonOutput,
+    options,
+    rootPath: resolveCliRoot(context, rootPath),
+    yes,
+  };
+};
+
+export const isChangeSubcommand = (
+  value: string | undefined
+): value is ChangeSubcommand =>
+  value === "add" ||
+  value === "amend" ||
+  value === "check" ||
+  value === "history" ||
+  value === "list" ||
+  value === "migrate" ||
+  value === "reason" ||
+  value === "show" ||
+  value === "status";
+
+export const readChangeScopes = (value: string): readonly string[] => {
+  const scopes = tokenizeCsv(value);
+  if (scopes.length === 0) {
+    throw new Error(
+      "skillset: --scope requires at least one source unit scope"
+    );
+  }
+  return scopes.map(sourceUnitSelector);
+};
+
+export const readChangeBump = (value: string): ChangeBump => {
+  if (
+    value === "major" ||
+    value === "minor" ||
+    value === "none" ||
+    value === "patch"
+  ) {
+    return value;
+  }
+  throw new Error("skillset: expected --bump major, minor, patch, or none");
+};
+
+export const setChangeReason = (
+  current: ChangeReasonInput | undefined,
+  next: ChangeReasonInput
+): ChangeReasonInput => {
+  if (current !== undefined) {
+    throw new Error("skillset: pass only one of --reason or --reason-file");
+  }
+  return next;
+};
+
+const readChangeSubcommand = (value: string | undefined): ChangeSubcommand => {
+  if (isChangeSubcommand(value)) return value;
+  throw new Error(
+    "skillset: expected change subcommand add, amend, check, history, list, reason, show, or status"
+  );
+};
+
+const supportsPositionalRef = (subcommand: ChangeSubcommand): boolean =>
+  subcommand === "amend" ||
+  subcommand === "check" ||
+  subcommand === "history" ||
+  subcommand === "reason" ||
+  subcommand === "show";
+
+const readInlineReason = (value: string): ChangeReasonInput =>
+  value === "-" ? { kind: "stdin" } : { kind: "inline", value };
+
+const readChangeScopesForSubcommand = (
+  subcommand: ChangeSubcommand,
+  current: readonly string[] | undefined,
+  value: string
+): readonly string[] => {
+  if (subcommand === "add") {
+    return [...(current ?? []), ...readChangeScopes(value)];
+  }
+  if (subcommand === "status" || subcommand === "check") {
+    throw new Error(
+      `skillset: change ${subcommand} is a whole-source command; --scope is not supported`
+    );
+  }
+  throw new Error(
+    "skillset: --scope is only supported with change add source-unit entries"
+  );
+};
+
+const validateChangeOptions = (
+  subcommand: ChangeSubcommand,
+  change: {
+    readonly append: boolean;
+    readonly bump: ChangeBump | undefined;
+    readonly group: string | undefined;
+    readonly reason: ChangeReasonInput | undefined;
+    readonly ref: string | undefined;
+    readonly scopes: readonly string[] | undefined;
+    readonly staged: boolean;
+    readonly yes: boolean;
+  }
+): void => {
+  if (change.yes && subcommand !== "migrate") {
+    throw new Error("skillset: --yes is only supported with change migrate");
+  }
+  if (change.append && subcommand !== "reason") {
+    throw new Error("skillset: --append is only supported with change reason");
+  }
+  if (change.bump !== undefined && subcommand !== "add") {
+    throw new Error("skillset: --bump is only supported with change add");
+  }
+  if (
+    change.group !== undefined &&
+    subcommand !== "add" &&
+    subcommand !== "list"
+  ) {
+    throw new Error(
+      "skillset: --group is only supported with change add or change list"
+    );
+  }
+  if (
+    change.reason !== undefined &&
+    subcommand !== "add" &&
+    subcommand !== "amend" &&
+    subcommand !== "reason"
+  ) {
+    throw new Error(
+      "skillset: --reason and --reason-file are only supported with change add, change amend, or change reason"
+    );
+  }
+  if (change.ref !== undefined && !supportsPositionalRef(subcommand)) {
+    throw new Error(
+      "skillset: --ref is only supported with change amend, change check, change history, change reason, or change show"
+    );
+  }
+  if (change.scopes !== undefined && subcommand !== "add") {
+    throw new Error(
+      "skillset: source-unit --scope is only supported with change add"
+    );
+  }
+  if (change.staged && subcommand !== "check" && subcommand !== "status") {
+    throw new Error(
+      "skillset: --staged is only supported with change status or change check"
+    );
+  }
+};

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -872,32 +872,6 @@ function parseArgs(
     ...(newPresets === undefined ? {} : { presets: newPresets }),
     ...(newScope === undefined ? {} : { scope: newScope }),
   });
-  if (command === "change" && changeSubcommand === "add") {
-    if (changeScopes === undefined || changeScopes.length === 0) {
-      throw new Error("skillset: change add requires at least one --scope");
-    }
-    if (changeBump === undefined) {
-      throw new Error(
-        "skillset: change add requires --bump major, minor, patch, or none"
-      );
-    }
-  }
-  if (
-    command === "change" &&
-    (changeSubcommand === "amend" ||
-      changeSubcommand === "reason" ||
-      changeSubcommand === "show") &&
-    changeRef === undefined
-  ) {
-    throw new Error(`skillset: change ${changeSubcommand} requires @ref`);
-  }
-  if (
-    command === "release" &&
-    releaseSubcommand === "amend" &&
-    releaseRef === undefined
-  ) {
-    throw new Error("skillset: release amend requires @ref");
-  }
   const options: SkillsetOptions = {
     ...(buildMode === undefined ? {} : { buildMode }),
     ...(scopes === undefined ? {} : { scopes }),

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -1,5 +1,4 @@
 import type { LookupSubject, LookupView } from "@skillset/core";
-import { sourceUnitSelector } from "@skillset/core/internal/source-unit-selector";
 import type {
   BuildScope,
   CompileBuildMode,
@@ -11,6 +10,13 @@ import {
   parseBuildCommandRequest,
   parseDiffCommandRequest,
 } from "./build-args";
+import {
+  isChangeSubcommand,
+  parseChangeCommandRequest,
+  readChangeBump,
+  readChangeScopes,
+  setChangeReason,
+} from "./change-args";
 import type { ChangeBump } from "./change-entries";
 import type { ChangeReasonInput, ChangeSubcommand } from "./change-workflow";
 import { parseCheckCommandRequest } from "./check-args";
@@ -46,7 +52,15 @@ import {
 } from "./lookup-cli";
 import type { NewSourceKind, NewSourceScope } from "./new-source";
 import type { ReconcileChoice } from "./reconcile";
+import {
+  parseReconcileCommandRequest,
+  parseRestoreCommandRequest,
+} from "./recovery-args";
 import type { ReleaseSubcommand } from "./release";
+import {
+  isReleaseSubcommand,
+  parseReleaseCommandRequest,
+} from "./release-args";
 import {
   readHookRuntimeContextField,
   readHookRuntimeContextFormat,
@@ -75,15 +89,6 @@ type MarketplaceSubcommand = "check" | "update";
 
 interface ParsedArgs {
   readonly command: Command;
-  readonly changeAppend: boolean;
-  readonly changeBump?: ChangeBump;
-  readonly changeGroup?: string;
-  readonly changeReason?: ChangeReasonInput;
-  readonly changeRef?: string;
-  readonly changeSince?: string;
-  readonly changeStaged: boolean;
-  readonly changeScopes?: readonly string[];
-  readonly changeSubcommand?: ChangeSubcommand;
   readonly hookAgentRuntime: boolean;
   readonly hookContextEvent?: string;
   readonly hookContextFields?: readonly HookRuntimeContextField[];
@@ -103,9 +108,6 @@ interface ParsedArgs {
   readonly lookupTargets: readonly TargetName[];
   readonly lookupViews: readonly LookupView[];
   readonly options: SkillsetOptions;
-  readonly releaseSubcommand?: ReleaseSubcommand;
-  readonly releaseReason?: ChangeReasonInput;
-  readonly releaseRef?: string;
   readonly tryBackground: boolean;
   readonly tryClaudeSettingSources?: TryClaudeSettingSources;
   readonly tryLines?: number;
@@ -119,7 +121,6 @@ interface ParsedArgs {
   readonly tryTimeoutMs?: number;
   readonly rootExplicit: boolean;
   readonly rootPath: string;
-  readonly reconcileChoice?: ReconcileChoice;
   readonly testName?: string;
   readonly yes: boolean;
 }
@@ -730,7 +731,7 @@ function parseArgs(
     }
   }
 
-  validateChangeFlags(command, changeSubcommand, {
+  validateLegacyChangeFlags(command, {
     append: changeAppend,
     ...(changeBump === undefined ? {} : { bump: changeBump }),
     ...(changeGroup === undefined ? {} : { group: changeGroup }),
@@ -738,7 +739,6 @@ function parseArgs(
     ...(changeRef === undefined ? {} : { ref: changeRef }),
     staged: changeStaged,
     ...(changeScopes === undefined ? {} : { scopes: changeScopes }),
-    yes,
   });
 
   validateHookFlags(command, {
@@ -846,15 +846,7 @@ function parseArgs(
 
   validateLegacyIsolatedFlag(command, isolated);
 
-  if (command === "release" && scopes !== undefined) {
-    throw new Error(
-      "skillset: --scope is not supported with release commands yet"
-    );
-  }
-  if (command === "release" && releaseSubcommand !== "apply" && yes) {
-    throw new Error("skillset: --yes is only supported with release apply");
-  }
-  validateReleaseFlags(command, releaseSubcommand, {
+  validateLegacyReleaseFlags(command, {
     ...(releaseReason === undefined ? {} : { reason: releaseReason }),
     ...(releaseRef === undefined ? {} : { ref: releaseRef }),
   });
@@ -868,22 +860,9 @@ function parseArgs(
     ...(trySubcommand === undefined ? {} : { subcommand: trySubcommand }),
     yes,
   });
-  validateRestoreFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(changeSince === undefined ? {} : { changeSince }),
-    ...(distDir === undefined ? {} : { distDir }),
-    ...(scopes === undefined ? {} : { scopes }),
-    ...(sourceDir === undefined ? {} : { sourceDir }),
-  });
   validateStatusFlags(command, args);
-  validateReconcileFlags(command, {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(changeSince === undefined ? {} : { changeSince }),
-    ...(distDir === undefined ? {} : { distDir }),
-    ...(scopes === undefined ? {} : { scopes }),
+  validateLegacyReconcileFlags(command, {
     ...(reconcileChoice === undefined ? {} : { choice: reconcileChoice }),
-    ...(sourceDir === undefined ? {} : { sourceDir }),
-    yes,
   });
   validateLegacyNewSourceFlags(command, {
     ...(newContainer === undefined ? {} : { container: newContainer }),
@@ -929,15 +908,6 @@ function parseArgs(
 
   return {
     command,
-    changeAppend,
-    ...(changeBump === undefined ? {} : { changeBump }),
-    ...(changeGroup === undefined ? {} : { changeGroup }),
-    ...(changeReason === undefined ? {} : { changeReason }),
-    ...(changeRef === undefined ? {} : { changeRef }),
-    ...(changeSince === undefined ? {} : { changeSince }),
-    changeStaged,
-    ...(changeScopes === undefined ? {} : { changeScopes }),
-    ...(changeSubcommand === undefined ? {} : { changeSubcommand }),
     hookAgentRuntime,
     ...(hookContextEvent === undefined ? {} : { hookContextEvent }),
     ...(hookContextFields === undefined ? {} : { hookContextFields }),
@@ -957,9 +927,6 @@ function parseArgs(
     lookupTargets,
     lookupViews,
     options,
-    ...(releaseSubcommand === undefined ? {} : { releaseSubcommand }),
-    ...(releaseReason === undefined ? {} : { releaseReason }),
-    ...(releaseRef === undefined ? {} : { releaseRef }),
     tryBackground,
     ...(tryClaudeSettingSources === undefined
       ? {}
@@ -975,7 +942,6 @@ function parseArgs(
     ...(tryTimeoutMs === undefined ? {} : { tryTimeoutMs }),
     rootExplicit,
     rootPath: resolveCliRoot(context, rootPath),
-    ...(reconcileChoice === undefined ? {} : { reconcileChoice }),
     ...(testName === undefined ? {} : { testName }),
     yes,
   };
@@ -983,49 +949,6 @@ function parseArgs(
 
 function createCliRequest(parsed: ParsedArgs): CliRequest {
   const { command, jsonOutput, options, rootPath, yes } = parsed;
-  if (command === "change")
-    return {
-      command,
-      request: {
-        changeAppend: parsed.changeAppend,
-        changeBump: parsed.changeBump,
-        changeGroup: parsed.changeGroup,
-        changeReason: parsed.changeReason,
-        changeRef: parsed.changeRef,
-        changeScopes: parsed.changeScopes,
-        changeSince: parsed.changeSince,
-        changeStaged: parsed.changeStaged,
-        changeSubcommand: parsed.changeSubcommand,
-        jsonOutput,
-        options,
-        rootPath,
-        yes,
-      },
-    };
-  if (command === "release")
-    return {
-      command,
-      request: {
-        jsonOutput,
-        options,
-        releaseReason: parsed.releaseReason,
-        releaseRef: parsed.releaseRef,
-        releaseSubcommand: parsed.releaseSubcommand,
-        rootPath,
-        yes,
-      },
-    };
-  if (command === "restore")
-    return {
-      command,
-      request: {
-        backupId: parsed.importPath,
-        jsonOutput,
-        options,
-        rootPath,
-        yes,
-      },
-    };
   if (command === "hooks")
     return {
       command,
@@ -1091,18 +1014,6 @@ function createCliRequest(parsed: ParsedArgs): CliRequest {
       command,
       request: { jsonOutput, options, path: parsed.importPath, rootPath },
     };
-  if (command === "reconcile")
-    return {
-      command,
-      request: {
-        jsonOutput,
-        managedPath: parsed.importPath,
-        options,
-        reconcileChoice: parsed.reconcileChoice,
-        rootPath,
-        yes,
-      },
-    };
   if (command === "status")
     return { command, request: { jsonOutput, options, rootPath } };
   throw new Error(`skillset: unhandled command ${command}`);
@@ -1120,6 +1031,9 @@ export function parseCliRequest(
       );
     }
     const parsed = parseArgs(command, args, context);
+    if (command === "change") {
+      return { command, request: parseChangeCommandRequest(args, context) };
+    }
     if (command === "build") {
       return { command, request: parseBuildCommandRequest(args, context) };
     }
@@ -1153,6 +1067,18 @@ export function parseCliRequest(
     if (command === "new") {
       return { command, request: parseNewCommandRequest(args, context) };
     }
+    if (command === "reconcile") {
+      return {
+        command,
+        request: parseReconcileCommandRequest(args, context),
+      };
+    }
+    if (command === "release") {
+      return { command, request: parseReleaseCommandRequest(args, context) };
+    }
+    if (command === "restore") {
+      return { command, request: parseRestoreCommandRequest(args, context) };
+    }
     if (command === "update") {
       return { command, request: parseUpdateCommandRequest(args, context) };
     }
@@ -1166,33 +1092,6 @@ export function parseCliRequest(
   }
 }
 
-function isReleaseSubcommand(
-  value: string | undefined
-): value is ReleaseSubcommand {
-  return (
-    value === "amend" ||
-    value === "apply" ||
-    value === "audit" ||
-    value === "plan"
-  );
-}
-
-function isChangeSubcommand(
-  value: string | undefined
-): value is ChangeSubcommand {
-  return (
-    value === "add" ||
-    value === "amend" ||
-    value === "check" ||
-    value === "history" ||
-    value === "list" ||
-    value === "migrate" ||
-    value === "reason" ||
-    value === "show" ||
-    value === "status"
-  );
-}
-
 function isNewSourceKind(value: string | undefined): value is NewSourceKind {
   return value === "agent" || value === "hook" || value === "skill";
 }
@@ -1202,16 +1101,6 @@ function readNewSourceScope(value: string): NewSourceScope {
     return value;
   }
   throw new Error("skillset: new currently supports only --scope repo");
-}
-
-function readChangeScopes(value: string): readonly string[] {
-  const scopes = tokenizeCsv(value);
-  if (scopes.length === 0) {
-    throw new Error(
-      "skillset: --scope requires at least one source unit scope"
-    );
-  }
-  return scopes.map(sourceUnitSelector);
 }
 
 function readHookRuntimeContextFields(
@@ -1224,31 +1113,8 @@ function readHookRuntimeContextFields(
   return fields.map(readHookRuntimeContextField);
 }
 
-function readChangeBump(value: string): ChangeBump {
-  if (
-    value === "major" ||
-    value === "minor" ||
-    value === "none" ||
-    value === "patch"
-  ) {
-    return value;
-  }
-  throw new Error("skillset: expected --bump major, minor, patch, or none");
-}
-
-function setChangeReason(
-  current: ChangeReasonInput | undefined,
-  next: ChangeReasonInput
-): ChangeReasonInput {
-  if (current !== undefined) {
-    throw new Error("skillset: pass only one of --reason or --reason-file");
-  }
-  return next;
-}
-
-function validateChangeFlags(
+function validateLegacyChangeFlags(
   command: Command,
-  subcommand: ChangeSubcommand | undefined,
   change: {
     readonly append: boolean;
     readonly bump?: ChangeBump;
@@ -1257,7 +1123,6 @@ function validateChangeFlags(
     readonly ref?: string;
     readonly scopes?: readonly string[];
     readonly staged: boolean;
-    readonly yes: boolean;
   }
 ): void {
   const hasChangeFlag =
@@ -1273,63 +1138,10 @@ function validateChangeFlags(
       "skillset: change options are only supported with change commands"
     );
   }
-  if (command !== "change") {
-    return;
-  }
-  if (change.yes && subcommand !== "migrate") {
-    throw new Error("skillset: --yes is only supported with change migrate");
-  }
-  const allowed = {
-    append: subcommand === "reason",
-    bump: subcommand === "add",
-    group: subcommand === "add" || subcommand === "list",
-    reason:
-      subcommand === "add" || subcommand === "amend" || subcommand === "reason",
-    ref:
-      subcommand === "amend" ||
-      subcommand === "check" ||
-      subcommand === "history" ||
-      subcommand === "reason" ||
-      subcommand === "show",
-    scopes: subcommand === "add",
-    staged: subcommand === "check" || subcommand === "status",
-  };
-  if (change.append && !allowed.append) {
-    throw new Error("skillset: --append is only supported with change reason");
-  }
-  if (change.bump !== undefined && !allowed.bump) {
-    throw new Error("skillset: --bump is only supported with change add");
-  }
-  if (change.group !== undefined && !allowed.group) {
-    throw new Error(
-      "skillset: --group is only supported with change add or change list"
-    );
-  }
-  if (change.reason !== undefined && !allowed.reason) {
-    throw new Error(
-      "skillset: --reason and --reason-file are only supported with change add, change amend, or change reason"
-    );
-  }
-  if (change.ref !== undefined && !allowed.ref) {
-    throw new Error(
-      "skillset: --ref is only supported with change amend, change check, change history, change reason, or change show"
-    );
-  }
-  if (change.scopes !== undefined && !allowed.scopes) {
-    throw new Error(
-      "skillset: source-unit --scope is only supported with change add"
-    );
-  }
-  if (change.staged && !allowed.staged) {
-    throw new Error(
-      "skillset: --staged is only supported with change status or change check"
-    );
-  }
 }
 
-function validateReleaseFlags(
+function validateLegacyReleaseFlags(
   command: Command,
-  subcommand: ReleaseSubcommand | undefined,
   release: {
     readonly reason?: ChangeReasonInput;
     readonly ref?: string;
@@ -1341,18 +1153,6 @@ function validateReleaseFlags(
     throw new Error(
       "skillset: release options are only supported with release commands"
     );
-  }
-  if (command !== "release") {
-    return;
-  }
-
-  if (release.reason !== undefined && subcommand !== "amend") {
-    throw new Error(
-      "skillset: --reason and --reason-file are only supported with release amend"
-    );
-  }
-  if (release.ref !== undefined && subcommand !== "amend") {
-    throw new Error("skillset: --ref is only supported with release amend");
   }
 }
 
@@ -1502,30 +1302,6 @@ function validateListFlags(
   }
 }
 
-function validateRestoreFlags(
-  command: Command,
-  restore: {
-    readonly buildMode?: CompileBuildMode;
-    readonly changeSince?: string;
-    readonly distDir?: string;
-    readonly scopes?: readonly BuildScope[];
-    readonly sourceDir?: string;
-  }
-): void {
-  if (command !== "restore") {
-    return;
-  }
-  if (
-    restore.buildMode !== undefined ||
-    restore.changeSince !== undefined ||
-    restore.distDir !== undefined ||
-    restore.scopes !== undefined ||
-    restore.sourceDir !== undefined
-  ) {
-    throw new Error("skillset: restore only supports --root and --yes");
-  }
-}
-
 function validateStatusFlags(command: Command, args: readonly string[]): void {
   if (command !== "status") {
     return;
@@ -1550,37 +1326,14 @@ function validateStatusFlags(command: Command, args: readonly string[]): void {
   }
 }
 
-function validateReconcileFlags(
+function validateLegacyReconcileFlags(
   command: Command,
   reconcile: {
-    readonly buildMode?: CompileBuildMode;
-    readonly changeSince?: string;
-    readonly scopes?: readonly BuildScope[];
     readonly choice?: ReconcileChoice;
-    readonly yes: boolean;
   }
 ): void {
   if (reconcile.choice !== undefined && command !== "reconcile") {
     throw new Error("skillset: --use is only supported with reconcile");
-  }
-  if (command !== "reconcile") {
-    return;
-  }
-  if (reconcile.buildMode !== undefined) {
-    throw new Error(
-      "skillset: --updated and --all are not supported with reconcile"
-    );
-  }
-  if (reconcile.changeSince !== undefined) {
-    throw new Error("skillset: --since is not supported with reconcile");
-  }
-  if (reconcile.scopes !== undefined) {
-    throw new Error("skillset: --scope is not supported with reconcile");
-  }
-  if (reconcile.yes && reconcile.choice === undefined) {
-    throw new Error(
-      "skillset: reconcile --yes requires --use source or --use output"
-    );
   }
 }
 

--- a/apps/skillset/src/recovery-args.ts
+++ b/apps/skillset/src/recovery-args.ts
@@ -1,0 +1,217 @@
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import { readChangeBump, setChangeReason } from "./change-args";
+import type { ChangeReasonInput } from "./change-workflow";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { ReconcileChoice } from "./reconcile";
+import type {
+  ReconcileCommandRequest,
+  RestoreCommandRequest,
+} from "./recovery-cli";
+
+export const parseRestoreCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): RestoreCommandRequest => {
+  const backupId = readRequiredPath(args[1], "backup id to restore");
+  const parsed = parseRecoveryOptions(args, 2, context);
+  validateRecoveryOwnership(parsed);
+  if (parsed.buildMode !== undefined || parsed.scopes !== undefined) {
+    throw new Error("skillset: restore only supports --root and --yes");
+  }
+  if (parsed.choice !== undefined) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  return {
+    backupId,
+    jsonOutput: parsed.jsonOutput,
+    options: {},
+    rootPath: parsed.rootPath,
+    yes: parsed.yes,
+  };
+};
+
+export const parseReconcileCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): ReconcileCommandRequest => {
+  const managedPath = readRequiredPath(args[1], "a path to reconcile");
+  const parsed = parseRecoveryOptions(args, 2, context);
+  validateRecoveryOwnership(parsed);
+  if (parsed.buildMode !== undefined) {
+    throw new Error(
+      "skillset: --updated and --all are not supported with reconcile"
+    );
+  }
+  if (parsed.scopes !== undefined) {
+    throw new Error("skillset: --scope is not supported with reconcile");
+  }
+  if (parsed.yes && parsed.choice === undefined) {
+    throw new Error(
+      "skillset: reconcile --yes requires --use source or --use output"
+    );
+  }
+  return {
+    jsonOutput: parsed.jsonOutput,
+    managedPath,
+    options: {},
+    reconcileChoice: parsed.choice,
+    rootPath: parsed.rootPath,
+    yes: parsed.yes,
+  };
+};
+
+interface RecoveryOptions {
+  readonly buildMode: "all" | "updated" | undefined;
+  readonly changeFlag: boolean;
+  readonly changeSince: string | undefined;
+  readonly choice: ReconcileChoice | undefined;
+  readonly jsonOutput: boolean;
+  readonly rootPath: string;
+  readonly scopes: SkillsetOptions["scopes"];
+  readonly yes: boolean;
+}
+
+const parseRecoveryOptions = (
+  args: readonly string[],
+  index: number,
+  context: CliParseContext
+): RecoveryOptions => {
+  let buildMode: "all" | "updated" | undefined;
+  let changeAppend = false;
+  let changeBump = false;
+  let changeGroup: string | undefined;
+  let changeReason: ChangeReasonInput | undefined;
+  let changeRef: string | undefined;
+  let changeStaged = false;
+  let changeSince: string | undefined;
+  let choice: ReconcileChoice | undefined;
+  let jsonOutput = false;
+  let rootPath: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let yes = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--since":
+        changeSince = reader.readRequiredOptionValue(option);
+        break;
+      case "--ref":
+        changeRef = reader.readRequiredOptionValue(option);
+        break;
+      case "--reason": {
+        const value = reader.readRequiredOptionValue(option);
+        changeReason = setChangeReason(
+          changeReason,
+          value === "-" ? { kind: "stdin" } : { kind: "inline", value }
+        );
+        break;
+      }
+      case "--reason-file":
+        changeReason = setChangeReason(changeReason, {
+          kind: "file",
+          path: reader.readRequiredOptionValue(option),
+        });
+        break;
+      case "--group":
+        changeGroup = reader.readRequiredOptionValue(option);
+        break;
+      case "--bump":
+        readChangeBump(reader.readRequiredOptionValue(option));
+        changeBump = true;
+        break;
+      case "--append":
+        assertBooleanOption(option);
+        changeAppend = true;
+        break;
+      case "--staged":
+        assertBooleanOption(option);
+        changeStaged = true;
+        break;
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        choice = value;
+        break;
+      }
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--name":
+      case "--kind":
+      case "--from":
+        reader.readRequiredOptionValue(option);
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+  return {
+    buildMode,
+    changeFlag:
+      changeAppend ||
+      changeBump ||
+      changeGroup !== undefined ||
+      changeReason !== undefined ||
+      changeRef !== undefined ||
+      changeStaged,
+    changeSince,
+    choice,
+    jsonOutput,
+    rootPath: resolveCliRoot(context, rootPath),
+    scopes,
+    yes,
+  };
+};
+
+const validateRecoveryOwnership = (parsed: RecoveryOptions): void => {
+  if (parsed.changeFlag) {
+    throw new Error(
+      "skillset: change options are only supported with change commands"
+    );
+  }
+  if (parsed.changeSince !== undefined) {
+    throw new Error(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  }
+};
+
+const readRequiredPath = (
+  value: string | undefined,
+  expectation: string
+): string => {
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`skillset: expected ${expectation}`);
+  }
+  return value;
+};

--- a/apps/skillset/src/release-args.ts
+++ b/apps/skillset/src/release-args.ts
@@ -1,0 +1,202 @@
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import { readChangeBump, setChangeReason } from "./change-args";
+import type { ChangeReasonInput } from "./change-workflow";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  resolveCliRoot,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { ReleaseSubcommand } from "./release";
+import type { ReleaseCommandRequest } from "./release-cli";
+
+export const parseReleaseCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): ReleaseCommandRequest => {
+  const releaseSubcommand = readReleaseSubcommand(args[1]);
+  let index = 2;
+  let releaseRef: string | undefined;
+  const positionalRef = args[index];
+  if (
+    releaseSubcommand === "amend" &&
+    positionalRef !== undefined &&
+    !positionalRef.startsWith("--")
+  ) {
+    releaseRef = positionalRef;
+    index += 1;
+  }
+  let buildMode: "all" | "updated" | undefined;
+  let changeAppend = false;
+  let changeBump = false;
+  let changeGroup: string | undefined;
+  let changeReason: ChangeReasonInput | undefined;
+  let changeRef: string | undefined;
+  let changeSince: string | undefined;
+  let changeStaged = false;
+  let jsonOutput = false;
+  let reconcileChoice: "output" | "source" | undefined;
+  let releaseReason: ChangeReasonInput | undefined;
+  let rootPath: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let yes = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) break;
+    switch (option.flag) {
+      case "--root":
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      case "--ref":
+        if (releaseSubcommand === "amend") {
+          releaseRef = reader.readRequiredOptionValue(option);
+        } else {
+          changeRef = reader.readRequiredOptionValue(option);
+        }
+        break;
+      case "--reason": {
+        const value = reader.readRequiredOptionValue(option);
+        const reason: ChangeReasonInput =
+          value === "-" ? { kind: "stdin" } : { kind: "inline", value };
+        if (releaseSubcommand === "amend") {
+          releaseReason = setChangeReason(releaseReason, reason);
+        } else {
+          changeReason = setChangeReason(changeReason, reason);
+        }
+        break;
+      }
+      case "--reason-file": {
+        const reason = {
+          kind: "file",
+          path: reader.readRequiredOptionValue(option),
+        } as const;
+        if (releaseSubcommand === "amend") {
+          releaseReason = setChangeReason(releaseReason, reason);
+        } else {
+          changeReason = setChangeReason(changeReason, reason);
+        }
+        break;
+      }
+      case "--since":
+        changeSince = reader.readRequiredOptionValue(option);
+        break;
+      case "--group":
+        changeGroup = reader.readRequiredOptionValue(option);
+        break;
+      case "--bump":
+        readChangeBump(reader.readRequiredOptionValue(option));
+        changeBump = true;
+        break;
+      case "--append":
+        assertBooleanOption(option);
+        changeAppend = true;
+        break;
+      case "--staged":
+        assertBooleanOption(option);
+        changeStaged = true;
+        break;
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        reconcileChoice = value;
+        break;
+      }
+      case "--yes":
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      case "--json":
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--scope":
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      case "--name":
+      case "--kind":
+      case "--from":
+        reader.readRequiredOptionValue(option);
+        break;
+      default:
+        throw new Error(`skillset: unknown option ${option.raw}`);
+    }
+  }
+
+  if (
+    changeAppend ||
+    changeBump ||
+    changeGroup !== undefined ||
+    changeReason !== undefined ||
+    changeRef !== undefined ||
+    changeStaged
+  ) {
+    throw new Error(
+      "skillset: change options are only supported with change commands"
+    );
+  }
+  if (changeSince !== undefined) {
+    throw new Error(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  }
+  if (scopes !== undefined) {
+    throw new Error(
+      "skillset: --scope is not supported with release commands yet"
+    );
+  }
+  if (releaseSubcommand !== "apply" && yes) {
+    throw new Error("skillset: --yes is only supported with release apply");
+  }
+  if (releaseReason !== undefined && releaseSubcommand !== "amend") {
+    throw new Error(
+      "skillset: --reason and --reason-file are only supported with release amend"
+    );
+  }
+  if (releaseRef !== undefined && releaseSubcommand !== "amend") {
+    throw new Error("skillset: --ref is only supported with release amend");
+  }
+  if (reconcileChoice !== undefined) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  return {
+    jsonOutput,
+    options: {
+      ...(buildMode === undefined ? {} : { buildMode }),
+    },
+    releaseReason,
+    releaseRef,
+    releaseSubcommand,
+    rootPath: resolveCliRoot(context, rootPath),
+    yes,
+  };
+};
+
+export const isReleaseSubcommand = (
+  value: string | undefined
+): value is ReleaseSubcommand =>
+  value === "amend" ||
+  value === "apply" ||
+  value === "audit" ||
+  value === "plan";
+
+const readReleaseSubcommand = (
+  value: string | undefined
+): ReleaseSubcommand => {
+  if (isReleaseSubcommand(value)) return value;
+  throw new Error(
+    "skillset: expected release subcommand amend, apply, audit, or plan"
+  );
+};

--- a/apps/skillset/src/release-args.ts
+++ b/apps/skillset/src/release-args.ts
@@ -171,6 +171,9 @@ export const parseReleaseCommandRequest = (
   if (reconcileChoice !== undefined) {
     throw new Error("skillset: --use is only supported with reconcile");
   }
+  if (releaseSubcommand === "amend" && releaseRef === undefined) {
+    throw new Error("skillset: release amend requires @ref");
+  }
   return {
     jsonOutput,
     options: {


### PR DESCRIPTION
## Context

SET-303 moves change, release, reconcile, and restore grammar into typed command owners.

## What changed

- Added route-local parsers for lifecycle and recovery commands.
- Preserved option classification, precedence, repeat semantics, machine output, and write timing.
- Validated required scopes, bumps, and refs inside the parser boundary so incomplete invocations exit 2.

## Verification

- Focused lifecycle/recovery and contract suites
- 10,007-scenario route-local parity proof
- Typecheck, guards, generated output, conformance, Changeset, whitespace, and `bun run check`

## Risk

Parser ownership only; no release execution, publish action, prompt, handler IO, or runtime configuration change.

Linear: SET-303