### PR TITLE
refactor(core): derive Cursor hook event casing

### DIFF
--- a/.changeset/cursor-hook-event-casing.md
+++ b/.changeset/cursor-hook-event-casing.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Derive Cursor hook event casing from registry evidence so newly registered events render with provider-native lower-camel names automatically.

--- a/packages/core/src/__tests__/hook-capabilities.test.ts
+++ b/packages/core/src/__tests__/hook-capabilities.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { getProviderHookEvidence } from "@skillset/registry";
 
 import {
   CODEX_HOOK_EVENTS,
   canonicalHookEventName,
   classifyAdaptiveHookUnitPath,
+  deriveCursorHookEventNames,
   hookEventSupported,
   hookHandlerTypesForEvent,
   hookProviderCapabilities,
@@ -128,6 +130,20 @@ describe("hook provider capabilities", () => {
   });
 
   test("records Cursor handler, scope, and native event-name constraints", () => {
+    const cursorEvidence = getProviderHookEvidence("cursor");
+    for (const { name } of cursorEvidence.events) {
+      const native = `${name[0]?.toLowerCase()}${name.slice(1)}`;
+      expect(nativeHookEventName("cursor", name), name).toBe(native);
+      expect(canonicalHookEventName("cursor", native), native).toBe(name);
+    }
+    const extended = deriveCursorHookEventNames([
+      ...cursorEvidence.events.map((event) => event.name),
+      "FutureCursorEvent",
+    ]);
+    expect(extended.nativeByCanonical.FutureCursorEvent).toBe("futureCursorEvent");
+    expect(extended.canonicalByNative.futureCursorEvent).toBe("FutureCursorEvent");
+    expect(nativeHookEventName("cursor", "AfterMCPExecution")).toBe("afterMCPExecution");
+
     const cursor = hookProviderCapabilities.cursor;
     expect(hookEventSupported("cursor", "SessionStart")).toBe(true);
     expect(hookEventSupported("cursor", "sessionStart")).toBe(true);

--- a/packages/core/src/hook-capabilities.ts
+++ b/packages/core/src/hook-capabilities.ts
@@ -71,35 +71,11 @@ const CLAUDE_HOOK_EVIDENCE = getProviderHookEvidence("claude");
 const CODEX_HOOK_EVIDENCE = getProviderHookEvidence("codex");
 const CURSOR_HOOK_EVIDENCE = getProviderHookEvidence("cursor");
 
-const CURSOR_NATIVE_EVENT_BY_CANONICAL: Readonly<Record<string, string>> = {
-  AfterAgentResponse: "afterAgentResponse",
-  AfterAgentThought: "afterAgentThought",
-  AfterFileEdit: "afterFileEdit",
-  AfterMCPExecution: "afterMCPExecution",
-  AfterShellExecution: "afterShellExecution",
-  AfterTabFileEdit: "afterTabFileEdit",
-  BeforeMCPExecution: "beforeMCPExecution",
-  BeforeReadFile: "beforeReadFile",
-  BeforeShellExecution: "beforeShellExecution",
-  BeforeSubmitPrompt: "beforeSubmitPrompt",
-  BeforeTabFileRead: "beforeTabFileRead",
-  PostCompact: "postCompact",
-  PostToolUse: "postToolUse",
-  PostToolUseFailure: "postToolUseFailure",
-  PreCompact: "preCompact",
-  PreToolUse: "preToolUse",
-  SessionEnd: "sessionEnd",
-  SessionStart: "sessionStart",
-  Stop: "stop",
-  SubagentStart: "subagentStart",
-  SubagentStop: "subagentStop",
-  UserPromptSubmit: "userPromptSubmit",
-  WorkspaceOpen: "workspaceOpen",
-};
-
-const CURSOR_CANONICAL_EVENT_BY_NATIVE: Readonly<Record<string, string>> = Object.fromEntries(
-  Object.entries(CURSOR_NATIVE_EVENT_BY_CANONICAL).map(([canonical, native]) => [native, canonical])
+const CURSOR_EVENT_NAMES = deriveCursorHookEventNames(
+  CURSOR_HOOK_EVIDENCE.events.map((event) => event.name)
 );
+const CURSOR_NATIVE_EVENT_BY_CANONICAL = CURSOR_EVENT_NAMES.nativeByCanonical;
+const CURSOR_CANONICAL_EVENT_BY_NATIVE = CURSOR_EVENT_NAMES.canonicalByNative;
 
 export const CLAUDE_HOOK_EVENTS: ReadonlySet<string> = eventSet(CLAUDE_HOOK_EVIDENCE);
 export const CODEX_HOOK_EVENTS: ReadonlySet<string> = eventSet(CODEX_HOOK_EVIDENCE);
@@ -197,6 +173,25 @@ export function canonicalHookEventName(provider: HookCapabilityProvider, event: 
 export function nativeHookEventName(provider: HookCapabilityProvider, event: string): string {
   if (provider !== "cursor") return event;
   return CURSOR_NATIVE_EVENT_BY_CANONICAL[event] ?? event;
+}
+
+export function deriveCursorHookEventNames(events: readonly string[]): {
+  readonly canonicalByNative: Readonly<Record<string, string>>;
+  readonly nativeByCanonical: Readonly<Record<string, string>>;
+} {
+  const nativeByCanonical = Object.fromEntries(
+    events.map((event) => [event, lowerFirst(event)])
+  );
+  return {
+    canonicalByNative: Object.fromEntries(
+      Object.entries(nativeByCanonical).map(([canonical, native]) => [native, canonical])
+    ),
+    nativeByCanonical,
+  };
+}
+
+function lowerFirst(value: string): string {
+  return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
 }
 
 export function classifyAdaptiveHookUnitPath(path: string): AdaptiveHookUnitPath {


### PR DESCRIPTION
## Context

SET-316 removes a second source of truth for Cursor hook event casing. Core previously duplicated all 23 registry events in a manual PascalCase-to-lowerCamel map, so a new registry event could silently render with an invalid native key.

## What changed

- derive both Cursor event-name directions from registry hook evidence
- apply the provider-documented lower-first transform while preserving acronym casing
- retain pass-through behavior for unknown events
- prove every current registry event round-trips
- prove an in-test future registry event derives without another Core list edit
- add the Core patch changeset

## Verification

- standing and fresh targeted Terra High reviews: 5/5 clean, zero P0-P2
- hook capability and adaptive render suites: 33 tests, 209 expectations
- `bun run typecheck`
- `bun run conformance:fast`
- `bun run check`: 1,258 tests, 53,969 expectations
- `bun run hooks:pre-push`

## Risk and rollout

This changes only internal Core event-name derivation and tests. Existing events, acronym behavior, and unknown-event fallback are pinned. No registry mutation, renderer topology change, generated-source edit, publication, global configuration, or bridge worktree mutation.

Linear: SET-316
