### PR TITLE
fix(core): load Cursor target-native islands

### DIFF
--- a/.changeset/cursor-target-native-islands.md
+++ b/.changeset/cursor-target-native-islands.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Load Cursor target-native islands at workspace and plugin scope, and report the pass-through contract for every canonical target.

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -481,6 +481,60 @@ Changed after the generated lock was written.
   expect(status.sourceChanges.map((change) => change.id)).not.toContain("skill:demo");
 });
 
+test("release-state-only Cursor islands retain their source kind", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-release-state-root
+claude: false
+codex: false
+cursor: true
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+`,
+  });
+
+  await buildSkillset(root);
+  await commitFixture(root);
+  await writeReleaseState(
+    root,
+    {
+      scopes: {
+        "cursor.native:removed.txt": {
+          sourceHash: `sha256:${"a".repeat(64)}`,
+          version: "1.0.0",
+        },
+        "plugin.alpha.cursor.native:removed.txt": {
+          sourceHash: `sha256:${"b".repeat(64)}`,
+          version: "1.0.0",
+        },
+      },
+    },
+    { sourceDir: ".skillset" }
+  );
+
+  const status = await changeStatus(root);
+
+  expect(
+    status.sourceChanges
+      .filter((change) => change.id.includes("cursor.native"))
+      .map(({ id, kind, status: changeStatus }) => ({ id, kind, status: changeStatus }))
+  ).toEqual([
+    {
+      id: "cursor.native:removed.txt",
+      kind: "target-native-island",
+      status: "removed",
+    },
+    {
+      id: "plugin.alpha.cursor.native:removed.txt",
+      kind: "target-native-island",
+      status: "removed",
+    },
+  ]);
+});
+
 test("dedicated 1.0 release baseline seeding writes to .skillset/changes/state.json", async () => {
   const root = await fixture({
     "skillset.yaml": `

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -2882,6 +2882,8 @@ claude:
   projectRoot: project-claude
 codex:
   projectRoot: project-codex
+cursor:
+  projectRoot: project-cursor
 `,
     ".skillset/_codex/rules/deny.rules": `
 match = "rm -rf"
@@ -2898,6 +2900,9 @@ description: Reviews code.
 
 Use {{this.description}}.
 `,
+    ".skillset/_cursor/native.txt": `
+cursor only
+`,
     ".skillset/plugins/alpha/skillset.yaml": `
 skillset:
   name: alpha
@@ -2913,11 +2918,15 @@ skillset:
   expect(await readFile(join(root, "project-claude/agents/reviewer.md"), "utf8")).toContain(
     "Use Reviews code."
   );
+  expect(await readFile(join(root, "project-cursor/native.txt"), "utf8")).toContain("cursor only");
   expect(await exists(join(root, "project-codex/agents/reviewer.md"))).toBe(false);
   expect(await exists(join(root, "project-claude/rules/deny.rules"))).toBe(false);
+  expect(await exists(join(root, "project-claude/native.txt"))).toBe(false);
+  expect(await exists(join(root, "project-codex/native.txt"))).toBe(false);
   const codexLock = await readFile(join(root, "skillset.lock"), "utf8");
   expect(codexLock).toContain(`"kind": "island"`);
   expect(codexLock).toContain(`"outputPath": "project-codex/rules/deny.rules"`);
+  expect(codexLock).toContain(`"outputPath": "project-cursor/native.txt"`);
 });
 
 test("target-native islands reject frontmatter target escapes", async () => {
@@ -2927,10 +2936,11 @@ skillset:
   name: test-root
 claude: true
 codex: false
+cursor: true
 `,
-    ".skillset/_claude/agents/bad.md": `
+    ".skillset/_cursor/agents/bad.md": `
 ---
-codex: true
+claude: true
 ---
 
 Bad.
@@ -3106,6 +3116,7 @@ skillset:
   name: test-root
 claude: true
 codex: true
+cursor: true
 `,
     ".skillset/plugins/alpha/skillset.yaml": `
 skillset:
@@ -3117,6 +3128,9 @@ skillset:
     ".skillset/plugins/alpha/_codex/config.json": `
 {"codex": true}
 `,
+    ".skillset/plugins/alpha/_cursor/native.txt": `
+cursor plugin only
+`,
   });
 
   await buildSkillset(root);
@@ -3125,6 +3139,9 @@ skillset:
   expect(await exists(join(root, "plugins/alpha/codex/commands/review.md"))).toBe(false);
   expect(await exists(join(root, "plugins/alpha/codex/config.json"))).toBe(true);
   expect(await exists(join(root, "plugins/alpha/claude/config.json"))).toBe(false);
+  expect(await readFile(join(root, "plugins/alpha/cursor/native.txt"), "utf8")).toContain("cursor plugin only");
+  expect(await exists(join(root, "plugins/alpha/claude/native.txt"))).toBe(false);
+  expect(await exists(join(root, "plugins/alpha/codex/native.txt"))).toBe(false);
 });
 
 test("plugin-local provider source requires a plugin manifest", async () => {

--- a/apps/skillset/src/change-status.ts
+++ b/apps/skillset/src/change-status.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readdir, readFile, rename, rm, rmdir, stat, writeFile }
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 
-import { diffSkillset, type SkillsetDiff } from "@skillset/core";
+import { diffSkillset, isTargetName, type SkillsetDiff } from "@skillset/core";
 import { readString } from "@skillset/core/internal/config";
 import { compareStrings, resolveInside } from "@skillset/core/internal/path";
 import { gitSafeEnv } from "./git-env";
@@ -1061,7 +1061,9 @@ function kindForSourceUnitId(id: string): SourceUnitKind {
   if (/^plugin\.[^.]+\.config:/.test(selector)) return "plugin-config";
   if (/^plugin\.[^.]+\.feature:/.test(selector)) return "plugin-feature";
   if (/^plugin\.[^.]+\.skill:/.test(selector)) return "plugin-skill";
-  if (/^(?:plugin\.[^.]+\.)?(?:claude|codex)\.[^.]+:/.test(selector)) return "target-native-island";
+  const projectTarget = selector.match(/^([^.]+)\.[^.]+:/)?.[1];
+  const pluginTarget = selector.match(/^plugin\.[^.]+\.([^.]+)\.[^.]+:/)?.[1];
+  if (isTargetName(projectTarget) || isTargetName(pluginTarget)) return "target-native-island";
   return "root-config";
 }
 

--- a/docs/features/target-native-islands.md
+++ b/docs/features/target-native-islands.md
@@ -38,7 +38,7 @@ Provider source should mirror only into the matching target root. It must not le
 
 Codex `.rules` files are execution policy for shell-command decisions. They are not `<source-root>/rules` and must not receive prose instruction rendering. The correct portable instruction path remains `<source-root>/rules/**/*.md` to Claude `.claude/rules/**/*.md` and Codex `AGENTS.md`. Codex `.rules` pass-through is accepted only from `<source-root>/_codex/rules/**/*.rules`; project `.rules` elsewhere and all Codex plugin `.rules` fail loudly.
 
-Provider source Markdown may carry source frontmatter for preprocessing, but it may not carry `claude`, `codex`, or `targets` overrides because the path already scopes the target. Known text and structured files use the SET-22 preprocessing and validation boundary; unknown and binary files copy byte-for-byte.
+Provider source Markdown may carry source frontmatter for preprocessing, but it may not carry `claude`, `codex`, `cursor`, or `targets` overrides because the path already scopes the target. Known text and structured files use the SET-22 preprocessing and validation boundary; unknown and binary files copy byte-for-byte.
 
 ## Diagnostics
 

--- a/docs/features/target-native-islands.md
+++ b/docs/features/target-native-islands.md
@@ -20,19 +20,21 @@ Project-level provider source uses explicit provider directories:
 
 ## Support Table
 
-| Source or surface | Claude | Codex | Status | Notes |
-| --- | --- | --- | --- | --- |
-| `<source-root>/_claude/**` | `.claude/**` | n/a | `target_native` / `implemented` | Project-level Claude native mirror; `claude.projectRoot` can override `.claude`. |
-| `<source-root>/_codex/**` | n/a | `.codex/**` | `target_native` / `implemented` | Project-level Codex native mirror; `codex.projectRoot` can override `.codex`. |
-| `<source-root>/_codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | `target_native` / `implemented` | Codex command execution policy, not instruction prose. |
-| `<source-root>/plugins/<plugin>/_claude/**` | Claude plugin bundle | n/a | `target_native` / `implemented` | Mirrors only when Claude plugin output is active. |
-| `<source-root>/plugins/<plugin>/_codex/**` | n/a | Codex plugin bundle | `target_native` / `implemented` | Mirrors only when Codex plugin output is active; Codex plugin `.rules` remains unsupported. |
-| `<source-root>/rules/**/*.md` | `.claude/rules/**/*.md` | `AGENTS.md` | `portable` / `implemented` | Durable repo guidance; not a provider source. |
-| `.codex/AGENTS.md` default guidance | n/a | n/a | `unsupported` | Codex project guidance belongs in `AGENTS.md` files at repo/scoped directories. |
+| Source or surface | Claude | Codex | Cursor | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `<source-root>/_claude/**` | `.claude/**` | n/a | n/a | `target_native` / `implemented` | Project-level Claude native mirror; `claude.projectRoot` can override `.claude`. |
+| `<source-root>/_codex/**` | n/a | `.codex/**` | n/a | `target_native` / `implemented` | Project-level Codex native mirror; `codex.projectRoot` can override `.codex`. |
+| `<source-root>/_cursor/**` | n/a | n/a | `.cursor/**` | `target_native` / `implemented` | Project-level Cursor native mirror; `cursor.projectRoot` can override `.cursor`. |
+| `<source-root>/_codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | n/a | `target_native` / `implemented` | Codex command execution policy, not instruction prose. |
+| `<source-root>/plugins/<plugin>/_claude/**` | Claude plugin bundle | n/a | n/a | `target_native` / `implemented` | Mirrors only when Claude plugin output is active. |
+| `<source-root>/plugins/<plugin>/_codex/**` | n/a | Codex plugin bundle | n/a | `target_native` / `implemented` | Mirrors only when Codex plugin output is active; Codex plugin `.rules` remains unsupported. |
+| `<source-root>/plugins/<plugin>/_cursor/**` | n/a | n/a | Cursor plugin bundle | `target_native` / `implemented` | Mirrors only when Cursor plugin output is active. |
+| `<source-root>/rules/**/*.md` | `.claude/rules/**/*.md` | `AGENTS.md` | n/a | `portable` / `implemented` | Durable repo guidance; not a provider source. |
+| `.codex/AGENTS.md` default guidance | n/a | n/a | n/a | `unsupported` | Codex project guidance belongs in `AGENTS.md` files at repo/scoped directories. |
 
 ## Target Rendering
 
-Provider source should mirror only into the matching target root. It must not leak into the other provider, and confirmed builds must back up unmanaged target-file collisions before replacing them. Project provider-source files are tracked as file-level workspace-managed output in the root `skillset.lock`; `skillset build` must not claim or delete the whole `.claude/` or `.codex/` directory. Known structured files should be validated after preprocessing where the target requires a schema. Unknown files can be opaque pass-through only when path safety, ownership, and lock provenance are clear.
+Provider source should mirror only into the matching target root. It must not leak into another provider, and confirmed builds must back up unmanaged target-file collisions before replacing them. Project provider-source files are tracked as file-level workspace-managed output in the root `skillset.lock`; `skillset build` must not claim or delete the whole `.claude/`, `.codex/`, or `.cursor/` directory. Known structured files should be validated after preprocessing where the target requires a schema. Unknown files can be opaque pass-through only when path safety, ownership, and lock provenance are clear.
 
 Codex `.rules` files are execution policy for shell-command decisions. They are not `<source-root>/rules` and must not receive prose instruction rendering. The correct portable instruction path remains `<source-root>/rules/**/*.md` to Claude `.claude/rules/**/*.md` and Codex `AGENTS.md`. Codex `.rules` pass-through is accepted only from `<source-root>/_codex/rules/**/*.rules`; project `.rules` elsewhere and all Codex plugin `.rules` fail loudly.
 
@@ -52,4 +54,4 @@ Locks record provider-source paths, generated output paths, target provider, has
 
 ## Tests and Fixtures
 
-Fixtures cover Claude-only and Codex-only project provider source, Codex `.rules` pass-through, unmanaged collision backups, project-root/output-root overlap refusal, binary copy, plugin-local provider source, unknown plugin owners, no cross-target leakage, and explain/list provenance.
+Fixtures cover Claude, Codex, and Cursor project provider source, Codex `.rules` pass-through, unmanaged collision backups, project-root/output-root overlap refusal, binary copy, plugin-local provider source, unknown plugin owners, no cross-target leakage, and explain/list provenance.

--- a/packages/core/src/__tests__/feature-registry.test.ts
+++ b/packages/core/src/__tests__/feature-registry.test.ts
@@ -22,7 +22,7 @@ import {
   type SkillsetFeatureEntry,
   type SkillsetRuntimeSupport,
 } from "../feature-registry";
-import { targetRecord } from "../targets";
+import { targetNames, targetRecord } from "../targets";
 
 const SEEDED_FEATURE_IDS = [
   "activation-probes",
@@ -79,6 +79,14 @@ const REPRESENTATIVE_DIAGNOSTIC_FEATURE_IDS = [
 ] as const;
 
 describe("feature registry", () => {
+  it("reports target-native islands as pass-through for every canonical target", () => {
+    const feature = getSkillsetFeature("target-native-islands");
+    expect(feature).toBeDefined();
+    for (const target of targetNames()) {
+      expect(feature?.targetSupport[target].status, target).toBe("pass_through");
+    }
+  });
+
   it("ships the current feature seed in deterministic order with docs and evidence", () => {
     const features = listSkillsetFeatures();
 

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -961,7 +961,7 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
     sourceShape: ".skillset/_claude/**, .skillset/_codex/**, .skillset/_cursor/**, and plugin-local provider source subdirs",
     status: "implemented",
     summary: "Mirrors explicit provider-specific files only to their intended provider output.",
-    targetSupport: bothTargets("pass_through"),
+    targetSupport: targetRecord(() => ({ status: "pass_through" })),
     title: "Provider Source",
     validationOwner: "packages/core/src/resolver.ts",
   }),

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -364,16 +364,18 @@ async function loadProjectIslands(
   if (!(await exists(srcPath))) return [];
 
   const islands: SourceIslandFile[] = [];
-  islands.push(...(await loadTargetIsland(rootPath, join(srcPath, PROVIDER_SOURCE_DIRS.claude), "claude")));
-  islands.push(...(await loadTargetIsland(rootPath, join(srcPath, PROVIDER_SOURCE_DIRS.codex), "codex")));
+  for (const target of targetNames()) {
+    islands.push(...(await loadTargetIsland(rootPath, join(srcPath, PROVIDER_SOURCE_DIRS[target]), target)));
+  }
 
   const pluginsPath = join(srcPath, "plugins");
   if (await exists(pluginsPath)) {
     await validatePluginIslandOwners(rootPath, pluginsPath, plugins);
     for (const plugin of plugins) {
       const pluginPath = join(pluginsPath, plugin.id);
-      islands.push(...(await loadTargetIsland(rootPath, join(pluginPath, PROVIDER_SOURCE_DIRS.claude), "claude", plugin.id)));
-      islands.push(...(await loadTargetIsland(rootPath, join(pluginPath, PROVIDER_SOURCE_DIRS.codex), "codex", plugin.id)));
+      for (const target of targetNames()) {
+        islands.push(...(await loadTargetIsland(rootPath, join(pluginPath, PROVIDER_SOURCE_DIRS[target]), target, plugin.id)));
+      }
     }
   }
 


### PR DESCRIPTION
## Context

SET-315 closes the Cursor gap in target-native island loading. The resolver and feature registry still enumerated only Claude and Codex even though the canonical target registry and provider source directory contract include Cursor.

## What changed

- load workspace and plugin target-native islands by iterating the canonical target set
- describe target-native island support with a target-exhaustive feature record
- classify release-state-only target-native selectors through the canonical target predicate
- document Cursor project/plugin island paths and the complete target-override restriction
- add project/plugin Cursor loading, isolation, diagnostics, lock provenance, feature registry, and release-state regressions

## Verification

- focused Skillset and feature-registry suites: 127 tests / 1,226 expectations
- review-fix island/change-status focus: 10 tests / 31 expectations
- `bun run typecheck`
- `bun run conformance:fast`
- `bun run skillset:check:outputs`
- `bun run check`: 1,260 tests / 53,981 expectations
- `bun run hooks:pre-push`
- two Terra High local reviews: 5/5 clean, zero P0-P2

## Risk / rollout

Low and bounded to target-native island discovery, support reporting, release-state classification, documentation, and tests. Provider boundaries remain unchanged: Cursor source mirrors only to Cursor output. No publication or global configuration mutation.

Linear: SET-315
