### PR TITLE
fix: remove inert schema surfaces

### DIFF
--- a/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
+++ b/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
@@ -22,7 +22,7 @@ validate completeness and print the project finding counts.
 | 01.9 | confirmed | open | SET-318 | — | Use the shared target-list formatter. |
 | 02.1 | confirmed | open | SET-320 | — | Define effective override semantics; SET-351 is the rendering follow-on. |
 | 02.2 | confirmed | open | SET-320 | — | `run.*` acceptance belongs to the effective-definition contract. |
-| 02.3 | confirmed | open | SET-321 | — | Remove only the inert definition-level status surface. |
+| 02.3 | confirmed | fixed | SET-321 | https://github.com/outfitter-dev/skillset/pull/193 | Audit evidence was stale: merged plugin (`537e3e7f9e06613fba557069ee0a311aa2fa131a`) and frontmatter (`dae73c666b5a14ab29216eb329ea57825f05122b`) renderers consume attachment status first, then definition status. SET-321 adds explicit fallback and precedence coverage. |
 | 02.4 | confirmed | open | SET-321 | — | Reject unsupported Codex symlink mode during validation. |
 | 02.5 | confirmed | open | SET-319 | — | Single-source context-specific configuration key contracts. |
 | 02.6 | confirmed | open | SET-321 | — | Remove the fixed-value test output kind if it carries no information. |

--- a/.changeset/remove-inert-test-output.md
+++ b/.changeset/remove-inert-test-output.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Reject unsupported Codex instruction symlink mode during shared schema validation and remove the inert fixed-value test output declaration.

--- a/.skillset/tests.yaml
+++ b/.skillset/tests.yaml
@@ -5,5 +5,3 @@ self-hosted:
   checks:
     projection: true
     pluginManifests: true
-  output:
-    kind: isolated

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -1943,8 +1943,6 @@ self:
   select:
     skills:
       primary: ["demo"]
-  output:
-    kind: isolated
   checks:
     projection: true
     files:

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -832,8 +832,6 @@ self:
   select:
     skills:
       primary: ["demo"]
-  output:
-    kind: isolated
   checks:
     projection: true
     files:
@@ -858,6 +856,35 @@ Demo ordinary workspace skill.
   expect(await exists(cachePath(root, ".skillset/cache/tests/latest/workspace/.skillset/snapshots/recovery/git/config"))).toBe(false);
 });
 
+test("skillset test rejects the removed output field without runtime probes", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: ordinary-root
+claude: true
+codex: false
+`,
+    ".skillset/tests.yaml": `
+self:
+  output:
+    kind: isolated
+  checks:
+    projection: true
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+description: Demo.
+---
+
+Demo.
+`,
+  });
+
+  await expect(runSkillsetTest(root, "self")).rejects.toThrow(
+    "unsupported test key output in .skillset/tests.yaml.self"
+  );
+});
+
 test("skillset test stages dedicated workspace source without copying unrelated repo files", async () => {
   const root = await fixture({
     "package.json": "{\"private\":true}\n",
@@ -871,8 +898,6 @@ codex: false
 select:
   skills:
     primary: ["demo"]
-output:
-  kind: isolated
 checks:
   projection: true
   files:
@@ -3748,7 +3773,7 @@ paths:
   await expect(verifySkillset(root)).rejects.toThrow("stale generated file: docs/AGENTS.md");
 });
 
-test("rules reject Codex symlink mode until target-clean symlinks are designed", async () => {
+test("rules reject Codex symlink mode during source validation", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -3768,7 +3793,9 @@ codex:
 `,
   });
 
-  await expect(buildSkillset(root)).rejects.toThrow("codex: symlink");
+  await expect(buildSkillset(root)).rejects.toThrow(
+    "frontmatter failed schema validation: Codex instruction mode symlink is unsupported"
+  );
 });
 
 test("build lowers normalized skill policy to Claude frontmatter and Codex agent metadata", async () => {

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -532,7 +532,7 @@ async function readTestObject(
     if (key === "source") {
       throw new Error(`skillset: ${label}.source is retired; use ${label}.select`);
     }
-    if (key !== "activation" && key !== "checks" && key !== "output" && key !== "select" && key !== "targets") {
+    if (key !== "activation" && key !== "checks" && key !== "select" && key !== "targets") {
       throw new Error(`skillset: unsupported test key ${key} in ${label}`);
     }
   }
@@ -542,18 +542,6 @@ async function readTestObject(
   const checks = readChecks(record.checks, `${label}.checks`, selection);
   const activationProbes = await readActivationProbes(graph, record.activation, `${label}.activation`, targets);
   validateActivationProbeNames(activationProbes, targets);
-  const output = record.output;
-  if (output !== undefined) {
-    if (!isJsonRecord(output)) throw new Error(`skillset: expected ${label}.output to be an object`);
-    for (const key of Object.keys(output)) {
-      if (key !== "kind") throw new Error(`skillset: unsupported test output key ${key} in ${label}.output`);
-    }
-    const kind = readString(output, "kind");
-    if (kind !== undefined && kind !== "isolated") {
-      throw new Error(`skillset: ${label}.output.kind ${JSON.stringify(kind)} is not supported yet; use isolated`);
-    }
-  }
-
   return { activationProbes, checks, name, selection, targets };
 }
 

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -36,8 +36,6 @@ self-hosted:
   targets:
     - claude
     - codex
-  output:
-    kind: isolated
   checks:
     projection: true
     pluginManifests: true

--- a/docs/reference/examples/test-declaration.yaml
+++ b/docs/reference/examples/test-declaration.yaml
@@ -14,8 +14,6 @@ activation:
       - claude
 checks:
   projection: true
-output:
-  kind: isolated
 select:
   skills:
     primary:

--- a/docs/reference/schemas/0.1.0/instruction-frontmatter.schema.json
+++ b/docs/reference/schemas/0.1.0/instruction-frontmatter.schema.json
@@ -19,6 +19,16 @@
           "type": "boolean"
         },
         {
+          "not": {
+            "properties": {
+              "mode": {
+                "const": "symlink"
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
           "type": "object"
         }
       ]

--- a/docs/reference/schemas/0.1.0/skillset.schema.json
+++ b/docs/reference/schemas/0.1.0/skillset.schema.json
@@ -1092,6 +1092,16 @@
               "type": "boolean"
             },
             {
+              "not": {
+                "properties": {
+                  "mode": {
+                    "const": "symlink"
+                  }
+                },
+                "required": [
+                  "mode"
+                ]
+              },
               "type": "object"
             }
           ]
@@ -2295,16 +2305,6 @@
             },
             "projection": {
               "type": "boolean"
-            }
-          },
-          "type": "object"
-        },
-        "output": {
-          "additionalProperties": false,
-          "properties": {
-            "kind": {
-              "const": "isolated",
-              "type": "string"
             }
           },
           "type": "object"

--- a/docs/reference/schemas/0.1.0/test-declaration.schema.json
+++ b/docs/reference/schemas/0.1.0/test-declaration.schema.json
@@ -208,16 +208,6 @@
       },
       "type": "object"
     },
-    "output": {
-      "additionalProperties": false,
-      "properties": {
-        "kind": {
-          "const": "isolated",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "select": {
       "additionalProperties": false,
       "minProperties": 1,

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -586,6 +586,7 @@ hooks:
 `,
       ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
         events: ["PreToolUse"],
+        status: "Checking the definition",
         run: {
           env: {
             CHECK: "1",
@@ -627,6 +628,39 @@ hooks:
       "plugins/demo/claude/scripts/check.sh",
       "plugins/demo/codex/scripts/check.sh",
     ]));
+  });
+
+  test("renders definition hook status when an attachment does not override it", async () => {
+    const graph = await loadBuildGraph(await fixture({
+      "skillset.yaml": `
+skillset:
+  name: adaptive-hook-definition-status
+claude: true
+codex: false
+`,
+      ".skillset/plugins/demo/skillset.yaml": `
+skillset:
+  name: demo
+hooks:
+  PreToolUse:
+    - hook: shell-policy
+`,
+      ".skillset/plugins/demo/hooks/shell-policy.json": JSON.stringify({
+        events: ["PreToolUse"],
+        run: { command: "echo ok" },
+        status: "Checking the definition",
+      }),
+    }));
+
+    const rendered = await renderBuildGraph(graph);
+    expect(renderedJson(rendered, "plugins/demo/claude/hooks/hooks.json")).toEqual({
+      hooks: {
+        PreToolUse: [{
+          hooks: [{ command: "echo ok", type: "command" }],
+          statusMessage: "Checking the definition",
+        }],
+      },
+    });
   });
 
   test("renders target-effective plugin hook definitions without leaking portable base values", async () => {

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -592,7 +592,7 @@ async function loadInstructions(
     const content = await readFile(sourcePath, "utf8");
     const parts = parseMarkdown(content, sourcePath);
     const relativePath = relative(canonicalPath, sourcePath);
-    const frontmatter = normalizeRuleFrontmatter(parts.frontmatter, sourcePath);
+    const frontmatter = parts.frontmatter;
     validateSourceFrontmatter(
       validateInstructionFrontmatter(frontmatter, relative(rootPath, sourcePath)).diagnostics,
       relative(rootPath, sourcePath),
@@ -634,18 +634,6 @@ function readDialect(frontmatter: JsonRecord, label: string): SourceDialect | un
   throw new Error(
     `skillset: ${label} declares unsupported dialect ${JSON.stringify(value)}; only "claude" is supported`
   );
-}
-
-function normalizeRuleFrontmatter(frontmatter: SourceRule["frontmatter"], label: string): SourceRule["frontmatter"] {
-  const codexMode = isJsonRecord(frontmatter.codex)
-    ? readString(frontmatter.codex, "mode")
-    : undefined;
-  if (frontmatter.codex === "symlink" || codexMode === "symlink") {
-    throw new Error(
-      `skillset: ${label} uses codex: symlink, which is not supported yet; use codex: true or codex: false`
-    );
-  }
-  return frontmatter;
 }
 
 async function loadAdaptiveHooks(

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -428,6 +428,14 @@ describe("@skillset/schema contracts", () => {
       "schema/test-declaration/runtime-expect",
       "schema/test-declaration/runtime-timeout",
     ]);
+    expect(validateTestDeclaration({
+      checks: { projection: true },
+      output: { kind: "isolated" },
+    }).diagnostics).toContainEqual({
+      code: "schema/test-declaration/key",
+      message: "unsupported key output",
+      path: "$.output",
+    });
   });
 
   it("reports invalid workspace config structure without raw schema noise", () => {
@@ -743,6 +751,11 @@ describe("@skillset/schema contracts", () => {
       code: "schema/instruction-frontmatter/paths",
       message: "$.paths entries must be strings",
       path: "$.paths[0]",
+    });
+    expect(validateInstructionFrontmatter({ codex: { mode: "symlink" } }).diagnostics).toContainEqual({
+      code: "schema/instruction-frontmatter/codex-mode",
+      message: "Codex instruction mode symlink is unsupported; use codex: true or codex: false",
+      path: "$.codex.mode",
     });
     expect(validateHookDefinitionSource({
       hooks: {

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -236,7 +236,7 @@ export const instructionFrontmatterContract = contract("instruction-frontmatter"
   additionalProperties: true,
   properties: {
     claude: targetOverrideSchema(),
-    codex: targetOverrideSchema(),
+    codex: instructionCodexOverrideSchema(),
     cursor: targetOverrideSchema(),
     description: nonEmptyStringSchema(),
     dialect: { enum: ["claude"], type: "string" },
@@ -424,9 +424,6 @@ export const testDeclarationContract = contract("test-declaration", "Test Declar
         { properties: { pluginManifests: { const: true } }, required: ["pluginManifests"] },
         { properties: { projection: { const: true } }, required: ["projection"] },
       ],
-    },
-    output: {
-      ...strictObjectSchema({ kind: { const: "isolated", type: "string" } }),
     },
     select: {
       ...strictObjectSchema({
@@ -869,6 +866,21 @@ function targetOverrideSchema(): SchemaJsonRecord {
     anyOf: [
       { type: "boolean" },
       { type: "object" },
+    ],
+  };
+}
+
+function instructionCodexOverrideSchema(): SchemaJsonRecord {
+  return {
+    anyOf: [
+      { type: "boolean" },
+      {
+        not: {
+          properties: { mode: { const: "symlink" } },
+          required: ["mode"],
+        },
+        type: "object",
+      },
     ],
   };
 }

--- a/packages/schema/src/examples.ts
+++ b/packages/schema/src/examples.ts
@@ -423,7 +423,6 @@ export const skillsetSchemaExamples = [
       checks: {
         projection: true,
       },
-      output: { kind: "isolated" },
       select: {
         skills: { primary: ["docs-cli"] },
       },

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -205,13 +205,12 @@ function validateConfigContext(
 export function validateTestDeclaration(value: unknown, path = "$"): SkillsetSchemaValidationResult {
   const diagnostics: SkillsetSchemaDiagnostic[] = [];
   if (!isSchemaRecord(value)) return result([diagnostic(path, "schema/test-declaration/type", "test declaration must be an object")]);
-  checkAllowedKeys(value, new Set(["activation", "checks", "output", "select", "targets"]), path, "schema/test-declaration/key", diagnostics);
+  checkAllowedKeys(value, new Set(["activation", "checks", "select", "targets"]), path, "schema/test-declaration/key", diagnostics);
   if (!isSchemaRecord(value.checks)) {
     diagnostics.push(diagnostic(`${path}.checks`, "schema/test-declaration/checks", "test declaration checks must be an object"));
   } else {
     checkTestChecks(value.checks, `${path}.checks`, diagnostics);
   }
-  if (value.output !== undefined) checkTestOutput(value.output, `${path}.output`, diagnostics);
   if (value.select !== undefined) checkTestSelection(value.select, `${path}.select`, diagnostics);
   if (value.targets !== undefined) {
     checkTargetNameArray(value.targets, `${path}.targets`, "schema/test-declaration/targets", diagnostics);
@@ -254,17 +253,6 @@ function checkTestChecks(value: SchemaJsonRecord, path: string, diagnostics: Ski
   }
   if (value.files === undefined && value.pluginManifests !== true && value.projection !== true) {
     diagnostics.push(diagnostic(path, "schema/test-declaration/checks", "test checks must enable files, pluginManifests, or projection"));
-  }
-}
-
-function checkTestOutput(value: SchemaJsonValue, path: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
-  if (!isSchemaRecord(value)) {
-    diagnostics.push(diagnostic(path, "schema/test-declaration/output", "test output must be an object"));
-    return;
-  }
-  checkAllowedKeys(value, new Set(["kind"]), path, "schema/test-declaration/output-key", diagnostics);
-  if (value.kind !== undefined && value.kind !== "isolated") {
-    diagnostics.push(diagnostic(`${path}.kind`, "schema/test-declaration/output-kind", "test output kind must be isolated"));
   }
 }
 
@@ -486,6 +474,13 @@ export function validateInstructionFrontmatter(value: unknown, path = "$"): Skil
   checkOptionalStringArray(value.paths, `${path}.paths`, "schema/instruction-frontmatter/paths", diagnostics);
   checkTargetBlock(value.claude, `${path}.claude`, "schema/instruction-frontmatter/target", diagnostics);
   checkTargetBlock(value.codex, `${path}.codex`, "schema/instruction-frontmatter/target", diagnostics);
+  if (isSchemaRecord(value.codex) && value.codex.mode === "symlink") {
+    diagnostics.push(diagnostic(
+      `${path}.codex.mode`,
+      "schema/instruction-frontmatter/codex-mode",
+      "Codex instruction mode symlink is unsupported; use codex: true or codex: false"
+    ));
+  }
   checkTargetBlock(value.cursor, `${path}.cursor`, "schema/instruction-frontmatter/target", diagnostics);
   checkSourceMetadata(value.skillset, `${path}.skillset`, diagnostics);
   checkSupports(value.supports, `${path}.supports`, diagnostics);

--- a/packages/workbench/src/__tests__/schema.test.ts
+++ b/packages/workbench/src/__tests__/schema.test.ts
@@ -103,7 +103,7 @@ describe("workbench source contract schema checks", () => {
     });
     expect(grammarDiagnostics.map((diagnostic) => diagnostic.message)).toEqual([
       "unsupported key invented",
-      "test output kind must be isolated",
+      "unsupported key output",
       "test checks must enable files, pluginManifests, or projection",
       "unsupported key imaginary",
     ]);
@@ -229,6 +229,18 @@ describe("workbench source contract schema checks", () => {
       ".skillset/rules/root.md:2: error: schema/instruction-frontmatter: dialect must be claude when present",
       ".skillset/rules/root.md:3: error: schema/instruction-frontmatter: claude must be true, false, or an object when present",
       ".skillset/rules/root.md:5: error: schema/instruction-frontmatter: unsupported supports key tools; v1 supports packages",
+    ]);
+  });
+
+  test("rejects unsupported Codex instruction symlink mode", () => {
+    const diagnostics = checkWorkbenchSourceContract({
+      content: "---\ncodex:\n  mode: symlink\n---\nFollow the repo.\n",
+      kind: "instruction",
+      path: ".skillset/rules/root.md",
+    });
+
+    expect(diagnostics.map(formatWorkbenchDiagnostic)).toEqual([
+      ".skillset/rules/root.md:3: error: schema/instruction-frontmatter: Codex instruction mode symlink is unsupported; use codex: true or codex: false",
     ]);
   });
 


### PR DESCRIPTION
## Context

SET-321 reconciles narrow schema surfaces that were accepted more broadly than the runtime contract. Live history also showed that adaptive-hook definition status was already consumed, so this preserves that behavior and corrects the stale audit claim.

## What changed

- Reject Codex instruction `mode: symlink` in the shared schema and Workbench validation path, then remove the late Core rejection.
- Remove the inert fixed-value test `output` property from contracts, runtime parsing, docs, fixtures, and generated schemas.
- Add regression coverage for definition-status fallback and attachment-status precedence.
- Update the finding disposition with the pre-audit consuming commits.
- Add a patch Changeset for the public `skillset` package.

## How to test

- `bun test packages/schema/src/__tests__/schema.test.ts packages/workbench/src/__tests__/schema.test.ts apps/skillset/src/__tests__/contract.test.ts apps/skillset/src/__tests__/skillset.test.ts packages/core/src/__tests__/adaptive-hook-attachments.test.ts`
- `bun run typecheck`
- `bun run schema:check`
- `bun run skillset:check:outputs`
- `bun run conformance:fast`
- `bun run check`
- `bun run skillset:check:ci`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run hooks:pre-push`

## Review and risk

Two independent Terra reviews are 5/5 clean with zero P0-P3 after correcting the Changeset package list. The contract removal is intentionally breaking only for an inert single-value test field; no expressible runtime behavior is removed. No publication or global configuration mutation was performed.

Linear: https://linear.app/outfitter/issue/SET-321/remove-or-reject-narrow-schema-surfaces-with-no-runtime-contract