### PR TITLE
fix(cli): validate ignored metadata option values

### DIFF
--- a/.changeset/cli-metadata-value-validation.md
+++ b/.changeset/cli-metadata-value-validation.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Restore provider and import-kind validation for recognized metadata options across command-owned CLI parsers.

--- a/apps/skillset/src/__tests__/cli-args.test.ts
+++ b/apps/skillset/src/__tests__/cli-args.test.ts
@@ -954,6 +954,31 @@ describe("SET-300 CLI parse context", () => {
 
 describe("SET-299 parser failure contract", () => {
   const cases = [
+    ...[
+      {
+        args: ["change", "add", "--scope", "plugin:demo", "--bump", "patch"],
+        command: "change add",
+      },
+      { args: ["release", "plan"], command: "release plan" },
+      { args: ["restore", "backup-id"], command: "restore" },
+      { args: ["distribute", "plan"], command: "distribute plan" },
+      { args: ["list"], command: "list" },
+      { args: ["lookup", "hooks", "events"], command: "lookup" },
+      { args: ["test"], command: "test" },
+      { args: ["hooks", "print"], command: "hooks print" },
+    ].flatMap(({ args, command }) => [
+      {
+        args: [...args, "--from", "typo"],
+        command,
+        message:
+          "skillset: expected --from claude, codex, cursor, agents, or skillset",
+      },
+      {
+        args: [...args, "--kind", "typo"],
+        command,
+        message: "skillset: expected --kind skill, skills, plugin, or plugins",
+      },
+    ]),
     {
       args: ["missing"],
       command: "cli",

--- a/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
+++ b/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
@@ -41,6 +41,38 @@ const readOutcome = (run: () => unknown) => {
 };
 
 describe("SET-304 inspection and runtime route parsers", () => {
+  test("validates recognized import metadata across inspection and runtime owners", () => {
+    const routes = [
+      ["list"],
+      ["lookup", "hooks", "events"],
+      ["test"],
+      ["hooks", "print"],
+    ] as const;
+
+    for (const args of routes) {
+      for (const [flag, value, message] of [
+        [
+          "--from",
+          "typo",
+          "skillset: expected --from claude, codex, cursor, agents, or skillset",
+        ],
+        [
+          "--kind",
+          "typo",
+          "skillset: expected --kind skill, skills, plugin, or plugins",
+        ],
+      ] as const) {
+        const input = [...args, flag, value];
+        expect(() => parseDirectRequest(input)).toThrow(message);
+        expect(() => parseCliRequest(input, CONTEXT)).toThrow(message);
+      }
+    }
+
+    expect(
+      parseListCommandRequest(["list", "--from", "codex"], CONTEXT)
+    ).toMatchObject({ options: {} });
+  });
+
   test("inspection routes own roots, scopes, machine mode, and paths", () => {
     expect(
       parseListCommandRequest(
@@ -325,7 +357,10 @@ describe("SET-304 inspection and runtime route parsers", () => {
       {
         message: "skillset: unknown option --jsonl",
         run: () =>
-          parseHooksCommandRequest(["hooks", "run", "stop", "--jsonl"], CONTEXT),
+          parseHooksCommandRequest(
+            ["hooks", "run", "stop", "--jsonl"],
+            CONTEXT
+          ),
       },
     ] as const;
     for (const { message, run } of cases) {

--- a/apps/skillset/src/__tests__/lifecycle-args.test.ts
+++ b/apps/skillset/src/__tests__/lifecycle-args.test.ts
@@ -10,6 +10,65 @@ import { parseReleaseCommandRequest } from "../release-args";
 const CONTEXT = { cwd: "/workspace/repo" } as const;
 
 describe("SET-303 lifecycle and recovery route parsers", () => {
+  test("validates recognized import metadata before ignoring it", () => {
+    const cases = [
+      {
+        run: (flag: string, value: string) =>
+          parseChangeCommandRequest(
+            [
+              "change",
+              "add",
+              "--scope",
+              "plugin:demo",
+              "--bump",
+              "patch",
+              flag,
+              value,
+            ],
+            CONTEXT
+          ),
+      },
+      {
+        run: (flag: string, value: string) =>
+          parseReleaseCommandRequest(["release", "plan", flag, value], CONTEXT),
+      },
+      {
+        run: (flag: string, value: string) =>
+          parseRestoreCommandRequest(
+            ["restore", "backup-id", flag, value],
+            CONTEXT
+          ),
+      },
+    ] as const;
+
+    for (const { run } of cases) {
+      expect(() => run("--from", "typo")).toThrow(
+        "skillset: expected --from claude, codex, cursor, agents, or skillset"
+      );
+      expect(() => run("--kind", "typo")).toThrow(
+        "skillset: expected --kind skill, skills, plugin, or plugins"
+      );
+    }
+
+    expect(
+      parseChangeCommandRequest(
+        [
+          "change",
+          "add",
+          "--scope",
+          "plugin:demo",
+          "--bump",
+          "patch",
+          "--from",
+          "codex",
+          "--kind",
+          "skill",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({ changeBump: "patch", changeScopes: ["plugin:demo"] });
+  });
+
   test("change owns subcommands, refs, reasons, scopes, and repeat policy", () => {
     expect(
       parseChangeCommandRequest(

--- a/apps/skillset/src/__tests__/source-distribution-args.test.ts
+++ b/apps/skillset/src/__tests__/source-distribution-args.test.ts
@@ -13,6 +13,35 @@ import {
 const CONTEXT = { cwd: "/workspace/repo" } as const;
 
 describe("SET-302 source and distribution route parsers", () => {
+  test("validates recognized distribution import metadata before ignoring it", () => {
+    for (const [flag, value, message] of [
+      [
+        "--from",
+        "typo",
+        "skillset: expected --from claude, codex, cursor, agents, or skillset",
+      ],
+      [
+        "--kind",
+        "typo",
+        "skillset: expected --kind skill, skills, plugin, or plugins",
+      ],
+    ] as const) {
+      expect(() =>
+        parseDistributionCommandRequest(
+          ["distribute", "plan", flag, value],
+          CONTEXT
+        )
+      ).toThrow(message);
+    }
+
+    expect(
+      parseDistributionCommandRequest(
+        ["distribute", "plan", "--from", "codex", "--kind", "skill"],
+        CONTEXT
+      )
+    ).toMatchObject({ distributionSubcommand: "plan" });
+  });
+
   test("init owns acquisition, adoption, setup, and confirmation inputs", () => {
     expect(
       parseInitCommandRequest(

--- a/apps/skillset/src/change-args.ts
+++ b/apps/skillset/src/change-args.ts
@@ -7,6 +7,7 @@ import type { ChangeReasonInput, ChangeSubcommand } from "./change-workflow";
 import { assertBooleanOption, CliArgReader } from "./cli-arg-reader";
 import { mergeBuildMode, resolveCliRoot, tokenizeCsv } from "./cli-arg-values";
 import type { CliParseContext } from "./cli-arg-values";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 
 export const parseChangeCommandRequest = (
   args: readonly string[],
@@ -109,9 +110,13 @@ export const parseChangeCommandRequest = (
         );
         break;
       case "--name":
-      case "--kind":
-      case "--from":
         reader.readRequiredOptionValue(option);
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from":
+        readImportProvider(reader.readRequiredOptionValue(option));
         break;
       default:
         throw new Error(`skillset: unknown option ${option.raw}`);

--- a/apps/skillset/src/distribution-args.ts
+++ b/apps/skillset/src/distribution-args.ts
@@ -9,6 +9,7 @@ import type {
   DistributionCommandRequest,
   MarketplaceCommandRequest,
 } from "./distribution-cli";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 
 type DistributionSubcommand = "plan";
 type MarketplaceSubcommand = "check" | "update";
@@ -120,9 +121,13 @@ const parseDistributionOptions = (
         scopes = readBuildScopes(reader.readRequiredOptionValue(option));
         break;
       case "--name":
-      case "--kind":
-      case "--from":
         reader.readRequiredOptionValue(option);
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from":
+        readImportProvider(reader.readRequiredOptionValue(option));
         break;
       default:
         throw new Error(`skillset: unknown option ${option.raw}`);

--- a/apps/skillset/src/hooks-args.ts
+++ b/apps/skillset/src/hooks-args.ts
@@ -30,6 +30,7 @@ import type {
   HookRunner,
   HookSubcommand,
 } from "./runtime-hooks";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 
 export const parseHooksCommandRequest = (
   args: readonly string[],
@@ -209,9 +210,15 @@ export const parseHooksCommandRequest = (
         break;
       }
       case "--name":
-      case "--kind":
-      case "--from": {
         reader.readRequiredOptionValue(option);
+        importMetadata = true;
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        importMetadata = true;
+        break;
+      case "--from": {
+        readImportProvider(reader.readRequiredOptionValue(option));
         importMetadata = true;
         break;
       }

--- a/apps/skillset/src/inspect-args.ts
+++ b/apps/skillset/src/inspect-args.ts
@@ -38,6 +38,7 @@ import {
   readHookRuntimeContextField,
   readHookRuntimeContextFormat,
 } from "./runtime-hooks";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 
 type LookupCommandRequest =
   | { readonly kind: "features"; readonly value: LookupFeaturesCommandRequest }
@@ -174,9 +175,13 @@ export const parseLookupCommandRequest = (
       }
       case "--scope":
       case "--name":
-      case "--kind":
-      case "--from": {
         reader.readRequiredOptionValue(option);
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from": {
+        readImportProvider(reader.readRequiredOptionValue(option));
         break;
       }
       case "--updated":
@@ -681,9 +686,15 @@ const parseInspectionOptions = (
         break;
       }
       case "--name":
-      case "--kind":
-      case "--from": {
         reader.readRequiredOptionValue(option);
+        statusUnsupported = true;
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        statusUnsupported = true;
+        break;
+      case "--from": {
+        readImportProvider(reader.readRequiredOptionValue(option));
         statusUnsupported = true;
         break;
       }

--- a/apps/skillset/src/recovery-args.ts
+++ b/apps/skillset/src/recovery-args.ts
@@ -14,6 +14,7 @@ import type {
   ReconcileCommandRequest,
   RestoreCommandRequest,
 } from "./recovery-cli";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 
 export const parseRestoreCommandRequest = (
   args: readonly string[],
@@ -172,9 +173,13 @@ const parseRecoveryOptions = (
           "skillset: --write is only supported with check or dev"
         );
       case "--name":
-      case "--kind":
-      case "--from":
         reader.readRequiredOptionValue(option);
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from":
+        readImportProvider(reader.readRequiredOptionValue(option));
         break;
       default:
         throw new Error(`skillset: unknown option ${option.raw}`);

--- a/apps/skillset/src/release-args.ts
+++ b/apps/skillset/src/release-args.ts
@@ -11,6 +11,7 @@ import {
 import type { CliParseContext } from "./cli-arg-values";
 import type { ReleaseSubcommand } from "./release";
 import type { ReleaseCommandRequest } from "./release-cli";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 
 export const parseReleaseCommandRequest = (
   args: readonly string[],
@@ -126,9 +127,13 @@ export const parseReleaseCommandRequest = (
         scopes = readBuildScopes(reader.readRequiredOptionValue(option));
         break;
       case "--name":
-      case "--kind":
-      case "--from":
         reader.readRequiredOptionValue(option);
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from":
+        readImportProvider(reader.readRequiredOptionValue(option));
         break;
       default:
         throw new Error(`skillset: unknown option ${option.raw}`);

--- a/apps/skillset/src/test-args.ts
+++ b/apps/skillset/src/test-args.ts
@@ -22,6 +22,7 @@ import {
   readHookRuntimeContextField,
   readHookRuntimeContextFormat,
 } from "./runtime-hooks";
+import { readImportKind, readImportProvider } from "./source-arg-values";
 import type { TestCommandRequest } from "./test-cli";
 import type { TryClaudeSettingSources, TrySubcommand } from "./try";
 import { isTrySubcommand, validateTryFlags } from "./try-cli";
@@ -236,8 +237,10 @@ export const parseTestCommandRequest = (
         break;
       }
       case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
       case "--from": {
-        reader.readRequiredOptionValue(option);
+        readImportProvider(reader.readRequiredOptionValue(option));
         break;
       }
       case "--append":


### PR DESCRIPTION
## Context

The typed parser facade cutover in SET-305 moved option ownership into route parsers, but several routes that intentionally accept and ignore import metadata stopped validating the values of `--from` and `--kind`. A late Codex review on PR #286 caught that invalid values such as `--from typo` were silently accepted.

Closes SET-306 and follows up on the unresolved PR #286 review thread.

## What changed

- Route every recognized provider metadata value through `readImportProvider`.
- Route every recognized import-kind metadata value through `readImportKind`.
- Preserve valid no-op behavior and all route-specific diagnostics.
- Keep `init --from` unchanged because it accepts an acquisition source rather than a provider enum.
- Add direct-owner and public-facade regression matrices across lifecycle, recovery, distribution, inspection, lookup, test, and hooks routes.
- Add a patch Changeset for the restored CLI validation contract.

## Verification

- `bun test apps/skillset/src/__tests__/lifecycle-args.test.ts apps/skillset/src/__tests__/source-distribution-args.test.ts apps/skillset/src/__tests__/inspection-runtime-args.test.ts apps/skillset/src/__tests__/cli-args.test.ts`
- `bun run typecheck`
- `bun run cli-surface:guard`
- `bun run package-ownership:guard`
- `bun run changeset:check -- --base main`
- `bun run check` (1,168 tests; 53,014 expectations)
- Local targeted review: 5/5, zero open findings

## Risk

Low and parser-local. The change restores the pre-cutover scalar-domain validation while leaving route acceptance, request construction, machine output, handlers, and write behavior unchanged.
