### PR TITLE
feat(cli): add interactive prompt session foundation

### DIFF
--- a/.changeset/interactive-prompt-adapter.md
+++ b/.changeset/interactive-prompt-adapter.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add an app-local Inquirer prompt adapter, deterministic scripted prompts, centralized interactive-session eligibility, and controlled prompt cancellation; migrate the existing interactive init adoption chooser onto the shared seam.

--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -30,6 +30,7 @@
     "skillset-toolkit": "dist/toolkit.js"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.5.2",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/apps/skillset/src/__tests__/interactive-session.test.ts
+++ b/apps/skillset/src/__tests__/interactive-session.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { pathToFileURL } from "node:url";
+
+import { promptForInitAdoption, runInitCommand } from "../init-cli";
+import {
+  createInteractiveSession,
+  interactiveSessionEligible,
+} from "../interactive-session";
+import {
+  InquirerPromptAdapter,
+  normalizePromptError,
+  PromptCancelledError,
+  ScriptedPromptAdapter,
+} from "../prompt-adapter";
+
+const ttyInput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+const ttyOutput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+const interactiveEnv = { CI: "false" } as const;
+
+describe("SET-291 interactive session eligibility", () => {
+  test("requires interactive input and output", () => {
+    expect(
+      interactiveSessionEligible({
+        env: interactiveEnv,
+        input: ttyInput(),
+        output: ttyOutput(),
+      })
+    ).toBe(true);
+    expect(
+      interactiveSessionEligible({
+        input: new PassThrough(),
+        output: ttyOutput(),
+      })
+    ).toBe(false);
+    expect(
+      interactiveSessionEligible({
+        input: ttyInput(),
+        output: new PassThrough(),
+      })
+    ).toBe(false);
+  });
+
+  test("excludes machine, CI, and raw protocol execution", () => {
+    const streams = { input: ttyInput(), output: ttyOutput() };
+    expect(interactiveSessionEligible({ ...streams, machineMode: true })).toBe(
+      false
+    );
+    expect(interactiveSessionEligible({ ...streams, rawProtocol: true })).toBe(
+      false
+    );
+    expect(
+      interactiveSessionEligible({ ...streams, env: { CI: "true" } })
+    ).toBe(false);
+    expect(
+      interactiveSessionEligible({ ...streams, env: { CI: "false" } })
+    ).toBe(true);
+  });
+});
+
+describe("SET-291 prompt adapters", () => {
+  test("scripted prompts are deterministic and record display contracts", async () => {
+    const adapter = new ScriptedPromptAdapter([
+      { kind: "input", value: "demo" },
+      { kind: "confirm", value: false },
+      { kind: "select", value: "one" },
+      { kind: "search", value: "two" },
+      { kind: "checkbox", value: ["one", "two"] },
+    ]);
+
+    await expect(adapter.input({ message: "Name:" })).resolves.toBe("demo");
+    await expect(
+      adapter.confirm({ default: false, message: "Proceed?" })
+    ).resolves.toBe(false);
+    await expect(
+      adapter.select({
+        choices: [{ name: "One", value: "one" }],
+        message: "Choose:",
+      })
+    ).resolves.toBe("one");
+    await expect(
+      adapter.search({
+        message: "Find:",
+        source: () => [{ name: "Two", value: "two" }],
+      })
+    ).resolves.toBe("two");
+    await expect(
+      adapter.checkbox({
+        choices: [
+          { name: "One", value: "one" },
+          { name: "Two", value: "two" },
+        ],
+        message: "Include:",
+      })
+    ).resolves.toEqual(["one", "two"]);
+    adapter.assertComplete();
+    expect(adapter.prompts).toHaveLength(5);
+    expect(adapter.prompts[1]).toEqual({
+      kind: "confirm",
+      prompt: { default: false, message: "Proceed?" },
+    });
+  });
+
+  test("scripted prompts fail loudly on order and unused-answer drift", async () => {
+    const wrongOrder = new ScriptedPromptAdapter([
+      { kind: "confirm", value: false },
+    ]);
+    await expect(wrongOrder.input({ message: "Name:" })).rejects.toThrow(
+      "expected confirm, received input"
+    );
+
+    const unused = new ScriptedPromptAdapter([
+      { kind: "input", value: "demo" },
+    ]);
+    expect(() => unused.assertComplete()).toThrow("1 unused answer");
+  });
+
+  test("Inquirer cancellation and abort errors become one controlled error", () => {
+    for (const name of [
+      "AbortPromptError",
+      "CancelPromptError",
+      "ExitPromptError",
+    ]) {
+      const error = new Error("internal details");
+      error.name = name;
+      expect(() => normalizePromptError(error)).toThrow(PromptCancelledError);
+      expect(() => normalizePromptError(error)).toThrow(
+        "skillset: interactive prompt cancelled"
+      );
+    }
+  });
+
+  test("the real adapter normalizes an aborted prompt", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const adapter = new InquirerPromptAdapter({
+      input: ttyInput(),
+      output: ttyOutput(),
+      signal: controller.signal,
+    });
+
+    await expect(adapter.input({ message: "Name:" })).rejects.toThrow(
+      PromptCancelledError
+    );
+  });
+
+  test("the CLI reports controlled cancellation with exit 130", async () => {
+    const cliCoreUrl = pathToFileURL(join(import.meta.dir, "../cli-core.ts")).href;
+    const promptAdapterUrl = pathToFileURL(
+      join(import.meta.dir, "../prompt-adapter.ts")
+    ).href;
+    const proc = Bun.spawn([
+      process.execPath,
+      "-e",
+      `import { reportCliError } from ${JSON.stringify(cliCoreUrl)}; import { PromptCancelledError } from ${JSON.stringify(promptAdapterUrl)}; reportCliError(new PromptCancelledError());`,
+    ], {
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(await proc.exited).toBe(130);
+    expect(await new Response(proc.stderr).text()).toBe(
+      "skillset: interactive prompt cancelled\n"
+    );
+  });
+
+  test("sessions route banner and prompts through injected streams", () => {
+    const input = ttyInput();
+    const output = ttyOutput();
+    const adapter = new ScriptedPromptAdapter([]);
+    const session = createInteractiveSession({
+      adapter,
+      env: interactiveEnv,
+      input,
+      output,
+    });
+
+    expect(session).toBeDefined();
+    session?.banner();
+    session?.write("Plan\n");
+    expect(output.read()?.toString()).toMatch(
+      /^Skillset v\d+\.\d+\.\d+\n\nPlan\n$/u
+    );
+  });
+
+  test("the migrated init adoption flow preserves selection and default-No confirmation", async () => {
+    const input = ttyInput();
+    const output = ttyOutput();
+    const adapter = new ScriptedPromptAdapter([
+      { kind: "input", value: "all" },
+      { kind: "confirm", value: false },
+    ]);
+    const session = createInteractiveSession({
+      adapter,
+      env: interactiveEnv,
+      input,
+      output,
+    });
+    if (session === undefined) throw new Error("expected interactive session");
+
+    await expect(
+      promptForInitAdoption(
+        [
+          { kind: "instructions", path: "AGENTS.md" },
+          { kind: "skill", path: ".agents/skills/review" },
+        ],
+        session
+      )
+    ).resolves.toEqual({
+      candidates: ["instructions:AGENTS.md", "skill:.agents/skills/review"],
+      confirmed: false,
+    });
+    adapter.assertComplete();
+    expect(adapter.prompts).toHaveLength(2);
+    expect(adapter.prompts[0]).toEqual({
+      kind: "input",
+      prompt: expect.objectContaining({
+        default: "none",
+        message: "Adopt all, comma-separated candidate ids, or none:",
+      }),
+    });
+    const inputPrompt = adapter.prompts[0];
+    if (
+      inputPrompt?.kind !== "input" ||
+      inputPrompt.prompt.validate === undefined
+    ) {
+      throw new Error("expected init input validation");
+    }
+    expect(await inputPrompt.prompt.validate("missing:path")).toBe(
+      "skillset: unknown adoption candidate missing:path"
+    );
+    expect(await inputPrompt.prompt.validate("all")).toBe(true);
+    expect(adapter.prompts[1]).toEqual({
+      kind: "confirm",
+      prompt: {
+        default: false,
+        message: "Write init plan (2 adoption candidate(s))?",
+      },
+    });
+    expect(output.read()?.toString()).toContain(
+      "skillset: detected adoptable sources\n  instructions:AGENTS.md\n"
+    );
+  });
+
+  test("the init orchestration boundary previews then leaves default-No repositories untouched", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-interactive-init-"));
+    await writeFile(join(root, "AGENTS.md"), "# Existing instructions\n");
+    const adapter = new ScriptedPromptAdapter([
+      { kind: "input", value: "all" },
+      { kind: "confirm", value: false },
+    ]);
+    const session = createInteractiveSession({
+      adapter,
+      env: interactiveEnv,
+      input: ttyInput(),
+      output: ttyOutput(),
+    });
+    if (session === undefined) throw new Error("expected interactive session");
+
+    await runInitCommand(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        jsonOutput: false,
+        options: {},
+        rootExplicit: true,
+        rootPath: root,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+        yes: false,
+      },
+      { interactiveSession: session }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "input",
+      "confirm",
+    ]);
+    expect(await readdir(root)).toEqual(["AGENTS.md"]);
+  });
+
+  test("explicit init adoption bypasses an injected interactive session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-explicit-init-"));
+    await writeFile(join(root, "AGENTS.md"), "# Existing instructions\n");
+    const adapter = new ScriptedPromptAdapter([]);
+    const session = createInteractiveSession({
+      adapter,
+      env: interactiveEnv,
+      input: ttyInput(),
+      output: ttyOutput(),
+    });
+    if (session === undefined) throw new Error("expected interactive session");
+
+    await runInitCommand(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: ["instructions:AGENTS.md"],
+        initFrom: undefined,
+        jsonOutput: false,
+        options: {},
+        rootExplicit: true,
+        rootPath: root,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+        yes: false,
+      },
+      { interactiveSession: session }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts).toEqual([]);
+    expect(await readdir(root)).toEqual(["AGENTS.md"]);
+  });
+
+  test("machine init bypasses an injected interactive session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-machine-init-"));
+    await writeFile(join(root, "AGENTS.md"), "# Existing instructions\n");
+    const adapter = new ScriptedPromptAdapter([]);
+    const session = createInteractiveSession({
+      adapter,
+      env: interactiveEnv,
+      input: ttyInput(),
+      output: ttyOutput(),
+    });
+    if (session === undefined) throw new Error("expected interactive session");
+
+    await runInitCommand(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        jsonOutput: true,
+        options: {},
+        rootExplicit: true,
+        rootPath: root,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+        yes: false,
+      },
+      { interactiveSession: session }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts).toEqual([]);
+    expect(await readdir(root)).toEqual(["AGENTS.md"]);
+  });
+});

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -17,6 +17,7 @@ import {
   runLookupRoute,
   runStatusCommand,
 } from "./inspect-cli";
+import { PromptCancelledError } from "./prompt-adapter";
 import { runReconcileCommand, runRestoreCommand } from "./recovery-cli";
 import { runReleaseCommand } from "./release-cli";
 import { runImportCommand, runNewCommand } from "./source-cli";
@@ -81,5 +82,5 @@ export async function runCli(
 export function reportCliError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
-  process.exitCode = 1;
+  process.exitCode = error instanceof PromptCancelledError ? error.exitCode : 1;
 }

--- a/apps/skillset/src/init-cli.ts
+++ b/apps/skillset/src/init-cli.ts
@@ -1,5 +1,4 @@
 import { resolve } from "node:path";
-import { createInterface } from "node:readline/promises";
 
 import { sourceUnitDisplay } from "@skillset/core/internal/source-unit-selector";
 import type {
@@ -11,6 +10,10 @@ import { ADOPT_REPORT_DIR, adoptCandidateId, adoptSkillset } from "./adopt";
 import type { AdoptReport } from "./adopt";
 import { rememberKnownSkillsetWorkspace } from "./cli-known-workspaces";
 import { printCliJsonData } from "./cli-output";
+import {
+  createInteractiveSession,
+  type InteractiveSession,
+} from "./interactive-session";
 import { initSkillset } from "./setup";
 import type { SetupInclude, SetupReport } from "./setup";
 
@@ -28,19 +31,26 @@ export interface InitCommandRequest {
   readonly yes: boolean;
 }
 
-export async function runInitCommand({
-  importName,
-  destination,
-  initAdopt,
-  initFrom,
-  jsonOutput,
-  options,
-  rootExplicit,
-  rootPath,
-  setupIncludes,
-  setupTargets,
-  yes,
-}: InitCommandRequest): Promise<void> {
+export interface InitCommandContext {
+  readonly interactiveSession?: InteractiveSession;
+}
+
+export async function runInitCommand(
+  {
+    importName,
+    destination,
+    initAdopt,
+    initFrom,
+    jsonOutput,
+    options,
+    rootExplicit,
+    rootPath,
+    setupIncludes,
+    setupTargets,
+    yes,
+  }: InitCommandRequest,
+  context: InitCommandContext = {}
+): Promise<void> {
   const initCwd = resolve(rootPath);
   const explicitInitRootPath = rootExplicit ? initCwd : undefined;
   const setupRootPath = destination ?? explicitInitRootPath;
@@ -104,7 +114,11 @@ export async function runInitCommand({
     }
     return;
   }
-  if (!jsonOutput && !yes && process.stdin.isTTY && process.stdout.isTTY) {
+  const interactiveSession = jsonOutput
+    ? undefined
+    : (context.interactiveSession ?? createInteractiveSession());
+  if (!yes && interactiveSession !== undefined) {
+    interactiveSession.banner();
     const survey = await initSkillset({
       cwd: initCwd,
       ...(setupRootPath === undefined ? {} : { rootPath: setupRootPath }),
@@ -115,7 +129,10 @@ export async function runInitCommand({
     });
     if (survey.importCandidates.length > 0) {
       printSetupReport(survey, "interactive preview");
-      const selection = await promptForInitAdoption(survey.importCandidates);
+      const selection = await promptForInitAdoption(
+        survey.importCandidates,
+        interactiveSession
+      );
       if (selection.confirmed && selection.candidates.length > 0) {
         const report = await adoptSkillset(destination ?? survey.rootPath, {
           candidates: selection.candidates,
@@ -218,35 +235,35 @@ export function readInitAdoptionSelection(
   return [...new Set(selected)];
 }
 
-async function promptForInitAdoption(
-  candidates: readonly { readonly kind: string; readonly path: string }[]
+export async function promptForInitAdoption(
+  candidates: readonly { readonly kind: string; readonly path: string }[],
+  session: InteractiveSession
 ): Promise<{
   readonly candidates: readonly string[];
   readonly confirmed: boolean;
 }> {
-  console.log("skillset: detected adoptable sources");
+  session.write("skillset: detected adoptable sources\n");
   for (const candidate of candidates) {
-    console.log(`  ${adoptCandidateId(candidate)}`);
+    session.write(`  ${adoptCandidateId(candidate)}\n`);
   }
-  const prompt = createInterface({
-    input: process.stdin,
-    output: process.stdout,
+  const answer = await session.prompts.input({
+    default: "none",
+    message: "Adopt all, comma-separated candidate ids, or none:",
+    validate: (value) => {
+      try {
+        readInitAdoptionSelection(value, candidates);
+        return true;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    },
   });
-  try {
-    const answer = await prompt.question(
-      "Adopt all, comma-separated candidate ids, or none [none]: "
-    );
-    const selected = readInitAdoptionSelection(answer, candidates);
-    const confirmation = await prompt.question(
-      `Write init plan (${selected.length === 0 ? "scaffold only" : `${selected.length} adoption candidate(s)`})? [y/N]: `
-    );
-    return {
-      candidates: selected,
-      confirmed: /^(?:y|yes)$/iu.test(confirmation.trim()),
-    };
-  } finally {
-    prompt.close();
-  }
+  const selected = readInitAdoptionSelection(answer, candidates);
+  const confirmed = await session.prompts.confirm({
+    default: false,
+    message: `Write init plan (${selected.length === 0 ? "scaffold only" : `${selected.length} adoption candidate(s)`})?`,
+  });
+  return { candidates: selected, confirmed };
 }
 
 function printAdoptReport(report: AdoptReport, reason: string): void {

--- a/apps/skillset/src/interactive-session.ts
+++ b/apps/skillset/src/interactive-session.ts
@@ -1,0 +1,77 @@
+import packageJson from "../package.json";
+import {
+  InquirerPromptAdapter,
+  type PromptAdapter,
+  type PromptContext,
+} from "./prompt-adapter";
+
+interface TtyReadable extends NodeJS.ReadableStream {
+  readonly isTTY?: boolean;
+}
+
+interface TtyWritable extends NodeJS.WritableStream {
+  readonly isTTY?: boolean;
+}
+
+export interface InteractiveSessionOptions {
+  readonly adapter?: PromptAdapter;
+  readonly clearPromptOnDone?: boolean;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly input?: TtyReadable;
+  readonly machineMode?: boolean;
+  readonly output?: TtyWritable;
+  readonly rawProtocol?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export interface InteractiveSession {
+  readonly prompts: PromptAdapter;
+  readonly signal: AbortSignal | undefined;
+  banner(): void;
+  write(message: string): void;
+}
+
+export function interactiveSessionEligible({
+  env = process.env,
+  input = process.stdin,
+  machineMode = false,
+  output = process.stdout,
+  rawProtocol = false,
+}: InteractiveSessionOptions = {}): boolean {
+  return (
+    !machineMode &&
+    !rawProtocol &&
+    !ciEnabled(env.CI) &&
+    input.isTTY === true &&
+    output.isTTY === true
+  );
+}
+
+export function createInteractiveSession(
+  options: InteractiveSessionOptions = {}
+): InteractiveSession | undefined {
+  if (!interactiveSessionEligible(options)) return undefined;
+  const input = options.input ?? process.stdin;
+  const output = options.output ?? process.stdout;
+  const context: PromptContext = {
+    ...(options.clearPromptOnDone === undefined
+      ? {}
+      : { clearPromptOnDone: options.clearPromptOnDone }),
+    input,
+    output,
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+  };
+  const prompts = options.adapter ?? new InquirerPromptAdapter(context);
+  return {
+    prompts,
+    signal: options.signal,
+    banner: () => output.write(`Skillset v${packageJson.version}\n\n`),
+    write: (message) => output.write(message),
+  };
+}
+
+function ciEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false";
+}

--- a/apps/skillset/src/prompt-adapter.ts
+++ b/apps/skillset/src/prompt-adapter.ts
@@ -1,0 +1,213 @@
+import {
+  checkbox as inquirerCheckbox,
+  confirm as inquirerConfirm,
+  input as inquirerInput,
+  search as inquirerSearch,
+  select as inquirerSelect,
+} from "@inquirer/prompts";
+
+export interface PromptChoice<Value> {
+  readonly checked?: boolean;
+  readonly description?: string;
+  readonly disabled?: boolean | string;
+  readonly name: string;
+  readonly value: Value;
+}
+
+export interface InputPrompt {
+  readonly default?: string;
+  readonly message: string;
+  readonly validate?: (
+    value: string
+  ) => boolean | string | Promise<boolean | string>;
+}
+
+export interface ConfirmPrompt {
+  readonly default?: boolean;
+  readonly message: string;
+}
+
+export interface ChoicePrompt<Value> {
+  readonly choices: readonly PromptChoice<Value>[];
+  readonly default?: Value;
+  readonly message: string;
+  readonly pageSize?: number;
+}
+
+export interface CheckboxPrompt<Value> extends Omit<
+  ChoicePrompt<Value>,
+  "default"
+> {
+  readonly required?: boolean;
+}
+
+export interface SearchPrompt<Value> {
+  readonly default?: Value;
+  readonly message: string;
+  readonly pageSize?: number;
+  readonly source: (
+    term: string | undefined,
+    options: { readonly signal: AbortSignal }
+  ) => readonly PromptChoice<Value>[] | Promise<readonly PromptChoice<Value>[]>;
+}
+
+export interface PromptAdapter {
+  checkbox<Value>(prompt: CheckboxPrompt<Value>): Promise<readonly Value[]>;
+  confirm(prompt: ConfirmPrompt): Promise<boolean>;
+  input(prompt: InputPrompt): Promise<string>;
+  search<Value>(prompt: SearchPrompt<Value>): Promise<Value>;
+  select<Value>(prompt: ChoicePrompt<Value>): Promise<Value>;
+}
+
+export interface PromptContext {
+  readonly clearPromptOnDone?: boolean;
+  readonly input?: NodeJS.ReadableStream;
+  readonly output?: NodeJS.WritableStream;
+  readonly signal?: AbortSignal;
+}
+
+export class PromptCancelledError extends Error {
+  readonly exitCode = 130;
+
+  constructor() {
+    super("skillset: interactive prompt cancelled");
+    this.name = "PromptCancelledError";
+  }
+}
+
+const CANCELLATION_ERROR_NAMES = new Set([
+  "AbortPromptError",
+  "CancelPromptError",
+  "ExitPromptError",
+]);
+
+export function normalizePromptError(error: unknown): never {
+  if (
+    error instanceof PromptCancelledError ||
+    (error instanceof Error && CANCELLATION_ERROR_NAMES.has(error.name))
+  ) {
+    throw new PromptCancelledError();
+  }
+  throw error;
+}
+
+export class InquirerPromptAdapter implements PromptAdapter {
+  readonly #context: PromptContext;
+
+  constructor(context: PromptContext = {}) {
+    this.#context = context;
+  }
+
+  async checkbox<Value>(
+    prompt: CheckboxPrompt<Value>
+  ): Promise<readonly Value[]> {
+    try {
+      return await inquirerCheckbox(prompt, this.#context);
+    } catch (error) {
+      return normalizePromptError(error);
+    }
+  }
+
+  async confirm(prompt: ConfirmPrompt): Promise<boolean> {
+    try {
+      return await inquirerConfirm(prompt, this.#context);
+    } catch (error) {
+      return normalizePromptError(error);
+    }
+  }
+
+  async input(prompt: InputPrompt): Promise<string> {
+    try {
+      return await inquirerInput(prompt, this.#context);
+    } catch (error) {
+      return normalizePromptError(error);
+    }
+  }
+
+  async search<Value>(prompt: SearchPrompt<Value>): Promise<Value> {
+    try {
+      return await inquirerSearch(prompt, this.#context);
+    } catch (error) {
+      return normalizePromptError(error);
+    }
+  }
+
+  async select<Value>(prompt: ChoicePrompt<Value>): Promise<Value> {
+    try {
+      return await inquirerSelect(prompt, this.#context);
+    } catch (error) {
+      return normalizePromptError(error);
+    }
+  }
+}
+
+export type ScriptedPromptAnswer =
+  | { readonly kind: "checkbox"; readonly value: readonly unknown[] }
+  | { readonly kind: "confirm"; readonly value: boolean }
+  | { readonly kind: "input"; readonly value: string }
+  | { readonly kind: "search"; readonly value: unknown }
+  | { readonly kind: "select"; readonly value: unknown };
+
+export type RecordedPrompt =
+  | { readonly kind: "checkbox"; readonly prompt: CheckboxPrompt<unknown> }
+  | { readonly kind: "confirm"; readonly prompt: ConfirmPrompt }
+  | { readonly kind: "input"; readonly prompt: InputPrompt }
+  | { readonly kind: "search"; readonly prompt: SearchPrompt<unknown> }
+  | { readonly kind: "select"; readonly prompt: ChoicePrompt<unknown> };
+
+export class ScriptedPromptAdapter implements PromptAdapter {
+  readonly prompts: RecordedPrompt[] = [];
+  readonly #answers: ScriptedPromptAnswer[];
+
+  constructor(answers: readonly ScriptedPromptAnswer[]) {
+    this.#answers = [...answers];
+  }
+
+  async checkbox<Value>(
+    prompt: CheckboxPrompt<Value>
+  ): Promise<readonly Value[]> {
+    this.prompts.push({ kind: "checkbox", prompt });
+    return this.#read("checkbox") as readonly Value[];
+  }
+
+  async confirm(prompt: ConfirmPrompt): Promise<boolean> {
+    this.prompts.push({ kind: "confirm", prompt });
+    return this.#read("confirm") as boolean;
+  }
+
+  async input(prompt: InputPrompt): Promise<string> {
+    this.prompts.push({ kind: "input", prompt });
+    return this.#read("input") as string;
+  }
+
+  async search<Value>(prompt: SearchPrompt<Value>): Promise<Value> {
+    this.prompts.push({ kind: "search", prompt });
+    return this.#read("search") as Value;
+  }
+
+  async select<Value>(prompt: ChoicePrompt<Value>): Promise<Value> {
+    this.prompts.push({ kind: "select", prompt });
+    return this.#read("select") as Value;
+  }
+
+  assertComplete(): void {
+    if (this.#answers.length > 0) {
+      throw new Error(
+        `skillset: scripted prompt adapter has ${this.#answers.length} unused answer(s)`
+      );
+    }
+  }
+
+  #read(kind: ScriptedPromptAnswer["kind"]): unknown {
+    const answer = this.#answers.shift();
+    if (answer === undefined) {
+      throw new Error(`skillset: scripted prompt adapter is missing ${kind}`);
+    }
+    if (answer.kind !== kind) {
+      throw new Error(
+        `skillset: scripted prompt adapter expected ${answer.kind}, received ${kind}`
+      );
+    }
+    return answer.value;
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -16,12 +16,13 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.16.2",
+      "version": "0.17.1",
       "bin": {
         "skillset": "dist/cli.js",
         "skillset-toolkit": "dist/toolkit.js",
       },
       "dependencies": {
+        "@inquirer/prompts": "^8.5.2",
         "yaml": "^2.8.1",
       },
       "devDependencies": {
@@ -118,7 +119,37 @@
 
     "@clack/prompts": ["@clack/prompts@1.5.1", "", { "dependencies": { "@clack/core": "1.4.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw=="],
 
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.7", "", {}, "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.2.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/core": "^11.2.1", "@inquirer/figures": "^2.0.7", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.1.1", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ=="],
+
+    "@inquirer/core": ["@inquirer/core@11.2.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/figures": "^2.0.7", "@inquirer/type": "^4.0.7", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.2.2", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/external-editor": "^3.0.3", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.1.1", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g=="],
+
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.7", "", {}, "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw=="],
+
+    "@inquirer/input": ["@inquirer/input@5.1.2", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg=="],
+
+    "@inquirer/number": ["@inquirer/number@4.1.1", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA=="],
+
+    "@inquirer/password": ["@inquirer/password@5.1.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/core": "^11.2.1", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.5.2", "", { "dependencies": { "@inquirer/checkbox": "^5.2.1", "@inquirer/confirm": "^6.1.1", "@inquirer/editor": "^5.2.2", "@inquirer/expand": "^5.1.1", "@inquirer/input": "^5.1.2", "@inquirer/number": "^4.1.1", "@inquirer/password": "^5.1.1", "@inquirer/rawlist": "^5.3.1", "@inquirer/search": "^4.2.1", "@inquirer/select": "^5.2.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.3.1", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og=="],
+
+    "@inquirer/search": ["@inquirer/search@4.2.1", "", { "dependencies": { "@inquirer/core": "^11.2.1", "@inquirer/figures": "^2.0.7", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g=="],
+
+    "@inquirer/select": ["@inquirer/select@5.2.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/core": "^11.2.1", "@inquirer/figures": "^2.0.7", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -246,6 +277,8 @@
 
     "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -348,6 +381,8 @@
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
     "nypm": ["nypm@0.6.6", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.1.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
@@ -443,6 +478,8 @@
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@inquirer/editor/@inquirer/external-editor": ["@inquirer/external-editor@3.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 


### PR DESCRIPTION
## Context

[SET-291](https://linear.app/outfitter/issue/SET-291) establishes the shared app-local prompt seam required by the interactive authoring stack.

## What changed

- add an Inquirer-backed prompt adapter plus a deterministic scripted adapter;
- centralize TTY, CI, machine-mode, and raw-protocol eligibility;
- normalize prompt cancellation to the existing controlled exit-130 path;
- migrate the existing init adoption chooser off the one-off readline implementation.

## Verification

- focused interactive-session and init orchestration tests;
- real PTY default-No, cancellation, invalid-input, and CI-exclusion proof;
- `bun run check` and `bun run hooks:pre-push` pass on the final stack tip.

## Risk / rollout

Human TTY behavior changes only when required inputs are missing. Explicit flags, JSON/JSONL, CI, non-TTY, piped input, and raw protocol routes remain non-interactive. Draft until hosted CI and review are clean.