### PR TITLE
refactor: consolidate target topology descriptors

### DIFF
--- a/.changeset/target-descriptor-consolidation.md
+++ b/.changeset/target-descriptor-consolidation.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Consolidate target-native project, generated session, and display conventions in Core, lint active plugin hooks for every configured target, and keep Cursor out of the Claude/Codex runtime-hook suggestion.

--- a/apps/skillset/src/__tests__/audit-hardening.test.ts
+++ b/apps/skillset/src/__tests__/audit-hardening.test.ts
@@ -278,6 +278,37 @@ Alpha body.
   await expect(lintSkillset(root)).rejects.toThrow("Codex does not support");
 });
 
+test("Cursor hook lint diagnostics identify Cursor", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-lint-root
+claude: false
+codex: false
+cursor: true
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+`,
+    ".skillset/plugins/alpha/hooks/hooks.json": "not-json\n",
+    ".skillset/plugins/alpha/skills/alpha-skill/SKILL.md": `
+---
+name: alpha-skill
+description: Alpha skill.
+---
+
+Alpha body.
+`,
+  });
+
+  const lintReport = await inspectSkillset(await loadBuildGraph(root));
+  expect(lintReport.issues).toContainEqual(expect.objectContaining({
+    code: "hook-invalid-json",
+    message: expect.stringContaining("Cursor hook file"),
+  }));
+});
+
 test("Codex hooks reject non-command handler types", async () => {
   const root = await fixture({
     "skillset.yaml": `

--- a/apps/skillset/src/__tests__/cli-arg-values.test.ts
+++ b/apps/skillset/src/__tests__/cli-arg-values.test.ts
@@ -34,7 +34,10 @@ describe("SET-300 CLI scalar values", () => {
       "codex",
     ]);
     expect(() => readTargetName("other")).toThrow(
-      "skillset: expected --target"
+      "skillset: expected --target claude, codex, or cursor"
+    );
+    expect(() => readTargetNames("other")).toThrow(
+      "skillset: expected --targets claude, codex, or cursor"
     );
     expect(() => readTargetNames("")).toThrow(
       "skillset: --targets requires at least one target"

--- a/apps/skillset/src/__tests__/cli-args.test.ts
+++ b/apps/skillset/src/__tests__/cli-args.test.ts
@@ -991,7 +991,7 @@ describe("SET-299 parser failure contract", () => {
         args: [...args, "--from", "typo"],
         command,
         message:
-          "skillset: expected --from claude, codex, cursor, agents, or skillset",
+          "skillset: expected --from claude, codex, or cursor; also agents or skillset",
       },
       {
         args: [...args, "--kind", "typo"],

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1684,6 +1684,10 @@ test("SET-41: hooks print emits target runtime suggestions without installing", 
   expect(codex.stdout).toContain("skillset hooks run post-tool-use");
   expect(codex.stdout).toContain("skillset hooks run stop");
 
+  const cursor = await runSkillsetCli("hooks", "print", "--target", "cursor", "--agent-runtime");
+  expect(cursor.exitCode).toBe(1);
+  expect(cursor.stderr).toContain("only supports --target claude or --target codex");
+
   const invalid = await runSkillsetCli("hooks", "print", "--runner", "git", "--agent-runtime");
   expect(invalid.exitCode).toBe(1);
   expect(invalid.stderr).toContain("cannot be combined");

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1688,6 +1688,10 @@ test("SET-41: hooks print emits target runtime suggestions without installing", 
   expect(cursor.exitCode).toBe(1);
   expect(cursor.stderr).toContain("only supports --target claude or --target codex");
 
+  const cursorWithoutRuntime = await runSkillsetCli("hooks", "print", "--target", "cursor");
+  expect(cursorWithoutRuntime.exitCode).toBe(1);
+  expect(cursorWithoutRuntime.stderr).toContain("--target is only supported with --agent-runtime");
+
   const invalid = await runSkillsetCli("hooks", "print", "--runner", "git", "--agent-runtime");
   expect(invalid.exitCode).toBe(1);
   expect(invalid.stderr).toContain("cannot be combined");

--- a/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
+++ b/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
@@ -54,7 +54,7 @@ describe("SET-304 inspection and runtime route parsers", () => {
         [
           "--from",
           "typo",
-          "skillset: expected --from claude, codex, cursor, agents, or skillset",
+          "skillset: expected --from claude, codex, or cursor; also agents or skillset",
         ],
         [
           "--kind",

--- a/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
+++ b/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
@@ -284,6 +284,10 @@ describe("SET-304 inspection and runtime route parsers", () => {
   });
 
   test("preserves exceptional validation and diagnostic precedence", () => {
+    expect(() =>
+      parseExplainCommandRequest(["explain", "README.md", "--target", "cursor"], CONTEXT)
+    ).toThrow("hook options are only supported with hooks print");
+
     const cases = [
       {
         message: "skillset: status only supports --root and --json",

--- a/apps/skillset/src/__tests__/lifecycle-args.test.ts
+++ b/apps/skillset/src/__tests__/lifecycle-args.test.ts
@@ -43,7 +43,7 @@ describe("SET-303 lifecycle and recovery route parsers", () => {
 
     for (const { run } of cases) {
       expect(() => run("--from", "typo")).toThrow(
-        "skillset: expected --from claude, codex, cursor, agents, or skillset"
+        "skillset: expected --from claude, codex, or cursor; also agents or skillset"
       );
       expect(() => run("--kind", "typo")).toThrow(
         "skillset: expected --kind skill, skills, plugin, or plugins"

--- a/apps/skillset/src/__tests__/lifecycle-args.test.ts
+++ b/apps/skillset/src/__tests__/lifecycle-args.test.ts
@@ -67,6 +67,24 @@ describe("SET-303 lifecycle and recovery route parsers", () => {
         CONTEXT
       )
     ).toMatchObject({ changeBump: "patch", changeScopes: ["plugin:demo"] });
+
+    expect(
+      parseChangeCommandRequest(
+        [
+          "change",
+          "add",
+          "--scope",
+          "plugin:demo",
+          "--bump",
+          "patch",
+          "--from",
+          "cursor",
+          "--kind",
+          "skill",
+        ],
+        CONTEXT
+      )
+    ).toMatchObject({ changeBump: "patch", changeScopes: ["plugin:demo"] });
   });
 
   test("change owns subcommands, refs, reasons, scopes, and repeat policy", () => {

--- a/apps/skillset/src/__tests__/projection-args.test.ts
+++ b/apps/skillset/src/__tests__/projection-args.test.ts
@@ -217,7 +217,7 @@ describe("SET-301 projection and readiness route parsers", () => {
       {
         args: ["--from", "invalid"],
         message:
-          "skillset: expected --from claude, codex, cursor, agents, or skillset",
+          "skillset: expected --from claude, codex, or cursor; also agents or skillset",
       },
     ] as const;
 

--- a/apps/skillset/src/__tests__/source-distribution-args.test.ts
+++ b/apps/skillset/src/__tests__/source-distribution-args.test.ts
@@ -19,7 +19,7 @@ describe("SET-302 source and distribution route parsers", () => {
       [
         "--from",
         "typo",
-        "skillset: expected --from claude, codex, cursor, agents, or skillset",
+        "skillset: expected --from claude, codex, or cursor; also agents or skillset",
       ],
       [
         "--kind",

--- a/apps/skillset/src/__tests__/source-distribution-args.test.ts
+++ b/apps/skillset/src/__tests__/source-distribution-args.test.ts
@@ -235,7 +235,7 @@ describe("SET-302 source and distribution route parsers", () => {
     });
     expect(() =>
       parseNewCommandRequest(["new", "hook", "--provider", "unknown"], CONTEXT)
-    ).toThrow("expected --provider claude, codex, cursor");
+    ).toThrow("expected --provider claude, codex, or cursor");
   });
 
   test("distribution routes own subcommands, names, machine mode, and writes", () => {

--- a/apps/skillset/src/__tests__/try.test.ts
+++ b/apps/skillset/src/__tests__/try.test.ts
@@ -12,6 +12,7 @@ import {
   startTryRun,
   tailTryRun,
 } from "../try";
+import { runTryCommand } from "../try-cli";
 import { runSkillsetTest } from "../test-runner";
 import { parseCliEventStream } from "../cli-output";
 
@@ -62,6 +63,16 @@ Use this skill to answer fixture questions.
 
   const runs = await listTryRuns(root, { xdg });
   expect(runs.map((run) => run.runId)).toContain(report.runId);
+});
+
+test("ad hoc test target diagnostics use the canonical target list", async () => {
+  await expect(runTryCommand("/tmp", {
+    background: false,
+    json: false,
+    plugins: [],
+    prompt: "Inspect the fixture.",
+    skillsetOptions: {},
+  })).rejects.toThrow("skillset: ad hoc test requires --target claude, codex, or cursor");
 });
 
 test("provider output cannot terminate the retained test event stream", async () => {

--- a/apps/skillset/src/cli-arg-values.ts
+++ b/apps/skillset/src/cli-arg-values.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { isTargetName, targetNames } from "@skillset/core";
+import { isTargetName, TARGET_LIST_TEXT } from "@skillset/core";
 import type {
   BuildScope,
   CompileBuildMode,
@@ -64,13 +64,13 @@ export const readTargetName = (value: string): TargetName => {
   if (isTargetName(value)) {
     return value;
   }
-  throw new Error(`skillset: expected --target ${targetNames().join(", ")}`);
+  throw new Error(`skillset: expected --target ${TARGET_LIST_TEXT}`);
 };
 
 export const readLookupTarget = (value: string): TargetName => {
   if (isTargetName(value)) return value;
   throw new Error(
-    `skillset: unknown lookup compatibility target ${value}; expected ${targetNames().join(", ")}`
+    `skillset: unknown lookup compatibility target ${value}; expected ${TARGET_LIST_TEXT}`
   );
 };
 
@@ -85,7 +85,7 @@ export const readTargetNames = (
   const seen = new Set<TargetName>();
   for (const target of targets) {
     if (!isTargetName(target)) {
-      throw new Error(`skillset: expected ${flag} ${targetNames().join(", ")}`);
+      throw new Error(`skillset: expected ${flag} ${TARGET_LIST_TEXT}`);
     }
     seen.add(target);
   }

--- a/apps/skillset/src/hooks-args.ts
+++ b/apps/skillset/src/hooks-args.ts
@@ -452,5 +452,8 @@ const readHookTarget = (value: string): TargetName => {
   if (value === "claude" || value === "codex") {
     return value;
   }
+  if (value === "cursor") {
+    throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
+  }
   throw new Error("skillset: expected --target claude or codex");
 };

--- a/apps/skillset/src/hooks-args.ts
+++ b/apps/skillset/src/hooks-args.ts
@@ -12,6 +12,7 @@ import {
   readBuildScopes,
   readClaudeSettingSources,
   readPositiveInteger,
+  readTargetName,
   readTargetNames,
   resolveCliRoot,
   tokenizeCsv,
@@ -449,11 +450,5 @@ const readHookRunner = (value: string): HookRunner => {
 };
 
 const readHookTarget = (value: string): TargetName => {
-  if (value === "claude" || value === "codex") {
-    return value;
-  }
-  if (value === "cursor") {
-    throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
-  }
-  throw new Error("skillset: expected --target claude or codex");
+  return readTargetName(value);
 };

--- a/apps/skillset/src/inspect-args.ts
+++ b/apps/skillset/src/inspect-args.ts
@@ -631,6 +631,9 @@ const readHookRunner = (value: string): void => {
 };
 
 const readHookTarget = (value: string): void => {
+  if (value === "cursor") {
+    throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
+  }
   if (value !== "claude" && value !== "codex") {
     throw new Error("skillset: expected --target claude or codex");
   }

--- a/apps/skillset/src/inspect-args.ts
+++ b/apps/skillset/src/inspect-args.ts
@@ -16,6 +16,7 @@ import {
   readBuildScopes,
   readClaudeSettingSources,
   readPositiveInteger,
+  readTargetName,
   readTargetNames,
   resolveCliRoot,
   tokenizeCsv,
@@ -631,12 +632,7 @@ const readHookRunner = (value: string): void => {
 };
 
 const readHookTarget = (value: string): void => {
-  if (value === "cursor") {
-    throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
-  }
-  if (value !== "claude" && value !== "codex") {
-    throw new Error("skillset: expected --target claude or codex");
-  }
+  readTargetName(value);
 };
 
 const parseInspectionOptions = (

--- a/apps/skillset/src/runtime-hooks/print.ts
+++ b/apps/skillset/src/runtime-hooks/print.ts
@@ -30,6 +30,9 @@ function validateHookPrintOptions(options: HookPrintOptions): void {
   }
   if (options.agentRuntime) {
     if (options.target === undefined) throw new Error("skillset: hooks print --agent-runtime requires --target claude or --target codex");
+    if (options.target === "cursor") {
+      throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
+    }
     if (options.preCommit || options.prePush) {
       throw new Error("skillset: hooks print --agent-runtime cannot be combined with --pre-commit or --pre-push");
     }
@@ -147,6 +150,9 @@ function renderGitSnippet(options: { readonly preCommit: boolean; readonly prePu
 
 function renderAgentRuntimeSnippet(target: TargetName | undefined): string {
   if (target === undefined) throw new Error("skillset: hooks print --agent-runtime requires --target");
+  if (target === "cursor") {
+    throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
+  }
   const note =
     "Generated suggestion only. Review before adding to project-local runtime config; Skillset does not install or trust hooks.";
   const value = {

--- a/apps/skillset/src/source-arg-values.ts
+++ b/apps/skillset/src/source-arg-values.ts
@@ -1,4 +1,4 @@
-import { isTargetName, targetNames } from "@skillset/core";
+import { isTargetName, TARGET_LIST_TEXT } from "@skillset/core";
 import type { TargetName } from "@skillset/core/internal/types";
 
 export type ImportKind = "plugin" | "plugins" | "skill" | "skills";
@@ -26,6 +26,6 @@ export const readImportProvider = (value: string): ImportProvider => {
     return value;
   }
   throw new Error(
-    `skillset: expected --from ${targetNames().join(", ")}, agents, or skillset`
+    `skillset: expected --from ${TARGET_LIST_TEXT}; also agents or skillset`
   );
 };

--- a/apps/skillset/src/source-arg-values.ts
+++ b/apps/skillset/src/source-arg-values.ts
@@ -1,9 +1,10 @@
+import { isTargetName, targetNames } from "@skillset/core";
+import type { TargetName } from "@skillset/core/internal/types";
+
 export type ImportKind = "plugin" | "plugins" | "skill" | "skills";
 export type ImportProvider =
   | "agents"
-  | "claude"
-  | "codex"
-  | "cursor"
+  | TargetName
   | "skillset";
 
 export const readImportKind = (value: string): ImportKind => {
@@ -21,16 +22,10 @@ export const readImportKind = (value: string): ImportKind => {
 };
 
 export const readImportProvider = (value: string): ImportProvider => {
-  if (
-    value === "agents" ||
-    value === "claude" ||
-    value === "codex" ||
-    value === "cursor" ||
-    value === "skillset"
-  ) {
+  if (value === "agents" || isTargetName(value) || value === "skillset") {
     return value;
   }
   throw new Error(
-    "skillset: expected --from claude, codex, cursor, agents, or skillset"
+    `skillset: expected --from ${targetNames().join(", ")}, agents, or skillset`
   );
 };

--- a/apps/skillset/src/test-interactive.ts
+++ b/apps/skillset/src/test-interactive.ts
@@ -2,6 +2,7 @@ import type {
   SkillsetOptions,
   TargetName,
 } from "@skillset/core/internal/types";
+import { TARGET_LIST_TEXT } from "@skillset/core";
 
 import type { InteractiveSession } from "./interactive-session";
 import type { PromptChoice } from "./prompt-adapter";
@@ -136,7 +137,7 @@ async function promptForTarget(
   const first = targets[0];
   if (first === undefined) {
     throw new Error(
-      "skillset: ad hoc test requires an enabled claude, codex, or cursor target"
+      `skillset: ad hoc test requires an enabled ${TARGET_LIST_TEXT} target`
     );
   }
   if (targets.length === 1) return first;

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -3,7 +3,15 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } 
 import { tmpdir } from "node:os";
 
 import { buildSkillset, diffSkillset } from "@skillset/core";
-import { isTargetName, readCompileTargets, readRecord, readString, resolveTargets, targetNames } from "@skillset/core/internal/config";
+import {
+  isTargetName,
+  readCompileTargets,
+  readRecord,
+  readString,
+  resolveTargets,
+  targetDescriptor,
+  targetNames,
+} from "@skillset/core/internal/config";
 import { compareStrings, resolveInside } from "@skillset/core/internal/path";
 import { pluginManifestPath as pluginManifestOutputPath, pluginTargetRoot } from "@skillset/core/internal/plugin-output";
 import {
@@ -1278,7 +1286,7 @@ function activationExpectationCandidatePaths(
     const projectRoot = targetProjectRoot(graph, target);
     return graph.projectAgents
       .filter((agent) => agent.name === expect.name || agent.outputName === expect.name)
-      .map((agent) => join(projectRoot, "agents", `${agent.outputName}.${target === "codex" ? "toml" : "md"}`));
+      .map((agent) => join(projectRoot, "agents", `${agent.outputName}.${targetDescriptor(target).projectAgentExtension}`));
   }
 
   return [
@@ -1295,7 +1303,7 @@ function activationExpectationCandidatePaths(
 
 function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
   return readString(graph.root.targets[target].options, "projectRoot") ??
-    (target === "claude" ? ".claude" : target === "codex" ? ".codex" : ".cursor");
+    targetDescriptor(target).projectRoot;
 }
 
 async function writeActivationProbes(

--- a/apps/skillset/src/try-cli.ts
+++ b/apps/skillset/src/try-cli.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
+import { TARGET_LIST_TEXT } from "@skillset/core";
 import {
   executeTryRun,
   listTryRuns,
@@ -128,7 +129,7 @@ export function validateTryFlags(
     throw new Error("skillset: build/write options are not supported with ad hoc test runs; test uses logical .skillset/cache/tests/ad-hoc");
   }
   if (subcommand === undefined) {
-    if (runtime.target === undefined) throw new Error("skillset: ad hoc test requires --target claude, codex, or cursor");
+    if (runtime.target === undefined) throw new Error(`skillset: ad hoc test requires --target ${TARGET_LIST_TEXT}`);
     if ((runtime.prompt === undefined && runtime.promptFile === undefined) || (runtime.prompt !== undefined && runtime.promptFile !== undefined)) {
       throw new Error("skillset: ad hoc test requires exactly one of --prompt or --prompt-file");
     }
@@ -153,7 +154,7 @@ async function readTryPrompt(
 }
 
 function requireTryTarget(target: TargetName | undefined): TargetName {
-  if (target === undefined) throw new Error("skillset: ad hoc test requires --target claude, codex, or cursor");
+  if (target === undefined) throw new Error(`skillset: ad hoc test requires --target ${TARGET_LIST_TEXT}`);
   return target;
 }
 

--- a/packages/core/src/__tests__/targets.test.ts
+++ b/packages/core/src/__tests__/targets.test.ts
@@ -6,11 +6,33 @@ import {
   readCompileConfig,
   readCompileTargets,
   readOutputConfig,
+  targetDescriptor,
   targetNames,
 } from "../config";
 import type { JsonRecord } from "../types";
 
 describe("target vocabulary", () => {
+  it("owns target-native project and generated-runtime conventions in one exhaustive descriptor", () => {
+    expect(targetDescriptor("claude")).toEqual({
+      displayLabel: "Claude",
+      generatedSessionIdExpression: "${CLAUDE_SESSION_ID:-}",
+      projectAgentExtension: "md",
+      projectRoot: ".claude",
+    });
+    expect(targetDescriptor("codex")).toEqual({
+      displayLabel: "Codex",
+      generatedSessionIdExpression: "${CODEX_SESSION_ID:-}",
+      projectAgentExtension: "toml",
+      projectRoot: ".codex",
+    });
+    expect(targetDescriptor("cursor")).toEqual({
+      displayLabel: "Cursor",
+      generatedSessionIdExpression: "${CURSOR_SESSION_ID:-}",
+      projectAgentExtension: "md",
+      projectRoot: ".cursor",
+    });
+  });
+
   it("includes cursor in the default target plan while preserving explicit narrowing", () => {
     const record: JsonRecord = {
       compile: {

--- a/packages/core/src/adaptive-hook-classifier.ts
+++ b/packages/core/src/adaptive-hook-classifier.ts
@@ -1,7 +1,7 @@
 import type { ResolvedAdaptiveHookAttachment } from "./adaptive-hook-attachments";
 import { readRecord } from "./config";
 import { canonicalHookEventName, hookProviderCapabilities } from "./hook-capabilities";
-import { targetNames } from "./targets";
+import { targetDescriptor, targetNames } from "./targets";
 import type { AdaptiveHookScope, TargetName } from "./types";
 
 export type AdaptiveHookRenderSurface = "frontmatter" | "plugin";
@@ -232,7 +232,5 @@ function providerListAllows(providers: readonly TargetName[] | undefined, target
 }
 
 function targetLabel(target: TargetName): string {
-  if (target === "claude") return "Claude";
-  if (target === "codex") return "Codex";
-  return "Cursor";
+  return targetDescriptor(target).displayLabel;
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -38,7 +38,13 @@ import {
 } from "./targets";
 import { isJsonRecord } from "./yaml";
 
-export { defaultTargetNames, isTargetName, targetNames, targetRecord } from "./targets";
+export {
+  defaultTargetNames,
+  isTargetName,
+  targetDescriptor,
+  targetNames,
+  targetRecord,
+} from "./targets";
 
 export type FeatureSurface = "agents" | "instructions" | "plugins" | "skills";
 

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -6,6 +6,7 @@ import {
   hookEventSupported,
   hookProviderCapabilities,
 } from "./hook-capabilities";
+import { targetDescriptor } from "./targets";
 export {
   CLAUDE_HOOK_EVENTS,
   CODEX_HOOK_EVENTS,
@@ -82,7 +83,5 @@ function formatHandlerTypes(types: ReadonlySet<string>): string {
 }
 
 function labelForTarget(target: TargetName): string {
-  if (target === "claude") return "Claude";
-  if (target === "codex") return "Codex";
-  return "Cursor";
+  return targetDescriptor(target).displayLabel;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,10 +153,13 @@ export {
   type FeatureRegistryDriftReport,
 } from "./feature-registry-check";
 export {
+  TARGET_LIST_TEXT,
   defaultTargetNames,
   isTargetName,
+  targetDescriptor,
   targetNames,
   targetRecord,
+  type TargetDescriptor,
 } from "./targets";
 export {
   assertNoHostLeaks,

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -16,7 +16,7 @@ import {
   readClaudeNativeToolRules,
   readToolsPolicyMetadata,
 } from "./skill-policy";
-import { targetNames } from "./targets";
+import { targetDescriptor, targetNames } from "./targets";
 import type {
   BuildGraph,
   JsonValue,
@@ -149,11 +149,9 @@ async function lintPluginHooks(graph: BuildGraph): Promise<readonly LintIssue[]>
   const issues: LintIssue[] = [];
 
   for (const plugin of graph.plugins) {
-    if (shouldLintPluginHook(graph, plugin, "claude")) {
-      issues.push(...(await lintHookFile(graph, plugin, join("hooks", "hooks.json"), "claude")));
-    }
-    if (shouldLintPluginHook(graph, plugin, "codex")) {
-      issues.push(...(await lintHookFile(graph, plugin, join("hooks", "hooks.json"), "codex")));
+    for (const target of targetNames()) {
+      if (!shouldLintPluginHook(graph, plugin, target)) continue;
+      issues.push(...(await lintHookFile(graph, plugin, join("hooks", "hooks.json"), target)));
     }
   }
 
@@ -186,7 +184,7 @@ async function lintHookFile(
     parsed = JSON.parse(await readFile(hookPath, "utf8")) as JsonValue;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const targetLabel = target === "claude" ? "Claude" : "Codex";
+    const targetLabel = targetDescriptor(target).displayLabel;
     return [
       {
         code: "hook-invalid-json",

--- a/packages/core/src/render-result-collector.ts
+++ b/packages/core/src/render-result-collector.ts
@@ -18,7 +18,7 @@ import {
 } from "./render-result";
 import { compareStrings } from "./path";
 import { pluginPathPartsForOutput, pluginTargetForOutputPath } from "./plugin-output";
-import { isTargetName, targetNames } from "./targets";
+import { isTargetName, targetDescriptor, targetNames } from "./targets";
 import { readClaudeNativeToolRules, readEffectiveToolsPolicy } from "./skill-policy";
 import {
   planToolsRealization,
@@ -768,13 +768,11 @@ function isCompanionPath(path: string, topLevelPath: string): boolean {
 
 function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
   return readString(graph.root.targets[target].options, "projectRoot") ??
-    (target === "claude" ? ".claude" : target === "codex" ? ".codex" : ".cursor");
+    targetDescriptor(target).projectRoot;
 }
 
 function targetLabel(target: TargetName): string {
-  if (target === "claude") return "Claude";
-  if (target === "codex") return "Codex";
-  return "Cursor";
+  return targetDescriptor(target).displayLabel;
 }
 
 function pluginTargetSelected(graph: BuildGraph, pluginId: string, target: TargetName): boolean {

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -80,7 +80,7 @@ import type {
   StandaloneSkill,
   TargetName,
 } from "./types";
-import { targetNames } from "./targets";
+import { targetDescriptor, targetNames } from "./targets";
 import { pluginVersion, rootVersion, skillVersion, skillVersionLabel } from "./versioning";
 import { isJsonRecord, parseMarkdown, parseYamlRecord, stringifyJson } from "./yaml";
 
@@ -287,9 +287,7 @@ function renderRepositoryReadmes(graph: BuildGraph): readonly RenderedFile[] {
 }
 
 function targetLabel(target: TargetName): string {
-  if (target === "claude") return "Claude";
-  if (target === "codex") return "Codex";
-  return "Cursor";
+  return targetDescriptor(target).displayLabel;
 }
 
 function marketplaceReadmeLines(outputRoot: string, target: TargetName): readonly string[] {
@@ -1222,9 +1220,7 @@ function isTextIslandFile(path: string): boolean {
 function targetProjectRoot(graph: BuildGraph, target: TargetName): string {
   const configured = readString(graph.root.targets[target].options, "projectRoot");
   if (configured !== undefined) return configured;
-  if (target === "claude") return ".claude";
-  if (target === "codex") return ".codex";
-  return ".cursor";
+  return targetDescriptor(target).projectRoot;
 }
 
 async function renderStandaloneSkill(
@@ -2344,9 +2340,7 @@ function adaptiveHookContextAssignment(
 }
 
 function targetSessionIdExpression(target: TargetName): string {
-  if (target === "claude") return "${CLAUDE_SESSION_ID:-}";
-  if (target === "codex") return "${CODEX_SESSION_ID:-}";
-  return "${CURSOR_SESSION_ID:-}";
+  return targetDescriptor(target).generatedSessionIdExpression;
 }
 
 function shellLiteral(value: string): string {

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -28,6 +28,7 @@ import {
   readStringArray,
   resolveFeatureTargets,
   resolveTargets,
+  targetDescriptor,
   targetNames,
   targetRecord,
   validateConfigDocument,
@@ -45,6 +46,7 @@ import { DEFAULT_PLUGIN_OUTPUT_ROOT } from "./plugin-output";
 import { readReleaseState } from "./release-state";
 import { readSkillResources } from "./resources";
 import { validateSupports } from "./supports";
+import { TARGET_LIST_TEXT } from "./targets";
 import type {
   BuildGraph,
   JsonRecord,
@@ -1175,10 +1177,10 @@ function sourceFrontmatterSchemaMessage(diagnostic: SkillsetSchemaDiagnostic, fr
     );
   }
   if (diagnostic.code === "schema/skill-frontmatter/allowed-tools-key") {
-    return "target map to contain only claude, codex, or cursor keys";
+    return `target map to contain only ${TARGET_LIST_TEXT} keys`;
   }
   if (diagnostic.code === "schema/skill-frontmatter/implicit-invocation-key") {
-    return "target map to contain only claude, codex, or cursor keys";
+    return `target map to contain only ${TARGET_LIST_TEXT} keys`;
   }
   if (diagnostic.code === "schema/skill-frontmatter/version") {
     return `expected ${diagnostic.path} to be a semantic version`;
@@ -1434,13 +1436,11 @@ function targetProjectRoot(rootTargets: BuildGraph["root"]["targets"], target: T
 }
 
 function projectAgentOutputPath(projectRoot: string, target: TargetName, agent: SourceProjectAgent): string {
-  return join(projectRoot, "agents", `${agent.outputName}.${target === "codex" ? "toml" : "md"}`);
+  return join(projectRoot, "agents", `${agent.outputName}.${targetDescriptor(target).projectAgentExtension}`);
 }
 
 function defaultProjectRoot(target: TargetName): string {
-  if (target === "claude") return ".claude";
-  if (target === "codex") return ".codex";
-  return ".cursor";
+  return targetDescriptor(target).projectRoot;
 }
 
 function validateOutputRoots(

--- a/packages/core/src/targets.ts
+++ b/packages/core/src/targets.ts
@@ -5,10 +5,37 @@ import {
 
 import type { TargetName } from "./types";
 
+export interface TargetDescriptor {
+  readonly displayLabel: string;
+  readonly generatedSessionIdExpression: string;
+  readonly projectAgentExtension: "md" | "toml";
+  readonly projectRoot: string;
+}
+
 export const TARGET_NAMES = SCHEMA_TARGET_NAMES as readonly TargetName[];
 export const DEFAULT_TARGET_NAMES = SCHEMA_DEFAULT_TARGET_NAMES as readonly TargetName[];
 export const TARGET_NAME_SET = new Set<TargetName>(TARGET_NAMES);
 export const DEFAULT_TARGET_NAME_SET = new Set<TargetName>(DEFAULT_TARGET_NAMES);
+export const TARGET_DESCRIPTORS: Readonly<Record<TargetName, TargetDescriptor>> = {
+  claude: {
+    displayLabel: "Claude",
+    generatedSessionIdExpression: "${CLAUDE_SESSION_ID:-}",
+    projectAgentExtension: "md",
+    projectRoot: ".claude",
+  },
+  codex: {
+    displayLabel: "Codex",
+    generatedSessionIdExpression: "${CODEX_SESSION_ID:-}",
+    projectAgentExtension: "toml",
+    projectRoot: ".codex",
+  },
+  cursor: {
+    displayLabel: "Cursor",
+    generatedSessionIdExpression: "${CURSOR_SESSION_ID:-}",
+    projectAgentExtension: "md",
+    projectRoot: ".cursor",
+  },
+};
 export const TARGET_LIST_TEXT = formatList(TARGET_NAMES);
 
 export function targetNames(): readonly TargetName[] {
@@ -21,6 +48,10 @@ export function defaultTargetNames(): readonly TargetName[] {
 
 export function isTargetName(value: unknown): value is TargetName {
   return typeof value === "string" && TARGET_NAME_SET.has(value as TargetName);
+}
+
+export function targetDescriptor(target: TargetName): TargetDescriptor {
+  return TARGET_DESCRIPTORS[target];
 }
 
 export function targetRecord<T>(create: (target: TargetName) => T): Record<TargetName, T> {


### PR DESCRIPTION
## Context

SET-318 removes implicit final-target fallbacks from target-native topology and presentation logic so future providers cannot silently inherit Cursor or Codex behavior.

## What changed

- add one typed exhaustive Core descriptor for project roots, project-agent extensions, display labels, and generated session expressions
- route resolver, renderer, result collection, lint, hook labels, and activation paths through that descriptor
- lint native plugin hooks for every configured canonical target and label Cursor failures correctly
- derive target-list diagnostics from shared canonical prose
- explicitly reject Cursor from the Claude/Codex-only runtime-hook suggestion boundary
- add focused regressions and a patch changeset

## Verification

- focused Core, CLI, parser, hook-lint, runtime-hook, and activation tests
- bun run typecheck
- bun run conformance:fast
- bun run skillset:check:outputs
- bun run check (1,266 tests / 54,021 expectations)
- bun run hooks:pre-push
- standing and fresh targeted Terra High reviews: 5/5 clean, zero P0-P3

## Risk and rollout

Low to moderate. This touches shared topology helpers but preserves current target values and generated bytes. No schema, registry, toolkit, or generated-output contract changed.

Linear: https://linear.app/outfitter/issue/SET-318