### PR TITLE
refactor(cli): extract inspection and runtime parsers

### DIFF
--- a/.changeset/cli-inspection-runtime-parsers.md
+++ b/.changeset/cli-inspection-runtime-parsers.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Move inspection, lookup, test runtime, hidden worker, and hook argument handling into typed command-owned parsers.

--- a/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
+++ b/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCliRequest } from "../cli-args";
+import { parseHooksCommandRequest } from "../hooks-args";
+import {
+  parseExplainCommandRequest,
+  parseListCommandRequest,
+  parseLookupCommandRequest,
+  parseStatusCommandRequest,
+} from "../inspect-args";
+import { parseTestCommandRequest } from "../test-args";
+
+const CONTEXT = { cwd: "/workspace/repo" } as const;
+
+const parseDirectRequest = (args: readonly string[]) => {
+  switch (args[0]) {
+    case "list":
+      return parseListCommandRequest(args, CONTEXT);
+    case "status":
+      return parseStatusCommandRequest(args, CONTEXT);
+    case "explain":
+      return parseExplainCommandRequest(args, CONTEXT);
+    case "lookup":
+      return parseLookupCommandRequest(args);
+    case "test":
+      return parseTestCommandRequest(args, CONTEXT);
+    default:
+      return parseHooksCommandRequest(args, CONTEXT);
+  }
+};
+
+const readOutcome = (run: () => unknown) => {
+  try {
+    return { ok: true, value: run() } as const;
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      ok: false,
+    } as const;
+  }
+};
+
+describe("SET-304 inspection and runtime route parsers", () => {
+  test("inspection routes own roots, scopes, machine mode, and paths", () => {
+    expect(
+      parseListCommandRequest(
+        ["list", "--root", "nested", "--scope", "plugins", "--json"],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      options: { scopes: ["plugins"] },
+      rootPath: "/workspace/repo/nested",
+    });
+    expect(
+      parseStatusCommandRequest(["status", "--root=nested", "--json"], CONTEXT)
+    ).toEqual({
+      jsonOutput: true,
+      options: {},
+      rootPath: "/workspace/repo/nested",
+    });
+    expect(
+      parseExplainCommandRequest(
+        ["explain", "plugins/example", "--scope=plugins", "--json", "--yes"],
+        CONTEXT
+      )
+    ).toEqual({
+      jsonOutput: true,
+      options: { scopes: ["plugins"] },
+      path: "plugins/example",
+      rootPath: "/workspace/repo",
+    });
+  });
+
+  test("lookup owns optional compatibility values and feature grammar", () => {
+    expect(
+      parseLookupCommandRequest([
+        "lookup",
+        "hooks",
+        "events",
+        "--compat",
+        "claude",
+        "codex,cursor",
+        "--compat=codex",
+        "--fields",
+        "--field",
+        "payload.command",
+        "--json",
+      ])
+    ).toEqual({
+      kind: "query",
+      value: {
+        jsonOutput: true,
+        lookupAspects: ["events"],
+        lookupField: "payload.command",
+        lookupSubject: "hooks",
+        lookupTargets: ["claude", "codex", "cursor"],
+        lookupViews: ["compat", "fields"],
+      },
+    });
+    expect(parseLookupCommandRequest(["lookup", "--compat"])).toEqual({
+      kind: "query",
+      value: {
+        jsonOutput: false,
+        lookupAspects: [],
+        lookupField: undefined,
+        lookupSubject: undefined,
+        lookupTargets: [],
+        lookupViews: ["compat"],
+      },
+    });
+    expect(
+      parseLookupCommandRequest([
+        "lookup",
+        "features",
+        "hooks.runtime-context",
+        "--json",
+      ])
+    ).toEqual({
+      kind: "features",
+      value: { featureId: "hooks.runtime-context", jsonOutput: true },
+    });
+    expect(
+      parseLookupCommandRequest([
+        "lookup",
+        "--scope",
+        "plugins",
+        "--updated",
+        "--yes",
+        "--name",
+        "ignored",
+      ])
+    ).toMatchObject({ kind: "query" });
+  });
+
+  test("test owns declared, ad hoc, retained, and hidden worker grammar", () => {
+    expect(
+      parseTestCommandRequest(
+        ["test", "declared", "--root", "nested", "--json"],
+        CONTEXT
+      )
+    ).toMatchObject({
+      jsonOutput: true,
+      rootPath: "/workspace/repo/nested",
+      testName: "declared",
+      tryPlugins: [],
+    });
+    expect(
+      parseTestCommandRequest(
+        [
+          "test",
+          "--target",
+          "codex",
+          "--prompt",
+          "Run it",
+          "--plugin",
+          "first",
+          "--plugin=second",
+          "--background",
+          "--timeout-ms",
+          "5000",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({
+      tryBackground: true,
+      tryPlugins: ["first", "second"],
+      tryPrompt: "Run it",
+      tryTarget: "codex",
+      tryTimeoutMs: 5000,
+    });
+    expect(
+      parseTestCommandRequest(
+        ["test", "tail", "run-id", "--lines=25", "--json"],
+        CONTEXT
+      )
+    ).toMatchObject({
+      jsonOutput: true,
+      tryLines: 25,
+      tryRunId: "run-id",
+      trySubcommand: "tail",
+    });
+    expect(
+      parseTestCommandRequest(
+        ["test", "worker", "run-id", "--root", "nested"],
+        CONTEXT
+      )
+    ).toMatchObject({
+      rootPath: "/workspace/repo/nested",
+      tryRunId: "run-id",
+      trySubcommand: "worker",
+    });
+  });
+
+  test("hooks owns context, print, and run protocol grammar", () => {
+    expect(
+      parseHooksCommandRequest(
+        [
+          "hooks",
+          "context",
+          "--event",
+          "Stop",
+          "--format",
+          "env",
+          "--context-fields",
+          "provider,hook.event",
+          "--root",
+          "nested",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({
+      hookContextEvent: "Stop",
+      hookContextFields: ["provider", "hook.event"],
+      hookContextFormat: "env",
+      hookSubcommand: "context",
+      rootPath: "/workspace/repo/nested",
+    });
+    expect(
+      parseHooksCommandRequest(
+        [
+          "hooks",
+          "print",
+          "--runner",
+          "lefthook",
+          "--target",
+          "codex",
+          "--pre-push",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({
+      hookPrePush: true,
+      hookRunner: "lefthook",
+      hookSubcommand: "print",
+      hookTarget: "codex",
+    });
+    expect(
+      parseHooksCommandRequest(
+        ["hooks", "run", "stop", "--root", "nested"],
+        CONTEXT
+      )
+    ).toMatchObject({
+      hookRunEvent: "stop",
+      hookSubcommand: "run",
+      rootPath: "/workspace/repo/nested",
+    });
+  });
+
+  test("preserves exceptional validation and diagnostic precedence", () => {
+    const cases = [
+      {
+        message: "skillset: status only supports --root and --json",
+        run: () =>
+          parseStatusCommandRequest(["status", "--scope", "plugins"], CONTEXT),
+      },
+      {
+        message:
+          "skillset: expected lookup features to use only an optional feature id and --json",
+        run: () =>
+          parseLookupCommandRequest(["lookup", "features", "id", "--fields"]),
+      },
+      {
+        message:
+          "skillset: expected lookup features to use only an optional feature id and --json",
+        run: () =>
+          parseLookupCommandRequest([
+            "lookup",
+            "features",
+            "id",
+            "--scope",
+            "plugins",
+          ]),
+      },
+      {
+        message: "skillset: --root is not supported with lookup",
+        run: () => parseLookupCommandRequest(["lookup", "--root", "nested"]),
+      },
+      {
+        message:
+          "skillset: declared test declared cannot be combined with ad hoc test flags",
+        run: () =>
+          parseTestCommandRequest(
+            ["test", "declared", "--target", "codex", "--prompt", "run"],
+            CONTEXT
+          ),
+      },
+      {
+        message: "skillset: test worker requires run id",
+        run: () => parseTestCommandRequest(["test", "worker"], CONTEXT),
+      },
+      {
+        message:
+          "skillset: test worker only supports <run-id> and --root <path>",
+        run: () =>
+          parseTestCommandRequest(
+            ["test", "worker", "run-id", "--json"],
+            CONTEXT
+          ),
+      },
+      {
+        message: "skillset: hook options are only supported with hooks print",
+        run: () =>
+          parseHooksCommandRequest(
+            ["hooks", "context", "--runner", "git"],
+            CONTEXT
+          ),
+      },
+      {
+        message: "skillset: --root is not supported with hooks print",
+        run: () =>
+          parseHooksCommandRequest(
+            ["hooks", "print", "--root", "nested", "--updated"],
+            CONTEXT
+          ),
+      },
+    ] as const;
+    for (const { message, run } of cases) {
+      expect(run).toThrow(message);
+    }
+  });
+
+  test("matches facade compatibility across owned routes and known flag families", () => {
+    const routes = [
+      ["list"],
+      ["status"],
+      ["explain", "managed/path"],
+      ["lookup"],
+      ["lookup", "hooks", "events"],
+      ["lookup", "features", "hooks.runtime-context"],
+      ["test"],
+      ["test", "declared"],
+      ["test", "list"],
+      ["test", "status", "run-id"],
+      ["test", "tail", "run-id"],
+      ["test", "worker", "run-id"],
+      ["hooks", "context", "--event", "Stop"],
+      ["hooks", "print"],
+      ["hooks", "run", "stop"],
+    ] as const;
+    const options = [
+      ["--root", "nested"],
+      ["--root=nested"],
+      ["--json"],
+      ["--jsonl"],
+      ["--scope", "plugins"],
+      ["--updated"],
+      ["--all"],
+      ["--yes"],
+      ["--compat"],
+      ["--compat", "claude", "codex,cursor"],
+      ["--compat=codex"],
+      ["--frontmatter"],
+      ["--fields"],
+      ["--field", "payload.command"],
+      ["--values"],
+      ["--events"],
+      ["--examples"],
+      ["--schema"],
+      ["--target", "codex"],
+      ["--prompt", "Run it"],
+      ["--prompt-file", "prompt.md"],
+      ["--plugin", "example"],
+      ["--claude-setting-sources", "user,project"],
+      ["--timeout-ms", "5000"],
+      ["--lines", "25"],
+      ["--name", "named"],
+      ["--background"],
+      ["--runner", "git"],
+      ["--event", "Stop"],
+      ["--format", "env"],
+      ["--context-fields", "provider,hook.event"],
+      ["--agent-runtime"],
+      ["--pre-commit"],
+      ["--pre-push"],
+      ["--id", "source-id"],
+      ["--in", "plugin-id"],
+      ["--adopt", "candidate"],
+      ["--preset", "default"],
+      ["--append"],
+      ["--bump", "patch"],
+      ["--group", "group-id"],
+      ["--reason", "because"],
+      ["--reason-file", "reason.md"],
+      ["--ref", "change-ref"],
+      ["--since", "origin/main"],
+      ["--staged"],
+      ["--isolated"],
+      ["--targets", "codex"],
+      ["--include", "ci"],
+      ["--fix"],
+      ["--ci"],
+      ["--only", "outputs"],
+      ["--use", "source"],
+      ["--report", "report.md"],
+      ["--write"],
+    ] as const;
+    const scenarios = routes.flatMap((route) => [
+      ...options.map((option) => [...route, ...option]),
+      ...options.flatMap((first) =>
+        options.map((second) => [...route, ...first, ...second])
+      ),
+    ]);
+
+    for (const args of scenarios) {
+      const direct = readOutcome(() => parseDirectRequest(args));
+      const facade = readOutcome(() => parseCliRequest(args, CONTEXT).request);
+      expect(direct).toEqual(facade);
+    }
+  });
+});

--- a/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
+++ b/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
@@ -314,6 +314,19 @@ describe("SET-304 inspection and runtime route parsers", () => {
             CONTEXT
           ),
       },
+      {
+        message: "skillset: unknown option --jsonl",
+        run: () => parseListCommandRequest(["list", "--jsonl"], CONTEXT),
+      },
+      {
+        message: "skillset: unknown option --jsonl",
+        run: () => parseTestCommandRequest(["test", "--jsonl"], CONTEXT),
+      },
+      {
+        message: "skillset: unknown option --jsonl",
+        run: () =>
+          parseHooksCommandRequest(["hooks", "run", "stop", "--jsonl"], CONTEXT),
+      },
     ] as const;
     for (const { message, run } of cases) {
       expect(run).toThrow(message);

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -41,8 +41,15 @@ import {
   parseDistributionCommandRequest,
   parseMarketplaceCommandRequest,
 } from "./distribution-args";
+import { parseHooksCommandRequest } from "./hooks-args";
 import type { ImportKind, ImportProvider } from "./import";
 import { parseInitCommandRequest } from "./init-args";
+import {
+  parseExplainCommandRequest,
+  parseListCommandRequest,
+  parseLookupCommandRequest,
+  parseStatusCommandRequest,
+} from "./inspect-args";
 import {
   addLookupTarget,
   addLookupTargets,
@@ -78,6 +85,7 @@ import {
   parseImportCommandRequest,
   parseNewCommandRequest,
 } from "./source-args";
+import { parseTestCommandRequest } from "./test-args";
 import { readClaudeSettingSources } from "./try";
 import type { TryClaudeSettingSources, TrySubcommand } from "./try";
 import { isTrySubcommand, validateTryFlags } from "./try-cli";
@@ -87,49 +95,7 @@ type Command = CliCommand;
 type DistributionSubcommand = "plan";
 type MarketplaceSubcommand = "check" | "update";
 
-interface ParsedArgs {
-  readonly command: Command;
-  readonly hookAgentRuntime: boolean;
-  readonly hookContextEvent?: string;
-  readonly hookContextFields?: readonly HookRuntimeContextField[];
-  readonly hookContextFormat?: HookRuntimeContextFormat;
-  readonly hookPreCommit: boolean;
-  readonly hookPrePush: boolean;
-  readonly hookRunner?: HookRunner;
-  readonly hookRunEvent?: HookRunEvent;
-  readonly hookSubcommand?: HookSubcommand;
-  readonly hookTarget?: TargetName;
-  readonly importPath?: string;
-  readonly jsonOutput: boolean;
-  readonly lookupAspects: readonly string[];
-  readonly lookupField?: string;
-  readonly lookupFeatures: boolean;
-  readonly lookupSubject?: LookupSubject;
-  readonly lookupTargets: readonly TargetName[];
-  readonly lookupViews: readonly LookupView[];
-  readonly options: SkillsetOptions;
-  readonly tryBackground: boolean;
-  readonly tryClaudeSettingSources?: TryClaudeSettingSources;
-  readonly tryLines?: number;
-  readonly tryName?: string;
-  readonly tryPlugins: readonly string[];
-  readonly tryPrompt?: string;
-  readonly tryPromptFile?: string;
-  readonly tryRunId?: string;
-  readonly trySubcommand?: TrySubcommand;
-  readonly tryTarget?: TargetName;
-  readonly tryTimeoutMs?: number;
-  readonly rootExplicit: boolean;
-  readonly rootPath: string;
-  readonly testName?: string;
-  readonly yes: boolean;
-}
-
-function parseArgs(
-  command: Command,
-  args: readonly string[],
-  context: CliParseContext
-): ParsedArgs {
+function parseArgs(command: Command, args: readonly string[]): void {
   let changeSubcommand: ChangeSubcommand | undefined;
   let distributionName: string | undefined;
   let distributionSubcommand: DistributionSubcommand | undefined;
@@ -843,7 +809,6 @@ function parseArgs(
     rootExplicit
   );
   validateListFlags(command, buildMode);
-
   validateLegacyIsolatedFlag(command, isolated);
 
   validateLegacyReleaseFlags(command, {
@@ -872,125 +837,6 @@ function parseArgs(
     ...(newPresets === undefined ? {} : { presets: newPresets }),
     ...(newScope === undefined ? {} : { scope: newScope }),
   });
-  const options: SkillsetOptions = {
-    ...(buildMode === undefined ? {} : { buildMode }),
-    ...(scopes === undefined ? {} : { scopes }),
-    ...(sourceDir === undefined ? {} : { sourceDir }),
-    ...(distDir === undefined ? {} : { distDir }),
-    ...(isolated ? { isolated: true } : {}),
-  };
-
-  return {
-    command,
-    hookAgentRuntime,
-    ...(hookContextEvent === undefined ? {} : { hookContextEvent }),
-    ...(hookContextFields === undefined ? {} : { hookContextFields }),
-    ...(hookContextFormat === undefined ? {} : { hookContextFormat }),
-    hookPreCommit,
-    hookPrePush,
-    ...(hookRunner === undefined ? {} : { hookRunner }),
-    ...(hookRunEvent === undefined ? {} : { hookRunEvent }),
-    ...(hookSubcommand === undefined ? {} : { hookSubcommand }),
-    ...(hookTarget === undefined ? {} : { hookTarget }),
-    ...(importPath === undefined ? {} : { importPath }),
-    jsonOutput,
-    lookupAspects,
-    ...(lookupField === undefined ? {} : { lookupField }),
-    lookupFeatures,
-    ...(lookupSubject === undefined ? {} : { lookupSubject }),
-    lookupTargets,
-    lookupViews,
-    options,
-    tryBackground,
-    ...(tryClaudeSettingSources === undefined
-      ? {}
-      : { tryClaudeSettingSources }),
-    ...(tryLines === undefined ? {} : { tryLines }),
-    ...(tryName === undefined ? {} : { tryName }),
-    tryPlugins,
-    ...(tryPrompt === undefined ? {} : { tryPrompt }),
-    ...(tryPromptFile === undefined ? {} : { tryPromptFile }),
-    ...(tryRunId === undefined ? {} : { tryRunId }),
-    ...(trySubcommand === undefined ? {} : { trySubcommand }),
-    ...(tryTarget === undefined ? {} : { tryTarget }),
-    ...(tryTimeoutMs === undefined ? {} : { tryTimeoutMs }),
-    rootExplicit,
-    rootPath: resolveCliRoot(context, rootPath),
-    ...(testName === undefined ? {} : { testName }),
-    yes,
-  };
-}
-
-function createCliRequest(parsed: ParsedArgs): CliRequest {
-  const { command, jsonOutput, options, rootPath, yes } = parsed;
-  if (command === "hooks")
-    return {
-      command,
-      request: {
-        hookAgentRuntime: parsed.hookAgentRuntime,
-        hookContextEvent: parsed.hookContextEvent,
-        hookContextFields: parsed.hookContextFields,
-        hookContextFormat: parsed.hookContextFormat,
-        hookPreCommit: parsed.hookPreCommit,
-        hookPrePush: parsed.hookPrePush,
-        hookRunEvent: parsed.hookRunEvent,
-        hookRunner: parsed.hookRunner,
-        hookSubcommand: parsed.hookSubcommand,
-        hookTarget: parsed.hookTarget,
-        rootPath,
-      },
-    };
-  if (command === "test")
-    return {
-      command,
-      request: {
-        jsonOutput,
-        options,
-        rootPath,
-        testName: parsed.testName,
-        tryBackground: parsed.tryBackground,
-        tryClaudeSettingSources: parsed.tryClaudeSettingSources,
-        tryLines: parsed.tryLines,
-        tryName: parsed.tryName,
-        tryPlugins: parsed.tryPlugins,
-        tryPrompt: parsed.tryPrompt,
-        tryPromptFile: parsed.tryPromptFile,
-        tryRunId: parsed.tryRunId,
-        trySubcommand: parsed.trySubcommand,
-        tryTarget: parsed.tryTarget,
-        tryTimeoutMs: parsed.tryTimeoutMs,
-      },
-    };
-  if (command === "list")
-    return { command, request: { jsonOutput, options, rootPath } };
-  if (command === "lookup")
-    return {
-      command,
-      request: parsed.lookupFeatures
-        ? {
-            kind: "features",
-            value: { featureId: parsed.importPath, jsonOutput },
-          }
-        : {
-            kind: "query",
-            value: {
-              jsonOutput,
-              lookupAspects: parsed.lookupAspects,
-              lookupField: parsed.lookupField,
-              lookupSubject: parsed.lookupSubject,
-              lookupTargets: parsed.lookupTargets,
-              lookupViews: parsed.lookupViews,
-            },
-          },
-    };
-  if (command === "explain")
-    return {
-      command,
-      request: { jsonOutput, options, path: parsed.importPath, rootPath },
-    };
-  if (command === "status")
-    return { command, request: { jsonOutput, options, rootPath } };
-  throw new Error(`skillset: unhandled command ${command}`);
 }
 
 export function parseCliRequest(
@@ -1004,7 +850,7 @@ export function parseCliRequest(
         `skillset: expected command ${renderExpectedCliCommands()}\n${USAGE}`
       );
     }
-    const parsed = parseArgs(command, args, context);
+    parseArgs(command, args);
     if (command === "change") {
       return { command, request: parseChangeCommandRequest(args, context) };
     }
@@ -1026,11 +872,23 @@ export function parseCliRequest(
         request: parseDistributionCommandRequest(args, context),
       };
     }
+    if (command === "explain") {
+      return { command, request: parseExplainCommandRequest(args, context) };
+    }
+    if (command === "hooks") {
+      return { command, request: parseHooksCommandRequest(args, context) };
+    }
     if (command === "import") {
       return { command, request: parseImportCommandRequest(args, context) };
     }
     if (command === "init") {
       return { command, request: parseInitCommandRequest(args, context) };
+    }
+    if (command === "list") {
+      return { command, request: parseListCommandRequest(args, context) };
+    }
+    if (command === "lookup") {
+      return { command, request: parseLookupCommandRequest(args) };
     }
     if (command === "marketplace") {
       return {
@@ -1053,10 +911,16 @@ export function parseCliRequest(
     if (command === "restore") {
       return { command, request: parseRestoreCommandRequest(args, context) };
     }
+    if (command === "status") {
+      return { command, request: parseStatusCommandRequest(args, context) };
+    }
+    if (command === "test") {
+      return { command, request: parseTestCommandRequest(args, context) };
+    }
     if (command === "update") {
       return { command, request: parseUpdateCommandRequest(args, context) };
     }
-    return createCliRequest(parsed);
+    throw new Error(`skillset: unhandled command ${command}`);
   } catch (error) {
     if (error instanceof CliOutputError) {
       throw error;

--- a/apps/skillset/src/hooks-args.ts
+++ b/apps/skillset/src/hooks-args.ts
@@ -379,7 +379,7 @@ export const parseHooksCommandRequest = (
     throw new Error("skillset: --json is not supported for this command route");
   }
   if (jsonlOutput) {
-    throw new Error("skillset: --jsonl is only supported with dev");
+    throw new Error("skillset: unknown option --jsonl");
   }
   if (lookupField !== undefined || lookupTargets.length > 0 || lookupView) {
     throw new Error("skillset: lookup flags are only supported with lookup");

--- a/apps/skillset/src/hooks-args.ts
+++ b/apps/skillset/src/hooks-args.ts
@@ -1,0 +1,449 @@
+import type {
+  BuildScope,
+  CompileBuildMode,
+  TargetName,
+} from "@skillset/core/internal/types";
+
+import { readChangeBump, setChangeReason } from "./change-args";
+import type { ChangeReasonInput } from "./change-workflow";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  readPositiveInteger,
+  readTargetNames,
+  resolveCliRoot,
+  tokenizeCsv,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type { HooksCommandRequest } from "./hooks-cli";
+import { addLookupTargets, setLookupField } from "./lookup-cli";
+import {
+  readHookRuntimeContextField,
+  readHookRuntimeContextFormat,
+  readHookRunEvent,
+} from "./runtime-hooks";
+import type {
+  HookRuntimeContextField,
+  HookRuntimeContextFormat,
+  HookRunner,
+  HookSubcommand,
+} from "./runtime-hooks";
+import { readClaudeSettingSources } from "./try";
+
+export const parseHooksCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): HooksCommandRequest => {
+  const hookSubcommand = readHookSubcommand(args[1]);
+  let index = 2;
+  let hookRunEvent: ReturnType<typeof readHookRunEvent> | undefined;
+  if (hookSubcommand === "run") {
+    hookRunEvent = readHookRunEvent(args[index]);
+    index += 1;
+  }
+
+  let buildMode: CompileBuildMode | undefined;
+  let changeSince: string | undefined;
+  let hookAgentRuntime = false;
+  let hookContextEvent: string | undefined;
+  let hookContextFields: readonly HookRuntimeContextField[] | undefined;
+  let hookContextFormat: HookRuntimeContextFormat | undefined;
+  let hookPreCommit = false;
+  let hookPrePush = false;
+  let hookRunner: HookRunner | undefined;
+  let hookTarget: TargetName | undefined;
+  let importMetadata = false;
+  let rootExplicit = false;
+  let rootPath: string | undefined;
+  let scopes: readonly BuildScope[] | undefined;
+  let yes = false;
+  let jsonOutput = false;
+  let jsonlOutput = false;
+  let lookupField: string | undefined;
+  let lookupTargets: TargetName[] = [];
+  let lookupView = false;
+  let testFlag = false;
+  let isolated = false;
+  let newFlag = false;
+  let reconcileFlag = false;
+  let adoptFlag = false;
+  let changeFlag = false;
+  let changeReason: ChangeReasonInput | undefined;
+  let readinessFlag = false;
+  let setupFlag = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    switch (option.flag) {
+      case "--root": {
+        rootPath = reader.readRequiredOptionValue(option);
+        rootExplicit = true;
+        break;
+      }
+      case "--runner": {
+        hookRunner = readHookRunner(reader.readRequiredOptionValue(option));
+        break;
+      }
+      case "--target": {
+        hookTarget = readHookTarget(reader.readRequiredOptionValue(option));
+        break;
+      }
+      case "--event": {
+        hookContextEvent = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--format": {
+        hookContextFormat = readHookRuntimeContextFormat(
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      }
+      case "--context-fields": {
+        hookContextFields = readHookRuntimeContextFields(
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      }
+      case "--agent-runtime": {
+        assertBooleanOption(option);
+        hookAgentRuntime = true;
+        break;
+      }
+      case "--pre-commit": {
+        assertBooleanOption(option);
+        hookPreCommit = true;
+        break;
+      }
+      case "--pre-push": {
+        assertBooleanOption(option);
+        hookPrePush = true;
+        break;
+      }
+      case "--updated":
+      case "--all": {
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      }
+      case "--scope": {
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      }
+      case "--since": {
+        changeSince = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--yes": {
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      }
+      case "--json": {
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      }
+      case "--jsonl": {
+        assertBooleanOption(option);
+        jsonlOutput = true;
+        break;
+      }
+      case "--compat": {
+        lookupView = true;
+        for (const value of reader.readOptionalOptionValues(option)) {
+          lookupTargets = addLookupTargets(lookupTargets, value);
+        }
+        break;
+      }
+      case "--frontmatter":
+      case "--fields":
+      case "--values":
+      case "--events":
+      case "--examples":
+      case "--schema": {
+        assertBooleanOption(option);
+        lookupView = true;
+        break;
+      }
+      case "--field": {
+        lookupField = setLookupField(
+          lookupField,
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      }
+      case "--prompt":
+      case "--prompt-file":
+      case "--plugin": {
+        reader.readRequiredOptionValue(option);
+        testFlag = true;
+        break;
+      }
+      case "--claude-setting-sources": {
+        readClaudeSettingSources(
+          reader.readRequiredOptionValue(option),
+          "--claude-setting-sources"
+        );
+        testFlag = true;
+        break;
+      }
+      case "--timeout-ms":
+      case "--lines": {
+        readPositiveInteger(
+          reader.readRequiredOptionValue(option),
+          option.flag
+        );
+        testFlag = true;
+        break;
+      }
+      case "--background": {
+        assertBooleanOption(option);
+        testFlag = true;
+        break;
+      }
+      case "--name":
+      case "--kind":
+      case "--from": {
+        reader.readRequiredOptionValue(option);
+        importMetadata = true;
+        break;
+      }
+      case "--append":
+      case "--staged": {
+        assertBooleanOption(option);
+        changeFlag = true;
+        break;
+      }
+      case "--group":
+      case "--ref": {
+        reader.readRequiredOptionValue(option);
+        changeFlag = true;
+        break;
+      }
+      case "--bump": {
+        readChangeBump(reader.readRequiredOptionValue(option));
+        changeFlag = true;
+        break;
+      }
+      case "--reason": {
+        const value = reader.readRequiredOptionValue(option);
+        changeReason = setChangeReason(
+          changeReason,
+          value === "-" ? { kind: "stdin" } : { kind: "inline", value }
+        );
+        changeFlag = true;
+        break;
+      }
+      case "--reason-file": {
+        changeReason = setChangeReason(changeReason, {
+          kind: "file",
+          path: reader.readRequiredOptionValue(option),
+        });
+        changeFlag = true;
+        break;
+      }
+      case "--targets": {
+        readTargetNames(reader.readRequiredOptionValue(option));
+        setupFlag = true;
+        break;
+      }
+      case "--include": {
+        const includes = tokenizeCsv(reader.readRequiredOptionValue(option));
+        if (includes.length === 0) {
+          throw new Error("skillset: --include requires at least one value");
+        }
+        if (includes.some((include) => include !== "ci")) {
+          throw new Error("skillset: expected --include ci");
+        }
+        setupFlag = true;
+        break;
+      }
+      case "--adopt": {
+        reader.readRequiredOptionValue(option);
+        adoptFlag = true;
+        break;
+      }
+      case "--fix":
+      case "--ci": {
+        assertBooleanOption(option);
+        readinessFlag = true;
+        break;
+      }
+      case "--only":
+      case "--report": {
+        const value = reader.readRequiredOptionValue(option);
+        if (option.flag === "--only" && value !== "outputs") {
+          throw new Error("skillset: expected --only outputs");
+        }
+        readinessFlag = true;
+        break;
+      }
+      case "--write": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --write is only supported with check or dev"
+        );
+      }
+      case "--isolated": {
+        assertBooleanOption(option);
+        isolated = true;
+        break;
+      }
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        reconcileFlag = true;
+        break;
+      }
+      case "--id":
+      case "--in":
+      case "--preset": {
+        reader.readRequiredOptionValue(option);
+        newFlag = true;
+        break;
+      }
+      default: {
+        throw new Error(`skillset: unknown option ${option.raw}`);
+      }
+    }
+  }
+
+  if (changeFlag) {
+    throw new Error(
+      "skillset: change options are only supported with change commands"
+    );
+  }
+  const hasPrintFlag =
+    hookAgentRuntime ||
+    hookPreCommit ||
+    hookPrePush ||
+    hookRunner !== undefined ||
+    hookTarget !== undefined;
+  if (hasPrintFlag && hookSubcommand !== "print") {
+    throw new Error(
+      "skillset: hook options are only supported with hooks print"
+    );
+  }
+  const hasContextFlag =
+    hookContextEvent !== undefined ||
+    hookContextFields !== undefined ||
+    hookContextFormat !== undefined;
+  if (hasContextFlag && hookSubcommand !== "context") {
+    throw new Error(
+      "skillset: hook context options are only supported with hooks context"
+    );
+  }
+  if (hookSubcommand === "context" && hookContextEvent === undefined) {
+    throw new Error("skillset: hooks context requires --event");
+  }
+  if (hookSubcommand === "print" && rootExplicit) {
+    throw new Error("skillset: --root is not supported with hooks print");
+  }
+  if (
+    buildMode !== undefined ||
+    scopes !== undefined ||
+    changeSince !== undefined ||
+    importMetadata ||
+    yes
+  ) {
+    throw new Error(
+      `skillset: non-hook options are not supported with hooks ${hookSubcommand}`
+    );
+  }
+  if (setupFlag) {
+    throw new Error("skillset: setup options are only supported with init");
+  }
+  if (adoptFlag) {
+    throw new Error(
+      "skillset: --adopt and init acquisition --from are only supported with init"
+    );
+  }
+  if (readinessFlag) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (testFlag) {
+    throw new Error(
+      "skillset: ad hoc test options are only supported with test"
+    );
+  }
+  if (jsonOutput) {
+    throw new Error("skillset: --json is not supported for this command route");
+  }
+  if (jsonlOutput) {
+    throw new Error("skillset: --jsonl is only supported with dev");
+  }
+  if (lookupField !== undefined || lookupTargets.length > 0 || lookupView) {
+    throw new Error("skillset: lookup flags are only supported with lookup");
+  }
+  if (isolated) {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+  if (reconcileFlag) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  if (newFlag) {
+    throw new Error("skillset: new options are only supported with new");
+  }
+  return {
+    hookAgentRuntime,
+    hookContextEvent,
+    hookContextFields,
+    hookContextFormat,
+    hookPreCommit,
+    hookPrePush,
+    hookRunEvent,
+    hookRunner,
+    hookSubcommand,
+    hookTarget,
+    rootPath: resolveCliRoot(context, rootPath),
+  };
+};
+
+const readHookSubcommand = (value: string | undefined): HookSubcommand => {
+  if (value === "context" || value === "print" || value === "run") {
+    return value;
+  }
+  throw new Error("skillset: expected hooks subcommand context, print, or run");
+};
+
+const readHookRuntimeContextFields = (
+  value: string
+): readonly HookRuntimeContextField[] => {
+  const fields = tokenizeCsv(value);
+  if (fields.length === 0) {
+    throw new Error("skillset: --context-fields requires at least one field");
+  }
+  return fields.map(readHookRuntimeContextField);
+};
+
+const readHookRunner = (value: string): HookRunner => {
+  if (
+    value === "git" ||
+    value === "husky" ||
+    value === "lefthook" ||
+    value === "pre-commit"
+  ) {
+    return value;
+  }
+  throw new Error(
+    "skillset: expected --runner lefthook, husky, pre-commit, or git"
+  );
+};
+
+const readHookTarget = (value: string): TargetName => {
+  if (value === "claude" || value === "codex") {
+    return value;
+  }
+  throw new Error("skillset: expected --target claude or codex");
+};

--- a/apps/skillset/src/inspect-args.ts
+++ b/apps/skillset/src/inspect-args.ts
@@ -1,0 +1,803 @@
+import type { LookupView } from "@skillset/core";
+import type {
+  SkillsetOptions,
+  TargetName,
+} from "@skillset/core/internal/types";
+
+import { readChangeBump, setChangeReason } from "./change-args";
+import type { ChangeReasonInput } from "./change-workflow";
+import {
+  assertBooleanOption,
+  CliArgReader,
+  type CliOptionToken,
+} from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  readPositiveInteger,
+  readTargetNames,
+  resolveCliRoot,
+  tokenizeCsv,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import type {
+  ExplainCommandRequest,
+  ListCommandRequest,
+  LookupFeaturesCommandRequest,
+  LookupRouteRequest,
+  StatusCommandRequest,
+} from "./inspect-cli";
+import {
+  addLookupTargets,
+  addLookupView,
+  readLookupSubject,
+  setLookupField,
+} from "./lookup-cli";
+import {
+  readHookRuntimeContextField,
+  readHookRuntimeContextFormat,
+} from "./runtime-hooks";
+import { readClaudeSettingSources } from "./try";
+
+type LookupCommandRequest =
+  | { readonly kind: "features"; readonly value: LookupFeaturesCommandRequest }
+  | { readonly kind: "query"; readonly value: LookupRouteRequest };
+
+export const parseListCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): ListCommandRequest => {
+  const parsed = parseInspectionOptions("list", args, 1, context);
+  if (parsed.options.buildMode !== undefined) {
+    throw new Error(
+      "skillset: --updated and --all are not supported with list"
+    );
+  }
+  return {
+    jsonOutput: parsed.jsonOutput,
+    options: parsed.options,
+    rootPath: parsed.rootPath,
+  };
+};
+
+export const parseStatusCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): StatusCommandRequest => {
+  const parsed = parseInspectionOptions("status", args, 1, context);
+  return {
+    jsonOutput: parsed.jsonOutput,
+    options: {},
+    rootPath: parsed.rootPath,
+  };
+};
+
+export const parseExplainCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): ExplainCommandRequest => {
+  const path = args[1];
+  if (path === undefined || path.startsWith("--")) {
+    throw new Error("skillset: expected a path to explain");
+  }
+  const parsed = parseInspectionOptions("explain", args, 2, context);
+  return {
+    jsonOutput: parsed.jsonOutput,
+    options: parsed.options,
+    path,
+    rootPath: parsed.rootPath,
+  };
+};
+
+export const parseLookupCommandRequest = (
+  args: readonly string[]
+): LookupCommandRequest => {
+  let index = 1;
+  let featureId: string | undefined;
+  let features = false;
+  let lookupAspects: string[] = [];
+  let lookupField: string | undefined;
+  let lookupSubject: ReturnType<typeof readLookupSubject> | undefined;
+  let lookupTargets: TargetName[] = [];
+  let lookupViews: LookupView[] = [];
+  let jsonOutput = false;
+  let featureOption = false;
+  let rootExplicit = false;
+  let ignoredBuildMode: "all" | "updated" | undefined;
+  const cross = createInspectionCrossFlags();
+
+  const first = args[index];
+  if (first === "features") {
+    features = true;
+    index += 1;
+    const value = args[index];
+    if (value !== undefined && !value.startsWith("--")) {
+      featureId = value;
+      index += 1;
+    }
+  } else if (first !== undefined && !first.startsWith("--")) {
+    lookupSubject = readLookupSubject(first);
+    index += 1;
+    while (args[index] !== undefined && !args[index]?.startsWith("--")) {
+      const aspect = args[index];
+      if (aspect !== undefined) {
+        lookupAspects = [...lookupAspects, aspect];
+      }
+      index += 1;
+    }
+  }
+
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    if (features && option.flag !== "--json") {
+      featureOption = true;
+    }
+    if (readInspectionCrossOption(reader, option, cross, true)) {
+      continue;
+    }
+    switch (option.flag) {
+      case "--compat": {
+        lookupViews = addLookupView(lookupViews, "compat");
+        for (const value of reader.readOptionalOptionValues(option)) {
+          lookupTargets = addLookupTargets(lookupTargets, value);
+        }
+        break;
+      }
+      case "--frontmatter":
+      case "--fields":
+      case "--values":
+      case "--events":
+      case "--examples":
+      case "--schema": {
+        assertBooleanOption(option);
+        lookupViews = addLookupView(
+          lookupViews,
+          option.flag.slice(2) as LookupView
+        );
+        break;
+      }
+      case "--field": {
+        lookupField = setLookupField(
+          lookupField,
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      }
+      case "--json": {
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      }
+      case "--scope":
+      case "--name":
+      case "--kind":
+      case "--from": {
+        reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        ignoredBuildMode = mergeBuildMode(
+          ignoredBuildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--yes": {
+        assertBooleanOption(option);
+        break;
+      }
+      case "--root": {
+        reader.readRequiredOptionValue(option);
+        rootExplicit = true;
+        break;
+      }
+      case "--append":
+      case "--staged": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: change options are only supported with change commands"
+        );
+      }
+      case "--bump":
+      case "--group":
+      case "--reason":
+      case "--reason-file":
+      case "--ref": {
+        reader.readRequiredOptionValue(option);
+        throw new Error(
+          "skillset: change options are only supported with change commands"
+        );
+      }
+      case "--targets":
+      case "--include": {
+        reader.readRequiredOptionValue(option);
+        throw new Error("skillset: setup options are only supported with init");
+      }
+      case "--adopt": {
+        reader.readRequiredOptionValue(option);
+        throw new Error(
+          "skillset: --adopt and init acquisition --from are only supported with init"
+        );
+      }
+      case "--fix":
+      case "--ci": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: readiness flags are only supported with check"
+        );
+      }
+      case "--only":
+      case "--report": {
+        const value = reader.readRequiredOptionValue(option);
+        if (option.flag === "--only" && value !== "outputs") {
+          throw new Error("skillset: expected --only outputs");
+        }
+        throw new Error(
+          "skillset: readiness flags are only supported with check"
+        );
+      }
+      case "--since": {
+        reader.readRequiredOptionValue(option);
+        throw new Error(
+          "skillset: --since is only supported with check --ci or change commands"
+        );
+      }
+      case "--write": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --write is only supported with check or dev"
+        );
+      }
+      case "--isolated": {
+        assertBooleanOption(option);
+        if (features) {
+          featureOption = true;
+          break;
+        }
+        throw new Error(
+          "skillset: --isolated is only supported with build, check --only outputs, or diff"
+        );
+      }
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        if (features) {
+          featureOption = true;
+          break;
+        }
+        throw new Error("skillset: --use is only supported with reconcile");
+      }
+      case "--id":
+      case "--in":
+      case "--preset": {
+        reader.readRequiredOptionValue(option);
+        if (features) {
+          featureOption = true;
+          break;
+        }
+        throw new Error("skillset: new options are only supported with new");
+      }
+      default: {
+        throw new Error(`skillset: unknown option ${option.raw}`);
+      }
+    }
+  }
+
+  validateInspectionCrossFlags(cross);
+
+  if (features) {
+    if (
+      lookupField !== undefined ||
+      lookupTargets.length > 0 ||
+      lookupViews.length > 0 ||
+      featureOption ||
+      cross.isolated ||
+      cross.newSource ||
+      cross.reconcile ||
+      rootExplicit
+    ) {
+      throw new Error(
+        "skillset: expected lookup features to use only an optional feature id and --json"
+      );
+    }
+    return { kind: "features", value: { featureId, jsonOutput } };
+  }
+  if (rootExplicit) {
+    throw new Error("skillset: --root is not supported with lookup");
+  }
+  validateInspectionLateFlags(cross);
+  return {
+    kind: "query",
+    value: {
+      jsonOutput,
+      lookupAspects,
+      lookupField,
+      lookupSubject,
+      lookupTargets,
+      lookupViews,
+    },
+  };
+};
+
+interface InspectionOptions {
+  readonly jsonOutput: boolean;
+  readonly options: SkillsetOptions;
+  readonly rootPath: string;
+}
+
+interface InspectionCrossFlags {
+  adopt: boolean;
+  change: boolean;
+  changeReason?: ChangeReasonInput;
+  hookContext: boolean;
+  hookPrint: boolean;
+  jsonl: boolean;
+  isolated: boolean;
+  lookup: boolean;
+  lookupField?: string;
+  newSource: boolean;
+  readiness: boolean;
+  reconcile: boolean;
+  setup: boolean;
+  since: boolean;
+  test: boolean;
+}
+
+const createInspectionCrossFlags = (): InspectionCrossFlags => ({
+  adopt: false,
+  change: false,
+  hookContext: false,
+  hookPrint: false,
+  jsonl: false,
+  isolated: false,
+  lookup: false,
+  newSource: false,
+  readiness: false,
+  reconcile: false,
+  setup: false,
+  since: false,
+  test: false,
+});
+
+const readInspectionCrossOption = (
+  reader: CliArgReader,
+  option: CliOptionToken,
+  flags: InspectionCrossFlags,
+  lookupOwned: boolean
+): boolean => {
+  switch (option.flag) {
+    case "--runner":
+      readHookRunner(reader.readRequiredOptionValue(option));
+      flags.hookPrint = true;
+      return true;
+    case "--target":
+      readHookTarget(reader.readRequiredOptionValue(option));
+      flags.hookPrint = true;
+      return true;
+    case "--agent-runtime":
+    case "--pre-commit":
+    case "--pre-push":
+      assertBooleanOption(option);
+      flags.hookPrint = true;
+      return true;
+    case "--event":
+      reader.readRequiredOptionValue(option);
+      flags.hookContext = true;
+      return true;
+    case "--format":
+      readHookRuntimeContextFormat(reader.readRequiredOptionValue(option));
+      flags.hookContext = true;
+      return true;
+    case "--context-fields": {
+      const fields = tokenizeCsv(reader.readRequiredOptionValue(option));
+      if (fields.length === 0) {
+        throw new Error(
+          "skillset: --context-fields requires at least one field"
+        );
+      }
+      fields.map(readHookRuntimeContextField);
+      flags.hookContext = true;
+      return true;
+    }
+    case "--prompt":
+    case "--prompt-file":
+    case "--plugin":
+      reader.readRequiredOptionValue(option);
+      flags.test = true;
+      return true;
+    case "--claude-setting-sources":
+      readClaudeSettingSources(
+        reader.readRequiredOptionValue(option),
+        "--claude-setting-sources"
+      );
+      flags.test = true;
+      return true;
+    case "--timeout-ms":
+    case "--lines":
+      readPositiveInteger(reader.readRequiredOptionValue(option), option.flag);
+      flags.test = true;
+      return true;
+    case "--background":
+      assertBooleanOption(option);
+      flags.test = true;
+      return true;
+    case "--jsonl":
+      assertBooleanOption(option);
+      flags.jsonl = true;
+      return true;
+    case "--compat":
+      if (lookupOwned) return false;
+      addLookupTargets([], reader.readOptionalOptionValues(option).join(","));
+      flags.lookup = true;
+      return true;
+    case "--frontmatter":
+    case "--fields":
+    case "--values":
+    case "--events":
+    case "--examples":
+    case "--schema":
+      if (lookupOwned) return false;
+      assertBooleanOption(option);
+      flags.lookup = true;
+      return true;
+    case "--field":
+      if (lookupOwned) return false;
+      flags.lookupField = setLookupField(
+        flags.lookupField,
+        reader.readRequiredOptionValue(option)
+      );
+      flags.lookup = true;
+      return true;
+    case "--append":
+    case "--staged":
+      assertBooleanOption(option);
+      flags.change = true;
+      return true;
+    case "--bump":
+      readChangeBump(reader.readRequiredOptionValue(option));
+      flags.change = true;
+      return true;
+    case "--group":
+    case "--ref":
+      reader.readRequiredOptionValue(option);
+      flags.change = true;
+      return true;
+    case "--reason": {
+      const value = reader.readRequiredOptionValue(option);
+      flags.changeReason = setChangeReason(
+        flags.changeReason,
+        value === "-" ? { kind: "stdin" } : { kind: "inline", value }
+      );
+      flags.change = true;
+      return true;
+    }
+    case "--reason-file":
+      flags.changeReason = setChangeReason(flags.changeReason, {
+        kind: "file",
+        path: reader.readRequiredOptionValue(option),
+      });
+      flags.change = true;
+      return true;
+    case "--targets":
+      readTargetNames(reader.readRequiredOptionValue(option));
+      flags.setup = true;
+      return true;
+    case "--include": {
+      const includes = tokenizeCsv(reader.readRequiredOptionValue(option));
+      if (includes.length === 0) {
+        throw new Error("skillset: --include requires at least one value");
+      }
+      if (includes.some((include) => include !== "ci")) {
+        throw new Error("skillset: expected --include ci");
+      }
+      flags.setup = true;
+      return true;
+    }
+    case "--adopt":
+      reader.readRequiredOptionValue(option);
+      flags.adopt = true;
+      return true;
+    case "--fix":
+    case "--ci":
+      assertBooleanOption(option);
+      flags.readiness = true;
+      return true;
+    case "--only": {
+      const value = reader.readRequiredOptionValue(option);
+      if (value !== "outputs") {
+        throw new Error("skillset: expected --only outputs");
+      }
+      flags.readiness = true;
+      return true;
+    }
+    case "--report":
+      reader.readRequiredOptionValue(option);
+      flags.readiness = true;
+      return true;
+    case "--since":
+      reader.readRequiredOptionValue(option);
+      flags.since = true;
+      return true;
+    case "--write":
+      assertBooleanOption(option);
+      throw new Error("skillset: --write is only supported with check or dev");
+    case "--isolated":
+      assertBooleanOption(option);
+      flags.isolated = true;
+      return true;
+    case "--use": {
+      const value = reader.readRequiredOptionValue(option);
+      if (value !== "source" && value !== "output") {
+        throw new Error("skillset: --use expects source or output");
+      }
+      flags.reconcile = true;
+      return true;
+    }
+    case "--id":
+    case "--in":
+    case "--preset":
+      reader.readRequiredOptionValue(option);
+      flags.newSource = true;
+      return true;
+    default:
+      return false;
+  }
+};
+
+const validateInspectionCrossFlags = (flags: InspectionCrossFlags): void => {
+  if (flags.change) {
+    throw new Error(
+      "skillset: change options are only supported with change commands"
+    );
+  }
+  if (flags.hookPrint) {
+    throw new Error(
+      "skillset: hook options are only supported with hooks print"
+    );
+  }
+  if (flags.hookContext) {
+    throw new Error(
+      "skillset: hook context options are only supported with hooks context"
+    );
+  }
+  if (flags.setup) {
+    throw new Error("skillset: setup options are only supported with init");
+  }
+  if (flags.adopt) {
+    throw new Error(
+      "skillset: --adopt and init acquisition --from are only supported with init"
+    );
+  }
+  if (flags.readiness) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (flags.since) {
+    throw new Error(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  }
+  if (flags.test) {
+    throw new Error(
+      "skillset: ad hoc test options are only supported with test"
+    );
+  }
+  if (flags.jsonl) {
+    throw new Error("skillset: --jsonl is only supported with dev");
+  }
+  if (flags.lookup) {
+    throw new Error("skillset: lookup flags are only supported with lookup");
+  }
+};
+
+const validateInspectionLateFlags = (flags: InspectionCrossFlags): void => {
+  if (flags.isolated) {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+  if (flags.reconcile) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  if (flags.newSource) {
+    throw new Error("skillset: new options are only supported with new");
+  }
+};
+
+const readHookRunner = (value: string): void => {
+  if (
+    value !== "git" &&
+    value !== "husky" &&
+    value !== "lefthook" &&
+    value !== "pre-commit"
+  ) {
+    throw new Error(
+      "skillset: expected --runner lefthook, husky, pre-commit, or git"
+    );
+  }
+};
+
+const readHookTarget = (value: string): void => {
+  if (value !== "claude" && value !== "codex") {
+    throw new Error("skillset: expected --target claude or codex");
+  }
+};
+
+const parseInspectionOptions = (
+  route: "explain" | "list" | "status",
+  args: readonly string[],
+  index: number,
+  context: CliParseContext
+): InspectionOptions => {
+  let buildMode: "all" | "updated" | undefined;
+  let jsonOutput = false;
+  let rootPath: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let statusUnsupported = false;
+  const cross = createInspectionCrossFlags();
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    if (readInspectionCrossOption(reader, option, cross, false)) {
+      continue;
+    }
+    switch (option.flag) {
+      case "--root": {
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--scope": {
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        statusUnsupported = true;
+        break;
+      }
+      case "--updated":
+      case "--all": {
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        statusUnsupported = true;
+        break;
+      }
+      case "--json": {
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      }
+      case "--yes": {
+        assertBooleanOption(option);
+        statusUnsupported = true;
+        break;
+      }
+      case "--name":
+      case "--kind":
+      case "--from": {
+        reader.readRequiredOptionValue(option);
+        statusUnsupported = true;
+        break;
+      }
+      case "--append":
+      case "--staged": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: change options are only supported with change commands"
+        );
+      }
+      case "--bump":
+      case "--group":
+      case "--reason":
+      case "--reason-file":
+      case "--ref": {
+        reader.readRequiredOptionValue(option);
+        throw new Error(
+          "skillset: change options are only supported with change commands"
+        );
+      }
+      case "--targets":
+      case "--include": {
+        reader.readRequiredOptionValue(option);
+        throw new Error("skillset: setup options are only supported with init");
+      }
+      case "--adopt": {
+        reader.readRequiredOptionValue(option);
+        throw new Error(
+          "skillset: --adopt and init acquisition --from are only supported with init"
+        );
+      }
+      case "--fix":
+      case "--ci": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: readiness flags are only supported with check"
+        );
+      }
+      case "--only":
+      case "--report": {
+        const value = reader.readRequiredOptionValue(option);
+        if (option.flag === "--only" && value !== "outputs") {
+          throw new Error("skillset: expected --only outputs");
+        }
+        throw new Error(
+          "skillset: readiness flags are only supported with check"
+        );
+      }
+      case "--since": {
+        reader.readRequiredOptionValue(option);
+        throw new Error(
+          "skillset: --since is only supported with check --ci or change commands"
+        );
+      }
+      case "--write": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --write is only supported with check or dev"
+        );
+      }
+      case "--isolated": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --isolated is only supported with build, check --only outputs, or diff"
+        );
+      }
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        if (route === "status") {
+          statusUnsupported = true;
+          break;
+        }
+        throw new Error("skillset: --use is only supported with reconcile");
+      }
+      case "--id":
+      case "--in":
+      case "--preset": {
+        reader.readRequiredOptionValue(option);
+        if (route === "status") {
+          statusUnsupported = true;
+          break;
+        }
+        throw new Error("skillset: new options are only supported with new");
+      }
+      default: {
+        throw new Error(`skillset: unknown option ${option.raw}`);
+      }
+    }
+  }
+  validateInspectionCrossFlags(cross);
+  if (route === "list" && buildMode !== undefined) {
+    throw new Error(
+      "skillset: --updated and --all are not supported with list"
+    );
+  }
+  if (cross.isolated) {
+    validateInspectionLateFlags(cross);
+  }
+  if (
+    route === "status" &&
+    (statusUnsupported || cross.reconcile || cross.newSource)
+  ) {
+    throw new Error("skillset: status only supports --root and --json");
+  }
+  validateInspectionLateFlags(cross);
+  return {
+    jsonOutput,
+    options: {
+      ...(buildMode === undefined ? {} : { buildMode }),
+      ...(scopes === undefined ? {} : { scopes }),
+    },
+    rootPath: resolveCliRoot(context, rootPath),
+  };
+};

--- a/apps/skillset/src/inspect-args.ts
+++ b/apps/skillset/src/inspect-args.ts
@@ -589,7 +589,7 @@ const validateInspectionCrossFlags = (flags: InspectionCrossFlags): void => {
     );
   }
   if (flags.jsonl) {
-    throw new Error("skillset: --jsonl is only supported with dev");
+    throw new Error("skillset: unknown option --jsonl");
   }
   if (flags.lookup) {
     throw new Error("skillset: lookup flags are only supported with lookup");

--- a/apps/skillset/src/test-args.ts
+++ b/apps/skillset/src/test-args.ts
@@ -411,7 +411,7 @@ export const parseTestCommandRequest = (
     yes,
   });
   if (jsonlOutput) {
-    throw new Error("skillset: --jsonl is only supported with dev");
+    throw new Error("skillset: unknown option --jsonl");
   }
   if (lookupField !== undefined || lookupTargets.length > 0 || lookupView) {
     throw new Error("skillset: lookup flags are only supported with lookup");

--- a/apps/skillset/src/test-args.ts
+++ b/apps/skillset/src/test-args.ts
@@ -1,0 +1,475 @@
+import type {
+  SkillsetOptions,
+  TargetName,
+} from "@skillset/core/internal/types";
+
+import { readChangeBump, setChangeReason } from "./change-args";
+import type { ChangeReasonInput } from "./change-workflow";
+import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readBuildScopes,
+  readPositiveInteger,
+  readTargetName,
+  readTargetNames,
+  resolveCliRoot,
+  tokenizeCsv,
+} from "./cli-arg-values";
+import type { CliParseContext } from "./cli-arg-values";
+import { addLookupTargets, setLookupField } from "./lookup-cli";
+import {
+  readHookRuntimeContextField,
+  readHookRuntimeContextFormat,
+} from "./runtime-hooks";
+import type { TestCommandRequest } from "./test-cli";
+import { readClaudeSettingSources } from "./try";
+import type { TryClaudeSettingSources, TrySubcommand } from "./try";
+import { isTrySubcommand, validateTryFlags } from "./try-cli";
+
+export const parseTestCommandRequest = (
+  args: readonly string[],
+  context: CliParseContext
+): TestCommandRequest => {
+  let index = 1;
+  let trySubcommand: TrySubcommand | undefined;
+  const first = args[index];
+  if (isTrySubcommand(first)) {
+    trySubcommand = first;
+    index += 1;
+  }
+
+  let tryRunId: string | undefined;
+  if (
+    trySubcommand === "status" ||
+    trySubcommand === "tail" ||
+    trySubcommand === "worker"
+  ) {
+    const value = args[index];
+    if (value !== undefined && !value.startsWith("--")) {
+      tryRunId = value;
+      index += 1;
+    }
+  }
+
+  let testName: string | undefined;
+  if (trySubcommand === undefined) {
+    const value = args[index];
+    if (value !== undefined && !value.startsWith("--")) {
+      testName = value;
+      index += 1;
+    }
+  }
+
+  let buildMode: "all" | "updated" | undefined;
+  let jsonOutput = false;
+  let jsonlOutput = false;
+  let rootPath: string | undefined;
+  let scopes: SkillsetOptions["scopes"];
+  let tryBackground = false;
+  let tryClaudeSettingSources: TryClaudeSettingSources | undefined;
+  let tryLines: number | undefined;
+  let tryName: string | undefined;
+  let tryPlugins: string[] = [];
+  let tryPrompt: string | undefined;
+  let tryPromptFile: string | undefined;
+  let tryTarget: TargetName | undefined;
+  let tryTimeoutMs: number | undefined;
+  let yes = false;
+  let hookContext = false;
+  let hookPrint = false;
+  let lookupField: string | undefined;
+  let lookupTargets: TargetName[] = [];
+  let lookupView = false;
+  let newFlag = false;
+  let reconcileFlag = false;
+  let workerUnsupported = false;
+  let adoptFlag = false;
+  let changeFlag = false;
+  let changeReason: ChangeReasonInput | undefined;
+  let isolated = false;
+  let readinessFlag = false;
+  let setupFlag = false;
+  let sinceFlag = false;
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    if (trySubcommand === "worker" && option.flag !== "--root") {
+      workerUnsupported = true;
+    }
+    switch (option.flag) {
+      case "--root": {
+        rootPath = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--target": {
+        tryTarget = readTargetName(reader.readRequiredOptionValue(option));
+        break;
+      }
+      case "--prompt": {
+        tryPrompt = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--prompt-file": {
+        tryPromptFile = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--plugin": {
+        tryPlugins = [...tryPlugins, reader.readRequiredOptionValue(option)];
+        break;
+      }
+      case "--claude-setting-sources": {
+        tryClaudeSettingSources = readClaudeSettingSources(
+          reader.readRequiredOptionValue(option),
+          "--claude-setting-sources"
+        );
+        break;
+      }
+      case "--timeout-ms": {
+        tryTimeoutMs = readPositiveInteger(
+          reader.readRequiredOptionValue(option),
+          "--timeout-ms"
+        );
+        break;
+      }
+      case "--lines": {
+        tryLines = readPositiveInteger(
+          reader.readRequiredOptionValue(option),
+          "--lines"
+        );
+        break;
+      }
+      case "--name": {
+        tryName = reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--background": {
+        assertBooleanOption(option);
+        tryBackground = true;
+        break;
+      }
+      case "--updated":
+      case "--all": {
+        assertBooleanOption(option);
+        buildMode = mergeBuildMode(
+          buildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      }
+      case "--scope": {
+        scopes = readBuildScopes(reader.readRequiredOptionValue(option));
+        break;
+      }
+      case "--yes": {
+        assertBooleanOption(option);
+        yes = true;
+        break;
+      }
+      case "--json": {
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      }
+      case "--jsonl": {
+        assertBooleanOption(option);
+        jsonlOutput = true;
+        break;
+      }
+      case "--compat": {
+        lookupView = true;
+        for (const value of reader.readOptionalOptionValues(option)) {
+          lookupTargets = addLookupTargets(lookupTargets, value);
+        }
+        break;
+      }
+      case "--frontmatter":
+      case "--fields":
+      case "--values":
+      case "--events":
+      case "--examples":
+      case "--schema": {
+        assertBooleanOption(option);
+        lookupView = true;
+        break;
+      }
+      case "--field": {
+        lookupField = setLookupField(
+          lookupField,
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      }
+      case "--runner": {
+        readHookRunner(reader.readRequiredOptionValue(option));
+        hookPrint = true;
+        break;
+      }
+      case "--agent-runtime":
+      case "--pre-commit":
+      case "--pre-push": {
+        assertBooleanOption(option);
+        hookPrint = true;
+        break;
+      }
+      case "--event": {
+        reader.readRequiredOptionValue(option);
+        hookContext = true;
+        break;
+      }
+      case "--format": {
+        readHookRuntimeContextFormat(reader.readRequiredOptionValue(option));
+        hookContext = true;
+        break;
+      }
+      case "--context-fields": {
+        const fields = tokenizeCsv(reader.readRequiredOptionValue(option));
+        if (fields.length === 0) {
+          throw new Error(
+            "skillset: --context-fields requires at least one field"
+          );
+        }
+        fields.map(readHookRuntimeContextField);
+        hookContext = true;
+        break;
+      }
+      case "--kind":
+      case "--from": {
+        reader.readRequiredOptionValue(option);
+        break;
+      }
+      case "--append":
+      case "--staged": {
+        assertBooleanOption(option);
+        changeFlag = true;
+        break;
+      }
+      case "--group":
+      case "--ref": {
+        reader.readRequiredOptionValue(option);
+        changeFlag = true;
+        break;
+      }
+      case "--bump": {
+        readChangeBump(reader.readRequiredOptionValue(option));
+        changeFlag = true;
+        break;
+      }
+      case "--reason": {
+        const value = reader.readRequiredOptionValue(option);
+        changeReason = setChangeReason(
+          changeReason,
+          value === "-" ? { kind: "stdin" } : { kind: "inline", value }
+        );
+        changeFlag = true;
+        break;
+      }
+      case "--reason-file": {
+        changeReason = setChangeReason(changeReason, {
+          kind: "file",
+          path: reader.readRequiredOptionValue(option),
+        });
+        changeFlag = true;
+        break;
+      }
+      case "--targets": {
+        readTargetNames(reader.readRequiredOptionValue(option));
+        setupFlag = true;
+        break;
+      }
+      case "--include": {
+        const includes = tokenizeCsv(reader.readRequiredOptionValue(option));
+        if (includes.length === 0) {
+          throw new Error("skillset: --include requires at least one value");
+        }
+        if (includes.some((include) => include !== "ci")) {
+          throw new Error("skillset: expected --include ci");
+        }
+        setupFlag = true;
+        break;
+      }
+      case "--adopt": {
+        reader.readRequiredOptionValue(option);
+        adoptFlag = true;
+        break;
+      }
+      case "--fix":
+      case "--ci": {
+        assertBooleanOption(option);
+        readinessFlag = true;
+        break;
+      }
+      case "--only":
+      case "--report": {
+        const value = reader.readRequiredOptionValue(option);
+        if (option.flag === "--only" && value !== "outputs") {
+          throw new Error("skillset: expected --only outputs");
+        }
+        readinessFlag = true;
+        break;
+      }
+      case "--since": {
+        reader.readRequiredOptionValue(option);
+        sinceFlag = true;
+        break;
+      }
+      case "--write": {
+        assertBooleanOption(option);
+        throw new Error(
+          "skillset: --write is only supported with check or dev"
+        );
+      }
+      case "--isolated": {
+        assertBooleanOption(option);
+        isolated = true;
+        break;
+      }
+      case "--use": {
+        const value = reader.readRequiredOptionValue(option);
+        if (value !== "source" && value !== "output") {
+          throw new Error("skillset: --use expects source or output");
+        }
+        reconcileFlag = true;
+        break;
+      }
+      case "--id":
+      case "--in":
+      case "--preset": {
+        reader.readRequiredOptionValue(option);
+        newFlag = true;
+        break;
+      }
+      default: {
+        throw new Error(`skillset: unknown option ${option.raw}`);
+      }
+    }
+  }
+
+  if (changeFlag) {
+    throw new Error(
+      "skillset: change options are only supported with change commands"
+    );
+  }
+  if (hookPrint) {
+    throw new Error(
+      "skillset: hook options are only supported with hooks print"
+    );
+  }
+  if (hookContext) {
+    throw new Error(
+      "skillset: hook context options are only supported with hooks context"
+    );
+  }
+  if (setupFlag) {
+    throw new Error("skillset: setup options are only supported with init");
+  }
+  if (adoptFlag) {
+    throw new Error(
+      "skillset: --adopt and init acquisition --from are only supported with init"
+    );
+  }
+  if (readinessFlag) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (sinceFlag) {
+    throw new Error(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  }
+
+  const hasAdHocFlags =
+    trySubcommand !== undefined ||
+    tryTarget !== undefined ||
+    tryPrompt !== undefined ||
+    tryPromptFile !== undefined ||
+    tryPlugins.length > 0 ||
+    tryName !== undefined ||
+    tryTimeoutMs !== undefined ||
+    tryClaudeSettingSources !== undefined ||
+    tryBackground;
+  if (testName !== undefined && hasAdHocFlags) {
+    throw new Error(
+      `skillset: declared test ${testName} cannot be combined with ad hoc test flags`
+    );
+  }
+  validateTryFlags("test", trySubcommand, {
+    background: tryBackground,
+    ...(buildMode === undefined ? {} : { buildMode }),
+    ...(tryClaudeSettingSources === undefined
+      ? {}
+      : { claudeSettingSources: tryClaudeSettingSources }),
+    ...(tryLines === undefined ? {} : { lines: tryLines }),
+    ...(tryName === undefined ? {} : { name: tryName }),
+    plugins: tryPlugins,
+    ...(tryPrompt === undefined ? {} : { prompt: tryPrompt }),
+    ...(tryPromptFile === undefined ? {} : { promptFile: tryPromptFile }),
+    ...(scopes === undefined ? {} : { scopes }),
+    ...(tryTarget === undefined ? {} : { target: tryTarget }),
+    ...(tryTimeoutMs === undefined ? {} : { timeoutMs: tryTimeoutMs }),
+    yes,
+  });
+  if (jsonlOutput) {
+    throw new Error("skillset: --jsonl is only supported with dev");
+  }
+  if (lookupField !== undefined || lookupTargets.length > 0 || lookupView) {
+    throw new Error("skillset: lookup flags are only supported with lookup");
+  }
+  if (isolated) {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+  if (trySubcommand === "worker") {
+    if (tryRunId === undefined) {
+      throw new Error("skillset: test worker requires run id");
+    }
+    if (workerUnsupported) {
+      throw new Error(
+        "skillset: test worker only supports <run-id> and --root <path>"
+      );
+    }
+  }
+  if (buildMode !== undefined || scopes !== undefined || yes) {
+    throw new Error(
+      "skillset: build/write options are not supported with test; test output always writes under logical .skillset/cache/tests"
+    );
+  }
+  if (reconcileFlag) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  if (newFlag) {
+    throw new Error("skillset: new options are only supported with new");
+  }
+  return {
+    jsonOutput,
+    options: {},
+    rootPath: resolveCliRoot(context, rootPath),
+    testName,
+    tryBackground,
+    tryClaudeSettingSources,
+    tryLines,
+    tryName,
+    tryPlugins,
+    tryPrompt,
+    tryPromptFile,
+    tryRunId,
+    trySubcommand,
+    tryTarget,
+    tryTimeoutMs,
+  };
+};
+
+const readHookRunner = (value: string): void => {
+  if (
+    value !== "git" &&
+    value !== "husky" &&
+    value !== "lefthook" &&
+    value !== "pre-commit"
+  ) {
+    throw new Error(
+      "skillset: expected --runner lefthook, husky, pre-commit, or git"
+    );
+  }
+};


### PR DESCRIPTION
## Context

SET-304 completes command ownership for inspection, test runtime, and hook routes.

## What changed

- Added typed parsers for list, status, explain, lookup, test, and hooks routes.
- Preserved hidden `test worker` protocol grammar without exposing it in help.
- Moved cross-family recognition and precedence into command owners and eliminated inspection/runtime state from the global bag.

## Verification

- Focused parser, output, lookup, test, hooks, and contract suites
- 46,441-scenario ordered-pair parity matrix with zero request, acceptance, or diagnostic differences
- Typecheck, guards, generated output, conformance, Changeset, whitespace, and `bun run check`

## Risk

No runtime IO, hook protocol, machine mode, handler behavior, prompt, or write timing changed.

Linear: SET-304