### PR TITLE
feat(cli): add interactive source scaffolding

### DIFF
--- a/.changeset/interactive-new-source.md
+++ b/.changeset/interactive-new-source.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add derived TTY source scaffolding for `skillset new`, backed by shared kind, preset, and valid-container metadata with plan-first default-No confirmation.

--- a/apps/skillset/src/__tests__/cli-args.test.ts
+++ b/apps/skillset/src/__tests__/cli-args.test.ts
@@ -679,8 +679,8 @@ describe("SET-299 CLI request characterization", () => {
         expected: { request: { initAdopt: ["one", "two"] } },
       },
       {
-        args: ["new", "skill", "--preset", "one", "--preset=two"],
-        expected: { request: { newPresets: ["one", "two"] } },
+        args: ["new", "skill", "--preset", "support", "--preset=evals"],
+        expected: { request: { newPresets: ["support", "evals"] } },
       },
       {
         args: [

--- a/apps/skillset/src/__tests__/new-interactive.test.ts
+++ b/apps/skillset/src/__tests__/new-interactive.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+
+import { createInteractiveSession } from "../interactive-session";
+import {
+  listNewSourceContainers,
+  NEW_HOOK_UNAVAILABLE_REASON,
+  NEW_SOURCE_KINDS,
+  parseSkillPresets,
+  SKILL_PRESETS,
+} from "../new-source";
+import { PromptCancelledError, ScriptedPromptAdapter } from "../prompt-adapter";
+import { initSkillset } from "../setup";
+import { runNewCommand, type NewCommandRequest } from "../source-cli";
+
+const ttyInput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+const ttyOutput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+
+function scriptedSession(
+  answers: ConstructorParameters<typeof ScriptedPromptAdapter>[0]
+) {
+  const adapter = new ScriptedPromptAdapter(answers);
+  const session = createInteractiveSession({
+    adapter,
+    env: { CI: "false" },
+    input: ttyInput(),
+    output: ttyOutput(),
+  });
+  if (session === undefined) throw new Error("expected interactive session");
+  return { adapter, session };
+}
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-new-interactive-"));
+  await initSkillset({ cwd: root, rootPath: root, write: true });
+  return root;
+}
+
+function request(
+  rootPath: string,
+  overrides: Partial<NewCommandRequest> = {}
+): NewCommandRequest {
+  return {
+    jsonOutput: false,
+    newContainer: undefined,
+    newId: undefined,
+    newKind: undefined,
+    newName: undefined,
+    newPresets: undefined,
+    newScope: undefined,
+    options: {},
+    positionalName: undefined,
+    rootPath,
+    yes: false,
+    ...overrides,
+  };
+}
+
+describe("SET-293 derived new-source choices", () => {
+  test("kind and preset metadata drive validation and disabled choices", () => {
+    expect(NEW_SOURCE_KINDS.map((kind) => [kind.id, kind.enabled])).toEqual([
+      ["skill", true],
+      ["agent", true],
+      ["hook", false],
+    ]);
+    expect(SKILL_PRESETS.map((preset) => preset.id)).toEqual([
+      "minimal",
+      "support",
+      "references",
+      "assets",
+      "scripts",
+      "evals",
+      "reference-file",
+      "examples-file",
+    ]);
+    expect(parseSkillPresets(["support,evals", "support"])).toEqual([
+      "support",
+      "evals",
+    ]);
+    expect(() => parseSkillPresets(["missing"])).toThrow(
+      "expected --preset minimal, support, references, assets, scripts, evals, reference-file, or examples-file"
+    );
+  });
+
+  test("bare skill previews conditional prompts and defaults to no writes", async () => {
+    const root = await workspace();
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: "skill" },
+      { kind: "input", value: "Docs Expert" },
+      { kind: "checkbox", value: ["minimal"] },
+      { kind: "confirm", value: false },
+    ]);
+
+    await runNewCommand(request(root), { interactiveSession: session });
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "select",
+      "input",
+      "checkbox",
+      "confirm",
+    ]);
+    const kindPrompt = adapter.prompts[0];
+    if (kindPrompt?.kind !== "select") throw new Error("expected kind prompt");
+    expect(kindPrompt.prompt.message).toBe("Create a new:");
+    expect(kindPrompt.prompt.choices.at(-1)).toEqual(
+      expect.objectContaining({
+        disabled: NEW_HOOK_UNAVAILABLE_REASON,
+        value: "hook",
+      })
+    );
+    const identityPrompt = adapter.prompts[1];
+    if (identityPrompt?.kind !== "input") {
+      throw new Error("expected identity prompt");
+    }
+    expect(identityPrompt.prompt.message).toBe("Name:");
+    expect(
+      await Bun.file(
+        join(root, ".skillset/skills/docs-expert/SKILL.md")
+      ).exists()
+    ).toBe(false);
+  });
+
+  test("confirmed plugin skill forwards preset and placement without building", async () => {
+    const root = await workspace();
+    await mkdir(join(root, ".skillset/plugins/acme"), { recursive: true });
+    await writeFile(
+      join(root, ".skillset/plugins/acme/skillset.yaml"),
+      "skillset:\n  name: acme\n"
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "input", value: "Plugin Helper" },
+      { kind: "select", value: "acme" },
+      { kind: "checkbox", value: ["support", "evals"] },
+      { kind: "confirm", value: true },
+    ]);
+
+    await runNewCommand(request(root, { newKind: "skill" }), {
+      interactiveSession: session,
+    });
+
+    adapter.assertComplete();
+    const placementPrompt = adapter.prompts[1];
+    if (placementPrompt?.kind !== "select") {
+      throw new Error("expected placement prompt");
+    }
+    expect(placementPrompt.prompt.message).toBe("Destination:");
+    expect(placementPrompt.prompt.default).toBe("__workspace__");
+    const presetPrompt = adapter.prompts[2];
+    if (presetPrompt?.kind !== "checkbox") {
+      throw new Error("expected preset prompt");
+    }
+    expect(presetPrompt.prompt.message).toBe("Include starting surfaces:");
+    const skillRoot = join(root, ".skillset/plugins/acme/skills/plugin-helper");
+    expect(await Bun.file(join(skillRoot, "SKILL.md")).exists()).toBe(true);
+    expect(await Bun.file(join(skillRoot, "SKILL.md")).text()).toContain(
+      'title: "Plugin Helper"'
+    );
+    expect(
+      await Bun.file(join(skillRoot, "references/.gitkeep")).exists()
+    ).toBe(true);
+    expect(await Bun.file(join(skillRoot, "evals/evals.json")).exists()).toBe(
+      true
+    );
+    expect(await Bun.file(join(root, ".claude")).exists()).toBe(false);
+    expect(await Bun.file(join(root, ".agents")).exists()).toBe(false);
+  });
+
+  test("project agent skips skill-only placement and preset questions", async () => {
+    const root = await workspace();
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: "agent" },
+      { kind: "input", value: "Release Reviewer" },
+      { kind: "confirm", value: true },
+    ]);
+
+    await runNewCommand(request(root), { interactiveSession: session });
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "select",
+      "input",
+      "confirm",
+    ]);
+    expect(
+      await Bun.file(
+        join(root, ".skillset/agents/release-reviewer.md")
+      ).exists()
+    ).toBe(true);
+  });
+
+  test("explicit kind, id, name, container, and presets skip matching prompts", async () => {
+    const root = await workspace();
+    await mkdir(join(root, ".skillset/plugins/acme"), { recursive: true });
+    await writeFile(
+      join(root, ".skillset/plugins/acme/skillset.yaml"),
+      "skillset:\n  name: acme\n"
+    );
+    const { adapter, session } = scriptedSession([
+      { kind: "confirm", value: false },
+    ]);
+
+    await runNewCommand(
+      request(root, {
+        newContainer: "acme",
+        newId: "docs",
+        newKind: "skill",
+        newName: "Docs Expert",
+        newPresets: ["minimal"],
+      }),
+      { interactiveSession: session }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual(["confirm"]);
+  });
+
+  test("container discovery shares manifest validation and uses search at scale", async () => {
+    const root = await workspace();
+    for (let index = 0; index < 8; index += 1) {
+      const name = `plugin-${index}`;
+      await mkdir(join(root, ".skillset/plugins", name), { recursive: true });
+      await writeFile(
+        join(root, ".skillset/plugins", name, "skillset.yaml"),
+        `skillset:\n  name: ${name}\n`
+      );
+    }
+    expect(await listNewSourceContainers(root)).toHaveLength(8);
+    const { adapter, session } = scriptedSession([
+      { kind: "input", value: "Search Skill" },
+      { kind: "search", value: "plugin-7" },
+      { kind: "checkbox", value: ["minimal"] },
+      { kind: "confirm", value: false },
+    ]);
+
+    await runNewCommand(request(root, { newKind: "skill" }), {
+      interactiveSession: session,
+    });
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "input",
+      "search",
+      "checkbox",
+      "confirm",
+    ]);
+  });
+
+  test("workspace placement does not require a valid full build graph", async () => {
+    const root = await workspace();
+    await mkdir(join(root, ".skillset/plugins/demo"), { recursive: true });
+    await writeFile(
+      join(root, ".skillset/plugins/demo/skillset.yaml"),
+      "skillset:\n  name: demo\n"
+    );
+    await mkdir(join(root, ".skillset/skills/broken"), { recursive: true });
+    await writeFile(
+      join(root, ".skillset/skills/broken/SKILL.md"),
+      "---\nname: [\n---\n"
+    );
+    await expect(listNewSourceContainers(root)).rejects.toThrow();
+    const { adapter, session } = scriptedSession([
+      { kind: "input", value: "Workspace Skill" },
+      { kind: "select", value: "__workspace__" },
+      { kind: "checkbox", value: ["minimal"] },
+      { kind: "confirm", value: false },
+    ]);
+
+    const result = await runNewCommand(request(root, { newKind: "skill" }), {
+      interactiveSession: session,
+    });
+
+    adapter.assertComplete();
+    expect(result).toBeUndefined();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "input",
+      "select",
+      "checkbox",
+      "confirm",
+    ]);
+  });
+
+  test("container discovery and explicit placement share canonical plugin validation", async () => {
+    const legacyRoot = await workspace();
+    await mkdir(join(legacyRoot, ".skillset/plugins/legacy"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(legacyRoot, ".skillset/plugins/legacy/config.yaml"),
+      "skillset:\n  name: legacy\n"
+    );
+
+    await expect(listNewSourceContainers(legacyRoot)).rejects.toThrow(
+      "uses retired plugin config.yaml"
+    );
+    await expect(
+      runNewCommand(
+        request(legacyRoot, {
+          newContainer: "legacy",
+          newKind: "skill",
+          positionalName: "Legacy Skill",
+          yes: true,
+        })
+      )
+    ).rejects.toThrow("does not exist or has no skillset.yaml");
+    expect(
+      await Bun.file(
+        join(
+          legacyRoot,
+          ".skillset/plugins/legacy/skills/legacy-skill/SKILL.md"
+        )
+      ).exists()
+    ).toBe(false);
+
+    const malformedRoot = await workspace();
+    await mkdir(join(malformedRoot, ".skillset/plugins/malformed"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(malformedRoot, ".skillset/plugins/malformed/skillset.yaml"),
+      "skillset: [\n"
+    );
+
+    await expect(listNewSourceContainers(malformedRoot)).rejects.toThrow();
+    await expect(
+      runNewCommand(
+        request(malformedRoot, {
+          newContainer: "malformed",
+          newKind: "skill",
+          positionalName: "Malformed Skill",
+          yes: true,
+        })
+      )
+    ).rejects.toThrow();
+    expect(
+      await Bun.file(
+        join(
+          malformedRoot,
+          ".skillset/plugins/malformed/skills/malformed-skill/SKILL.md"
+        )
+      ).exists()
+    ).toBe(false);
+  });
+
+  test("uninitialized workspaces fail through the existing plan error before confirmation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-new-uninitialized-"));
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: "skill" },
+      { kind: "input", value: "Fresh Skill" },
+    ]);
+
+    await expect(
+      runNewCommand(request(root), { interactiveSession: session })
+    ).rejects.toThrow(
+      "new requires an initialized Skillset workspace; run skillset init --yes"
+    );
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "select",
+      "input",
+    ]);
+  });
+
+  test("cancellation stays controlled and leaves the source tree untouched", async () => {
+    const root = await workspace();
+    const controller = new AbortController();
+    controller.abort();
+    const session = createInteractiveSession({
+      env: { CI: "false" },
+      input: ttyInput(),
+      output: ttyOutput(),
+      signal: controller.signal,
+    });
+    if (session === undefined) throw new Error("expected interactive session");
+
+    await expect(
+      runNewCommand(request(root), { interactiveSession: session })
+    ).rejects.toThrow(PromptCancelledError);
+    expect(
+      await Bun.file(join(root, ".skillset/skills/cancelled/SKILL.md")).exists()
+    ).toBe(false);
+  });
+
+  test("JSON and yes requests bypass an injected prompt session", async () => {
+    const root = await workspace();
+    const { adapter, session } = scriptedSession([]);
+
+    await runNewCommand(
+      request(root, {
+        jsonOutput: true,
+        newKind: "skill",
+        positionalName: "JSON Preview",
+      }),
+      { interactiveSession: session }
+    );
+    await runNewCommand(
+      request(root, {
+        newKind: "skill",
+        positionalName: "Yes Write",
+        yes: true,
+      }),
+      { interactiveSession: session }
+    );
+
+    adapter.assertComplete();
+    expect(adapter.prompts).toEqual([]);
+    expect(
+      await Bun.file(
+        join(root, ".skillset/skills/json-preview/SKILL.md")
+      ).exists()
+    ).toBe(false);
+    expect(
+      await Bun.file(join(root, ".skillset/skills/yes-write/SKILL.md")).exists()
+    ).toBe(true);
+  });
+
+  test("CI and non-TTY CLI requests retain the non-interactive preview path", async () => {
+    const root = await workspace();
+    for (const env of [process.env, { ...process.env, CI: "true" }]) {
+      const result = await runCli(
+        ["new", "skill", "Piped Skill", "--root", root],
+        env
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("write confirmation required");
+      expect(result.stdout).not.toContain("Create source:");
+    }
+    expect(
+      await Bun.file(
+        join(root, ".skillset/skills/piped-skill/SKILL.md")
+      ).exists()
+    ).toBe(false);
+  });
+});
+
+async function runCli(
+  args: readonly string[],
+  env: Readonly<Record<string, string | undefined>>
+): Promise<{ readonly exitCode: number; readonly stdout: string }> {
+  const process = Bun.spawn(
+    ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    {
+      env,
+      stderr: "pipe",
+      stdout: "pipe",
+    }
+  );
+  const [exitCode, stdout] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+  ]);
+  return { exitCode, stdout };
+}

--- a/apps/skillset/src/__tests__/source-distribution-args.test.ts
+++ b/apps/skillset/src/__tests__/source-distribution-args.test.ts
@@ -132,8 +132,8 @@ describe("SET-302 source and distribution route parsers", () => {
           "--in",
           "quality",
           "--preset",
-          "base",
-          "--preset=security",
+          "support",
+          "--preset=evals",
           "--scope",
           "repo",
           "--root",
@@ -149,13 +149,29 @@ describe("SET-302 source and distribution route parsers", () => {
       newId: "review-agent",
       newKind: "agent",
       newName: "Reviewer",
-      newPresets: ["base", "security"],
+      newPresets: ["support", "evals"],
       newScope: "repo",
       options: {},
       positionalName: "reviewer",
       rootPath: "/workspace/repo/nested",
       yes: true,
     });
+    expect(
+      parseNewCommandRequest(["new", "--root", "nested"], CONTEXT)
+    ).toMatchObject({
+      newKind: undefined,
+      rootPath: "/workspace/repo/nested",
+    });
+    expect(
+      parseNewCommandRequest(["new", "Docs Expert", "--root", "nested"], CONTEXT)
+    ).toMatchObject({
+      newKind: undefined,
+      positionalName: "Docs Expert",
+      rootPath: "/workspace/repo/nested",
+    });
+    expect(() =>
+      parseNewCommandRequest(["new", "skill", "--preset", "missing"], CONTEXT)
+    ).toThrow("expected --preset minimal, support");
   });
 
   test("distribution routes own subcommands, names, machine mode, and writes", () => {

--- a/apps/skillset/src/cli-usage.ts
+++ b/apps/skillset/src/cli-usage.ts
@@ -37,7 +37,7 @@ export const USAGE = [
   "       skillset hooks run <post-tool-use|stop> [--root <path>]",
   "       skillset hooks context --event <event> [--format env|json] [--context-fields <field,...>] [--root <path>]",
   "       skillset init [destination] [--from <path|git-url>] [--adopt <all|candidate-id>] [--yes] [--targets claude,codex,cursor] [--include ci] [--name <name>] [--json] [--root <path>]",
-  "       skillset new <skill|agent|hook> [name] [--id <id>] [--name <name>] [--in <container>] [--scope repo] [--preset <preset>] [--yes] [--json] [--root <path>]",
+  "       skillset new [skill|agent|hook] [name] [--id <id>] [--name <name>] [--in <container>] [--scope repo] [--preset <preset>] [--yes] [--json] [--root <path>]",
   "       skillset explain <path> [--json] [--scope <scope>] [--root <path>]",
   "       skillset import <path> [--kind <skill|skills|plugin|plugins>] [--from <provider>] [--name <name>] [--json] [--root <path>]",
   "       skillset import <claude|codex|cursor|agents> [--json] [--root <path>]",

--- a/apps/skillset/src/new-interactive.ts
+++ b/apps/skillset/src/new-interactive.ts
@@ -1,0 +1,190 @@
+import type { SkillsetOptions } from "@skillset/core/internal/types";
+
+import type { InteractiveSession } from "./interactive-session";
+import {
+  discoverNewSourceContainers,
+  NEW_SOURCE_KINDS,
+  scaffoldSourceUnit,
+  SKILL_PRESETS,
+  type NewSourceKind,
+  type NewSourceReport,
+  type NewSourceScope,
+  type SkillPreset,
+} from "./new-source";
+
+const WORKSPACE_CONTAINER = "__workspace__";
+const SEARCH_THRESHOLD = 8;
+
+export interface InteractiveNewRequest {
+  readonly positionalName: string | undefined;
+  readonly newContainer: string | undefined;
+  readonly newId: string | undefined;
+  readonly newKind: NewSourceKind | undefined;
+  readonly newName: string | undefined;
+  readonly newPresets: readonly string[] | undefined;
+  readonly newScope: NewSourceScope | undefined;
+  readonly options: SkillsetOptions;
+  readonly rootPath: string;
+}
+
+export interface InteractiveNewContext {
+  readonly printPlan: (report: NewSourceReport) => void;
+}
+
+export interface InteractiveNewResult {
+  readonly reason: "write confirmation declined" | "written";
+  readonly report: NewSourceReport;
+}
+
+export async function runInteractiveNew(
+  request: InteractiveNewRequest,
+  session: InteractiveSession,
+  context: InteractiveNewContext
+): Promise<InteractiveNewResult> {
+  const kind = request.newKind ?? (await promptForKind(session));
+  const identity = await resolveIdentity(request, kind, session);
+  const container = await resolveContainer(request, kind, session);
+  const presets = await resolvePresets(request, kind, session);
+  const options = {
+    ...(container === undefined ? {} : { container }),
+    ...(identity.id === undefined ? {} : { id: identity.id }),
+    kind,
+    ...(identity.displayName === undefined
+      ? {}
+      : { displayName: identity.displayName }),
+    ...(identity.name === undefined ? {} : { name: identity.name }),
+    ...(presets === undefined ? {} : { presets }),
+    ...(request.newScope === undefined ? {} : { scope: request.newScope }),
+    skillsetOptions: request.options,
+  } as const;
+  const plan = await scaffoldSourceUnit(request.rootPath, {
+    ...options,
+    write: false,
+  });
+  context.printPlan(plan);
+  const confirmed = await session.prompts.confirm({
+    default: false,
+    message: "Proceed?",
+  });
+  if (!confirmed) {
+    return { reason: "write confirmation declined", report: plan };
+  }
+  const report = await scaffoldSourceUnit(request.rootPath, {
+    ...options,
+    write: true,
+  });
+  return { reason: "written", report };
+}
+
+async function promptForKind(
+  session: InteractiveSession
+): Promise<NewSourceKind> {
+  return session.prompts.select({
+    choices: NEW_SOURCE_KINDS.map((kind) => ({
+      description: kind.description,
+      ...(kind.enabled ? {} : { disabled: kind.reason ?? true }),
+      name: kind.name,
+      value: kind.id,
+    })),
+    default: "skill",
+    message: "Create a new:",
+  });
+}
+
+async function resolveIdentity(
+  request: InteractiveNewRequest,
+  kind: NewSourceKind,
+  session: InteractiveSession
+): Promise<{
+  readonly displayName: string | undefined;
+  readonly id: string | undefined;
+  readonly name: string | undefined;
+}> {
+  if (
+    request.positionalName !== undefined ||
+    request.newId !== undefined ||
+    request.newName !== undefined
+  ) {
+    return {
+      displayName: request.newName,
+      id: request.newId,
+      name: request.positionalName,
+    };
+  }
+  const name = await session.prompts.input({
+    message: "Name:",
+    validate: requiredValue("source name"),
+  });
+  return { displayName: undefined, id: undefined, name: name.trim() };
+}
+
+async function resolveContainer(
+  request: InteractiveNewRequest,
+  kind: NewSourceKind,
+  session: InteractiveSession
+): Promise<string | undefined> {
+  if (kind !== "skill" || request.newContainer !== undefined) {
+    return request.newContainer;
+  }
+  const containers = await discoverNewSourceContainers(
+    request.rootPath,
+    request.options
+  );
+  if (containers.length === 0) return undefined;
+  const choices = [
+    {
+      description: "Create under the workspace skills directory",
+      name: "Workspace",
+      value: WORKSPACE_CONTAINER,
+    },
+    ...containers.map((container) => ({
+      description: "Create inside this plugin",
+      name: container,
+      value: container,
+    })),
+  ];
+  const selected =
+    containers.length >= SEARCH_THRESHOLD
+      ? await session.prompts.search({
+          default: WORKSPACE_CONTAINER,
+          message: "Destination:",
+          source: (term) => {
+            const query = term?.trim().toLowerCase() ?? "";
+            return query.length === 0
+              ? choices
+              : choices.filter((choice) =>
+                  choice.name.toLowerCase().includes(query)
+                );
+          },
+        })
+      : await session.prompts.select({
+          choices,
+          default: WORKSPACE_CONTAINER,
+          message: "Destination:",
+        });
+  return selected === WORKSPACE_CONTAINER ? undefined : selected;
+}
+
+async function resolvePresets(
+  request: InteractiveNewRequest,
+  kind: NewSourceKind,
+  session: InteractiveSession
+): Promise<readonly SkillPreset[] | undefined> {
+  if (kind !== "skill" || request.newPresets !== undefined) {
+    return request.newPresets as readonly SkillPreset[] | undefined;
+  }
+  return session.prompts.checkbox({
+    choices: SKILL_PRESETS.map((preset) => ({
+      checked: preset.id === "minimal",
+      description: preset.description,
+      name: preset.name,
+      value: preset.id,
+    })),
+    message: "Include starting surfaces:",
+  });
+}
+
+function requiredValue(label: string): (value: string) => true | string {
+  return (value) =>
+    value.trim().length > 0 ? true : `skillset: ${label} is required`;
+}

--- a/apps/skillset/src/new-source.ts
+++ b/apps/skillset/src/new-source.ts
@@ -1,12 +1,56 @@
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { detectWorkspaceSourceDir } from "@skillset/core/internal/resolver";
-import { resolveInside, validateSlug } from "@skillset/core/internal/path";
+import {
+  detectWorkspaceSourceDir,
+  loadBuildGraph,
+} from "@skillset/core/internal/resolver";
+import {
+  compareStrings,
+  resolveInside,
+  validateSlug,
+} from "@skillset/core/internal/path";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
 
 export type NewSourceKind = "agent" | "hook" | "skill";
 export type NewSourceScope = "repo";
+
+export const NEW_HOOK_UNAVAILABLE_REASON =
+  "new hook is not available yet; current hook source is hooks/hooks.json";
+
+export interface NewSourceKindDefinition {
+  readonly description: string;
+  readonly enabled: boolean;
+  readonly id: NewSourceKind;
+  readonly name: string;
+  readonly reason?: string;
+}
+
+export const NEW_SOURCE_KINDS: readonly NewSourceKindDefinition[] = [
+  {
+    description: "Reusable source guidance with optional supporting files",
+    enabled: true,
+    id: "skill",
+    name: "Skill",
+  },
+  {
+    description: "Repository-level project agent",
+    enabled: true,
+    id: "agent",
+    name: "Project agent",
+  },
+  {
+    description: "Adaptive runtime hook",
+    enabled: false,
+    id: "hook",
+    name: "Hook",
+    reason: NEW_HOOK_UNAVAILABLE_REASON,
+  },
+];
+
+export const NEW_SOURCE_KIND_LIST_TEXT = formatList(
+  NEW_SOURCE_KINDS.map((kind) => kind.id)
+);
 
 export interface NewSourceOptions {
   readonly container?: string;
@@ -34,7 +78,7 @@ export interface NewSourceReport {
   readonly write: boolean;
 }
 
-type SkillPreset =
+export type SkillPreset =
   | "assets"
   | "evals"
   | "examples-file"
@@ -44,21 +88,41 @@ type SkillPreset =
   | "scripts"
   | "support";
 
+export interface SkillPresetDefinition {
+  readonly description: string;
+  readonly id: SkillPreset;
+  readonly name: string;
+}
+
 interface PlannedFile {
   readonly content: string;
   readonly path: string;
 }
 
-const SKILL_PRESETS = new Set<SkillPreset>([
-  "assets",
-  "evals",
-  "examples-file",
-  "minimal",
-  "reference-file",
-  "references",
-  "scripts",
-  "support",
-]);
+export const SKILL_PRESETS: readonly SkillPresetDefinition[] = [
+  { description: "Only SKILL.md", id: "minimal", name: "Minimal" },
+  {
+    description: "References, assets, and scripts directories",
+    id: "support",
+    name: "Support directories",
+  },
+  { description: "References directory", id: "references", name: "References" },
+  { description: "Assets directory", id: "assets", name: "Assets" },
+  { description: "Scripts directory", id: "scripts", name: "Scripts" },
+  { description: "Evaluation fixture", id: "evals", name: "Evals" },
+  {
+    description: "Top-level REFERENCE.md",
+    id: "reference-file",
+    name: "Reference file",
+  },
+  {
+    description: "Top-level EXAMPLES.md",
+    id: "examples-file",
+    name: "Examples file",
+  },
+];
+
+const SKILL_PRESET_IDS = new Set(SKILL_PRESETS.map((preset) => preset.id));
 
 export async function scaffoldSourceUnit(
   rootPath: string,
@@ -68,9 +132,7 @@ export async function scaffoldSourceUnit(
     throw new Error("skillset: new currently supports only --scope repo");
   }
   if (options.kind === "hook") {
-    throw new Error(
-      "skillset: new hook is not available yet; current hook source is hooks/hooks.json"
-    );
+    throw new Error(`skillset: ${NEW_HOOK_UNAVAILABLE_REASON}`);
   }
 
   const id = resolveSourceId(options);
@@ -107,6 +169,49 @@ export async function scaffoldSourceUnit(
   };
 }
 
+export function isNewSourceKind(value: unknown): value is NewSourceKind {
+  return NEW_SOURCE_KINDS.some((kind) => kind.id === value);
+}
+
+export async function listNewSourceContainers(
+  rootPath: string,
+  skillsetOptions: SkillsetOptions = {}
+): Promise<readonly string[]> {
+  const sourceRoot = await detectWorkspaceSourceDir(rootPath, skillsetOptions);
+  await assertWorkspaceInitialized(rootPath, sourceRoot);
+  const graph = await loadBuildGraph(rootPath, skillsetOptions);
+  return graph.plugins.map((plugin) => plugin.id);
+}
+
+export async function discoverNewSourceContainers(
+  rootPath: string,
+  skillsetOptions: SkillsetOptions = {}
+): Promise<readonly string[]> {
+  const sourceRoot = await detectWorkspaceSourceDir(rootPath, skillsetOptions);
+  await assertWorkspaceInitialized(rootPath, sourceRoot);
+  const pluginsPath = resolveInside(rootPath, join(sourceRoot, "plugins"));
+  let entries;
+  try {
+    entries = await readdir(pluginsPath, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const containers: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const id = validateSlug(entry.name, "plugin directory");
+    if (
+      await fileExists(
+        resolveInside(rootPath, join(sourceRoot, "plugins", id, "skillset.yaml"))
+      )
+    ) {
+      containers.push(id);
+    }
+  }
+  return containers.sort(compareStrings);
+}
+
 function resolveSourceId(options: NewSourceOptions): string {
   if (options.id !== undefined) return validateSlug(options.id, `${options.kind} id`);
   const name = options.name ?? options.displayName;
@@ -134,7 +239,14 @@ async function planSkill(
   const container = options.container === undefined
     ? undefined
     : validateSlug(options.container, "new --in container");
-  if (container !== undefined) await assertPluginContainer(rootPath, sourceRoot, container);
+  if (container !== undefined) {
+    await assertPluginContainer(
+      rootPath,
+      sourceRoot,
+      container,
+      options.skillsetOptions ?? {}
+    );
+  }
   const skillRoot = container === undefined
     ? join(sourceRoot, "skills", id)
     : join(sourceRoot, "plugins", container, "skills", id);
@@ -194,16 +306,31 @@ function planAgent(
 async function assertPluginContainer(
   rootPath: string,
   sourceRoot: string,
-  container: string
+  container: string,
+  skillsetOptions: SkillsetOptions
 ): Promise<void> {
   const pluginPath = join(sourceRoot, "plugins", container);
+  let hasCanonicalManifest = false;
   try {
     const stats = await stat(resolveInside(rootPath, pluginPath));
-    if (stats.isDirectory() && await hasPluginManifest(rootPath, pluginPath)) return;
+    hasCanonicalManifest =
+      stats.isDirectory() &&
+      (await fileExists(
+        resolveInside(rootPath, join(pluginPath, "skillset.yaml"))
+      ));
   } catch {
-    // Surface the normalized source-relative path below.
+    // Surface the stable source-relative diagnostic below.
   }
-  throw new Error(`skillset: new --in container does not exist or has no skillset.yaml: ${pluginPath}`);
+  if (!hasCanonicalManifest) throw missingPluginContainer(pluginPath);
+  const containers = await listNewSourceContainers(rootPath, skillsetOptions);
+  if (containers.includes(container)) return;
+  throw missingPluginContainer(pluginPath);
+}
+
+function missingPluginContainer(pluginPath: string): Error {
+  return new Error(
+    `skillset: new --in container does not exist or has no skillset.yaml: ${pluginPath}`
+  );
 }
 
 async function assertWorkspaceInitialized(rootPath: string, sourceDir: string): Promise<void> {
@@ -213,16 +340,19 @@ async function assertWorkspaceInitialized(rootPath: string, sourceDir: string): 
   );
 }
 
-function readSkillPresets(values: readonly string[] | undefined): readonly SkillPreset[] {
-  const raw = values === undefined || values.length === 0
-    ? ["minimal"]
-    : values.flatMap((value) => value.split(",")).map((value) => value.trim()).filter(Boolean);
+export function parseSkillPresets(
+  values: readonly string[]
+): readonly SkillPreset[] {
+  const raw = values
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
   const presets: SkillPreset[] = [];
   const seen = new Set<string>();
   for (const value of raw) {
-    if (!SKILL_PRESETS.has(value as SkillPreset)) {
+    if (!SKILL_PRESET_IDS.has(value as SkillPreset)) {
       throw new Error(
-        "skillset: expected --preset minimal, support, references, assets, scripts, evals, reference-file, or examples-file"
+        `skillset: expected --preset ${formatList(SKILL_PRESETS.map((preset) => preset.id))}`
       );
     }
     if (seen.has(value)) continue;
@@ -230,6 +360,17 @@ function readSkillPresets(values: readonly string[] | undefined): readonly Skill
     presets.push(value as SkillPreset);
   }
   return presets;
+}
+
+function readSkillPresets(
+  values: readonly string[] | undefined
+): readonly SkillPreset[] {
+  const presets = values === undefined ? [] : parseSkillPresets(values);
+  return presets.length === 0 ? ["minimal"] : presets;
+}
+
+function formatList(values: readonly string[]): string {
+  return `${values.slice(0, -1).join(", ")}, or ${values.at(-1)}`;
 }
 
 function uniquePlans(plans: readonly PlannedFile[]): readonly PlannedFile[] {
@@ -276,9 +417,4 @@ function yamlString(value: string): string {
 
 async function fileExists(path: string): Promise<boolean> {
   return Bun.file(path).exists();
-}
-
-async function hasPluginManifest(rootPath: string, pluginPath: string): Promise<boolean> {
-  return (await fileExists(resolveInside(rootPath, join(pluginPath, "skillset.yaml")))) ||
-    (await fileExists(resolveInside(rootPath, join(pluginPath, "config.yaml"))));
 }

--- a/apps/skillset/src/source-args.ts
+++ b/apps/skillset/src/source-args.ts
@@ -7,7 +7,12 @@ import {
   resolveCliRoot,
 } from "./cli-arg-values";
 import type { CliParseContext } from "./cli-arg-values";
-import type { NewSourceKind, NewSourceScope } from "./new-source";
+import {
+  isNewSourceKind,
+  parseSkillPresets,
+  type NewSourceKind,
+  type NewSourceScope,
+} from "./new-source";
 import {
   readImportKind,
   readImportProvider,
@@ -134,7 +139,7 @@ export const parseNewCommandRequest = (
   context: CliParseContext
 ): NewCommandRequest => {
   const kind = readNewSourceKind(args[1]);
-  let index = 2;
+  let index = kind === undefined ? 1 : 2;
   let positionalName: string | undefined;
   const positional = args[index];
   if (positional !== undefined && !positional.startsWith("--")) {
@@ -217,7 +222,7 @@ export const parseNewCommandRequest = (
     displayName,
     id,
     json,
-    presets,
+    presets: presets === undefined ? undefined : parseSkillPresets(presets),
     root,
     scope,
     yes,
@@ -250,9 +255,11 @@ const isImportProvider = (value: string | undefined): value is ImportProvider =>
   value === "cursor" ||
   value === "skillset";
 
-const readNewSourceKind = (value: string | undefined): NewSourceKind => {
-  if (value === "agent" || value === "hook" || value === "skill") return value;
-  throw new Error("skillset: expected new kind skill, agent, or hook");
+const readNewSourceKind = (
+  value: string | undefined
+): NewSourceKind | undefined => {
+  if (value === undefined || value.startsWith("--")) return undefined;
+  return isNewSourceKind(value) ? value : undefined;
 };
 
 const readNewSourceScope = (value: string): NewSourceScope => {

--- a/apps/skillset/src/source-cli.ts
+++ b/apps/skillset/src/source-cli.ts
@@ -6,13 +6,18 @@ import type { SkillsetOptions } from "@skillset/core/internal/types";
 import { printCliJsonData } from "./cli-output";
 import { ImportBatchError, importSources } from "./import";
 import type { ImportReport } from "./import";
-import type { ImportKind, ImportProvider } from "./source-arg-values";
+import {
+  createInteractiveSession,
+  type InteractiveSession,
+} from "./interactive-session";
+import { runInteractiveNew } from "./new-interactive";
 import { scaffoldSourceUnit } from "./new-source";
 import type {
   NewSourceKind,
   NewSourceReport,
   NewSourceScope,
 } from "./new-source";
+import type { ImportKind, ImportProvider } from "./source-arg-values";
 
 export interface ImportCommandRequest {
   readonly importKind: ImportKind | undefined;
@@ -112,19 +117,57 @@ export interface NewCommandRequest {
   readonly yes: boolean;
 }
 
-export async function runNewCommand({
-  positionalName,
-  jsonOutput,
-  newContainer,
-  newId,
-  newKind,
-  newName,
-  newPresets,
-  newScope,
-  options,
-  rootPath,
-  yes,
-}: NewCommandRequest): Promise<void> {
+export interface NewCommandContext {
+  readonly interactiveSession?: InteractiveSession;
+}
+
+export async function runNewCommand(
+  {
+    positionalName,
+    jsonOutput,
+    newContainer,
+    newId,
+    newKind,
+    newName,
+    newPresets,
+    newScope,
+    options,
+    rootPath,
+    yes,
+  }: NewCommandRequest,
+  context: NewCommandContext = {}
+): Promise<void> {
+  const interactiveSession = jsonOutput
+    ? undefined
+    : (context.interactiveSession ?? createInteractiveSession());
+  if (!yes && interactiveSession !== undefined) {
+    interactiveSession.banner();
+    interactiveSession.write("Create source:\n");
+    const result = await runInteractiveNew(
+      {
+        positionalName,
+        newContainer,
+        newId,
+        newKind,
+        newName,
+        newPresets,
+        newScope,
+        options,
+        rootPath,
+      },
+      interactiveSession,
+      {
+        printPlan: (plan) => {
+          interactiveSession.write("Skillset will:\n");
+          printNewSourceReport(plan, "interactive preview");
+        },
+      }
+    );
+    if (result.reason === "written") {
+      printNewSourceReport(result.report, result.reason);
+    }
+    return;
+  }
   if (newKind === undefined) {
     throw new Error("skillset: expected new kind skill, agent, or hook");
   }

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -36,7 +36,7 @@ The entries below are the complete final public flag set. Positional arguments a
 | --- | --- | --- |
 | `init [destination]` | `--root`, `--from`, `--adopt`, `--targets`, `--include`, `--name`, `--yes`, `--json` | `--adopt all` or repeat stable candidate ids. A TTY guides missing mode, source, adoption, target, and integration choices, previews the derived plan, then confirms with No as the default. |
 | `import` | `--root`, `--from`, `--kind`, `--name`, `--json` | Repeated-use asset conversion; import itself remains explicit. |
-| `new` | `--root`, `--id`, `--name`, `--in`, `--scope`, `--preset`, `--yes`, `--json` | Preview by default. |
+| `new` | `--root`, `--id`, `--name`, `--in`, `--scope`, `--preset`, `--yes`, `--json` | Preview by default. A TTY guides missing kind, identity, valid container, and preset choices before a default-No confirmation. |
 | `check` | `--root`, `--only`, `--write`, `--ci`, `--fix`, `--since`, `--report`, `--json` | `--fix` requires `--ci`; `--since` and `--report` are CI-only. |
 | `dev` | `--root`, `--write`, `--jsonl` | Watching is the command's default; `--watch` and `--apply` disappear. |
 | `reconcile <path>` | `--root`, `--use source` or `--use output`, `--yes`, `--json` | Diagnosis is default; direction can be previewed before confirmation. |

--- a/scripts/cli-contract-parity.ts
+++ b/scripts/cli-contract-parity.ts
@@ -294,6 +294,8 @@ function runtimeFlagArgs(flag: CliFlag, route: string): readonly string[] {
         return "1";
       case "--only":
         return "outputs";
+      case "--preset":
+        return "minimal";
       case "--ref":
         return "@example";
       case "--runner":


### PR DESCRIPTION
## Context

[SET-293](https://linear.app/outfitter/issue/SET-293) adds derived TTY scaffolding to `skillset new`. Stacked on #289.

## What changed

- derive source kinds, identity prompts, presets, and valid plugin containers from canonical runtime owners;
- use search for large valid-container inventories;
- render the existing scaffold report before default-No confirmation;
- preserve explicit flags, JSON, CI, non-TTY, and `--yes` behavior;
- keep build execution outside the new-source flow.

## Verification

- focused kind, preset, placement, search, validation, cancellation, and exclusion tests;
- real PTY plan/default-No/no-write proof;
- typecheck, CLI contract guards, final 1,213-test aggregate, and pre-push gate green;
- independent full-stack review 5/5.

## Risk / rollout

The prompt layer only fills missing request inputs; canonical validation and writes remain in existing domain owners. Draft until hosted CI and review are clean.