### PR TITLE
test: cover Cursor external adoption fixtures

### DIFF
--- a/.changeset/cursor-external-fixtures.md
+++ b/.changeset/cursor-external-fixtures.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Cover Cursor generated-output adoption and external fixture round trips.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -7019,12 +7019,16 @@ test("SET-255: shared plugin lock does not hide authored plugin import candidate
       name: "demo-marketplace",
       plugins: [
         { name: "authored", source: "./plugins/authored" },
-        { name: "generated", source: "./plugins/generated/claude" },
+        { name: "generated-claude", source: "./plugins/generated/claude" },
+        { name: "generated-codex", source: "./plugins/generated/codex" },
+        { name: "generated-cursor", source: "./plugins/generated/cursor" },
       ],
     }),
     "plugins/skillset.lock": "{}",
     "plugins/authored/.claude-plugin/plugin.json": JSON.stringify({ name: "authored" }),
-    "plugins/generated/claude/.claude-plugin/plugin.json": JSON.stringify({ name: "generated" }),
+    "plugins/generated/claude/.claude-plugin/plugin.json": JSON.stringify({ name: "generated-claude" }),
+    "plugins/generated/codex/.codex-plugin/plugin.json": JSON.stringify({ name: "generated-codex" }),
+    "plugins/generated/cursor/.cursor-plugin/plugin.json": JSON.stringify({ name: "generated-cursor" }),
   });
 
   const report = await initSkillset({ cwd: root, useGitRoot: false, write: false });

--- a/apps/skillset/src/setup.ts
+++ b/apps/skillset/src/setup.ts
@@ -614,7 +614,7 @@ async function isManagedPluginOutputCandidate(rootPath: string, absolutePath: st
   const relativePath = relative(resolvedOutputRoot, resolvedPath).replaceAll("\\", "/");
   if (relativePath.length === 0) return true;
   const parts = relativePath.split("/");
-  return parts.length >= 2 && (parts[1] === "claude" || parts[1] === "codex");
+  return parts.length >= 2 && isTargetName(parts[1]);
 }
 
 function compareCandidate(left: SetupImportCandidate, right: SetupImportCandidate): number {

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -74,7 +74,7 @@ The test: adding a runtime must not make `compile.targets` accept a new value. I
 | Gemini CLI | `planned` | Needs current extension/distribution docs and fixture evidence before Skillset claims rendering or distribution support. |
 | Devin | `future` | Tracked as a possible runtime, not a current target. |
 | Droid | `future` | Tracked as a possible runtime, not a current target. |
-| OpenCode | `planned` | Superpowers provides fixture evidence, but Skillset still needs target docs before claiming support. |
+| OpenCode | `planned` | Tracked as a possible runtime, but Skillset still needs target docs before claiming support. |
 
 ## Diagnostics
 
@@ -95,4 +95,4 @@ Runtime support records are registry evidence, not generated target files. Distr
 - [Provider Surface Evidence Matrix](../target-surfaces.md#cursor-provider-baseline) - Cursor evidence baseline and milestone boundary.
 - [Agents](agents.md) - project-agent support and Codex skill-preface shim.
 - [Tests and Evals](tests-and-evals.md) - activation/eval boundary.
-- `fixtures/external/repos.yaml` - pinned external multi-runtime fixture manifest, including Superpowers.
+- `fixtures/external/repos.yaml` - pinned external adoption fixtures across current targets.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -35,7 +35,7 @@ Current checked-in cases:
 
 ### External fixture repos (`fixtures/external/`)
 
-External fixtures are real published repos that Skillset should be able to adopt: `init` detects their import candidates, `import` lifts them into `.skillset/` source, `lint` and `build` succeed, and the generated Claude projection comes out substantially similar to the original. They are maintainer test material like the other tiers, but they track living upstreams instead of frozen fakes.
+External fixtures are real published repos that Skillset should be able to adopt: `init` detects their import candidates, `import` lifts them into `.skillset/` source, `lint` and `build` succeed, and each requested target projection is compared with the original. They are maintainer test material like the other tiers, but they track living upstreams instead of frozen fakes.
 
 - `fixtures/external/repos.yaml` is the committed manifest. Each entry pins a repo to a full commit SHA and may set `targets:` (default `claude`) and `notes:`.
 - `fixtures/external/repos/<name>/` holds gitignored clones at the pinned SHA. They are never scanned as this repo's own source.

--- a/fixtures/external/repos.yaml
+++ b/fixtures/external/repos.yaml
@@ -13,11 +13,11 @@ repos:
     repo: https://github.com/hamelsmu/claude-review-loop
     ref: 244f4c7bc15e98552af7cc5a67e70dfcdea9ab12
     notes: "Nested marketplace-style Claude plugin under plugins/review-loop."
-  - name: superpowers
-    repo: https://github.com/obra/superpowers
-    ref: 6fd4507659784c351abbd2bc264c7162cfd386dc
-    targets: [claude, codex]
-    notes: "Large multi-agent plugin repo with Claude and Codex manifests, shared skills, hooks, assets, scripts, and repo-level instructions."
+  - name: cursor-browser-motion-plugin
+    repo: https://github.com/dusa89/cursor-browser-motion-plugin
+    ref: c892f0982756e4d39ad4a007b0aa0e45908b88f1
+    targets: [cursor]
+    notes: "Root Cursor-native browser-motion plugin with a .cursor-plugin/plugin.json manifest, skill, MCP configuration, and scripts."
   - name: mattpocock-skills
     repo: https://github.com/mattpocock/skills
     ref: 00ff03cac21a8a845b06256d826d183122f58c5e

--- a/scripts/fixtures/__tests__/external.test.ts
+++ b/scripts/fixtures/__tests__/external.test.ts
@@ -18,10 +18,10 @@ test("manifest parses, defaults targets to claude, and round-trips through rende
       "    repo: https://github.com/example/demo",
       `    ref: ${SHA}`,
       '    notes: "A demo repo."',
-      "  - name: both-targets",
-      "    repo: https://github.com/example/both",
+      "  - name: all-targets",
+      "    repo: https://github.com/example/all",
       `    ref: ${SHA}`,
-      "    targets: [claude, codex]",
+      "    targets: [claude, codex, cursor]",
       "",
     ].join("\n"),
     "test manifest"
@@ -36,10 +36,10 @@ test("manifest parses, defaults targets to claude, and round-trips through rende
       targets: ["claude"],
     },
     {
-      name: "both-targets",
+      name: "all-targets",
       ref: SHA,
-      repo: "https://github.com/example/both",
-      targets: ["claude", "codex"],
+      repo: "https://github.com/example/all",
+      targets: ["claude", "codex", "cursor"],
     },
   ]);
 
@@ -69,8 +69,8 @@ test("manifest rejects short refs, duplicate names, and unknown targets", () => 
     )
   ).toThrow("duplicate entry name");
   expect(() =>
-    parseExternalManifest(entry(`    ref: ${SHA}\n    targets: [cursor]`), "m")
-  ).toThrow("targets must be claude or codex");
+    parseExternalManifest(entry(`    ref: ${SHA}\n    targets: [future]`), "m")
+  ).toThrow("targets must be claude, codex, or cursor");
   expect(() => parseExternalManifest("repos: {}\n", "m")).toThrow("repos list");
 });
 
@@ -98,7 +98,7 @@ test("compareTrees buckets identical, different, and one-sided files", async () 
 test("runExternalRepo adopts a marketplace-shaped repo in place and reports round-trips", async () => {
   const clone = await gitFixture(marketplaceFiles());
 
-  const report = await runExternalRepo("demo-marketplace", clone, ["claude"]);
+  const report = await runExternalRepo("demo-marketplace", clone, ["claude", "cursor"]);
 
   expect(report.stages.map((stage) => [stage.stage, stage.ok])).toEqual([
     ["init", true],
@@ -140,8 +140,12 @@ test("runExternalRepo adopts a marketplace-shaped repo in place and reports roun
       surface: "commands",
     }),
   ]);
-  expect(report.roundTrips).toHaveLength(1);
-  const roundTrip = report.roundTrips[0];
+  expect(report.roundTrips).toHaveLength(2);
+  expect(report.roundTrips.map((entry) => [entry.target, entry.generatedRoot])).toEqual([
+    ["claude", ".skillset/cache/latest/plugins/demo/claude"],
+    ["cursor", ".skillset/cache/latest/plugins/demo/cursor"],
+  ]);
+  const roundTrip = report.roundTrips.find((entry) => entry.target === "claude");
   expect(roundTrip?.kind).toBe("plugin");
   expect(roundTrip?.name).toBe("demo");
   expect(roundTrip?.originalRoot).toBe("plugins/demo");
@@ -178,7 +182,20 @@ test("runExternalRepo adopts a marketplace-shaped repo in place and reports roun
   expect(markdown).toContain(
     "instructions:AGENTS.md -> .skillset/rules/agents.md"
   );
-  expect(markdown).toContain("### plugin demo");
+  expect(markdown).toContain("## Round-trip (target projections, report-only)");
+  expect(markdown).toContain("### plugin demo (claude)");
+  expect(markdown).toContain("### plugin demo (cursor)");
+});
+
+test("SET-344: runExternalRepo reports a Cursor-only target projection", async () => {
+  const clone = await gitFixture(marketplaceFiles());
+
+  const report = await runExternalRepo("cursor-marketplace", clone, ["cursor"]);
+
+  expect(report.ok).toBe(true);
+  expect(report.roundTrips.map((entry) => [entry.target, entry.generatedRoot])).toEqual([
+    ["cursor", ".skillset/cache/latest/plugins/demo/cursor"],
+  ]);
 });
 
 test("runExternalRepo passes when re-run on the same clone", async () => {

--- a/scripts/fixtures/external.ts
+++ b/scripts/fixtures/external.ts
@@ -41,7 +41,9 @@ import {
   resolveOperationalPath,
 } from "../../packages/core/src/operational-cache";
 import { compareStrings, validateSlug } from "../../packages/core/src/path";
+import { pluginTargetRoot } from "../../packages/core/src/plugin-output";
 import { loadBuildGraph } from "../../packages/core/src/resolver";
+import { isTargetName, TARGET_LIST_TEXT } from "../../packages/core/src/targets";
 import type { TargetName } from "../../packages/core/src/types";
 import { parseYamlRecord } from "../../packages/core/src/yaml";
 
@@ -142,9 +144,9 @@ function readManifestTargets(
   }
   const targets: TargetName[] = [];
   for (const target of raw) {
-    if (target !== "claude" && target !== "codex") {
+    if (!isTargetName(target)) {
       throw new Error(
-        `skillset: ${label} entry ${name} targets must be claude or codex`
+        `skillset: ${label} entry ${name} targets must be ${TARGET_LIST_TEXT}`
       );
     }
     targets.push(target);
@@ -214,6 +216,7 @@ export interface ExternalRoundTrip {
   readonly kind: "plugin" | "skill";
   readonly name: string;
   readonly originalRoot: string;
+  readonly target: TargetName;
 }
 
 /** What init's whole-repo survey saw: import candidates plus the recognized
@@ -289,7 +292,7 @@ async function cleanSkillsetLeftovers(clonePath: string): Promise<void> {
  * lint, and build with the isolated mirror (reported under the logical
  * .skillset/cache/latest/ path and stored in XDG cache). The harness adds only
  * what the product command does not own: the purity invariant and the
- * round-trip comparison of the original clone against the generated Claude
+ * round-trip comparison of the original clone against each requested target
  * projection.
  */
 export async function runExternalRepo(
@@ -389,27 +392,33 @@ export async function runExternalRepo(
     stages.push({ detail: errorMessage(error), ok: false, stage: "purity" });
   }
 
+  const graph = await loadBuildGraph(clonePath);
   for (const item of imported) {
-    const generatedRoot =
-      item.kind === "plugin"
-        ? join(ISOLATED_OUT_ROOT, "plugins", item.name, "claude")
-        : join(ISOLATED_OUT_ROOT, ".claude", "skills", item.name);
-    const generatedRootPath = resolveOperationalPath(cloneCacheContext, generatedRoot);
-    const originalRoot =
-      item.sourcePath === "." ? clonePath : join(clonePath, item.sourcePath);
-    roundTrips.push({
-      comparison: await compareTrees(
-        originalRoot,
-        generatedRootPath
-      ),
-      generatedRoot,
-      kind: item.kind,
-      name: item.name,
-      originalRoot:
-        relative(clonePath, originalRoot) === ""
-          ? "."
-          : relative(clonePath, originalRoot),
-    });
+    for (const target of targets) {
+      const generatedRoot = item.kind === "plugin"
+        ? join(
+            ISOLATED_OUT_ROOT,
+            pluginTargetRoot(graph.root.outputs.plugins[target], target, item.name)
+          )
+        : join(ISOLATED_OUT_ROOT, graph.root.outputs.skills[target], item.name);
+      const generatedRootPath = resolveOperationalPath(cloneCacheContext, generatedRoot);
+      const originalRoot =
+        item.sourcePath === "." ? clonePath : join(clonePath, item.sourcePath);
+      roundTrips.push({
+        comparison: await compareTrees(
+          originalRoot,
+          generatedRootPath
+        ),
+        generatedRoot,
+        kind: item.kind,
+        name: item.name,
+        originalRoot:
+          relative(clonePath, originalRoot) === ""
+            ? "."
+            : relative(clonePath, originalRoot),
+        target,
+      });
+    }
   }
 
   return {
@@ -462,7 +471,7 @@ export function renderRunReportMarkdown(
   for (const skip of report.survey.skips) {
     lines.push(`- skipped ${skip.surface} \`${skip.path}\`: ${skip.reason}`);
   }
-  lines.push("", "## Round-trip (Claude projection, report-only)", "");
+  lines.push("", "## Round-trip (target projections, report-only)", "");
   if (report.roundTrips.length === 0) {
     lines.push("No imported units to compare.");
   }
@@ -473,7 +482,9 @@ export function renderRunReportMarkdown(
       comparison.different.length +
       comparison.originalOnly.length;
     lines.push(
-      `### ${roundTrip.kind} ${roundTrip.name} (original \`${roundTrip.originalRoot}\` vs generated \`${roundTrip.generatedRoot}\`)`,
+      `### ${roundTrip.kind} ${roundTrip.name} (${roundTrip.target})`,
+      "",
+      `Original \`${roundTrip.originalRoot}\` vs generated \`${roundTrip.generatedRoot}\`.`,
       "",
       `- identical: ${comparison.identical.length}/${total} original files`,
       `- different: ${comparison.different.length}`,
@@ -694,7 +705,7 @@ async function main(): Promise<void> {
     for (const roundTrip of report.roundTrips) {
       const { comparison } = roundTrip;
       console.log(
-        `  round-trip ${roundTrip.kind} ${roundTrip.name}: ${comparison.identical.length} identical, ` +
+        `  round-trip ${roundTrip.kind} ${roundTrip.name} (${roundTrip.target}): ${comparison.identical.length} identical, ` +
           `${comparison.different.length} different, ${comparison.originalOnly.length} original-only, ` +
           `${comparison.generatedOnly.length} generated-only`
       );


### PR DESCRIPTION
## Context

SET-344 closes Cursor coverage gaps in generated-output adoption and the opt-in external-fixture harness.

## What changed

- suppress managed Cursor plugin output from adoption candidates through the canonical target predicate
- accept every canonical target in external fixture manifests
- compare imported units against each requested target projection using resolved output roots
- add Cursor-only and mixed-target regression coverage
- pin a production Cursor-native external fixture and align fixture/runtime evidence docs

## Verification

- focused setup and external fixture tests
- bun run typecheck
- bun run conformance:fast
- bun run skillset:check:outputs
- bun run check
- bun run hooks:pre-push
- bun run conformance:external -- cursor-browser-motion-plugin
- two Terra High local reviews: 5/5 clean, zero P0-P3

## Risk and rollout

Low. The product behavior change is limited to recognizing managed Cursor output as generated. External fixture target expansion remains opt-in and report-only for round-trip differences. Existing metadata-conflict validation is unchanged.

Linear: https://linear.app/outfitter/issue/SET-344