### PR TITLE
fix(core): preserve hook attachment providers

### DIFF
--- a/.changeset/cursor-hook-attachment-providers.md
+++ b/.changeset/cursor-hook-attachment-providers.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Preserve Cursor and future canonical providers on adaptive hook attachments, and reject invalid plugin attachment provider lists through shared schema diagnostics.

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -9,6 +9,10 @@ import {
   type SourceAdaptiveHook,
   type SourceHookAttachment,
 } from "@skillset/core";
+import {
+  adaptiveHookIntentIsRenderable,
+  classifyAdaptiveHookIntent,
+} from "../adaptive-hook-classifier";
 import { renderBuildGraph } from "../render";
 import { loadBuildGraph } from "../resolver";
 import { targetNames } from "../targets";
@@ -110,6 +114,15 @@ hooks:
       hook: "shell-policy",
       providers: ["cursor"],
     }));
+    const resolution = resolveAdaptiveHookAttachments(graph.adaptiveHooks, graph.hookAttachments);
+    expect(resolution.issues).toEqual([]);
+    const classification = classifyAdaptiveHookIntent(resolution.resolved[0]!, "cursor", "plugin");
+    expect(classification).toEqual(expect.objectContaining({
+      reason: "Adaptive hook shell-policy is scoped to cursor.",
+      status: "provider-scoped-adaptive",
+      target: "cursor",
+    }));
+    expect(adaptiveHookIntentIsRenderable(classification)).toBe(true);
     const hookOutputs = (await renderBuildGraph(graph))
       .map((file) => file.path)
       .filter((path) => path.endsWith("/hooks/hooks.json"));

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@skillset/core";
 import { renderBuildGraph } from "../render";
 import { loadBuildGraph } from "../resolver";
+import { targetNames } from "../targets";
 import type { JsonRecord } from "../types";
 import { parseMarkdown } from "../yaml";
 
@@ -52,6 +53,130 @@ describe("adaptive hook attachment resolution", () => {
 });
 
 describe("adaptive hook graph loading", () => {
+  test("preserves every canonical attachment provider in author order", async () => {
+    const providers = [...targetNames()].reverse();
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-provider-order
+claude: true
+codex: true
+cursor: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - hook: shell-policy
+      providers: [${providers.join(", ")}]
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo ok" },
+      }),
+    }));
+
+    expect(graph.hookAttachments).toContainEqual(expect.objectContaining({
+      hook: "shell-policy",
+      providers,
+    }));
+  });
+
+  test("keeps Cursor-only attachments scoped through rendering", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-cursor-provider
+claude: true
+codex: true
+cursor: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - hook: shell-policy
+      providers: [cursor]
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo ok" },
+      }),
+    }));
+
+    expect(graph.hookAttachments).toContainEqual(expect.objectContaining({
+      hook: "shell-policy",
+      providers: ["cursor"],
+    }));
+    const hookOutputs = (await renderBuildGraph(graph))
+      .map((file) => file.path)
+      .filter((path) => path.endsWith("/hooks/hooks.json"));
+    expect(hookOutputs).toEqual(["plugins/demo/cursor/hooks/hooks.json"]);
+  });
+
+  test("keeps omitted attachment providers enabled for every configured target", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-omitted-providers
+claude: true
+codex: true
+cursor: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - shell-policy
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo ok" },
+      }),
+    }));
+
+    expect(graph.hookAttachments.find((attachment) => attachment.hook === "shell-policy")?.providers).toBeUndefined();
+    const hookOutputs = (await renderBuildGraph(graph))
+      .map((file) => file.path)
+      .filter((path) => path.endsWith("/hooks/hooks.json"));
+    expect(hookOutputs).toEqual([
+      "plugins/demo/claude/hooks/hooks.json",
+      "plugins/demo/codex/hooks/hooks.json",
+      "plugins/demo/cursor/hooks/hooks.json",
+    ]);
+  });
+
+  test("rejects invalid plugin attachment providers through schema diagnostics", async () => {
+    await expect(loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-invalid-provider
+claude: true
+codex: true
+cursor: true
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  Stop:
+    - hook: shell-policy
+      providers: [bad]
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        events: ["Stop"],
+        run: { command: "echo ok" },
+      }),
+    }))).rejects.toMatchObject({
+      code: "plugin-manifest-invalid",
+      featureId: "plugin-manifests",
+      message: expect.stringContaining("hook attachment providers entries must be claude, codex, or cursor"),
+    });
+  });
+
   test("loads root, plugin, and skill-local definitions plus frontmatter attachments", async () => {
     const graph = await loadBuildGraph(await fixture({
       "skillset.yaml": `

--- a/packages/core/src/adaptive-hook-attachments.ts
+++ b/packages/core/src/adaptive-hook-attachments.ts
@@ -1,4 +1,5 @@
 import { compareStrings } from "./path";
+import { isTargetName } from "./targets";
 import { isJsonRecord } from "./yaml";
 import type {
   AdaptiveHookScope,
@@ -126,7 +127,7 @@ function readHookAttachmentEntry(
 
 function readProviders(value: JsonValue | undefined): readonly TargetName[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const providers = value.filter((item): item is TargetName => item === "claude" || item === "codex");
+  const providers = value.filter(isTargetName);
   return providers.length === 0 ? undefined : providers;
 }
 

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative, sep } from "node:path";
 import {
   validateAgentFrontmatter,
   validateAdaptiveHookUnitSource,
+  validateHookAttachmentsSource,
   validateInstructionFrontmatter,
   validateSkillFrontmatter,
   type SkillsetSchemaDiagnostic,
@@ -858,6 +859,15 @@ async function loadPlugin(
   let targets: SourcePlugin["targets"];
   try {
     validateConfigDocument(config, configPath, { allowHooks: true, featureKeys: PLUGIN_FEATURE_KEYS });
+    const hookAttachmentDiagnostics = validateHookAttachmentsSource(
+      config.hooks,
+      `${configRelativePath}.hooks`
+    ).diagnostics;
+    if (hookAttachmentDiagnostics.length > 0) {
+      throw new Error(
+        `skillset: plugin ${configRelativePath} hook attachments failed schema validation: ${hookAttachmentDiagnostics.map((diagnostic) => diagnostic.message).join("; ")}`
+      );
+    }
     await validateSupports(config.supports, { label: configRelativePath, rootPath, warnings });
     dependencies = readPluginDependencies(config.dependencies, configRelativePath);
     metadata = readSkillsetMetadata(config, configPath);


### PR DESCRIPTION
## Context

SET-314 fixes a silent scope broadening in adaptive hook attachments: `providers: [cursor]` was filtered to an omitted list, which downstream code correctly interpreted as all targets.

## What changed

- parse attachment providers through Core's schema-derived canonical target predicate
- validate plugin hook attachments with the shared schema contract before parsing
- preserve mixed canonical provider order and future registered targets
- prove Cursor-only parse, resolution, classification, and rendering behavior
- preserve omitted-provider all-target behavior and reject invalid values through structured plugin diagnostics
- add the Core patch changeset

## Verification

- standing and fresh targeted Terra High reviews: 5/5 clean, zero P0-P2
- focused attachment and classifier suites: 30 tests, 83 expectations
- `bun run typecheck`
- `bun run conformance:fast`
- `bun run check`: 1,258 tests, 53,920 expectations
- `bun run hooks:pre-push`

## Risk and rollout

The change is limited to Core attachment parsing/plugin validation and regressions. Invalid plugin provider lists now fail loudly instead of being silently broadened. No generated source, publication, global configuration, or bridge worktree mutation.

Linear: SET-314
