### PR TITLE
fix(toolkit): add Cursor runtime context

### DIFF
--- a/.changeset/cursor-toolkit-runtime-context.md
+++ b/.changeset/cursor-toolkit-runtime-context.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Recognize Cursor provider and session context in the toolkit runtime boundary.

--- a/apps/skillset/src/__tests__/lookup-cli.test.ts
+++ b/apps/skillset/src/__tests__/lookup-cli.test.ts
@@ -116,7 +116,7 @@ test("SET-220: lookup hooks adaptive lens shows adaptive hook fields", async () 
 });
 
 test("SET-232: lookup hooks toolkit lens reports runtime context support", async () => {
-  const result = await runSkillsetCli("lookup", "hooks", "toolkit", "--field", "context.env", "--values", "--compat", "codex", "--json");
+  const result = await runSkillsetCli("lookup", "hooks", "toolkit", "--field", "context.env", "--values", "--compat", "cursor", "--json");
 
   expect(result.exitCode).toBe(0);
   const report = readResultData(result.stdout) as {
@@ -132,9 +132,9 @@ test("SET-232: lookup hooks toolkit lens reports runtime context support", async
   expect(report.compatibility).toEqual([
     expect.objectContaining({
       featureId: "runtime-context",
-      note: expect.stringContaining("raw Codex environment remains available"),
+      note: expect.stringContaining("raw Cursor environment remains available"),
       status: "transformed",
-      target: "codex",
+      target: "cursor",
     }),
   ]);
 });

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/skillset": {
       "name": "skillset",
-      "version": "0.17.1",
+      "version": "0.18.1",
       "bin": {
         "skillset": "dist/cli.js",
         "skillset-toolkit": "dist/toolkit.js",
@@ -62,6 +62,9 @@
       "version": "0.0.0",
       "bin": {
         "skillset-toolkit": "./src/cli.ts",
+      },
+      "dependencies": {
+        "@skillset/schema": "workspace:*",
       },
     },
     "packages/transforms": {

--- a/docs/features/hook-guardrails.md
+++ b/docs/features/hook-guardrails.md
@@ -26,14 +26,14 @@ skillset-toolkit runtime context --event Stop --format env --fields provider,hoo
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Git hook-runner snippet | n/a | n/a | `implemented` | Prints additive snippets for existing hook runners; does not install. |
-| Agent runtime hook suggestion | reviewed config suggestion | reviewed config suggestion | `implemented` / `target_specific` | Prints project-local suggestions; must not mutate runtime config automatically. |
-| Agent runtime hook execution | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `implemented` / `target_specific` | Core CLI behavior called by reviewed project-local runtime config. |
-| Runtime context helper | `skillset-toolkit runtime context --event <event> --format env|json` | `skillset-toolkit runtime context --event <event> --format env|json` | `implemented` / `target_specific` | Helper used by generated adaptive hook wrappers for `context.strategy: toolkit`; the shared context model lives in `@skillset/toolkit/runtime`. |
+| Source | Target output | Status | Notes |
+| --- | --- | --- | --- |
+| Git hook-runner snippet | n/a | `implemented` | Prints additive snippets for existing hook runners; does not install. |
+| Agent runtime hook suggestion | Claude/Codex reviewed config suggestion | `implemented` / `target_specific` | Prints project-local suggestions; must not mutate runtime config automatically. |
+| Agent runtime hook execution | `skillset hooks run post-tool-use`, `skillset hooks run stop` | `implemented` / `target_specific` | Core CLI behavior called by reviewed Claude/Codex project-local runtime config. |
+| Runtime context helper | Claude, Codex, and Cursor `skillset-toolkit runtime context --event <event> --format env|json` | `implemented` / `target_specific` | Helper used by generated adaptive hook wrappers for `context.strategy: toolkit`; the shared context model lives in `@skillset/toolkit/runtime`. |
 
-For the normalized runtime context support matrix, use `skillset lookup hooks toolkit --field context.env --values --compat claude,codex` or see [Hooks](hooks.md#runtime-context).
+For the normalized runtime context support matrix, use `skillset lookup hooks toolkit --field context.env --values --compat claude,codex,cursor` or see [Hooks](hooks.md#runtime-context).
 
 ## Diagnostics
 
@@ -53,7 +53,7 @@ Runtime hook execution resolves the Skillset command from the local compiler che
 
 ## Provenance
 
-Hook guardrails do not create source truth. They call Skillset commands that produce diagnostics from source entries, locks, and release state. Runtime context parsing is permissive: Claude-like env, Codex-like env, unknown env, and optional JSON stdin payloads are normalized at the boundary without making source-change safety depend on provider detection.
+Hook guardrails do not create source truth. They call Skillset commands that produce diagnostics from source entries, locks, and release state. Runtime context parsing is permissive: Claude-like env, Codex-like env, Cursor-like env, unknown env, and optional JSON stdin payloads are normalized at the boundary without making source-change safety depend on provider detection.
 
 ## Evidence
 

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -94,9 +94,9 @@ Inline v1 fields are deliberately small:
 
 | Field | Generated variable |
 | --- | --- |
-| `provider` | `SKILLSET_PROVIDER` (`claude` or `codex`) |
+| `provider` | `SKILLSET_PROVIDER` (`claude`, `codex`, or `cursor`) |
 | `hook.event` | `SKILLSET_HOOK_EVENT` |
-| `session.id` | `SKILLSET_SESSION_ID`, sourced from `${CLAUDE_SESSION_ID:-}` or `${CODEX_SESSION_ID:-}` |
+| `session.id` | `SKILLSET_SESSION_ID`, sourced from `${CLAUDE_SESSION_ID:-}`, `${CODEX_SESSION_ID:-}`, or `${CURSOR_SESSION_ID:-}` |
 
 Omitting `context` is equivalent to `context.strategy: none`, so existing hooks keep their command text unchanged.
 
@@ -106,7 +106,7 @@ For `context.strategy: toolkit`, generated hooks call the installable helper:
 skillset-toolkit runtime context --event <event> --format env --fields <field,...>
 ```
 
-The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. It does not erase target-native variables such as `CLAUDE_SESSION_ID` or `CODEX_SESSION_ID`; scripts that need provider-specific data can still read the raw environment deliberately.
+The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. It does not erase target-native variables such as `CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, or `CURSOR_SESSION_ID`; scripts that need provider-specific data can still read the raw environment deliberately.
 
 Generated hooks and out-of-repo scripts should use the `skillset-toolkit` CLI because it is shipped by the published `skillset` package. Repo-local tools that already depend on the internal workspace package can import the typed runtime surface directly:
 

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -616,6 +616,7 @@ hooks:
     });
     const cursorCommand = ((cursorHooks.hooks as JsonRecord).stop as readonly JsonRecord[])[0]?.hooks as readonly JsonRecord[];
     expect(await runGeneratedHookCommand(String(cursorCommand[0]?.command), {
+      CLAUDE_SESSION_ID: "wrong-claude-session",
       CURSOR_SESSION_ID: "cursor-session",
     })).toEqual({
       exitCode: 0,

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -553,6 +553,7 @@ skillset:
   name: adaptive-hook-toolkit-context-render
 claude: true
 codex: true
+cursor: true
 `,
       ".skillset/plugins/demo/skillset.yaml": `
 skillset:
@@ -567,19 +568,20 @@ hooks:
           strategy: "toolkit",
         },
         events: ["Stop"],
-        run: { command: "cat" },
+        run: { command: `printf '%s|%s|' "$SKILLSET_PROVIDER" "$SKILLSET_SESSION_ID"; cat` },
       }),
     }));
 
     const rendered = await renderBuildGraph(graph);
     const claudeHooks = renderedJson(rendered, "plugins/demo/claude/hooks/hooks.json");
     const codexHooks = renderedJson(rendered, "plugins/demo/codex/hooks/hooks.json");
+    const cursorHooks = renderedJson(rendered, "plugins/demo/cursor/hooks/hooks.json");
 
     expect(claudeHooks).toEqual({
       hooks: {
         Stop: [{
           hooks: [{
-            command: 'eval "$(SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\')" && cat',
+            command: 'eval "$(SKILLSET_PROVIDER=claude SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\')" && printf \'%s|%s|\' "$SKILLSET_PROVIDER" "$SKILLSET_SESSION_ID"; cat',
             type: "command",
           }],
         }],
@@ -589,7 +591,17 @@ hooks:
       hooks: {
         Stop: [{
           hooks: [{
-            command: 'eval "$(SKILLSET_PROVIDER=codex SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\')" && cat',
+            command: 'eval "$(SKILLSET_PROVIDER=codex SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\')" && printf \'%s|%s|\' "$SKILLSET_PROVIDER" "$SKILLSET_SESSION_ID"; cat',
+            type: "command",
+          }],
+        }],
+      },
+    });
+    expect(cursorHooks).toEqual({
+      hooks: {
+        stop: [{
+          hooks: [{
+            command: 'eval "$(SKILLSET_PROVIDER=cursor SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\')" && printf \'%s|%s|\' "$SKILLSET_PROVIDER" "$SKILLSET_SESSION_ID"; cat',
             type: "command",
           }],
         }],
@@ -600,7 +612,15 @@ hooks:
     expect(await runGeneratedHookCommand(String(command[0]?.command))).toEqual({
       exitCode: 0,
       stderr: "",
-      stdout: "payload",
+      stdout: "claude||payload",
+    });
+    const cursorCommand = ((cursorHooks.hooks as JsonRecord).stop as readonly JsonRecord[])[0]?.hooks as readonly JsonRecord[];
+    expect(await runGeneratedHookCommand(String(cursorCommand[0]?.command), {
+      CURSOR_SESSION_ID: "cursor-session",
+    })).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "cursor|cursor-session|payload",
     });
   });
 
@@ -837,7 +857,7 @@ function renderedMarkdown(files: readonly { readonly content: Uint8Array; readon
   return parseMarkdown(new TextDecoder().decode(file?.content), path);
 }
 
-async function runGeneratedHookCommand(command: string): Promise<{
+async function runGeneratedHookCommand(command: string, providerEnv: Record<string, string> = {}): Promise<{
   readonly exitCode: number;
   readonly stderr: string;
   readonly stdout: string;
@@ -858,6 +878,7 @@ async function runGeneratedHookCommand(command: string): Promise<{
       HOME: process.env.HOME ?? "",
       PATH: `${binDir}:${process.env.PATH ?? ""}`,
       TMPDIR: process.env.TMPDIR ?? "/tmp",
+      ...providerEnv,
     },
     stderr: "pipe",
     stdout: "pipe",

--- a/packages/core/src/__tests__/lookup.test.ts
+++ b/packages/core/src/__tests__/lookup.test.ts
@@ -169,7 +169,7 @@ describe("lookupSkillsetReference", () => {
       aspects: ["toolkit"],
       field: "context.env",
       subject: "hooks",
-      targets: ["claude", "codex"],
+      targets: ["claude", "codex", "cursor"],
       views: ["fields", "values", "compat"],
     });
 
@@ -194,6 +194,12 @@ describe("lookupSkillsetReference", () => {
         note: expect.stringContaining("raw Codex environment remains available"),
         status: "transformed",
         target: "codex",
+      }),
+      expect.objectContaining({
+        featureId: "runtime-context",
+        note: expect.stringContaining("raw Cursor environment remains available"),
+        status: "transformed",
+        target: "cursor",
       }),
     ]);
 

--- a/packages/core/src/feature-registry.ts
+++ b/packages/core/src/feature-registry.ts
@@ -872,6 +872,8 @@ export const skillsetFeatureRegistry = defineFeatureRegistry([
         evidence: [
           docs("docs/features/hooks.md"),
           source("packages/toolkit/src/runtime.ts"),
+          test("packages/toolkit/src/__tests__/runtime.test.ts", "Cursor-like environment normalization"),
+          test("packages/core/src/__tests__/adaptive-hook-attachments.test.ts", "generated Cursor toolkit hook execution"),
         ],
         note: "Normalized fields are provider, hook.event, and session.id; raw Cursor environment remains available to the hook command.",
         status: "transformed",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -10,5 +10,8 @@
     ".": "./src/index.ts",
     "./cli": "./src/cli.ts",
     "./runtime": "./src/runtime.ts"
+  },
+  "dependencies": {
+    "@skillset/schema": "workspace:*"
   }
 }

--- a/packages/toolkit/src/__tests__/cli.test.ts
+++ b/packages/toolkit/src/__tests__/cli.test.ts
@@ -8,8 +8,8 @@ const cliPath = join(repoRoot, "packages/toolkit/src/cli.ts");
 describe("@skillset/toolkit CLI", () => {
   test("prints deterministic JSON with normalized and raw namespaces", async () => {
     const result = await runToolkit(["runtime", "context", "--event", "Stop"], {
-      CODEX_REPO_ROOT: "/tmp/codex repo",
-      CODEX_SESSION_ID: "codex-session",
+      CURSOR_SESSION_ID: "cursor-session",
+      SKILLSET_PROVIDER: "cursor",
     });
 
     expect(result).toMatchObject({ exitCode: 0, stderr: "" });
@@ -21,10 +21,10 @@ describe("@skillset/toolkit CLI", () => {
       readonly session: { readonly id?: string };
     };
     expect(report.schemaVersion).toBe(1);
-    expect(report.provider).toBe("codex");
+    expect(report.provider).toBe("cursor");
     expect(report.hook.event).toBe("Stop");
-    expect(report.session.id).toBe("codex-session");
-    expect(report.raw.env.CODEX_REPO_ROOT).toBe("/tmp/codex repo");
+    expect(report.session.id).toBe("cursor-session");
+    expect(report.raw.env.CURSOR_SESSION_ID).toBe("cursor-session");
     expect(result.stdout).toBe(`${JSON.stringify(report, null, 2)}\n`);
   });
 
@@ -49,6 +49,12 @@ describe("@skillset/toolkit CLI", () => {
 
     const empty = await runShell(command, { SKILLSET_PROVIDER: "codex", SKILLSET_SESSION_ID: "" });
     expect(empty).toEqual({ exitCode: 0, stderr: "", stdout: "<codex>|<Stop Event>|<>" });
+
+    const cursor = await runShell(command, {
+      CURSOR_SESSION_ID: "cursor session",
+      SKILLSET_PROVIDER: "cursor",
+    });
+    expect(cursor).toEqual({ exitCode: 0, stderr: "", stdout: "<cursor>|<Stop Event>|<cursor session>" });
   });
 
   test("supports Python JSON consumption without provider-specific parsing", async () => {

--- a/packages/toolkit/src/__tests__/runtime.test.ts
+++ b/packages/toolkit/src/__tests__/runtime.test.ts
@@ -15,13 +15,13 @@ describe("@skillset/toolkit runtime", () => {
       "session.id",
     ]);
     expect(RUNTIME_CONTEXT_FIELD_DEFINITIONS.find((definition) => definition.field === "session.id")).toMatchObject({
-      availability: { claude: "available", codex: "available", unknown: "unknown" },
+      availability: { claude: "available", codex: "available", cursor: "available", unknown: "unknown" },
       confidence: "provider",
       envName: "SKILLSET_SESSION_ID",
     });
   });
 
-  test("reads unknown, Claude, Codex, missing, and conflicting provider context", async () => {
+  test("reads unknown, Claude, Codex, Cursor, missing, and conflicting provider context", async () => {
     const unknown = await readRuntimeContext({
       cwd: "/tmp/repo",
       env: {},
@@ -56,6 +56,28 @@ describe("@skillset/toolkit runtime", () => {
     expect(codex.repoRoot).toBe("/tmp/codex");
     expect(codex.payload).toBeUndefined();
     expect(codex.payloadError).toContain("JSON");
+
+    const cursor = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: { CURSOR_SESSION_ID: "session-3", SKILLSET_PROVIDER: "cursor" },
+      event: "afterAgentResponse",
+      rootPath: "/tmp/repo",
+    });
+    expect(cursor.provider).toBe("cursor");
+    expect(runtimeContextFieldValue(cursor, "session.id")).toBe("session-3");
+    expect(cursor.rawEnv).toEqual({
+      CURSOR_SESSION_ID: "session-3",
+      SKILLSET_PROVIDER: "cursor",
+    });
+
+    const nativeCursor = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: { CURSOR_SESSION_ID: "native-cursor-session" },
+      event: "afterAgentResponse",
+      rootPath: "/tmp/repo",
+    });
+    expect(nativeCursor.provider).toBe("cursor");
+    expect(runtimeContextFieldValue(nativeCursor, "session.id")).toBe("native-cursor-session");
 
     const conflicting = await readRuntimeContext({
       cwd: "/tmp/repo",

--- a/packages/toolkit/src/__tests__/runtime.test.ts
+++ b/packages/toolkit/src/__tests__/runtime.test.ts
@@ -79,6 +79,32 @@ describe("@skillset/toolkit runtime", () => {
     expect(nativeCursor.provider).toBe("cursor");
     expect(runtimeContextFieldValue(nativeCursor, "session.id")).toBe("native-cursor-session");
 
+    const explicitCursorWithMixedEnv = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: {
+        CLAUDE_SESSION_ID: "wrong-claude-session",
+        CURSOR_SESSION_ID: "right-cursor-session",
+        SKILLSET_PROVIDER: "cursor",
+      },
+      event: "afterAgentResponse",
+      rootPath: "/tmp/repo",
+    });
+    expect(explicitCursorWithMixedEnv.provider).toBe("cursor");
+    expect(runtimeContextFieldValue(explicitCursorWithMixedEnv, "session.id")).toBe("right-cursor-session");
+
+    const explicitCodexWithMixedEnv = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: {
+        CLAUDE_SESSION_ID: "wrong-claude-session",
+        CODEX_SESSION_ID: "right-codex-session",
+        SKILLSET_PROVIDER: "codex",
+      },
+      event: "Stop",
+      rootPath: "/tmp/repo",
+    });
+    expect(explicitCodexWithMixedEnv.provider).toBe("codex");
+    expect(runtimeContextFieldValue(explicitCodexWithMixedEnv, "session.id")).toBe("right-codex-session");
+
     const conflicting = await readRuntimeContext({
       cwd: "/tmp/repo",
       env: {

--- a/packages/toolkit/src/runtime.ts
+++ b/packages/toolkit/src/runtime.ts
@@ -155,6 +155,9 @@ export function runtimeContextFieldValue(
       return context.rawEnv.SKILLSET_HOOK_EVENT ?? context.event;
     case "session.id":
       if (context.rawEnv.SKILLSET_SESSION_ID !== undefined) return context.rawEnv.SKILLSET_SESSION_ID;
+      if (context.provider !== "unknown") {
+        return context.rawEnv[PROVIDER_ENV[context.provider].sessionId];
+      }
       for (const target of TARGET_NAMES) {
         const sessionId = context.rawEnv[PROVIDER_ENV[target].sessionId];
         if (sessionId !== undefined) return sessionId;

--- a/packages/toolkit/src/runtime.ts
+++ b/packages/toolkit/src/runtime.ts
@@ -1,4 +1,8 @@
-export type RuntimeProvider = "claude" | "codex" | "unknown";
+import { TARGET_NAMES } from "@skillset/schema";
+
+type RuntimeTarget = (typeof TARGET_NAMES)[number];
+
+export type RuntimeProvider = RuntimeTarget | "unknown";
 export type RuntimeContextField = "hook.event" | "provider" | "session.id";
 export type RuntimeContextFormat = "env" | "json";
 export type RuntimeContextFieldAvailability = "available" | "unavailable" | "unknown";
@@ -47,31 +51,58 @@ const CODEX_ENV_KEYS = [
   "CODEX_SESSION_ID",
   "OPENAI_WORKSPACE_ROOT",
 ] as const;
+const CURSOR_ENV_KEYS = ["CURSOR_SESSION_ID"] as const;
+const PROVIDER_ENV = {
+  claude: {
+    prefix: "CLAUDE_",
+    rawKeys: CLAUDE_ENV_KEYS,
+    sessionId: "CLAUDE_SESSION_ID",
+  },
+  codex: {
+    prefix: "CODEX_",
+    rawKeys: CODEX_ENV_KEYS,
+    sessionId: "CODEX_SESSION_ID",
+  },
+  cursor: {
+    prefix: "CURSOR_",
+    rawKeys: CURSOR_ENV_KEYS,
+    sessionId: "CURSOR_SESSION_ID",
+  },
+} as const satisfies Record<RuntimeTarget, {
+  readonly prefix: string;
+  readonly rawKeys: readonly string[];
+  readonly sessionId: string;
+}>;
 const SKILLSET_ENV_KEYS = [
   "SKILLSET_HOOK_COMMAND",
   "SKILLSET_HOOK_EVENT",
   "SKILLSET_PROVIDER",
   "SKILLSET_SESSION_ID",
 ] as const;
-const KNOWN_ENV_KEYS = [...CLAUDE_ENV_KEYS, ...CODEX_ENV_KEYS, ...SKILLSET_ENV_KEYS, "PWD"] as const;
+const RUNTIME_TARGETS = new Set<string>(TARGET_NAMES);
+const KNOWN_ENV_KEYS = [
+  ...TARGET_NAMES.flatMap((target) => PROVIDER_ENV[target].rawKeys),
+  ...SKILLSET_ENV_KEYS,
+  "PWD",
+] as const;
 
 export const RUNTIME_CONTEXT_FIELD_DEFINITIONS = [
   {
-    availability: { claude: "available", codex: "available", unknown: "unknown" },
+    availability: targetAvailability("available", "unknown"),
     confidence: "skillset",
     description: "Normalized provider lens selected from Skillset wrapper env or provider-specific environment.",
     envName: "SKILLSET_PROVIDER",
     field: "provider",
   },
   {
-    availability: { claude: "available", codex: "available", unknown: "available" },
+    availability: targetAvailability("available", "available"),
     confidence: "caller",
     description: "Hook event name passed by the generated wrapper or caller.",
     envName: "SKILLSET_HOOK_EVENT",
     field: "hook.event",
   },
   {
-    availability: { claude: "available", codex: "available", unknown: "unknown" },
+    availability: targetAvailability("available", "unknown"),
     confidence: "provider",
     description: "Provider session id when the runtime exposes one; absent when unavailable.",
     envName: "SKILLSET_SESSION_ID",
@@ -123,16 +154,42 @@ export function runtimeContextFieldValue(
     case "hook.event":
       return context.rawEnv.SKILLSET_HOOK_EVENT ?? context.event;
     case "session.id":
-      return context.rawEnv.SKILLSET_SESSION_ID ?? context.rawEnv.CLAUDE_SESSION_ID ?? context.rawEnv.CODEX_SESSION_ID;
+      if (context.rawEnv.SKILLSET_SESSION_ID !== undefined) return context.rawEnv.SKILLSET_SESSION_ID;
+      for (const target of TARGET_NAMES) {
+        const sessionId = context.rawEnv[PROVIDER_ENV[target].sessionId];
+        if (sessionId !== undefined) return sessionId;
+      }
+      return undefined;
   }
 }
 
 function detectProvider(env: Record<string, string | undefined>): RuntimeProvider {
-  if (env.SKILLSET_PROVIDER === "claude" || env.SKILLSET_PROVIDER === "codex") return env.SKILLSET_PROVIDER;
-  if (Object.keys(env).some((key) => key.startsWith("CLAUDE_"))) return "claude";
-  if (Object.keys(env).some((key) => key.startsWith("CODEX_"))) return "codex";
-  if (env.OPENAI_WORKSPACE_ROOT !== undefined) return "codex";
+  if (isRuntimeTarget(env.SKILLSET_PROVIDER)) return env.SKILLSET_PROVIDER;
+  const keys = Object.keys(env);
+  for (const target of TARGET_NAMES) {
+    const evidence = PROVIDER_ENV[target];
+    if (
+      keys.some((key) => key.startsWith(evidence.prefix)) ||
+      evidence.rawKeys.some((key) => env[key] !== undefined)
+    ) {
+      return target;
+    }
+  }
   return "unknown";
+}
+
+function isRuntimeTarget(value: string | undefined): value is RuntimeTarget {
+  return value !== undefined && RUNTIME_TARGETS.has(value);
+}
+
+function targetAvailability(
+  target: RuntimeContextFieldAvailability,
+  unknown: RuntimeContextFieldAvailability
+): Readonly<Record<RuntimeProvider, RuntimeContextFieldAvailability>> {
+  return Object.fromEntries([
+    ...TARGET_NAMES.map((provider) => [provider, target] as const),
+    ["unknown", unknown] as const,
+  ]) as Record<RuntimeProvider, RuntimeContextFieldAvailability>;
 }
 
 function relevantEnv(env: Record<string, string | undefined>): Readonly<Record<string, string>> {


### PR DESCRIPTION
## Context

SET-349 closes the Cursor runtime-context gap in the bundled `@skillset/toolkit` helper. Core already emits Cursor wrapper context, but the toolkit recognized only Claude, Codex, and unknown, losing Cursor provider and session identity.

## What changed

- derive toolkit runtime providers and availability metadata from schema `TARGET_NAMES`
- add an exhaustive provider-native environment/session map including `CURSOR_SESSION_ID`
- preserve explicit wrapper precedence and isolate native session selection to the detected provider
- retain canonical native-session fallback only for unknown contexts
- prove Cursor through the public toolkit API/CLI and a generated adaptive-hook command
- align registry evidence, lookup output, and scoped runtime-context documentation
- add the direct schema dependency and bundled `skillset` patch changeset

## Verification

- focused toolkit/Core/lookup suites: 51 tests / 222 expectations
- mixed-provider direct repros and contaminated Cursor generated-hook execution
- `bun run typecheck`
- `bun run schema:check`
- `bun run skillset:check:outputs`
- `bun run conformance:fast`
- `bun run check`: 1,260 tests / 53,994 expectations
- `bun run hooks:pre-push`
- standing and targeted Terra High reviews: 5/5 clean, zero P0-P2

## Risk / rollout

Bounded to toolkit runtime normalization, evidence, and docs. Explicit `SKILLSET_SESSION_ID` remains authoritative, invalid providers remain unknown, no Cursor repo-root heuristic was added, and Core rendering topology is unchanged. No publication or global configuration mutation.

Linear: SET-349
