### PR TITLE
feat(cli): complete interactive init onboarding

### DIFF
--- a/.changeset/interactive-init-onboarding.md
+++ b/.changeset/interactive-init-onboarding.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Complete the TTY `skillset init` onboarding flow with report-derived source selection, canonical target and integration choices, a read-only plan preview, and final default-No confirmation while preserving explicit and machine-mode behavior.

--- a/apps/skillset/package.json
+++ b/apps/skillset/package.json
@@ -30,6 +30,7 @@
     "skillset-toolkit": "dist/toolkit.js"
   },
   "dependencies": {
+    "@inquirer/core": "^11.2.1",
     "@inquirer/prompts": "^8.5.2",
     "yaml": "^2.8.1"
   },

--- a/apps/skillset/src/__tests__/adopt.test.ts
+++ b/apps/skillset/src/__tests__/adopt.test.ts
@@ -10,7 +10,6 @@ import { createOperationalPathContext, resolveOperationalPath } from "@skillset/
 import { ADOPT_REPORT_DIR, adoptCandidateId, adoptSkillset, renderAdoptReportMarkdown } from "../adopt";
 import { ISOLATED_OUT_ROOT } from "@skillset/core";
 import { gitSafeEnv } from "../git-env";
-import { readInitAdoptionSelection } from "../init-cli";
 
 const AGENTS_CONTENT = "# Demo agents\n\nHandwritten instructions.\n";
 
@@ -30,17 +29,6 @@ const MARKETPLACE_FIXTURE: Record<string, string> = {
   "plugins/demo/skills/demo-skill/SKILL.md":
     "---\nname: demo-skill\ndescription: Demo skill.\n---\n\nBody.\n",
 };
-
-test("SET-277: interactive init selection supports all, individual candidates, and scaffold-only", () => {
-  const candidates = [
-    { kind: "plugin", path: "plugins/demo" },
-    { kind: "skills", path: ".agents/skills" },
-  ];
-  expect(readInitAdoptionSelection("all", candidates)).toEqual(["plugin:plugins/demo", "skills:.agents/skills"]);
-  expect(readInitAdoptionSelection("skills:.agents/skills", candidates)).toEqual(["skills:.agents/skills"]);
-  expect(readInitAdoptionSelection("none", candidates)).toEqual([]);
-  expect(() => readInitAdoptionSelection("plugin:missing", candidates)).toThrow("unknown adoption candidate plugin:missing");
-});
 
 test("SET-277: removed setup commands have no aliases", async () => {
   const create = await runSkillsetCli("create");

--- a/apps/skillset/src/__tests__/init-interactive.test.ts
+++ b/apps/skillset/src/__tests__/init-interactive.test.ts
@@ -1,0 +1,574 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, writeFileSync } from "node:fs";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+
+import {
+  interactiveTargetDefaults,
+  promptForInteractiveCandidates,
+  runInteractiveInit,
+  selectInteractiveCandidateIds,
+  selectedInteractiveCandidates,
+} from "../init-interactive";
+import { createInteractiveSession } from "../interactive-session";
+import { ScriptedPromptAdapter } from "../prompt-adapter";
+
+const ttyInput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+const ttyOutput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+
+function scriptedSession(
+  answers: ConstructorParameters<typeof ScriptedPromptAdapter>[0]
+) {
+  const adapter = new ScriptedPromptAdapter(answers);
+  const session = createInteractiveSession({
+    adapter,
+    env: { CI: "false" },
+    input: ttyInput(),
+    output: ttyOutput(),
+  });
+  if (session === undefined) throw new Error("expected interactive session");
+  return { adapter, session };
+}
+
+describe("SET-292 derived init choices", () => {
+  test("normalizes all, individual, and scaffold-only candidate choices", () => {
+    const candidates = [
+      { kind: "instructions" as const, path: "AGENTS.md" },
+      { kind: "skills" as const, path: ".agents/skills" },
+    ];
+    expect(selectInteractiveCandidateIds(candidates, ["all"])).toEqual([
+      "instructions:AGENTS.md",
+      "skills:.agents/skills",
+    ]);
+    expect(
+      selectInteractiveCandidateIds(candidates, ["skills:.agents/skills"])
+    ).toEqual(["skills:.agents/skills"]);
+    expect(
+      selectInteractiveCandidateIds(candidates, [
+        "all",
+        "skills:.agents/skills",
+      ])
+    ).toEqual(["skills:.agents/skills"]);
+    expect(selectInteractiveCandidateIds(candidates, [])).toEqual([]);
+    expect(selectInteractiveCandidateIds([], [])).toEqual([]);
+  });
+
+  test("large adoption inventories use searchable multi-select with stable actions", async () => {
+    const candidates = Array.from({ length: 8 }, (_, index) => ({
+      kind: "plugin" as const,
+      path: `.claude/plugins/plugin-${index}`,
+    }));
+    const selectedIds = [
+      "plugin:.claude/plugins/plugin-2",
+      "plugin:.claude/plugins/plugin-7",
+    ];
+    const { adapter, session } = scriptedSession([
+      { kind: "search-checkbox", value: selectedIds },
+    ]);
+
+    await expect(
+      promptForInteractiveCandidates(candidates, session)
+    ).resolves.toEqual(selectedIds);
+    adapter.assertComplete();
+    const prompt = adapter.prompts[0];
+    if (prompt?.kind !== "search-checkbox") {
+      throw new Error("expected searchable candidate prompt");
+    }
+    expect(prompt.prompt.choices).toHaveLength(9);
+    expect(prompt.prompt.choices[0]).toEqual(
+      expect.objectContaining({ checked: true, value: "all" })
+    );
+    expect(
+      prompt.prompt
+        .source("plugin-7", prompt.prompt.choices)
+        .map((choice) => choice.value)
+    ).toEqual(["all", "plugin:.claude/plugins/plugin-7"]);
+  });
+
+  test("target defaults follow selected providers and reset for scaffold-only", () => {
+    const providerCandidate = (provider: "claude" | "codex") => ({
+      kind: "plugin" as const,
+      path: `.${provider}/plugins/demo`,
+      plugin: {
+        identity: `${provider}-demo`,
+        paths: [`.${provider}/plugins/demo`],
+        providers: [provider],
+        relation: "single-source" as const,
+      },
+    });
+
+    const candidates = [
+      providerCandidate("claude"),
+      providerCandidate("codex"),
+    ];
+    const codexOnly = selectedInteractiveCandidates(candidates, [
+      "plugin:.codex/plugins/demo",
+    ]);
+    const scaffoldOnly = selectedInteractiveCandidates(candidates, []);
+
+    expect(interactiveTargetDefaults(codexOnly)).toEqual(["codex"]);
+    expect(interactiveTargetDefaults(scaffoldOnly)).toEqual([
+      "claude",
+      "codex",
+      "cursor",
+    ]);
+  });
+
+  test("current mode pins the surveyed Git root from a nested directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-init-nested-root-"));
+    const nested = join(root, "packages/demo");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(root, "AGENTS.md"), "# Root instructions\n");
+    expect(Bun.spawnSync(["git", "init", "-q"], { cwd: root }).exitCode).toBe(
+      0
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: "current" },
+      { kind: "checkbox", value: ["all"] },
+      { kind: "checkbox", value: ["claude", "codex", "cursor"] },
+      { kind: "checkbox", value: [] },
+      { kind: "confirm", value: false },
+    ]);
+    let plannedRoot = "";
+
+    await runInteractiveInit(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        rootExplicit: false,
+        rootPath: nested,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      { printPlan: (plan) => (plannedRoot = plan.report.rootPath) }
+    );
+
+    adapter.assertComplete();
+    expect(await realpath(plannedRoot)).toBe(await realpath(root));
+    expect(await readdir(nested)).toEqual([]);
+    expect(await Bun.file(join(root, "skillset.yaml")).exists()).toBe(false);
+  });
+
+  test("preset adoption resolves the Git root from a nested directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-init-nested-adopt-"));
+    const nested = join(root, "packages/demo");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(root, "AGENTS.md"), "# Root instructions\n");
+    expect(Bun.spawnSync(["git", "init", "-q"], { cwd: root }).exitCode).toBe(
+      0
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "checkbox", value: ["claude", "codex", "cursor"] },
+      { kind: "checkbox", value: [] },
+      { kind: "confirm", value: false },
+    ]);
+    let plannedRoot = "";
+    let plannedCandidates: readonly string[] = [];
+
+    await runInteractiveInit(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: ["all"],
+        initFrom: undefined,
+        rootExplicit: false,
+        rootPath: nested,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      {
+        printPlan: (plan) => {
+          plannedRoot = plan.report.rootPath;
+          if (plan.kind === "adopt") {
+            plannedCandidates = plan.report.candidates.map(
+              (candidate) => `${candidate.kind}:${candidate.path}`
+            );
+          }
+        },
+      }
+    );
+
+    adapter.assertComplete();
+    expect(await realpath(plannedRoot)).toBe(await realpath(root));
+    expect(plannedCandidates).toContain("instructions:AGENTS.md");
+    expect(await readdir(nested)).toEqual([]);
+    expect(await Bun.file(join(root, "skillset.yaml")).exists()).toBe(false);
+  });
+
+  test("preset adoption copies the current repository into a positional destination", async () => {
+    const base = await mkdtemp(join(tmpdir(), "skillset-init-adopt-destination-"));
+    const root = join(base, "source");
+    const destination = join(base, "imported");
+    await mkdir(root);
+    await writeFile(join(root, "AGENTS.md"), "# Root instructions\n");
+    expect(Bun.spawnSync(["git", "init", "-q"], { cwd: root }).exitCode).toBe(
+      0
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "confirm", value: true },
+    ]);
+
+    const result = await runInteractiveInit(
+      {
+        destination: "../imported",
+        importName: undefined,
+        initAdopt: ["all"],
+        initFrom: undefined,
+        rootExplicit: false,
+        rootPath: root,
+        setupIncludes: [],
+        setupTargets: ["codex"],
+      },
+      session,
+      { printPlan: () => undefined }
+    );
+
+    adapter.assertComplete();
+    expect(result).toMatchObject({ kind: "adopt", reason: "written" });
+    expect(await Bun.file(join(root, "skillset.yaml")).exists()).toBe(false);
+    expect(await Bun.file(join(destination, "skillset.yaml")).exists()).toBe(
+      true
+    );
+    expect(
+      await Bun.file(join(destination, ".skillset/rules/agents.md")).exists()
+    ).toBe(true);
+  });
+
+  test("bare create prompts for mode and destination, then previews before default-No", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "skillset-init-create-"));
+    const destination = join(cwd, "new-workspace");
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: "create" },
+      { kind: "input", value: "new-workspace" },
+      { kind: "checkbox", value: ["claude", "codex", "cursor"] },
+      { kind: "checkbox", value: ["ci"] },
+      { kind: "confirm", value: false },
+    ]);
+    const events: string[] = [];
+
+    const result = await runInteractiveInit(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        rootExplicit: false,
+        rootPath: cwd,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      {
+        printPlan: (plan) =>
+          events.push(`${plan.kind}:${plan.report.rootPath}`),
+      }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "select",
+      "input",
+      "checkbox",
+      "checkbox",
+      "confirm",
+    ]);
+    const targetPrompt = adapter.prompts[2];
+    expect(targetPrompt?.kind).toBe("checkbox");
+    if (targetPrompt?.kind === "checkbox") {
+      expect(targetPrompt.prompt.choices.map((choice) => choice.value)).toEqual(
+        ["claude", "codex", "cursor"]
+      );
+      expect(targetPrompt.prompt.required).toBe(true);
+    }
+    const integrationPrompt = adapter.prompts[3];
+    expect(integrationPrompt?.kind).toBe("checkbox");
+    if (integrationPrompt?.kind === "checkbox") {
+      expect(integrationPrompt.prompt.choices).toEqual([
+        expect.objectContaining({ checked: true, value: "ci" }),
+      ]);
+    }
+    expect(events).toEqual([`setup:${destination}`]);
+    expect(result.reason).toBe("write confirmation declined");
+    expect(await readdir(cwd)).toEqual([]);
+  });
+
+  test("local import derives multiple candidates and leaves destination untouched when declined", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "skillset-init-import-cwd-"));
+    const source = await mkdtemp(
+      join(tmpdir(), "skillset-init-import-source-")
+    );
+    const destination = join(cwd, "imported");
+    await writeFile(join(source, "AGENTS.md"), "# Existing instructions\n");
+    await mkdir(join(source, ".agents/skills/demo"), { recursive: true });
+    await writeFile(
+      join(source, ".agents/skills/demo/SKILL.md"),
+      "---\nname: demo\ndescription: Demo.\n---\n\nDemo.\n"
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: "import" },
+      { kind: "input", value: "imported" },
+      { kind: "input", value: source },
+      { kind: "checkbox", value: ["all"] },
+      { kind: "checkbox", value: ["claude", "codex", "cursor"] },
+      { kind: "checkbox", value: [] },
+      { kind: "confirm", value: false },
+    ]);
+    let plannedCandidates: readonly string[] = [];
+
+    const result = await runInteractiveInit(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        rootExplicit: false,
+        rootPath: cwd,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      {
+        printPlan: (plan) => {
+          if (plan.kind === "adopt") {
+            plannedCandidates = plan.report.candidates.map(
+              (candidate) => `${candidate.kind}:${candidate.path}`
+            );
+          }
+        },
+      }
+    );
+
+    adapter.assertComplete();
+    expect(plannedCandidates).toEqual([
+      "instructions:AGENTS.md",
+      "skills:.agents/skills",
+    ]);
+    expect(result.kind).toBe("adopt");
+    expect(result.reason).toBe("write confirmation declined");
+    expect(await readdir(cwd)).toEqual([]);
+    expect(destination).not.toBe(source);
+  });
+
+  test("explicit source, destination, targets, includes, and adoption bypass matching prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "skillset-init-explicit-cwd-"));
+    const source = await mkdtemp(
+      join(tmpdir(), "skillset-init-explicit-source-")
+    );
+    await writeFile(join(source, "AGENTS.md"), "# Existing instructions\n");
+    const { adapter, session } = scriptedSession([
+      { kind: "confirm", value: false },
+    ]);
+
+    await runInteractiveInit(
+      {
+        destination: "imported",
+        importName: undefined,
+        initAdopt: ["instructions:AGENTS.md"],
+        initFrom: source,
+        rootExplicit: false,
+        rootPath: cwd,
+        setupIncludes: [],
+        setupTargets: ["codex"],
+      },
+      session,
+      { printPlan: () => undefined }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual(["confirm"]);
+  });
+
+  test("confirmed scaffold-only setup writes only after the plan callback", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-init-confirmed-"));
+    const { adapter, session } = scriptedSession([
+      { kind: "checkbox", value: ["codex"] },
+      { kind: "checkbox", value: [] },
+      { kind: "confirm", value: true },
+    ]);
+    let workspaceExistedAtPlan = true;
+
+    const result = await runInteractiveInit(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        rootExplicit: true,
+        rootPath: root,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      {
+        printPlan: () => {
+          workspaceExistedAtPlan = existsSync(join(root, "skillset.yaml"));
+        },
+      }
+    );
+
+    adapter.assertComplete();
+    expect(workspaceExistedAtPlan).toBe(false);
+    expect(result).toMatchObject({ kind: "setup", reason: "written" });
+    expect(await readdir(root)).toContain("skillset.yaml");
+  });
+
+  test("confirmed individual adoption forwards targets and integrations", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-init-individual-"));
+    await writeFile(join(root, "AGENTS.md"), "# Existing instructions\n");
+    await mkdir(join(root, ".agents/skills/demo"), { recursive: true });
+    await writeFile(
+      join(root, ".agents/skills/demo/SKILL.md"),
+      "---\nname: demo\ndescription: Demo.\n---\n\nDemo.\n"
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "checkbox", value: ["instructions:AGENTS.md"] },
+      { kind: "checkbox", value: ["codex"] },
+      { kind: "checkbox", value: ["ci"] },
+      { kind: "confirm", value: true },
+    ]);
+
+    const result = await runInteractiveInit(
+      {
+        destination: undefined,
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: undefined,
+        rootExplicit: true,
+        rootPath: root,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      { printPlan: () => undefined }
+    );
+
+    adapter.assertComplete();
+    expect(result).toMatchObject({ kind: "adopt", reason: "written" });
+    if (result.kind !== "adopt") throw new Error("expected adopt result");
+    expect(result.report.candidates.map((candidate) => candidate.path)).toEqual(
+      ["AGENTS.md"]
+    );
+    expect(
+      await Bun.file(join(root, ".skillset/rules/agents.md")).exists()
+    ).toBe(true);
+    expect(
+      await Bun.file(join(root, ".skillset/skills/demo/SKILL.md")).exists()
+    ).toBe(false);
+    expect(
+      await Bun.file(join(root, ".github/workflows/skillset-ci.yml")).exists()
+    ).toBe(true);
+    expect(await readFile(join(root, "skillset.yaml"), "utf8")).toContain(
+      "    - codex\n"
+    );
+  });
+
+  test("confirmed remote adopt-all reuses the exact surveyed acquisition", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "skillset-init-remote-cwd-"));
+    const source = await mkdtemp(
+      join(tmpdir(), "skillset-init-remote-source-")
+    );
+    await writeFile(join(source, "AGENTS.md"), "# Remote instructions\n");
+    for (const args of [
+      ["init", "-q"],
+      ["add", "AGENTS.md"],
+      [
+        "-c",
+        "user.name=Skillset Test",
+        "-c",
+        "user.email=skillset@example.com",
+        "commit",
+        "-qm",
+        "initial",
+      ],
+    ]) {
+      expect(Bun.spawnSync(["git", ...args], { cwd: source }).exitCode).toBe(0);
+    }
+    const destination = join(cwd, "imported");
+    const { adapter, session } = scriptedSession([
+      { kind: "checkbox", value: ["all"] },
+      { kind: "checkbox", value: ["codex"] },
+      { kind: "checkbox", value: [] },
+      { kind: "confirm", value: true },
+    ]);
+    let plannedRef = "";
+    let advancedRef = "";
+
+    const result = await runInteractiveInit(
+      {
+        destination: "imported",
+        importName: undefined,
+        initAdopt: undefined,
+        initFrom: `file://${source}`,
+        rootExplicit: false,
+        rootPath: cwd,
+        setupIncludes: undefined,
+        setupTargets: undefined,
+      },
+      session,
+      {
+        printPlan: (plan) => {
+          if (plan.kind === "adopt" && plan.report.acquisition.kind === "git") {
+            plannedRef = plan.report.acquisition.ref;
+            writeFileSync(
+              join(source, "AGENTS.md"),
+              "# Advanced after preview\n"
+            );
+            for (const args of [
+              ["add", "AGENTS.md"],
+              [
+                "-c",
+                "user.name=Skillset Test",
+                "-c",
+                "user.email=skillset@example.com",
+                "commit",
+                "-qm",
+                "advance after preview",
+              ],
+            ]) {
+              if (
+                Bun.spawnSync(["git", ...args], { cwd: source }).exitCode !== 0
+              ) {
+                throw new Error("failed to advance remote fixture");
+              }
+            }
+            advancedRef = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
+              cwd: source,
+            })
+              .stdout.toString()
+              .trim();
+          }
+        },
+      }
+    );
+
+    adapter.assertComplete();
+    expect(result).toMatchObject({ kind: "adopt", reason: "written" });
+    if (result.kind !== "adopt" || result.report.acquisition.kind !== "git") {
+      throw new Error("expected Git adoption result");
+    }
+    expect(result.report.acquisition.ref).toBe(plannedRef);
+    expect(result.report.acquisition.ref).not.toBe(advancedRef);
+    expect(result.report.rootPath).toBe(destination);
+    expect(
+      await Bun.file(join(destination, ".skillset/rules/agents.md")).exists()
+    ).toBe(true);
+    expect(await readFile(join(destination, "AGENTS.md"), "utf8")).toBe(
+      "# Remote instructions\n"
+    );
+  });
+});

--- a/apps/skillset/src/__tests__/interactive-session.test.ts
+++ b/apps/skillset/src/__tests__/interactive-session.test.ts
@@ -3,9 +3,9 @@ import { mkdtemp, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
-import { pathToFileURL } from "node:url";
 
-import { promptForInitAdoption, runInitCommand } from "../init-cli";
+import { cliErrorExitCode } from "../cli-core";
+import { runInitCommand } from "../init-cli";
 import {
   createInteractiveSession,
   interactiveSessionEligible,
@@ -22,6 +22,31 @@ const ttyInput = (): PassThrough & { isTTY: true } =>
 const ttyOutput = (): PassThrough & { isTTY: true } =>
   Object.assign(new PassThrough(), { isTTY: true as const });
 const interactiveEnv = { CI: "false" } as const;
+
+const waitForOutput = async (
+  output: PassThrough,
+  pattern: RegExp
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let rendered = "";
+    const onData = (chunk: Buffer): void => {
+      rendered += chunk.toString();
+      if (pattern.test(rendered)) {
+        cleanup();
+        resolve(rendered);
+      }
+    };
+    const onEnd = (): void => {
+      cleanup();
+      reject(new Error(`output ended before ${pattern.source} rendered`));
+    };
+    const cleanup = (): void => {
+      output.off("data", onData);
+      output.off("end", onEnd);
+    };
+    output.on("data", onData);
+    output.on("end", onEnd);
+  });
 
 describe("SET-291 interactive session eligibility", () => {
   test("requires interactive input and output", () => {
@@ -70,6 +95,7 @@ describe("SET-291 prompt adapters", () => {
       { kind: "confirm", value: false },
       { kind: "select", value: "one" },
       { kind: "search", value: "two" },
+      { kind: "search-checkbox", value: ["two"] },
       { kind: "checkbox", value: ["one", "two"] },
     ]);
 
@@ -90,6 +116,17 @@ describe("SET-291 prompt adapters", () => {
       })
     ).resolves.toBe("two");
     await expect(
+      adapter.searchCheckbox({
+        choices: [
+          { name: "One", value: "one" },
+          { name: "Two", value: "two" },
+        ],
+        message: "Find and include:",
+        source: (term, choices) =>
+          choices.filter((choice) => choice.name.includes(term ?? "")),
+      })
+    ).resolves.toEqual(["two"]);
+    await expect(
       adapter.checkbox({
         choices: [
           { name: "One", value: "one" },
@@ -99,7 +136,7 @@ describe("SET-291 prompt adapters", () => {
       })
     ).resolves.toEqual(["one", "two"]);
     adapter.assertComplete();
-    expect(adapter.prompts).toHaveLength(5);
+    expect(adapter.prompts).toHaveLength(6);
     expect(adapter.prompts[1]).toEqual({
       kind: "confirm",
       prompt: { default: false, message: "Proceed?" },
@@ -147,26 +184,96 @@ describe("SET-291 prompt adapters", () => {
     await expect(adapter.input({ message: "Name:" })).rejects.toThrow(
       PromptCancelledError
     );
+    await expect(
+      adapter.searchCheckbox({
+        choices: [{ name: "One", value: "one" }],
+        message: "Include:",
+        source: (_term, choices) => choices,
+      })
+    ).rejects.toThrow(PromptCancelledError);
   });
 
-  test("the CLI reports controlled cancellation with exit 130", async () => {
-    const cliCoreUrl = pathToFileURL(join(import.meta.dir, "../cli-core.ts")).href;
-    const promptAdapterUrl = pathToFileURL(
-      join(import.meta.dir, "../prompt-adapter.ts")
-    ).href;
-    const proc = Bun.spawn([
-      process.execPath,
-      "-e",
-      `import { reportCliError } from ${JSON.stringify(cliCoreUrl)}; import { PromptCancelledError } from ${JSON.stringify(promptAdapterUrl)}; reportCliError(new PromptCancelledError());`,
-    ], {
-      stderr: "pipe",
-      stdout: "pipe",
+  test("the real searchable checkbox filters, persists selections, and skips disabled choices", async () => {
+    const input = ttyInput();
+    const output = ttyOutput();
+    let transcript = "";
+    output.on("data", (chunk: Buffer) => {
+      transcript += chunk.toString();
+    });
+    const adapter = new InquirerPromptAdapter({ input, output });
+    const choices = [
+      { checked: true, name: "All", value: "all" },
+      { name: "Alpha", value: "alpha" },
+      { disabled: "unavailable", name: "Disabled", value: "disabled" },
+      { name: "Beta", value: "beta" },
+    ] as const;
+    const result = adapter.searchCheckbox({
+      choices,
+      message: "Include:",
+      source: (term, available) => {
+        const query = term?.toLowerCase().split("/").at(-1) ?? "";
+        return available.filter(
+          (choice) =>
+            choice.value === "all" || choice.name.toLowerCase().includes(query)
+        );
+      },
     });
 
-    expect(await proc.exited).toBe(130);
-    expect(await new Response(proc.stderr).text()).toBe(
-      "skillset: interactive prompt cancelled\n"
-    );
+    await waitForOutput(output, /Include:/u);
+    const disabledRendered = waitForOutput(output, /Disabled unavailable/u);
+    input.write("disabled");
+    expect(await disabledRendered).toContain("Disabled unavailable");
+    const writeText = async (text: string): Promise<void> => {
+      for (const key of text) {
+        input.write(key);
+        await Bun.sleep(1);
+      }
+    };
+    const pressKey = async (name: string, sequence: string): Promise<void> => {
+      input.emit("keypress", sequence, {
+        ctrl: false,
+        meta: false,
+        name,
+        sequence,
+        shift: false,
+      });
+      await Bun.sleep(1);
+    };
+    await pressKey("down", "\u001b[B");
+    await pressKey("space", " ");
+    await writeText("/alpha");
+    await pressKey("down", "\u001b[B");
+    await pressKey("space", " ");
+    await writeText("/beta");
+    await pressKey("down", "\u001b[B");
+    await pressKey("space", " ");
+    input.write("\r");
+
+    const selected = await result;
+    expect(selected).toEqual(["alpha", "beta"]);
+    expect(Bun.stripANSI(transcript)).toContain("Disabled unavailable");
+  });
+
+  test("the real searchable checkbox normalizes cancellation after rendering", async () => {
+    const input = ttyInput();
+    const output = ttyOutput();
+    const adapter = new InquirerPromptAdapter({ input, output });
+    const result = adapter.searchCheckbox({
+      choices: [{ name: "One", value: "one" }],
+      message: "Include:",
+      source: (_term, choices) => choices,
+    });
+
+    await waitForOutput(output, /Include:/u);
+    input.write("\u0003");
+
+    await expect(result).rejects.toThrow(PromptCancelledError);
+  });
+
+  test("the CLI reports controlled cancellation with exit 130", () => {
+    const error = new PromptCancelledError();
+    expect(cliErrorExitCode(error)).toBe(130);
+    expect(error.message).toBe("skillset: interactive prompt cancelled");
   });
 
   test("sessions route banner and prompts through injected streams", () => {
@@ -188,70 +295,13 @@ describe("SET-291 prompt adapters", () => {
     );
   });
 
-  test("the migrated init adoption flow preserves selection and default-No confirmation", async () => {
-    const input = ttyInput();
-    const output = ttyOutput();
-    const adapter = new ScriptedPromptAdapter([
-      { kind: "input", value: "all" },
-      { kind: "confirm", value: false },
-    ]);
-    const session = createInteractiveSession({
-      adapter,
-      env: interactiveEnv,
-      input,
-      output,
-    });
-    if (session === undefined) throw new Error("expected interactive session");
-
-    await expect(
-      promptForInitAdoption(
-        [
-          { kind: "instructions", path: "AGENTS.md" },
-          { kind: "skill", path: ".agents/skills/review" },
-        ],
-        session
-      )
-    ).resolves.toEqual({
-      candidates: ["instructions:AGENTS.md", "skill:.agents/skills/review"],
-      confirmed: false,
-    });
-    adapter.assertComplete();
-    expect(adapter.prompts).toHaveLength(2);
-    expect(adapter.prompts[0]).toEqual({
-      kind: "input",
-      prompt: expect.objectContaining({
-        default: "none",
-        message: "Adopt all, comma-separated candidate ids, or none:",
-      }),
-    });
-    const inputPrompt = adapter.prompts[0];
-    if (
-      inputPrompt?.kind !== "input" ||
-      inputPrompt.prompt.validate === undefined
-    ) {
-      throw new Error("expected init input validation");
-    }
-    expect(await inputPrompt.prompt.validate("missing:path")).toBe(
-      "skillset: unknown adoption candidate missing:path"
-    );
-    expect(await inputPrompt.prompt.validate("all")).toBe(true);
-    expect(adapter.prompts[1]).toEqual({
-      kind: "confirm",
-      prompt: {
-        default: false,
-        message: "Write init plan (2 adoption candidate(s))?",
-      },
-    });
-    expect(output.read()?.toString()).toContain(
-      "skillset: detected adoptable sources\n  instructions:AGENTS.md\n"
-    );
-  });
-
   test("the init orchestration boundary previews then leaves default-No repositories untouched", async () => {
     const root = await mkdtemp(join(tmpdir(), "skillset-interactive-init-"));
     await writeFile(join(root, "AGENTS.md"), "# Existing instructions\n");
     const adapter = new ScriptedPromptAdapter([
-      { kind: "input", value: "all" },
+      { kind: "checkbox", value: ["all"] },
+      { kind: "checkbox", value: ["claude", "codex", "cursor"] },
+      { kind: "checkbox", value: ["ci"] },
       { kind: "confirm", value: false },
     ]);
     const session = createInteractiveSession({
@@ -281,16 +331,22 @@ describe("SET-291 prompt adapters", () => {
 
     adapter.assertComplete();
     expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
-      "input",
+      "checkbox",
+      "checkbox",
+      "checkbox",
       "confirm",
     ]);
     expect(await readdir(root)).toEqual(["AGENTS.md"]);
   });
 
-  test("explicit init adoption bypasses an injected interactive session", async () => {
+  test("explicit adoption skips the matching prompt but collects missing choices", async () => {
     const root = await mkdtemp(join(tmpdir(), "skillset-explicit-init-"));
     await writeFile(join(root, "AGENTS.md"), "# Existing instructions\n");
-    const adapter = new ScriptedPromptAdapter([]);
+    const adapter = new ScriptedPromptAdapter([
+      { kind: "checkbox", value: ["claude", "codex"] },
+      { kind: "checkbox", value: [] },
+      { kind: "confirm", value: false },
+    ]);
     const session = createInteractiveSession({
       adapter,
       env: interactiveEnv,
@@ -317,7 +373,11 @@ describe("SET-291 prompt adapters", () => {
     );
 
     adapter.assertComplete();
-    expect(adapter.prompts).toEqual([]);
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "checkbox",
+      "checkbox",
+      "confirm",
+    ]);
     expect(await readdir(root)).toEqual(["AGENTS.md"]);
   });
 

--- a/apps/skillset/src/adopt.ts
+++ b/apps/skillset/src/adopt.ts
@@ -173,9 +173,18 @@ export async function adoptSkillset(
   source: string,
   options: AdoptOptions = {}
 ): Promise<AdoptReport> {
+  const basePath = options.cwd ?? process.cwd();
+  const acquired = await acquireAdoptSource(source, basePath);
+  return adoptAcquiredSkillset(acquired, options);
+}
+
+/** Reuses one surveyed acquisition so an interactive plan and write cannot drift. */
+export async function adoptAcquiredSkillset(
+  acquired: AdoptAcquisition,
+  options: AdoptOptions = {}
+): Promise<AdoptReport> {
   const { cwd, destination, targets, write, ...buildOptions } = options;
   const basePath = cwd ?? process.cwd();
-  const acquired = await acquireAdoptSource(source, basePath);
   if (destination !== undefined && write === true) {
     const preflight = await adoptResolvedRoot(acquired, {
       ...buildOptions,

--- a/apps/skillset/src/cli-core.ts
+++ b/apps/skillset/src/cli-core.ts
@@ -82,5 +82,9 @@ export async function runCli(
 export function reportCliError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
-  process.exitCode = error instanceof PromptCancelledError ? error.exitCode : 1;
+  process.exitCode = cliErrorExitCode(error);
+}
+
+export function cliErrorExitCode(error: unknown): number {
+  return error instanceof PromptCancelledError ? error.exitCode : 1;
 }

--- a/apps/skillset/src/init-cli.ts
+++ b/apps/skillset/src/init-cli.ts
@@ -10,6 +10,7 @@ import { ADOPT_REPORT_DIR, adoptCandidateId, adoptSkillset } from "./adopt";
 import type { AdoptReport } from "./adopt";
 import { rememberKnownSkillsetWorkspace } from "./cli-known-workspaces";
 import { printCliJsonData } from "./cli-output";
+import { runInteractiveInit } from "./init-interactive";
 import {
   createInteractiveSession,
   type InteractiveSession,
@@ -54,7 +55,13 @@ export async function runInitCommand(
   const initCwd = resolve(rootPath);
   const explicitInitRootPath = rootExplicit ? initCwd : undefined;
   const setupRootPath = destination ?? explicitInitRootPath;
-  if (initAdopt !== undefined || initFrom !== undefined) {
+  const interactiveSession = jsonOutput
+    ? undefined
+    : (context.interactiveSession ?? createInteractiveSession());
+  if (
+    (initAdopt !== undefined || initFrom !== undefined) &&
+    (yes || interactiveSession === undefined)
+  ) {
     const writeMode = initAdopt !== undefined && yes;
     const inferredRoot =
       initFrom === undefined
@@ -114,62 +121,62 @@ export async function runInitCommand(
     }
     return;
   }
-  const interactiveSession = jsonOutput
-    ? undefined
-    : (context.interactiveSession ?? createInteractiveSession());
   if (!yes && interactiveSession !== undefined) {
     interactiveSession.banner();
-    const survey = await initSkillset({
-      cwd: initCwd,
-      ...(setupRootPath === undefined ? {} : { rootPath: setupRootPath }),
-      ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
-      ...(setupTargets === undefined ? {} : { targets: setupTargets }),
-      useGitRoot: setupRootPath === undefined,
-      write: false,
-    });
-    if (survey.importCandidates.length > 0) {
-      printSetupReport(survey, "interactive preview");
-      const selection = await promptForInitAdoption(
-        survey.importCandidates,
-        interactiveSession
-      );
-      if (selection.confirmed && selection.candidates.length > 0) {
-        const report = await adoptSkillset(destination ?? survey.rootPath, {
-          candidates: selection.candidates,
-          cwd: initCwd,
-          ...(importName === undefined ? {} : { name: importName }),
-          ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
-          ...(setupTargets === undefined ? {} : { targets: setupTargets }),
-          write: true,
-        });
-        printAdoptReport(
-          report,
-          report.write ? "written" : "blocked before write"
-        );
-        if (!report.ok) {
-          process.exitCode = 1;
-        } else {
-          await rememberKnownSkillsetWorkspace(report.rootPath, options);
-        }
-        return;
+    interactiveSession.write("Initialize a skillset:\n");
+    const result = await runInteractiveInit(
+      {
+        destination,
+        importName,
+        initAdopt,
+        initFrom,
+        rootExplicit,
+        rootPath,
+        setupIncludes,
+        setupTargets,
+      },
+      interactiveSession,
+      {
+        printPlan: (plan) => {
+          interactiveSession.write(
+            [
+              "Skillset will:",
+              `Mode: ${plan.mode}`,
+              ...(plan.source === undefined ? [] : [`Source: ${plan.source}`]),
+              ...(plan.destination === undefined
+                ? []
+                : [`Destination: ${plan.destination}`]),
+              `Adoption: ${plan.candidates.length === 0 ? "scaffold only" : plan.candidates.join(", ")}`,
+              `Targets: ${plan.targets.join(", ")}`,
+              `Integrations: ${plan.include.length === 0 ? "none" : plan.include.join(", ")}`,
+              "",
+            ].join("\n")
+          );
+          if (plan.kind === "adopt") {
+            printAdoptReport(plan.report, "interactive preview");
+          } else {
+            printSetupReport(plan.report, "interactive preview");
+          }
+        },
       }
-      if (!selection.confirmed) {
-        printSetupReport(survey, "write confirmation declined");
-        return;
+    );
+    if (result.kind === "adopt") {
+      if (result.reason !== "write confirmation declined") {
+        printAdoptReport(result.report, result.reason);
       }
-      const setup = await initSkillset({
-        cwd: initCwd,
-        ...(setupRootPath === undefined ? {} : { rootPath: setupRootPath }),
-        ...(importName === undefined ? {} : { name: importName }),
-        ...(setupIncludes === undefined ? {} : { include: setupIncludes }),
-        ...(setupTargets === undefined ? {} : { targets: setupTargets }),
-        useGitRoot: setupRootPath === undefined,
-        write: true,
-      });
-      printSetupReport(setup, "written");
-      await rememberKnownSkillsetWorkspace(setup.rootPath, options);
-      return;
+      if (!result.report.ok) process.exitCode = 1;
+      if (result.reason === "written" && result.report.ok) {
+        await rememberKnownSkillsetWorkspace(result.report.rootPath, options);
+      }
+    } else {
+      if (result.reason !== "write confirmation declined") {
+        printSetupReport(result.report, result.reason);
+      }
+      if (result.reason === "written") {
+        await rememberKnownSkillsetWorkspace(result.report.rootPath, options);
+      }
     }
+    return;
   }
   const setup = await initSkillset({
     cwd: initCwd,
@@ -208,62 +215,6 @@ export async function runInitCommand(
     await rememberKnownSkillsetWorkspace(setup.rootPath, options);
   }
   return;
-}
-
-export function readInitAdoptionSelection(
-  answer: string,
-  candidates: readonly { readonly kind: string; readonly path: string }[]
-): readonly string[] {
-  const value = answer.trim();
-  if (value === "" || value === "none") {
-    return [];
-  }
-  const available = new Set(
-    candidates.map((candidate) => `${candidate.kind}:${candidate.path}`)
-  );
-  const selected =
-    value === "all"
-      ? [...available]
-      : value
-          .split(",")
-          .map((item) => item.trim())
-          .filter(Boolean);
-  for (const id of selected) {
-    if (!available.has(id))
-      throw new Error(`skillset: unknown adoption candidate ${id}`);
-  }
-  return [...new Set(selected)];
-}
-
-export async function promptForInitAdoption(
-  candidates: readonly { readonly kind: string; readonly path: string }[],
-  session: InteractiveSession
-): Promise<{
-  readonly candidates: readonly string[];
-  readonly confirmed: boolean;
-}> {
-  session.write("skillset: detected adoptable sources\n");
-  for (const candidate of candidates) {
-    session.write(`  ${adoptCandidateId(candidate)}\n`);
-  }
-  const answer = await session.prompts.input({
-    default: "none",
-    message: "Adopt all, comma-separated candidate ids, or none:",
-    validate: (value) => {
-      try {
-        readInitAdoptionSelection(value, candidates);
-        return true;
-      } catch (error) {
-        return error instanceof Error ? error.message : String(error);
-      }
-    },
-  });
-  const selected = readInitAdoptionSelection(answer, candidates);
-  const confirmed = await session.prompts.confirm({
-    default: false,
-    message: `Write init plan (${selected.length === 0 ? "scaffold only" : `${selected.length} adoption candidate(s)`})?`,
-  });
-  return { candidates: selected, confirmed };
 }
 
 function printAdoptReport(report: AdoptReport, reason: string): void {

--- a/apps/skillset/src/init-interactive.ts
+++ b/apps/skillset/src/init-interactive.ts
@@ -1,0 +1,434 @@
+import { resolve } from "node:path";
+
+import {
+  defaultTargetNames,
+  targetNames,
+} from "@skillset/core/internal/config";
+import type { TargetName } from "@skillset/core/internal/types";
+
+import {
+  adoptAcquiredSkillset,
+  adoptCandidateId,
+  adoptSkillset,
+  type AdoptAcquisition,
+  type AdoptOptions,
+  type AdoptReport,
+} from "./adopt";
+import type { InteractiveSession } from "./interactive-session";
+import type { PromptChoice } from "./prompt-adapter";
+import {
+  initSkillset,
+  type SetupImportCandidate,
+  type SetupInclude,
+  type SetupReport,
+} from "./setup";
+
+export type InteractiveInitMode = "create" | "current" | "import";
+type CandidateSelection = "all" | string;
+
+const ADOPTION_SEARCH_THRESHOLD = 8;
+
+export interface InteractiveInitRequest {
+  readonly destination: string | undefined;
+  readonly importName: string | undefined;
+  readonly initAdopt: readonly string[] | undefined;
+  readonly initFrom: string | undefined;
+  readonly rootExplicit: boolean;
+  readonly rootPath: string;
+  readonly setupIncludes: readonly SetupInclude[] | undefined;
+  readonly setupTargets: readonly TargetName[] | undefined;
+}
+
+export interface InteractiveInitContext {
+  readonly printPlan: (plan: InteractiveInitPlan) => void;
+}
+
+export type InteractiveInitPlan = (
+  | { readonly kind: "adopt"; readonly report: AdoptReport }
+  | { readonly kind: "setup"; readonly report: SetupReport }
+) & {
+  readonly candidates: readonly string[];
+  readonly destination: string | undefined;
+  readonly include: readonly SetupInclude[];
+  readonly mode: InteractiveInitMode;
+  readonly source: string | undefined;
+  readonly targets: readonly TargetName[];
+};
+
+export type InteractiveInitResult =
+  | {
+      readonly kind: "adopt";
+      readonly reason:
+        | "write confirmation declined"
+        | "written"
+        | "blocked before write";
+      readonly report: AdoptReport;
+    }
+  | {
+      readonly kind: "setup";
+      readonly reason: "write confirmation declined" | "written";
+      readonly report: SetupReport;
+    };
+
+/**
+ * Collects missing init inputs around the existing setup/adopt reports. The
+ * reports remain the source of truth for discoveries and the final plan; this
+ * layer only chooses among what they expose.
+ */
+export async function runInteractiveInit(
+  request: InteractiveInitRequest,
+  session: InteractiveSession,
+  context: InteractiveInitContext
+): Promise<InteractiveInitResult> {
+  const cwd = resolve(request.rootPath);
+  const mode = await resolveMode(request, session);
+  const destination = await resolveDestination(request, mode, session);
+  const source = await resolveSource(request, mode, session);
+  const presetCurrentRoot =
+    request.initAdopt !== undefined && source === undefined
+      ? (
+          await initSkillset({
+            cwd,
+            ...(request.rootExplicit ? { rootPath: cwd } : {}),
+            useGitRoot: !request.rootExplicit,
+            write: false,
+          })
+        ).rootPath
+      : undefined;
+  const initial = await preview({
+    candidates: request.initAdopt,
+    ...(presetCurrentRoot === undefined
+      ? {}
+      : { currentRoot: presetCurrentRoot }),
+    cwd,
+    destination,
+    include: request.setupIncludes,
+    mode,
+    name: request.importName,
+    rootExplicit: request.rootExplicit,
+    source,
+    targets: request.setupTargets,
+  });
+  const discovered =
+    initial.kind === "adopt"
+      ? initial.report.candidates
+      : initial.report.importCandidates;
+  const candidates =
+    request.initAdopt ??
+    (await promptForInteractiveCandidates(discovered, session));
+  const selectedCandidates = selectedInteractiveCandidates(
+    discovered,
+    candidates
+  );
+  const targets =
+    request.setupTargets ??
+    (await promptForTargets(selectedCandidates, session));
+  const include =
+    request.setupIncludes ?? (await promptForIntegrations(session));
+  const currentRoot =
+    presetCurrentRoot ??
+    (mode === "current" ? initial.report.rootPath : undefined);
+  const acquisition =
+    initial.kind === "adopt" ? initial.report.acquisition : undefined;
+  const plan = await preview({
+    ...(acquisition === undefined ? {} : { acquisition }),
+    candidates,
+    ...(currentRoot === undefined ? {} : { currentRoot }),
+    cwd,
+    destination,
+    include,
+    mode,
+    name: request.importName,
+    rootExplicit: request.rootExplicit,
+    source,
+    targets,
+  });
+  context.printPlan({
+    ...plan,
+    candidates,
+    destination,
+    include,
+    mode,
+    source,
+    targets,
+  });
+  const confirmed = await session.prompts.confirm({
+    default: false,
+    message: "Proceed?",
+  });
+  if (!confirmed) {
+    return { ...plan, reason: "write confirmation declined" };
+  }
+  return execute({
+    ...(acquisition === undefined ? {} : { acquisition }),
+    candidates,
+    ...(currentRoot === undefined ? {} : { currentRoot }),
+    cwd,
+    destination,
+    include,
+    mode,
+    name: request.importName,
+    rootExplicit: request.rootExplicit,
+    source,
+    targets,
+  });
+}
+
+interface ResolvedInteractiveInit {
+  readonly acquisition?: AdoptAcquisition;
+  readonly candidates: readonly string[] | undefined;
+  readonly currentRoot?: string;
+  readonly cwd: string;
+  readonly destination: string | undefined;
+  readonly include: readonly SetupInclude[] | undefined;
+  readonly mode: InteractiveInitMode;
+  readonly name: string | undefined;
+  readonly rootExplicit: boolean;
+  readonly source: string | undefined;
+  readonly targets: readonly TargetName[] | undefined;
+}
+
+async function preview(
+  input: ResolvedInteractiveInit
+): Promise<
+  | { readonly kind: "adopt"; readonly report: AdoptReport }
+  | { readonly kind: "setup"; readonly report: SetupReport }
+> {
+  const setupRoot = setupRootPath(input);
+  if (input.mode === "import" || (input.candidates?.length ?? 0) > 0) {
+    const report = await runAdopt(input, setupRoot, false);
+    return { kind: "adopt", report };
+  }
+  const report = await initSkillset({
+    cwd: input.cwd,
+    ...(setupRoot === undefined ? {} : { rootPath: setupRoot }),
+    ...(input.include === undefined ? {} : { include: input.include }),
+    ...(input.name === undefined ? {} : { name: input.name }),
+    ...(input.targets === undefined ? {} : { targets: input.targets }),
+    useGitRoot: setupRoot === undefined,
+    write: false,
+  });
+  return { kind: "setup", report };
+}
+
+async function execute(
+  input: ResolvedInteractiveInit
+): Promise<InteractiveInitResult> {
+  const setupRoot = setupRootPath(input);
+  if (input.mode === "import" || (input.candidates?.length ?? 0) > 0) {
+    const report = await runAdopt(input, setupRoot, true);
+    return {
+      kind: "adopt",
+      reason: report.write ? "written" : "blocked before write",
+      report,
+    };
+  }
+  const report = await initSkillset({
+    cwd: input.cwd,
+    ...(setupRoot === undefined ? {} : { rootPath: setupRoot }),
+    ...(input.include === undefined ? {} : { include: input.include }),
+    ...(input.name === undefined ? {} : { name: input.name }),
+    ...(input.targets === undefined ? {} : { targets: input.targets }),
+    useGitRoot: setupRoot === undefined,
+    write: true,
+  });
+  return { kind: "setup", reason: "written", report };
+}
+
+function runAdopt(
+  input: ResolvedInteractiveInit,
+  setupRoot: string | undefined,
+  write: boolean
+): Promise<AdoptReport> {
+  const options: AdoptOptions = {
+    ...(input.candidates === undefined ? {} : { candidates: input.candidates }),
+    cwd: input.cwd,
+    ...(input.mode === "import" && input.destination !== undefined
+      ? { destination: input.destination }
+      : {}),
+    ...(input.include === undefined ? {} : { include: input.include }),
+    ...(input.name === undefined ? {} : { name: input.name }),
+    ...(input.targets === undefined ? {} : { targets: input.targets }),
+    write,
+  };
+  if (input.acquisition !== undefined) {
+    return adoptAcquiredSkillset(input.acquisition, options);
+  }
+  return adoptSkillset(
+    input.source ?? input.currentRoot ?? setupRoot ?? input.cwd,
+    options
+  );
+}
+
+function setupRootPath(input: ResolvedInteractiveInit): string | undefined {
+  if (input.mode === "create") return input.destination;
+  if (input.mode === "current") {
+    return input.currentRoot ?? (input.rootExplicit ? input.cwd : undefined);
+  }
+  return undefined;
+}
+
+async function resolveMode(
+  request: InteractiveInitRequest,
+  session: InteractiveSession
+): Promise<InteractiveInitMode> {
+  if (request.initFrom !== undefined) return "import";
+  if (request.initAdopt !== undefined && request.destination !== undefined) {
+    return "import";
+  }
+  if (request.destination !== undefined) return "create";
+  if (request.rootExplicit || request.initAdopt !== undefined) return "current";
+  return session.prompts.select({
+    choices: [
+      { name: "Set up the current repository", value: "current" },
+      { name: "Create a new Skillset workspace", value: "create" },
+      { name: "Import an existing repository", value: "import" },
+    ],
+    default: "current",
+    message: "What would you like to initialize?",
+  });
+}
+
+async function resolveDestination(
+  request: InteractiveInitRequest,
+  mode: InteractiveInitMode,
+  session: InteractiveSession
+): Promise<string | undefined> {
+  if (mode === "current") return undefined;
+  if (request.destination !== undefined) {
+    return resolve(request.rootPath, request.destination);
+  }
+  const value = await session.prompts.input({
+    message: "Destination directory:",
+    validate: requiredValue("destination directory"),
+  });
+  return resolve(request.rootPath, value.trim());
+}
+
+async function resolveSource(
+  request: InteractiveInitRequest,
+  mode: InteractiveInitMode,
+  session: InteractiveSession
+): Promise<string | undefined> {
+  if (mode !== "import") return undefined;
+  if (request.initFrom !== undefined) return request.initFrom;
+  if (request.initAdopt !== undefined) return undefined;
+  const value = await session.prompts.input({
+    message: "Local path or Git URL to import:",
+    validate: requiredValue("import source"),
+  });
+  return value.trim();
+}
+
+export async function promptForInteractiveCandidates(
+  candidates: readonly SetupImportCandidate[],
+  session: InteractiveSession
+): Promise<readonly string[]> {
+  if (candidates.length === 0) return [];
+  const choices: readonly PromptChoice<CandidateSelection>[] = [
+    {
+      checked: true,
+      description: "Select every detected source",
+      name: "All detected sources (recommended)",
+      value: "all",
+    },
+    ...candidates.map((candidate) => ({
+      name: `${candidate.kind} ${candidate.path}`,
+      value: adoptCandidateId(candidate),
+    })),
+  ];
+  const prompt = {
+    choices,
+    message: "Sources to adopt (select none for scaffold only):",
+  };
+  const selected =
+    candidates.length >= ADOPTION_SEARCH_THRESHOLD
+      ? await session.prompts.searchCheckbox<CandidateSelection>({
+          ...prompt,
+          source: filterAdoptionChoices,
+        })
+      : await session.prompts.checkbox<CandidateSelection>(prompt);
+  return selectInteractiveCandidateIds(candidates, selected);
+}
+
+function filterAdoptionChoices(
+  term: string | undefined,
+  choices: readonly PromptChoice<CandidateSelection>[]
+): readonly PromptChoice<CandidateSelection>[] {
+  const query = term?.trim().toLowerCase() ?? "";
+  if (query.length === 0) return choices;
+  return choices.filter(
+    (choice) =>
+      choice.value === "all" ||
+      choice.name.toLowerCase().includes(query) ||
+      choice.description?.toLowerCase().includes(query)
+  );
+}
+
+export function selectInteractiveCandidateIds(
+  candidates: readonly SetupImportCandidate[],
+  selected: readonly CandidateSelection[]
+): readonly string[] {
+  const individual = selected.filter((candidate) => candidate !== "all");
+  if (individual.length === 0 && selected.includes("all")) {
+    return candidates.map(adoptCandidateId);
+  }
+  return [...new Set(individual)];
+}
+
+export function selectedInteractiveCandidates(
+  candidates: readonly SetupImportCandidate[],
+  selected: readonly string[]
+): readonly SetupImportCandidate[] {
+  if (selected.includes("all")) return candidates;
+  const selectedIds = new Set(selected);
+  return candidates.filter((candidate) =>
+    selectedIds.has(adoptCandidateId(candidate))
+  );
+}
+
+async function promptForTargets(
+  candidates: readonly SetupImportCandidate[],
+  session: InteractiveSession
+): Promise<readonly TargetName[]> {
+  const defaults = new Set(interactiveTargetDefaults(candidates));
+  return session.prompts.checkbox({
+    choices: targetNames().map((target) => ({
+      checked: defaults.has(target),
+      name: target[0]?.toUpperCase() + target.slice(1),
+      value: target,
+    })),
+    message: "Generate for:",
+    required: true,
+  });
+}
+
+export function interactiveTargetDefaults(
+  candidates: readonly SetupImportCandidate[]
+): readonly TargetName[] {
+  const detected = new Set(
+    candidates.flatMap((candidate) => candidate.plugin?.providers ?? [])
+  );
+  return detected.size > 0 ? [...detected] : defaultTargetNames();
+}
+
+async function promptForIntegrations(
+  session: InteractiveSession
+): Promise<readonly SetupInclude[]> {
+  return session.prompts.checkbox({
+    choices: [
+      {
+        checked: true,
+        description: "Add the repository CI workflow",
+        name: "Continuous integration",
+        value: "ci" as const,
+      },
+    ],
+    message: "Optional integrations:",
+  });
+}
+
+function requiredValue(label: string): (value: string) => true | string {
+  return (value) =>
+    value.trim().length > 0 ? true : `skillset: ${label} is required`;
+}

--- a/apps/skillset/src/prompt-adapter.ts
+++ b/apps/skillset/src/prompt-adapter.ts
@@ -6,6 +6,8 @@ import {
   select as inquirerSelect,
 } from "@inquirer/prompts";
 
+import { runSearchCheckbox } from "./search-checkbox";
+
 export interface PromptChoice<Value> {
   readonly checked?: boolean;
   readonly description?: string;
@@ -51,11 +53,21 @@ export interface SearchPrompt<Value> {
   ) => readonly PromptChoice<Value>[] | Promise<readonly PromptChoice<Value>[]>;
 }
 
+export interface SearchCheckboxPrompt<Value> extends CheckboxPrompt<Value> {
+  readonly source: (
+    term: string | undefined,
+    choices: readonly PromptChoice<Value>[]
+  ) => readonly PromptChoice<Value>[];
+}
+
 export interface PromptAdapter {
   checkbox<Value>(prompt: CheckboxPrompt<Value>): Promise<readonly Value[]>;
   confirm(prompt: ConfirmPrompt): Promise<boolean>;
   input(prompt: InputPrompt): Promise<string>;
   search<Value>(prompt: SearchPrompt<Value>): Promise<Value>;
+  searchCheckbox<Value>(
+    prompt: SearchCheckboxPrompt<Value>
+  ): Promise<readonly Value[]>;
   select<Value>(prompt: ChoicePrompt<Value>): Promise<Value>;
 }
 
@@ -132,6 +144,16 @@ export class InquirerPromptAdapter implements PromptAdapter {
     }
   }
 
+  async searchCheckbox<Value>(
+    prompt: SearchCheckboxPrompt<Value>
+  ): Promise<readonly Value[]> {
+    try {
+      return await runSearchCheckbox(prompt, this.#context);
+    } catch (error) {
+      return normalizePromptError(error);
+    }
+  }
+
   async select<Value>(prompt: ChoicePrompt<Value>): Promise<Value> {
     try {
       return await inquirerSelect(prompt, this.#context);
@@ -146,6 +168,7 @@ export type ScriptedPromptAnswer =
   | { readonly kind: "confirm"; readonly value: boolean }
   | { readonly kind: "input"; readonly value: string }
   | { readonly kind: "search"; readonly value: unknown }
+  | { readonly kind: "search-checkbox"; readonly value: readonly unknown[] }
   | { readonly kind: "select"; readonly value: unknown };
 
 export type RecordedPrompt =
@@ -153,6 +176,10 @@ export type RecordedPrompt =
   | { readonly kind: "confirm"; readonly prompt: ConfirmPrompt }
   | { readonly kind: "input"; readonly prompt: InputPrompt }
   | { readonly kind: "search"; readonly prompt: SearchPrompt<unknown> }
+  | {
+      readonly kind: "search-checkbox";
+      readonly prompt: SearchCheckboxPrompt<unknown>;
+    }
   | { readonly kind: "select"; readonly prompt: ChoicePrompt<unknown> };
 
 export class ScriptedPromptAdapter implements PromptAdapter {
@@ -183,6 +210,16 @@ export class ScriptedPromptAdapter implements PromptAdapter {
   async search<Value>(prompt: SearchPrompt<Value>): Promise<Value> {
     this.prompts.push({ kind: "search", prompt });
     return this.#read("search") as Value;
+  }
+
+  async searchCheckbox<Value>(
+    prompt: SearchCheckboxPrompt<Value>
+  ): Promise<readonly Value[]> {
+    // The recorder erases generic values while preserving the callable prompt.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    const recorded = prompt as unknown as SearchCheckboxPrompt<unknown>;
+    this.prompts.push({ kind: "search-checkbox", prompt: recorded });
+    return this.#read("search-checkbox") as readonly Value[];
   }
 
   async select<Value>(prompt: ChoicePrompt<Value>): Promise<Value> {

--- a/apps/skillset/src/search-checkbox.ts
+++ b/apps/skillset/src/search-checkbox.ts
@@ -1,0 +1,152 @@
+import {
+  createPrompt,
+  isDownKey,
+  isEnterKey,
+  isSpaceKey,
+  isUpKey,
+  makeTheme,
+  useKeypress,
+  usePagination,
+  usePrefix,
+  useState,
+} from "@inquirer/core";
+
+import type {
+  PromptChoice,
+  PromptContext,
+  SearchCheckboxPrompt,
+} from "./prompt-adapter";
+
+const valuesMatch = (left: unknown, right: unknown): boolean =>
+  Object.is(left, right);
+
+const disabledLabel = (choice: PromptChoice<unknown>): string => {
+  if (choice.disabled === true) {
+    return " (disabled)";
+  }
+  if (typeof choice.disabled === "string") {
+    return ` ${choice.disabled}`;
+  }
+  return "";
+};
+
+const renderChoice = (
+  choice: PromptChoice<unknown>,
+  isActive: boolean,
+  selected: readonly unknown[]
+): string => {
+  const cursor = isActive ? "❯" : " ";
+  const checked = selected.some((value) => valuesMatch(value, choice.value));
+  const marker = checked ? "◉" : "◯";
+  return `${cursor}${marker} ${choice.name}${disabledLabel(choice)}`;
+};
+
+const searchCheckboxPrompt = createPrompt<
+  readonly unknown[],
+  SearchCheckboxPrompt<unknown>
+>((config, done) => {
+  const { pageSize = 7, required = false } = config;
+  const theme = makeTheme();
+  const [status, setStatus] = useState<"done" | "idle">("idle");
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const [error, setError] = useState<string>();
+  const [selected, setSelected] = useState<readonly unknown[]>(
+    config.choices
+      .filter((choice) => choice.checked && !choice.disabled)
+      .map((choice) => choice.value)
+  );
+  const prefix = usePrefix({ status, theme });
+  const visible = config.source(query || undefined, config.choices);
+  const selectable = visible.filter((choice) => !choice.disabled);
+  const activeIndex = selectable.length === 0 ? -1 : active % selectable.length;
+  const activeChoice = selectable[activeIndex];
+  const activeVisibleIndex =
+    activeChoice === undefined ? -1 : visible.indexOf(activeChoice);
+
+  useKeypress((key, readline) => {
+    if (isEnterKey(key)) {
+      if (required && selected.length === 0) {
+        readline.clearLine(0);
+        readline.write(query);
+        setError("At least one choice must be selected");
+        return;
+      }
+      setStatus("done");
+      done(selected);
+      return;
+    }
+    if (isUpKey(key) || isDownKey(key)) {
+      readline.clearLine(0);
+      readline.write(query);
+      if (selectable.length > 0) {
+        const offset = isUpKey(key) ? -1 : 1;
+        setActive(
+          (activeIndex + offset + selectable.length) % selectable.length
+        );
+      }
+      return;
+    }
+    if (isSpaceKey(key)) {
+      readline.clearLine(0);
+      readline.write(query);
+      if (activeChoice !== undefined) {
+        setError(undefined);
+        setSelected(
+          selected.some((value) => valuesMatch(value, activeChoice.value))
+            ? selected.filter(
+                (value) => !valuesMatch(value, activeChoice.value)
+              )
+            : [...selected, activeChoice.value]
+        );
+      }
+      return;
+    }
+    setActive(0);
+    setError(undefined);
+    setQuery(readline.line);
+  });
+
+  const message = theme.style.message(config.message, status);
+  if (status === "done") {
+    const names = config.choices
+      .filter((choice) =>
+        selected.some((value) => valuesMatch(value, choice.value))
+      )
+      .map((choice) => choice.name);
+    return [prefix, message, theme.style.answer(names.join(", "))]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  const page = usePagination({
+    active: Math.max(activeVisibleIndex, 0),
+    items: visible,
+    loop: false,
+    pageSize,
+    renderItem: ({ item, isActive }) => renderChoice(item, isActive, selected),
+  });
+  const header = [prefix, message, theme.style.highlight(query)]
+    .filter(Boolean)
+    .join(" ")
+    .trimEnd();
+  const description = activeChoice?.description;
+  const body = [
+    visible.length === 0 ? theme.style.error("No results found") : page,
+    description === undefined ? undefined : theme.style.highlight(description),
+    error === undefined ? undefined : theme.style.error(error),
+    theme.style.help("Type to filter • ↑↓ navigate • space select • ⏎ submit"),
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
+  return [header, body];
+});
+
+export const runSearchCheckbox = <Value>(
+  prompt: SearchCheckboxPrompt<Value>,
+  context: PromptContext
+): Promise<readonly Value[]> =>
+  searchCheckboxPrompt(
+    prompt as SearchCheckboxPrompt<unknown>,
+    context
+  ) as Promise<readonly Value[]>;

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "skillset-toolkit": "dist/toolkit.js",
       },
       "dependencies": {
+        "@inquirer/core": "^11.2.1",
         "@inquirer/prompts": "^8.5.2",
         "yaml": "^2.8.1",
       },

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -34,7 +34,7 @@ The entries below are the complete final public flag set. Positional arguments a
 
 | Route | Flags | Notes |
 | --- | --- | --- |
-| `init [destination]` | `--root`, `--from`, `--adopt`, `--targets`, `--include`, `--name`, `--yes`, `--json` | `--adopt all` or repeat stable candidate ids. A TTY may select candidates interactively. |
+| `init [destination]` | `--root`, `--from`, `--adopt`, `--targets`, `--include`, `--name`, `--yes`, `--json` | `--adopt all` or repeat stable candidate ids. A TTY guides missing mode, source, adoption, target, and integration choices, previews the derived plan, then confirms with No as the default. |
 | `import` | `--root`, `--from`, `--kind`, `--name`, `--json` | Repeated-use asset conversion; import itself remains explicit. |
 | `new` | `--root`, `--id`, `--name`, `--in`, `--scope`, `--preset`, `--yes`, `--json` | Preview by default. |
 | `check` | `--root`, `--only`, `--write`, `--ci`, `--fix`, `--since`, `--report`, `--json` | `--fix` requires `--ci`; `--since` and `--report` are CI-only. |


### PR DESCRIPTION
## Context

[SET-292](https://linear.app/outfitter/issue/SET-292) completes the derived `skillset init` onboarding flow. Stacked on #288.

## What changed

- derive current/create mode, adoption candidates, targets, and integrations from existing reports and registries;
- render the existing setup/adoption plan before a default-No confirmation;
- freeze acquired remote sources across preview and confirmed execution;
- use searchable multi-select for inventories of eight or more candidates while keeping All available;
- preserve explicit `--from`, `--adopt`, `--targets`, `--include`, and `--yes` precedence.

## Verification

- current, create, scaffold-only, individual, adopt-all, local, remote, and exclusion tests;
- real rendered prompt proof for filtering, disabled-row skipping, multi-selection, submission, and cancellation;
- real PTY eight-candidate search proof;
- independent full-stack review 5/5 with FSR-001 closed;
- final `bun run check`: 1,213 tests; pre-push gate green.

## Risk / rollout

Writes still occur only after the existing plan and explicit confirmation, which defaults No. Machine and non-TTY behavior is unchanged. Draft until hosted CI and review are clean.