### PR TITLE
fix(core): derive target capability state

### DIFF
--- a/.changeset/capability-target-records.md
+++ b/.changeset/capability-target-records.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Derive capability reports and change-state dependencies from the canonical target registry.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -6,8 +6,12 @@ import { expect, test } from "bun:test";
 import { normalizeSkillsetFixtureFiles } from "../../../../scripts/test-helpers/skillset-config";
 import { createOperationalPathContext, planDistributions, resolveOperationalPath } from "@skillset/core";
 
-import { buildSkillset, buildSkillsetResult, verifySkillset, verifySkillsetResult, diffSkillset, diffSkillsetResult } from "@skillset/core";
-import { changeStatus, collectSourceInventory } from "../change-status";
+import { buildSkillset, buildSkillsetResult, verifySkillset, verifySkillsetResult, diffSkillset, diffSkillsetResult, targetNames } from "@skillset/core";
+import {
+  changeStatus,
+  collectSourceInventory,
+  pluginTargetOptionsForSourceHash,
+} from "../change-status";
 import { doctorSkillset, explainPath } from "@skillset/core/internal/authoring";
 import { importSource, importSources, normalizeCopiedImportPath } from "../import";
 import { inspectSkillset, lintSkillset } from "@skillset/core";
@@ -3665,6 +3669,95 @@ Plugin body.
   expect(report.sourceChanges.map((change) => change.id)).toEqual(
     expect.arrayContaining(["plugin.alpha.skill:plugin-skill", "plugin:alpha"])
   );
+});
+
+test("SET-345: plugin aggregate hashes preserve legacy shape and include Cursor options", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: aggregate-root
+claude: true
+codex: false
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+  version: 0.1.0
+`,
+    ".skillset/plugins/alpha/skills/plugin-skill/SKILL.md": `
+---
+name: plugin-skill
+description: Plugin skill.
+version: 0.1.0
+---
+
+Plugin body.
+`,
+  });
+
+  const before = await collectSourceInventory(root);
+  const beforeGraph = await loadBuildGraph(root);
+  const legacyHash = before.units.find((unit) => unit.id === "plugin:alpha")?.hash;
+  expect(legacyHash).toBe("sha256:1a3416ee2ebfb3fcf875ed2aa85f53ffffaaed12cb3b35caa8a9ae7f6c844c5a");
+  expect(pluginTargetOptionsForSourceHash(beforeGraph.plugins[0]!)).toEqual({ claude: {}, codex: {} });
+
+  await Bun.write(
+    join(root, ".skillset/plugins/alpha/skillset.yaml"),
+    `
+skillset:
+  name: alpha
+  version: 0.1.0
+cursor:
+  marketplace:
+    displayName: Alpha Cursor Marketplace
+`
+  );
+
+  const after = await collectSourceInventory(root);
+  const afterGraph = await loadBuildGraph(root);
+  const targetOptions = pluginTargetOptionsForSourceHash(afterGraph.plugins[0]!);
+  expect(afterGraph.plugins[0]!.targets.cursor.options).not.toEqual({});
+  expect(targetOptions.cursor).toEqual(afterGraph.plugins[0]!.targets.cursor.options);
+  for (const target of targetNames()) {
+    if (Object.keys(afterGraph.plugins[0]!.targets[target].options).length > 0) {
+      expect(targetOptions).toHaveProperty(target);
+    }
+  }
+  expect(after.units.find((unit) => unit.id === "plugin:alpha")?.hash).not.toBe(legacyHash);
+});
+
+test("SET-345: Cursor project-agent prompt partials participate in source hashes", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-agent-hash-root
+claude: false
+codex: false
+cursor: true
+`,
+    ".skillset/agents/reviewer.md": `
+---
+description: Reviews Cursor changes.
+cursor:
+  initialPrompt: "{{shared:templates/cursor-prompt.md }}"
+---
+
+Review changes.
+`,
+    ".skillset/shared/templates/cursor-prompt.md": "Start with Cursor evidence.\n",
+  });
+
+  const before = await collectSourceInventory(root);
+  const beforeAgent = before.units.find((unit) => unit.id === "agent:reviewer");
+  expect(beforeAgent?.sourcePaths).toContain(".skillset/shared/templates/cursor-prompt.md");
+
+  await Bun.write(
+    join(root, ".skillset/shared/templates/cursor-prompt.md"),
+    "Start with updated Cursor evidence.\n"
+  );
+
+  const after = await collectSourceInventory(root);
+  expect(after.units.find((unit) => unit.id === "agent:reviewer")?.hash).not.toBe(beforeAgent?.hash);
 });
 
 test("SET-34: partial dependencies participate in source status hashes", async () => {
@@ -7851,23 +7944,26 @@ Audit body.
       docs: readonly string[];
       id: string;
       status: string;
-      targetSupport: { claude: { status: string }; codex: { status: string } };
+      targetSupport: Record<string, { status: string }>;
       title: string;
     }[];
   } }).data;
+  const nativeTargetSupport = Object.fromEntries(
+    targetNames().map((target) => [target, { status: "native" }])
+  );
   expect(skillReport.features).toEqual([
     {
       docs: ["docs/features/resources.md"],
       id: "resources",
       status: "implemented",
-      targetSupport: { claude: { status: "native" }, codex: { status: "native" } },
+      targetSupport: nativeTargetSupport,
       title: "Resources",
     },
     {
       docs: ["docs/features/skills.md"],
       id: "standalone-skills",
       status: "implemented",
-      targetSupport: { claude: { status: "native" }, codex: { status: "native" } },
+      targetSupport: nativeTargetSupport,
       title: "Standalone Skills",
     },
   ]);
@@ -7882,7 +7978,9 @@ Audit body.
   const featureText = await runSkillsetCli("lookup", "features", "plugin-bin");
   expect(featureText.exitCode).toBe(0);
   expect(featureText.stdout).toContain("feature plugin-bin: Plugin Bin");
-  expect(featureText.stdout).toContain("codex: unsupported");
+  for (const target of targetNames()) {
+    expect(featureText.stdout).toContain(`${target}:`);
+  }
 
   const featureJson = await runSkillsetCli("lookup", "features", "plugin-bin", "--json");
   expect(featureJson.exitCode).toBe(0);
@@ -7892,7 +7990,7 @@ Audit body.
       docs: readonly string[];
       id: string;
       status: string;
-      targetSupport: { claude: { status: string }; codex: { reason?: string; status: string } };
+      targetSupport: Record<string, { reason?: string; status: string }>;
       title: string;
     }[];
   } }).data;
@@ -7904,11 +8002,12 @@ Audit body.
       targetSupport: {
         claude: { status: "pass_through" },
         codex: expect.objectContaining({ status: "unsupported" }),
+        cursor: expect.objectContaining({ status: "unsupported" }),
       },
       title: "Plugin Bin",
     },
   ]);
-  expect(featureReport.features[0]?.targetSupport.codex.reason).toContain("Codex plugins");
+  expect(featureReport.features[0]?.targetSupport.codex?.reason ?? "").toContain("Codex plugins");
 
   const missingFeature = await runSkillsetCli("lookup", "features", "no-such-feature", "--json");
   expect(missingFeature.exitCode).toBe(1);
@@ -7917,20 +8016,23 @@ Audit body.
   const doctor = await runSkillsetCli("status", "--root", root);
   expect(doctor.stdout).toContain("features:");
   expect(doctor.stdout).toContain("status implemented");
-  expect(doctor.stdout).toContain("feature support: claude");
-  expect(doctor.stdout).toContain("feature support: codex");
+  for (const target of targetNames()) {
+    expect(doctor.stdout).toContain(`feature support: ${target}`);
+  }
   const doctorJson = await runSkillsetCli("status", "--root", root, "--json");
   expect(JSON.parse(doctorJson.stdout)).toMatchObject({ command: "status" });
   const doctorReport = (JSON.parse(doctorJson.stdout) as { readonly data: {
     featureCapabilities: {
-      byTargetSupport: { claude: Record<string, number>; codex: Record<string, number> };
+      byTargetSupport: Record<string, Record<string, number>>;
       featureIds: readonly string[];
       total: number;
     };
   } }).data;
   expect(doctorReport.featureCapabilities.total).toBeGreaterThan(0);
-  expect(doctorReport.featureCapabilities.byTargetSupport.claude.native).toBeGreaterThan(0);
-  expect(doctorReport.featureCapabilities.byTargetSupport.codex.native).toBeGreaterThan(0);
+  expect(Object.keys(doctorReport.featureCapabilities.byTargetSupport)).toEqual([...targetNames()]);
+  for (const target of targetNames()) {
+    expect(doctorReport.featureCapabilities.byTargetSupport[target]?.native).toBeGreaterThan(0);
+  }
   expect(doctorReport.featureCapabilities.featureIds).toContain("plugin-bin");
 
   for (const retired of ["doctor", "features"]) {

--- a/apps/skillset/src/change-status.ts
+++ b/apps/skillset/src/change-status.ts
@@ -3,7 +3,13 @@ import { mkdir, mkdtemp, readdir, readFile, rename, rm, rmdir, stat, writeFile }
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 
-import { diffSkillset, isTargetName, type SkillsetDiff } from "@skillset/core";
+import {
+  diffSkillset,
+  isTargetName,
+  targetNames,
+  workspaceChangeFile,
+  type SkillsetDiff,
+} from "@skillset/core";
 import { readString } from "@skillset/core/internal/config";
 import { compareStrings, resolveInside } from "@skillset/core/internal/path";
 import { gitSafeEnv } from "./git-env";
@@ -39,7 +45,6 @@ import type {
   SourceRule,
   SourceSkill,
 } from "@skillset/core/internal/types";
-import { workspaceChangeFile } from "@skillset/core";
 import { isJsonRecord, parseMarkdown, parseYamlRecord, stringifyJson, stringifyYaml } from "@skillset/core/internal/yaml";
 
 export const SOURCE_HASH_SCHEMA = "skillset-source-unit-v2";
@@ -479,7 +484,7 @@ function pluginAggregateUnit(
   hash.update("\0metadata\0");
   hash.update(stringifyJson(plugin.metadata));
   hash.update("\0targets\0");
-  hash.update(stringifyJson({ claude: plugin.targets.claude.options, codex: plugin.targets.codex.options }));
+  hash.update(stringifyJson(pluginTargetOptionsForSourceHash(plugin)));
   hash.update("\0children\0");
   for (const child of childUnits) {
     hash.update(child.id);
@@ -500,6 +505,22 @@ function pluginAggregateUnit(
     sourcePath: relativePath(graph, plugin.configPath),
     sourcePaths,
   };
+}
+
+const PRE_CURSOR_PLUGIN_HASH_TARGET_COUNT = 2;
+
+export function pluginTargetOptionsForSourceHash(
+  plugin: Pick<SourcePlugin, "targets">
+): JsonRecord {
+  return Object.fromEntries(
+    targetNames().flatMap((target, index) => {
+      const options = plugin.targets[target].options;
+      // Preserve v2 hashes for configs whose only additional-target options are empty.
+      return index < PRE_CURSOR_PLUGIN_HASH_TARGET_COUNT || Object.keys(options).length > 0
+        ? [[target, options]]
+        : [];
+    })
+  );
 }
 
 async function sourcePathsForSkill(
@@ -669,8 +690,9 @@ async function projectAgentPreprocessDependencies(
 
   await collect(agent.body);
   await collect(readString(agent.frontmatter, "initialPrompt"));
-  await collect(readString(agent.targets.claude.options, "initialPrompt"));
-  await collect(readString(agent.targets.codex.options, "initialPrompt"));
+  for (const target of targetNames()) {
+    await collect(readString(agent.targets[target].options, "initialPrompt"));
+  }
   await collect(readString(agent.targets.codex.options, "developer_instructions"));
 
   return formattedPreprocessDependencies(graph, dependencies);

--- a/apps/skillset/src/inspect-cli.ts
+++ b/apps/skillset/src/inspect-cli.ts
@@ -3,6 +3,7 @@ import type {
   LookupSubject,
   LookupView,
 } from "@skillset/core";
+import { targetNames } from "@skillset/core";
 import {
   doctorSkillset,
   explainPath,
@@ -191,8 +192,9 @@ export async function runExplainCommand({
   }
   for (const feature of result.features) {
     console.log(`  feature ${feature.id}: ${feature.title}`);
-    console.log(`    claude: ${feature.targetSupport.claude.status}`);
-    console.log(`    codex: ${feature.targetSupport.codex.status}`);
+    for (const target of targetNames()) {
+      console.log(`    ${target}: ${feature.targetSupport[target].status}`);
+    }
   }
   for (const outcome of result.renderResults) {
     printRenderResult(outcome);
@@ -268,12 +270,11 @@ export async function runStatusCommand({
   console.log(
     `  features: ${report.featureCapabilities.total} registry entries; status ${formatCountSummary(report.featureCapabilities.byFeatureStatus)}`
   );
-  console.log(
-    `  feature support: claude ${formatCountSummary(report.featureCapabilities.byTargetSupport.claude)}`
-  );
-  console.log(
-    `  feature support: codex ${formatCountSummary(report.featureCapabilities.byTargetSupport.codex)}`
-  );
+  for (const target of targetNames()) {
+    console.log(
+      `  feature support: ${target} ${formatCountSummary(report.featureCapabilities.byTargetSupport[target])}`
+    );
+  }
   for (const outcome of report.notableRenderResults) {
     printRenderResult(outcome);
   }
@@ -318,18 +319,15 @@ function formatSourceOrigin(origin: SourceOrigin): string {
 function printFeatureCapability(feature: FeatureCapability): void {
   console.log(`feature ${feature.id}: ${feature.title}`);
   console.log(`  status: ${feature.status}`);
-  console.log(
-    `  claude: ${formatFeatureSupport(feature.targetSupport.claude)}`
-  );
-  console.log(`  codex: ${formatFeatureSupport(feature.targetSupport.codex)}`);
+  for (const target of targetNames()) {
+    console.log(`  ${target}: ${formatFeatureSupport(feature.targetSupport[target])}`);
+  }
   if (feature.docs.length > 0) {
     console.log(`  docs: ${feature.docs.join(", ")}`);
   }
 }
 
-function formatFeatureSupport(
-  support: FeatureCapability["targetSupport"]["claude"]
-): string {
+function formatFeatureSupport(support: FeatureCapability["targetSupport"][TargetName]): string {
   const reason = support.reason === undefined ? "" : ` (${support.reason})`;
   const note = support.note === undefined ? "" : ` note: ${support.note}`;
   return `${support.status}${reason}${note}`;

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -17,7 +17,7 @@ import { compareStrings } from "./path";
 import { renderBuildGraph } from "./render";
 import { loadBuildGraph } from "./resolver";
 import { readEffectiveToolsPolicy } from "./skill-policy";
-import { targetNames } from "./targets";
+import { targetNames, targetRecord } from "./targets";
 import { planToolsRealization, type ToolsRealizationPlanEntry } from "./tools-realization";
 import type { BuildGraph, GeneratedEntry, LintIssue, SkillsetOptions, SourceOrigin, TargetName } from "./types";
 import { isJsonRecord, parseMarkdown, stringifyMarkdown } from "./yaml";
@@ -66,13 +66,13 @@ export interface FeatureCapability {
   readonly docs: readonly string[];
   readonly id: string;
   readonly status: string;
-  readonly targetSupport: Readonly<Record<"claude" | "codex", FeatureSupportCapability>>;
+  readonly targetSupport: Readonly<Record<TargetName, FeatureSupportCapability>>;
   readonly title: string;
 }
 
 export interface FeatureCapabilitySummary {
   readonly byFeatureStatus: Readonly<Record<string, number>>;
-  readonly byTargetSupport: Readonly<Record<"claude" | "codex", Readonly<Record<string, number>>>>;
+  readonly byTargetSupport: Readonly<Record<TargetName, Readonly<Record<string, number>>>>;
   readonly featureIds: readonly string[];
   readonly total: number;
 }
@@ -354,10 +354,9 @@ export function summarizeFeatureCapabilities(
 ): FeatureCapabilitySummary {
   return {
     byFeatureStatus: countBy(features.map((feature) => feature.status)),
-    byTargetSupport: {
-      claude: countBy(features.map((feature) => feature.targetSupport.claude.status)),
-      codex: countBy(features.map((feature) => feature.targetSupport.codex.status)),
-    },
+    byTargetSupport: targetRecord((target) =>
+      countBy(features.map((feature) => feature.targetSupport[target].status))
+    ),
     featureIds: features.map((feature) => feature.id).sort(compareStrings),
     total: features.length,
   };
@@ -745,10 +744,7 @@ function featureCapability(feature: SkillsetFeatureEntry): FeatureCapability {
     docs: feature.docs,
     id: feature.id,
     status: feature.status,
-    targetSupport: {
-      claude: supportCapability(feature.targetSupport.claude),
-      codex: supportCapability(feature.targetSupport.codex),
-    },
+    targetSupport: targetRecord((target) => supportCapability(feature.targetSupport[target])),
     title: feature.title,
   };
 }


### PR DESCRIPTION
## Context

SET-345 closes the remaining Claude/Codex-only assumptions in feature capability reporting and plugin change-state hashing. Those paths could omit Cursor state even though Cursor is part of the canonical target registry.

## What changed

- derive feature capability records and summaries from the canonical target set
- render explain, lookup, and status capability rows in stable registry order
- include every non-empty canonical target option block in plugin aggregate hashes
- preserve the exact pre-Cursor v2 aggregate payload when later target options are empty
- collect project-agent `initialPrompt` partial dependencies for every canonical target
- prove Cursor option hashing, legacy hash stability, Cursor prompt provenance, and registry-derived report coverage
- add a bundled `skillset` patch changeset

## Verification

- focused SET-345/SET-78 suites: 3 tests / 40 expectations
- `bun run typecheck`
- `bun run schema:check`
- `bun run skillset:check:outputs`
- `bun run conformance:fast`
- `bun run check`: 1,262 tests / 54,005 expectations
- `bun run hooks:pre-push`: 1,262 tests / 54,007 expectations
- standing and targeted Terra High reviews: 5/5 clean, zero P0-P3

## Risk / rollout

The compatibility boundary is deliberate: configurations with empty later-target options retain their exact previous aggregate hash, while non-empty Cursor and future canonical target options become hash-significant. No schema, generated output, publication, or global configuration changes.

Linear: SET-345
