### PR TITLE
feat(cli): add interactive test chooser

### DIFF
--- a/.changeset/interactive-test-chooser.md
+++ b/.changeset/interactive-test-chooser.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Add a unified TTY test chooser for canonical declared tests, deterministic run-all execution, and current ad hoc retained runs.

--- a/apps/skillset/src/__tests__/test-interactive.test.ts
+++ b/apps/skillset/src/__tests__/test-interactive.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+
+import { createInteractiveSession } from "../interactive-session";
+import { PromptCancelledError, ScriptedPromptAdapter } from "../prompt-adapter";
+import { initSkillset } from "../setup";
+import { runTestCommand, type TestCommandRequest } from "../test-cli";
+import { resolveInteractiveTestSelection } from "../test-interactive";
+import {
+  listSkillsetTests,
+  runAllSkillsetTests,
+  runSkillsetTest,
+} from "../test-runner";
+
+const ttyInput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+const ttyOutput = (): PassThrough & { isTTY: true } =>
+  Object.assign(new PassThrough(), { isTTY: true as const });
+
+function scriptedSession(
+  answers: ConstructorParameters<typeof ScriptedPromptAdapter>[0]
+) {
+  const adapter = new ScriptedPromptAdapter(answers);
+  const session = createInteractiveSession({
+    adapter,
+    env: { CI: "false" },
+    input: ttyInput(),
+    output: ttyOutput(),
+  });
+  if (session === undefined) throw new Error("expected interactive session");
+  return { adapter, session };
+}
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "skillset-test-interactive-"));
+  await initSkillset({ cwd: root, rootPath: root, write: true });
+  await mkdir(join(root, ".skillset/skills/demo"), { recursive: true });
+  await writeFile(
+    join(root, ".skillset/skills/demo/SKILL.md"),
+    `---
+name: demo
+description: Demo test skill.
+---
+
+# Demo
+`
+  );
+  return root;
+}
+
+async function writeDeclarations(
+  root: string,
+  names: readonly string[],
+  failing: ReadonlySet<string> = new Set()
+): Promise<void> {
+  const content = names
+    .map(
+      (name) => `${name}:
+  select:
+    skills:
+      primary: ["demo"]
+  checks:
+${
+  failing.has(name)
+    ? "    files:\n      - path: .claude/skills/demo/MISSING.md"
+    : "    projection: true"
+}
+`
+    )
+    .join("");
+  await writeFile(join(root, ".skillset/tests.yaml"), content);
+}
+
+function request(
+  rootPath: string,
+  overrides: Partial<TestCommandRequest> = {}
+): TestCommandRequest {
+  return {
+    jsonOutput: false,
+    options: {},
+    rootPath,
+    testName: undefined,
+    tryBackground: false,
+    tryClaudeSettingSources: undefined,
+    tryLines: undefined,
+    tryName: undefined,
+    tryPlugins: [],
+    tryPrompt: undefined,
+    tryPromptFile: undefined,
+    tryRunId: undefined,
+    trySubcommand: undefined,
+    tryTarget: undefined,
+    tryTimeoutMs: undefined,
+    ...overrides,
+  };
+}
+
+describe("SET-294 canonical declared test inventory", () => {
+  test("zero declarations list cleanly for the ad hoc-only chooser", async () => {
+    const root = await workspace();
+    expect(await listSkillsetTests(root)).toEqual([]);
+    await expect(runSkillsetTest(root, undefined)).rejects.toThrow(
+      "must include tests.yaml or tests/*.yaml for skillset test"
+    );
+  });
+
+  test("aggregate and split declarations share canonical parsing and order", async () => {
+    const root = await workspace();
+    await writeDeclarations(root, ["zeta"]);
+    await mkdir(join(root, ".skillset/tests"), { recursive: true });
+    await writeFile(
+      join(root, ".skillset/tests/alpha.yaml"),
+      `select:
+  skills:
+    primary: ["demo"]
+targets: [codex, claude]
+checks:
+  projection: true
+`
+    );
+
+    expect(await listSkillsetTests(root)).toEqual([
+      { name: "alpha", targets: ["codex", "claude"] },
+      { name: "zeta", targets: ["claude", "codex", "cursor"] },
+    ]);
+  });
+
+  test("listing and execution reject duplicate and reserved declarations identically", async () => {
+    const duplicate = await workspace();
+    await writeDeclarations(duplicate, ["alpha"]);
+    await mkdir(join(duplicate, ".skillset/tests"), { recursive: true });
+    await writeFile(
+      join(duplicate, ".skillset/tests/alpha.yaml"),
+      "checks:\n  projection: true\n"
+    );
+    for (const operation of [
+      () => listSkillsetTests(duplicate),
+      () => runSkillsetTest(duplicate, "alpha"),
+    ]) {
+      await expect(operation()).rejects.toThrow("duplicate test alpha");
+    }
+
+    const reserved = await workspace();
+    await writeDeclarations(reserved, ["list"]);
+    for (const operation of [
+      () => listSkillsetTests(reserved),
+      () => runSkillsetTest(reserved, "list"),
+    ]) {
+      await expect(operation()).rejects.toThrow(
+        "test name list is reserved for the retained-run lifecycle"
+      );
+    }
+  });
+
+  test("explicit execution preserves its named-declaration validation boundary", async () => {
+    const root = await workspace();
+    await writeFile(
+      join(root, ".skillset/tests.yaml"),
+      `alpha:
+  select:
+    skills:
+      primary: ["demo"]
+  checks:
+    projection: true
+zeta:
+  unexpected: true
+`
+    );
+
+    await expect(runSkillsetTest(root, "alpha")).resolves.toMatchObject({
+      name: "alpha",
+      ok: true,
+    });
+    await expect(listSkillsetTests(root)).rejects.toThrow("unexpected");
+  });
+
+  test("run all keeps canonical order and continues after an ordinary failed report", async () => {
+    const root = await workspace();
+    await writeDeclarations(root, ["zeta", "alpha"], new Set(["alpha"]));
+
+    const suite = await runAllSkillsetTests(root);
+
+    expect(suite.ok).toBe(false);
+    expect(suite.reports.map((report) => [report.name, report.ok])).toEqual([
+      ["alpha", false],
+      ["zeta", true],
+    ]);
+    expect(
+      suite.reports.every((report) => report.runPath.includes("runs/"))
+    ).toBe(true);
+  });
+});
+
+describe("SET-294 unified interactive test chooser", () => {
+  test("zero declarations offer only ad hoc and construct current single-target runtime inputs", async () => {
+    const root = await workspace();
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: { kind: "ad-hoc" } },
+      { kind: "input", value: "Inspect the available guidance." },
+      { kind: "select", value: "codex" },
+      { kind: "select", value: false },
+    ]);
+
+    await expect(
+      resolveInteractiveTestSelection({ options: {}, rootPath: root }, session)
+    ).resolves.toEqual({
+      background: false,
+      kind: "ad-hoc",
+      prompt: "Inspect the available guidance.",
+      target: "codex",
+    });
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual([
+      "select",
+      "input",
+      "select",
+      "select",
+    ]);
+    const chooser = adapter.prompts[0];
+    if (chooser?.kind !== "select") throw new Error("expected test chooser");
+    expect(chooser.prompt.choices.map((choice) => choice.name)).toEqual([
+      "Ad hoc test",
+    ]);
+  });
+
+  test("one chooser contains all, each declaration, and ad hoc without redundant target prompts", async () => {
+    const root = await workspace();
+    await writeDeclarations(root, ["alpha"]);
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: { kind: "declared", name: "alpha" } },
+    ]);
+
+    await expect(
+      resolveInteractiveTestSelection({ options: {}, rootPath: root }, session)
+    ).resolves.toEqual({ kind: "declared", name: "alpha" });
+    adapter.assertComplete();
+    expect(adapter.prompts).toHaveLength(1);
+    const chooser = adapter.prompts[0];
+    if (chooser?.kind !== "select") throw new Error("expected test chooser");
+    expect(chooser.prompt.choices.map((choice) => choice.name)).toEqual([
+      "All tests",
+      "alpha",
+      "Ad hoc test",
+    ]);
+    expect(chooser.prompt.choices[1]?.description).toBe(
+      "Targets: claude, codex, cursor"
+    );
+  });
+
+  test("many declarations use search while retaining both actions during filtering", async () => {
+    const root = await workspace();
+    const names = Array.from({ length: 8 }, (_, index) => `test-${index}`);
+    await writeDeclarations(root, names);
+    const { adapter, session } = scriptedSession([
+      { kind: "search", value: { kind: "declared", name: "test-7" } },
+    ]);
+
+    await expect(
+      resolveInteractiveTestSelection({ options: {}, rootPath: root }, session)
+    ).resolves.toEqual({ kind: "declared", name: "test-7" });
+    adapter.assertComplete();
+    const chooser = adapter.prompts[0];
+    if (chooser?.kind !== "search") throw new Error("expected search chooser");
+    const filtered = await chooser.prompt.source("test-7", {
+      signal: new AbortController().signal,
+    });
+    expect(filtered.map((choice) => choice.name)).toEqual([
+      "All tests",
+      "test-7",
+      "Ad hoc test",
+    ]);
+  });
+
+  test("cancellation remains controlled before any retained run starts", async () => {
+    const root = await workspace();
+    const controller = new AbortController();
+    controller.abort();
+    const session = createInteractiveSession({
+      env: { CI: "false" },
+      input: ttyInput(),
+      output: ttyOutput(),
+      signal: controller.signal,
+    });
+    if (session === undefined) throw new Error("expected interactive session");
+
+    await expect(
+      resolveInteractiveTestSelection({ options: {}, rootPath: root }, session)
+    ).rejects.toThrow(PromptCancelledError);
+  });
+
+  test("the bare command runs the all selection through canonical retained executions", async () => {
+    const root = await workspace();
+    await writeDeclarations(root, ["zeta", "alpha"]);
+    const { adapter, session } = scriptedSession([
+      { kind: "select", value: { kind: "all" } },
+    ]);
+
+    await runTestCommand(request(root), { interactiveSession: session });
+
+    adapter.assertComplete();
+    expect(adapter.prompts.map((prompt) => prompt.kind)).toEqual(["select"]);
+  });
+
+  test("explicit, machine, lifecycle, and worker requests bypass an injected session", async () => {
+    const root = await workspace();
+    await writeDeclarations(root, ["alpha", "zeta"]);
+    const { adapter, session } = scriptedSession([]);
+
+    await runTestCommand(request(root, { testName: "alpha" }), {
+      interactiveSession: session,
+    });
+    await runTestCommand(request(root, { trySubcommand: "list" }), {
+      interactiveSession: session,
+    });
+    await expect(
+      runTestCommand(request(root, { tryTarget: "codex" }), {
+        interactiveSession: session,
+      })
+    ).rejects.toThrow("ad hoc test requires --prompt or --prompt-file");
+    await expect(
+      runTestCommand(request(root, { jsonOutput: true }), {
+        interactiveSession: session,
+      })
+    ).rejects.toThrow("multiple tests configured");
+    await expect(
+      runTestCommand(request(root, { trySubcommand: "worker" }), {
+        interactiveSession: session,
+      })
+    ).rejects.toThrow("test worker requires run id");
+
+    adapter.assertComplete();
+    expect(adapter.prompts).toEqual([]);
+  });
+
+  test("CI and non-TTY bare CLI requests keep the non-interactive contract", async () => {
+    const root = await workspace();
+    await writeDeclarations(root, ["alpha", "zeta"]);
+
+    for (const env of [process.env, { ...process.env, CI: "true" }]) {
+      const result = await runCli(["test", "--root", root], env);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("multiple tests configured");
+      expect(result.stdout).not.toContain("Run tests:");
+    }
+  });
+});
+
+async function runCli(
+  args: readonly string[],
+  env: Readonly<Record<string, string | undefined>>
+): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const process = Bun.spawn(
+    ["bun", join(import.meta.dir, "..", "cli.ts"), ...args],
+    {
+      env,
+      stderr: "pipe",
+      stdout: "pipe",
+    }
+  );
+  const [exitCode, stderr, stdout] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+    new Response(process.stdout).text(),
+  ]);
+  return { exitCode, stderr, stdout };
+}

--- a/apps/skillset/src/test-cli.ts
+++ b/apps/skillset/src/test-cli.ts
@@ -4,10 +4,15 @@ import type {
 } from "@skillset/core/internal/types";
 
 import { printCliJsonData } from "./cli-output";
-import { runSkillsetTest } from "./test-runner";
+import {
+  createInteractiveSession,
+  type InteractiveSession,
+} from "./interactive-session";
+import { resolveInteractiveTestSelection } from "./test-interactive";
+import { runAllSkillsetTests, runSkillsetTest } from "./test-runner";
 import type { SkillsetTestReport } from "./test-runner";
 import type { TryClaudeSettingSources, TrySubcommand } from "./try";
-import { runTryCommand } from "./try-cli";
+import { runTryCommand, validateTryFlags } from "./try-cli";
 
 export interface TestCommandRequest {
   readonly jsonOutput: boolean;
@@ -27,23 +32,75 @@ export interface TestCommandRequest {
   readonly tryTimeoutMs: number | undefined;
 }
 
-export async function runTestCommand({
-  jsonOutput,
-  options,
-  rootPath,
-  testName,
-  tryBackground,
-  tryClaudeSettingSources,
-  tryLines,
-  tryName,
-  tryPlugins,
-  tryPrompt,
-  tryPromptFile,
-  tryRunId,
-  trySubcommand,
-  tryTarget,
-  tryTimeoutMs,
-}: TestCommandRequest): Promise<void> {
+export interface TestCommandContext {
+  readonly interactiveSession?: InteractiveSession;
+}
+
+export async function runTestCommand(
+  request: TestCommandRequest,
+  context: TestCommandContext = {}
+): Promise<void> {
+  const {
+    jsonOutput,
+    options,
+    rootPath,
+    testName,
+    tryBackground,
+    tryClaudeSettingSources,
+    tryLines,
+    tryName,
+    tryPlugins,
+    tryPrompt,
+    tryPromptFile,
+    tryRunId,
+    trySubcommand,
+    tryTarget,
+    tryTimeoutMs,
+  } = request;
+  const interactiveSession =
+    context.interactiveSession ??
+    createInteractiveSession({
+      machineMode: jsonOutput,
+      rawProtocol: trySubcommand === "worker",
+    });
+  if (interactiveSession !== undefined && isBareTestRequest(request)) {
+    interactiveSession.banner();
+    interactiveSession.write("Run tests:\n");
+    const selection = await resolveInteractiveTestSelection(
+      { options, rootPath },
+      interactiveSession
+    );
+    if (selection.kind === "all") {
+      const suite = await runAllSkillsetTests(rootPath, options);
+      for (const report of suite.reports) printSkillsetTest(report);
+      const passed = suite.reports.filter((report) => report.ok).length;
+      console.log(
+        `skillset: test all ${suite.ok ? "passed" : "failed"} (${passed}/${suite.reports.length} passed)`
+      );
+      if (!suite.ok) process.exitCode = 1;
+      return;
+    }
+    if (selection.kind === "declared") {
+      await runDeclaredTest(rootPath, selection.name, options);
+      return;
+    }
+    validateTryFlags("test", undefined, {
+      background: selection.background,
+      plugins: [],
+      prompt: selection.prompt,
+      target: selection.target,
+      yes: false,
+    });
+    await runTryCommand(rootPath, {
+      background: selection.background,
+      json: false,
+      plugins: [],
+      prompt: selection.prompt,
+      skillsetOptions: options,
+      target: selection.target,
+    });
+    return;
+  }
   if (trySubcommand !== undefined || tryTarget !== undefined) {
     await runTryCommand(rootPath, {
       background: tryBackground,
@@ -74,6 +131,34 @@ export async function runTestCommand({
     process.exitCode = 1;
   }
   return;
+}
+
+function isBareTestRequest(request: TestCommandRequest): boolean {
+  return (
+    !request.jsonOutput &&
+    request.testName === undefined &&
+    !request.tryBackground &&
+    request.tryClaudeSettingSources === undefined &&
+    request.tryLines === undefined &&
+    request.tryName === undefined &&
+    request.tryPlugins.length === 0 &&
+    request.tryPrompt === undefined &&
+    request.tryPromptFile === undefined &&
+    request.tryRunId === undefined &&
+    request.trySubcommand === undefined &&
+    request.tryTarget === undefined &&
+    request.tryTimeoutMs === undefined
+  );
+}
+
+async function runDeclaredTest(
+  rootPath: string,
+  name: string,
+  options: SkillsetOptions
+): Promise<void> {
+  const report = await runSkillsetTest(rootPath, name, options);
+  printSkillsetTest(report);
+  if (!report.ok) process.exitCode = 1;
 }
 
 function printSkillsetTest(report: SkillsetTestReport): void {

--- a/apps/skillset/src/test-interactive.ts
+++ b/apps/skillset/src/test-interactive.ts
@@ -1,0 +1,151 @@
+import type {
+  SkillsetOptions,
+  TargetName,
+} from "@skillset/core/internal/types";
+
+import type { InteractiveSession } from "./interactive-session";
+import type { PromptChoice } from "./prompt-adapter";
+import {
+  listAdHocTestTargets,
+  listSkillsetTests,
+  type SkillsetTestSummary,
+} from "./test-runner";
+
+const SEARCH_THRESHOLD = 8;
+
+export interface InteractiveTestRequest {
+  readonly options: SkillsetOptions;
+  readonly rootPath: string;
+}
+
+export type InteractiveTestSelection =
+  | { readonly kind: "all" }
+  | { readonly kind: "declared"; readonly name: string }
+  | {
+      readonly background: boolean;
+      readonly kind: "ad-hoc";
+      readonly prompt: string;
+      readonly target: TargetName;
+    };
+
+type TestChoice =
+  | { readonly kind: "all" }
+  | { readonly kind: "declared"; readonly name: string }
+  | { readonly kind: "ad-hoc" };
+
+export async function resolveInteractiveTestSelection(
+  request: InteractiveTestRequest,
+  session: InteractiveSession
+): Promise<InteractiveTestSelection> {
+  const declarations = await listSkillsetTests(
+    request.rootPath,
+    request.options
+  );
+  const selection = await promptForSelection(declarations, session);
+  if (selection.kind === "all") return selection;
+  if (selection.kind === "declared") return selection;
+
+  const prompt = await session.prompts.input({ message: "Prompt:" });
+  const targets = await listAdHocTestTargets(request.rootPath, request.options);
+  const target = await promptForTarget(targets, session);
+  const background = await session.prompts.select({
+    choices: [
+      {
+        description: "Wait for the retained test result",
+        name: "Foreground",
+        value: false,
+      },
+      {
+        description: "Start the retained test and return immediately",
+        name: "Background",
+        value: true,
+      },
+    ],
+    default: false,
+    message: "Run:",
+  });
+  return { background, kind: "ad-hoc", prompt, target };
+}
+
+async function promptForSelection(
+  declarations: readonly SkillsetTestSummary[],
+  session: InteractiveSession
+): Promise<TestChoice> {
+  const choices = selectionChoices(declarations);
+  const defaultChoice = choices[0]?.value;
+  if (defaultChoice === undefined) {
+    throw new Error("skillset: interactive test chooser has no actions");
+  }
+  return declarations.length >= SEARCH_THRESHOLD
+    ? session.prompts.search({
+        default: defaultChoice,
+        message: "Run:",
+        source: (term) => filterSelectionChoices(choices, term),
+      })
+    : session.prompts.select({
+        choices,
+        default: defaultChoice,
+        message: "Run:",
+      });
+}
+
+function selectionChoices(
+  declarations: readonly SkillsetTestSummary[]
+): readonly PromptChoice<TestChoice>[] {
+  return [
+    ...(declarations.length === 0
+      ? []
+      : [
+          {
+            description: `Run ${declarations.length} committed ${declarations.length === 1 ? "test" : "tests"}`,
+            name: "All tests",
+            value: { kind: "all" } as const,
+          },
+        ]),
+    ...declarations.map((declaration) => ({
+      description: `Targets: ${declaration.targets.join(", ")}`,
+      name: declaration.name,
+      value: { kind: "declared", name: declaration.name } as const,
+    })),
+    {
+      description: "Run an isolated prompt against one enabled target",
+      name: "Ad hoc test",
+      value: { kind: "ad-hoc" } as const,
+    },
+  ];
+}
+
+function filterSelectionChoices(
+  choices: readonly PromptChoice<TestChoice>[],
+  term: string | undefined
+): readonly PromptChoice<TestChoice>[] {
+  const query = term?.trim().toLowerCase() ?? "";
+  if (query.length === 0) return choices;
+  return choices.filter(
+    (choice) =>
+      choice.value.kind !== "declared" ||
+      choice.name.toLowerCase().includes(query) ||
+      choice.description?.toLowerCase().includes(query)
+  );
+}
+
+async function promptForTarget(
+  targets: readonly TargetName[],
+  session: InteractiveSession
+): Promise<TargetName> {
+  const first = targets[0];
+  if (first === undefined) {
+    throw new Error(
+      "skillset: ad hoc test requires an enabled claude, codex, or cursor target"
+    );
+  }
+  if (targets.length === 1) return first;
+  return session.prompts.select({
+    choices: targets.map((target) => ({
+      name: `${target[0]?.toUpperCase() ?? ""}${target.slice(1)}`,
+      value: target,
+    })),
+    default: first,
+    message: "Run with:",
+  });
+}

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -53,6 +53,16 @@ export interface SkillsetTestOptions extends SkillsetOptions {
   readonly runtimeEnv?: Record<string, string | undefined>;
 }
 
+export interface SkillsetTestSummary {
+  readonly name: string;
+  readonly targets: readonly TargetName[];
+}
+
+export interface SkillsetTestSuiteReport {
+  readonly ok: boolean;
+  readonly reports: readonly SkillsetTestReport[];
+}
+
 export interface SkillsetRuntimeAssertionResult extends JsonRecord {
   readonly actual: boolean;
   readonly expected: string;
@@ -151,10 +161,60 @@ export async function runSkillsetTest(
   name: string | undefined,
   options: SkillsetTestOptions = {}
 ): Promise<SkillsetTestReport> {
-  await rejectRetiredWorkspaceTestConfig(rootPath, options);
-  const graph = await loadBuildGraph(rootPath, options);
+  const context = await loadTestDeclarationContext(
+    rootPath,
+    options
+  );
+  const selectedName = selectTestName(context.graph, context.names, name);
+  const source = context.tests[selectedName];
+  if (source === undefined) {
+    throw new Error(`skillset: test ${selectedName} is not configured`);
+  }
+  const declaration = await readTestObject(
+    context.graph,
+    source.record,
+    source.label,
+    selectedName,
+    context.defaultTargets
+  );
+  return runLoadedSkillsetTest(
+    rootPath,
+    context.graph,
+    declaration,
+    options
+  );
+}
+
+export async function runAllSkillsetTests(
+  rootPath: string,
+  options: SkillsetTestOptions = {}
+): Promise<SkillsetTestSuiteReport> {
+  const { declarations, graph } = await loadSkillsetTestContext(
+    rootPath,
+    options
+  );
+  if (declarations.length === 0) {
+    throw new Error(`skillset: ${testDeclarationRoot(graph)} must include tests.yaml or tests/*.yaml for skillset test`);
+  }
+  const reports: SkillsetTestReport[] = [];
+  for (const declaration of declarations) {
+    reports.push(
+      await runLoadedSkillsetTest(rootPath, graph, declaration, options)
+    );
+  }
+  return {
+    ok: reports.every((report) => report.ok),
+    reports,
+  };
+}
+
+async function runLoadedSkillsetTest(
+  rootPath: string,
+  graph: BuildGraph,
+  declaration: TestDeclaration,
+  options: SkillsetTestOptions
+): Promise<SkillsetTestReport> {
   const sourceDir = graph.sourceDir;
-  const declaration = await readTestDeclaration(graph, name);
   const buildOptions: SkillsetOptions = {
     buildMode: "all",
     ...(options.distDir === undefined ? {} : { distDir: options.distDir }),
@@ -276,6 +336,39 @@ export async function runSkillsetTest(
   }
 }
 
+export async function listSkillsetTests(
+  rootPath: string,
+  options: SkillsetTestOptions = {}
+): Promise<readonly SkillsetTestSummary[]> {
+  const { declarations } = await loadSkillsetTestContext(rootPath, options);
+  return declarations.map((declaration) => ({
+    name: declaration.name,
+    targets: declaration.targets,
+  }));
+}
+
+export async function listAdHocTestTargets(
+  rootPath: string,
+  options: SkillsetOptions = {}
+): Promise<readonly TargetName[]> {
+  const graph = await loadBuildGraph(rootPath, options);
+  return targetNames().filter((target) => graph.root.targets[target].enabled);
+}
+
+async function loadSkillsetTestContext(
+  rootPath: string,
+  options: SkillsetTestOptions
+): Promise<{
+  readonly declarations: readonly TestDeclaration[];
+  readonly graph: BuildGraph;
+}> {
+  const context = await loadTestDeclarationContext(rootPath, options);
+  return {
+    declarations: await parseTestDeclarations(context),
+    graph: context.graph,
+  };
+}
+
 async function rejectRetiredWorkspaceTestConfig(rootPath: string, options: SkillsetOptions): Promise<void> {
   const sourceDir = await detectWorkspaceSourceDir(rootPath, options);
   const configPaths = ["skillset.yaml"];
@@ -290,16 +383,11 @@ async function rejectRetiredWorkspaceTestConfig(rootPath: string, options: Skill
   }
 }
 
-async function readTestDeclaration(graph: BuildGraph, requestedName: string | undefined): Promise<TestDeclaration> {
-  const configPath = graph.rootConfigPath;
-  const config = parseYamlRecord(await readFile(configPath, "utf8"), configPath);
-  if (config.tests !== undefined) {
-    throw new Error(`skillset: ${configPath}.tests is retired; place test declarations in ${testDeclarationRoot(graph)}/tests.yaml or ${testDeclarationRoot(graph)}/tests/*.yaml`);
-  }
-  const defaultTargets = readEffectiveTargets(config, configPath);
-  const tests = await readTestDeclarations(graph);
-
-  const names = Object.keys(tests).sort(compareStrings);
+function selectTestName(
+  graph: BuildGraph,
+  names: readonly string[],
+  requestedName: string | undefined
+): string {
   if (names.length === 0) {
     throw new Error(`skillset: ${testDeclarationRoot(graph)} must include tests.yaml or tests/*.yaml for skillset test`);
   }
@@ -307,10 +395,54 @@ async function readTestDeclaration(graph: BuildGraph, requestedName: string | un
   if (name === undefined) {
     throw new Error(`skillset: multiple tests configured (${names.join(", ")}); pass a test name`);
   }
-  const declaration = tests[name];
-  if (declaration === undefined) throw new Error(`skillset: test ${name} is not configured; available tests: ${names.join(", ")}`);
+  if (!names.includes(name)) {
+    throw new Error(`skillset: test ${name} is not configured; available tests: ${names.join(", ")}`);
+  }
+  return name;
+}
 
-  return readTestObject(graph, declaration.record, declaration.label, name, defaultTargets);
+interface TestDeclarationContext {
+  readonly defaultTargets: readonly TargetName[];
+  readonly graph: BuildGraph;
+  readonly names: readonly string[];
+  readonly tests: Readonly<Record<string, TestDeclarationRecord>>;
+}
+
+async function loadTestDeclarationContext(
+  rootPath: string,
+  options: SkillsetTestOptions
+): Promise<TestDeclarationContext> {
+  await rejectRetiredWorkspaceTestConfig(rootPath, options);
+  const graph = await loadBuildGraph(rootPath, options);
+  const configPath = graph.rootConfigPath;
+  const config = parseYamlRecord(await readFile(configPath, "utf8"), configPath);
+  if (config.tests !== undefined) {
+    throw new Error(`skillset: ${configPath}.tests is retired; place test declarations in ${testDeclarationRoot(graph)}/tests.yaml or ${testDeclarationRoot(graph)}/tests/*.yaml`);
+  }
+  const defaultTargets = readEffectiveTargets(config, configPath);
+  const tests = await readTestDeclarations(graph);
+  const names = Object.keys(tests).sort(compareStrings);
+  return { defaultTargets, graph, names, tests };
+}
+
+async function parseTestDeclarations(
+  context: TestDeclarationContext
+): Promise<readonly TestDeclaration[]> {
+  const declarations: TestDeclaration[] = [];
+  for (const name of context.names) {
+    const declaration = context.tests[name];
+    if (declaration === undefined) continue;
+    declarations.push(
+      await readTestObject(
+        context.graph,
+        declaration.record,
+        declaration.label,
+        name,
+        context.defaultTargets
+      )
+    );
+  }
+  return declarations;
 }
 
 interface TestDeclarationRecord {

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -48,7 +48,7 @@ The entries below are the complete final public flag set. Positional arguments a
 | `list` | `--root`, `--scope`, `--json` | Inventory, not build-mode selection. |
 | `explain <path>` | `--root`, `--scope`, `--json` | Workspace-specific provenance. |
 | `lookup` | `--frontmatter`, `--fields`, `--field`, `--values`, `--events`, `--compat`, `--examples`, `--schema`, `--json` | Workspace-independent reference lookup; `--root` is rejected. Provider aliases become values of `--compat`, not separate `--claude`/`--codex`/`--cursor` flags. |
-| `test [name]` | `--root`, `--target`, `--prompt`, `--prompt-file`, `--plugin`, `--name`, `--timeout-ms`, `--claude-setting-sources`, `--background`, `--json` | Runtime flags select ad hoc execution; named declarations remain positional. |
+| `test [name]` | `--root`, `--target`, `--prompt`, `--prompt-file`, `--plugin`, `--name`, `--timeout-ms`, `--claude-setting-sources`, `--background`, `--json` | Runtime flags select ad hoc execution; named declarations remain positional. A bare TTY uses one chooser for all canonical declarations, one declaration, or an ad hoc prompt; retained `list`/`status`/`tail` history stays outside the picker. |
 | `test status` or `test list` | `--root`, `--json` | Retained-run lifecycle. |
 | `test tail` | `--root`, `--lines`, `--json` | Bounded retained output; a future `--follow` uses `--jsonl`. |
 | `change status` | `--root`, `--since`, `--staged`, `--json` | Read-only ledger status. |


### PR DESCRIPTION
## Context

[SET-294](https://linear.app/outfitter/issue/SET-294) unifies bare TTY test selection. Stacked on #290.

## What changed

- expose one chooser for run-all, each canonical declaration, and ad hoc retained runs;
- use search when declaration inventories warrant it;
- run all declarations in canonical order while continuing after ordinary failed reports;
- preserve explicit named-test validation boundaries and raw worker/lifecycle protocol routes.

## Verification

- 12 focused chooser and canonical-inventory tests;
- real PTY run-all proof with 2/2 declarations and controlled cancellation proof;
- affected selector contracts, typecheck, final 1,213-test aggregate, and pre-push gate green;
- independent full-stack review 5/5.

## Risk / rollout

Only the bare eligible TTY route prompts. Explicit, machine, CI, non-TTY, JSON/JSONL, and worker requests retain their established behavior. Draft until hosted CI and review are clean.