### PR TITLE
fix: refuse generated frontmatter divergence

### DIFF
--- a/.changeset/refuse-generated-frontmatter-reconciliation.md
+++ b/.changeset/refuse-generated-frontmatter-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Refuse output-wins reconciliation when generated frontmatter differs from the exact current rendered artifact so only body edits can flow back to source.

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -12,7 +12,7 @@ import {
   collectSourceInventory,
   pluginTargetOptionsForSourceHash,
 } from "../change-status";
-import { doctorSkillset, explainPath } from "@skillset/core/internal/authoring";
+import { doctorSkillset, explainPath, suggestSource } from "@skillset/core/internal/authoring";
 import { importSource, importSources, normalizeCopiedImportPath } from "../import";
 import { inspectSkillset, lintSkillset } from "@skillset/core";
 import { readReleaseState } from "@skillset/core/internal/release-state";
@@ -4968,9 +4968,13 @@ Original source body.
   await buildSkillset(root);
 
   const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
   await writeFile(
-    join(root, generatedPath),
-    "---\nname: demo\ndescription: Demo.\nmetadata:\n  generated: skillset@0.1.0\n---\n\nEdited generated body.\n",
+    generatedAbsolute,
+    (await readFile(generatedAbsolute, "utf8")).replace(
+      "Original source body.",
+      "Edited generated body."
+    ),
     "utf8"
   );
 
@@ -4994,6 +4998,406 @@ Original source body.
   const removed = await runSkillsetCli("suggest-source", generatedPath, "--root", root);
   expect(removed.exitCode).toBe(1);
   expect(removed.stderr).toContain("expected command");
+});
+
+test("SET-322: reconcile preserves provider-rendered frontmatter for body-only edits", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: reconcile-provider-frontmatter
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+implicit_invocation: false
+---
+
+Original source body.
+`,
+  });
+  await buildSkillset(root);
+
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
+  const expected = await readFile(generatedAbsolute, "utf8");
+  expect(expected).toContain("disable-model-invocation: true");
+  await writeFile(
+    generatedAbsolute,
+    expected
+      .replace("Original source body.", "Edited generated body.")
+      .replaceAll("\n", "\r\n"),
+    "utf8"
+  );
+
+  const preview = await runSkillsetCli("reconcile", generatedPath, "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("output wins: available");
+
+  const written = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+  expect(written.exitCode).toBe(0);
+  expect(await readFile(join(root, ".skillset/skills/demo/SKILL.md"), "utf8")).toContain(
+    "Edited generated body."
+  );
+});
+
+test("SET-322: reconcile refuses generated frontmatter divergence before writes", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: reconcile-frontmatter-divergence
+claude: true
+codex: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Original source body.
+`,
+  });
+  await buildSkillset(root);
+
+  const sourcePath = join(root, ".skillset/skills/demo/SKILL.md");
+  const originalSource = await readFile(sourcePath, "utf8");
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
+  const editedGenerated = (await readFile(generatedAbsolute, "utf8"))
+    .replace("---\n", "---\n# generated-only frontmatter comment\n")
+    .replace("Original source body.", "Edited generated body.");
+  await writeFile(generatedAbsolute, editedGenerated, "utf8");
+
+  const preview = await runSkillsetCli("reconcile", generatedPath, "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).toContain(
+    "Generated frontmatter differs from the expected rendered frontmatter"
+  );
+  expect(preview.stdout).toContain(
+    `skillset reconcile ${generatedPath} --use source --yes`
+  );
+
+  const structured = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--json",
+    "--root",
+    root
+  );
+  expect(structured.exitCode).toBe(0);
+  expect(JSON.parse(structured.stdout)).toMatchObject({
+    command: "reconcile",
+    data: {
+      report: {
+        outputResolution: {
+          nextSteps: expect.arrayContaining([
+            `Run \`skillset reconcile ${generatedPath} --use source --yes\` to restore the generated output.`,
+          ]),
+          status: "refused",
+          wouldWrite: false,
+          wrote: false,
+        },
+      },
+      state: "planned",
+      writes: [],
+    },
+    kind: "data",
+    ok: true,
+  });
+
+  const refused = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+  expect(refused.exitCode).toBe(1);
+  expect(refused.stderr).toContain(
+    "Generated frontmatter differs from the expected rendered frontmatter"
+  );
+  expect(await readFile(sourcePath, "utf8")).toBe(originalSource);
+  expect(await readFile(generatedAbsolute, "utf8")).toBe(editedGenerated);
+});
+
+test("SET-322: reconcile refuses output absent from the current render", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: reconcile-removed-target
+claude: true
+codex: false
+cursor: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Source body.
+`,
+  });
+  await buildSkillset(root);
+
+  const sourceAbsolute = join(root, ".skillset/skills/demo/SKILL.md");
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
+  const originalGenerated = await readFile(generatedAbsolute, "utf8");
+  await writeFile(
+    sourceAbsolute,
+    "---\nname: demo\ndescription: Demo.\nclaude: false\n---\n\nSource body.\n",
+    "utf8"
+  );
+  const originalSource = await readFile(sourceAbsolute, "utf8");
+
+  const preview = await runSkillsetCli("reconcile", generatedPath, "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).toContain("managed path is absent from the current rendered output");
+
+  const structured = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--json",
+    "--root",
+    root
+  );
+  expect(structured.exitCode).toBe(0);
+  expect(JSON.parse(structured.stdout)).toMatchObject({
+    command: "reconcile",
+    data: {
+      report: {
+        outputResolution: {
+          nextSteps: ["Update the adaptive source manually, then run `skillset build --yes`."],
+          status: "refused",
+          wouldWrite: false,
+          wrote: false,
+        },
+      },
+      state: "planned",
+      writes: [],
+    },
+    kind: "data",
+    ok: true,
+  });
+
+  const refused = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+  expect(refused.exitCode).toBe(1);
+  expect(refused.stderr).toContain("managed path is absent from the current rendered output");
+  expect(await readFile(sourceAbsolute, "utf8")).toBe(originalSource);
+  expect(await readFile(generatedAbsolute, "utf8")).toBe(originalGenerated);
+});
+
+test("SET-322: output resolution refuses stale ownership after a path remap", async () => {
+  const staleSourcePath = ".stale/skills/demo/SKILL.md";
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: reconcile-ownership-remap
+claude: true
+codex: false
+cursor: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Current source.
+---
+
+Current source body.
+`,
+    [staleSourcePath]: `
+---
+name: demo
+description: Stale source.
+---
+
+Stale source body.
+`,
+  });
+  await buildSkillset(root);
+
+  const currentSourceAbsolute = join(root, ".skillset/skills/demo/SKILL.md");
+  const staleSourceAbsolute = join(root, staleSourcePath);
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
+  const originalCurrentSource = await readFile(currentSourceAbsolute, "utf8");
+  const originalStaleSource = await readFile(staleSourceAbsolute, "utf8");
+  const originalGenerated = await readFile(generatedAbsolute, "utf8");
+  const ownershipEntries = [{
+    files: [generatedPath],
+    kind: "standalone-skill",
+    outputPath: generatedPath,
+    outputRoot: ".claude/skills",
+    sourcePath: staleSourcePath,
+    target: "claude",
+  }] as const;
+
+  const preview = await suggestSource(root, generatedPath, { ownershipEntries });
+  expect(preview).toMatchObject({
+    message: "Current rendered ownership differs from the selected lock ownership; output resolution was refused.",
+    sourcePath: staleSourcePath,
+    status: "refused",
+    wouldWrite: false,
+    wrote: false,
+  });
+
+  const refusedWrite = await suggestSource(root, generatedPath, {
+    ownershipEntries,
+    write: true,
+  });
+  expect(refusedWrite).toMatchObject({
+    status: "refused",
+    wouldWrite: false,
+    wrote: false,
+  });
+  expect(await readFile(currentSourceAbsolute, "utf8")).toBe(originalCurrentSource);
+  expect(await readFile(staleSourceAbsolute, "utf8")).toBe(originalStaleSource);
+  expect(await readFile(generatedAbsolute, "utf8")).toBe(originalGenerated);
+});
+
+test("SET-322: reconcile structurally refuses unclosed generated frontmatter", async () => {
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: reconcile-unclosed-frontmatter
+claude: true
+codex: false
+cursor: false
+`,
+    ".skillset/skills/demo/SKILL.md": `
+---
+name: demo
+description: Demo.
+---
+
+Source body.
+`,
+  });
+  await buildSkillset(root);
+
+  const sourceAbsolute = join(root, ".skillset/skills/demo/SKILL.md");
+  const originalSource = await readFile(sourceAbsolute, "utf8");
+  const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
+  const malformedGenerated = "---\nname: demo\ndescription: Unclosed generated frontmatter.\n";
+  await writeFile(generatedAbsolute, malformedGenerated, "utf8");
+
+  const preview = await runSkillsetCli("reconcile", generatedPath, "--root", root);
+  expect(preview.exitCode).toBe(0);
+  expect(preview.stdout).toContain("output wins: refused");
+  expect(preview.stdout).toContain(
+    "Generated frontmatter differs from the expected rendered frontmatter"
+  );
+
+  const structured = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--json",
+    "--root",
+    root
+  );
+  expect(structured.exitCode).toBe(0);
+  expect(JSON.parse(structured.stdout)).toMatchObject({
+    command: "reconcile",
+    data: {
+      report: {
+        outputResolution: {
+          status: "refused",
+          wouldWrite: false,
+          wrote: false,
+        },
+      },
+      state: "planned",
+      writes: [],
+    },
+    kind: "data",
+    ok: true,
+  });
+
+  const refused = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+  expect(refused.exitCode).toBe(1);
+  expect(refused.stderr).toContain(
+    "Generated frontmatter differs from the expected rendered frontmatter"
+  );
+  expect(await readFile(sourceAbsolute, "utf8")).toBe(originalSource);
+  expect(await readFile(generatedAbsolute, "utf8")).toBe(malformedGenerated);
+});
+
+test("SET-322: reconcile keeps provider-native skill islands out of output resolution", async () => {
+  const sourcePath = ".skillset/_claude/skills/native/SKILL.md";
+  const root = await contractFixture({
+    "skillset.yaml": `
+skillset:
+  name: reconcile-provider-native
+claude: true
+codex: false
+`,
+    [sourcePath]: `
+---
+name: native
+description: Provider-native skill.
+---
+
+Provider-native source body.
+`,
+  });
+  await buildSkillset(root);
+
+  const sourceAbsolute = join(root, sourcePath);
+  const originalSource = await readFile(sourceAbsolute, "utf8");
+  const generatedPath = ".claude/skills/native/SKILL.md";
+  const generatedAbsolute = join(root, generatedPath);
+  const editedGenerated = (await readFile(generatedAbsolute, "utf8")).replace(
+    "Provider-native source body.",
+    "Edited generated body."
+  );
+  await writeFile(generatedAbsolute, editedGenerated, "utf8");
+
+  const refused = await runSkillsetCli(
+    "reconcile",
+    generatedPath,
+    "--use",
+    "output",
+    "--yes",
+    "--root",
+    root
+  );
+  expect(refused.exitCode).toBe(1);
+  expect(refused.stderr).toContain("Only generated skill Markdown body edits are suggestible in v1");
+  expect(await readFile(sourceAbsolute, "utf8")).toBe(originalSource);
+  expect(await readFile(generatedAbsolute, "utf8")).toBe(editedGenerated);
 });
 
 test("SET-282: reconcile rejects adaptive source paths before writing", async () => {
@@ -5084,9 +5488,10 @@ test("SET-282: failed output-wins reconciliation restores source", async () => {
   const sourcePath = join(root, ".skillset/skills/demo/SKILL.md");
   const originalSource = await readFile(sourcePath, "utf8");
   const generatedPath = ".claude/skills/demo/SKILL.md";
+  const generatedSource = await readFile(join(root, generatedPath), "utf8");
   await writeFile(
     join(root, generatedPath),
-    "---\nname: demo\ndescription: Demo.\n---\n\nSee [missing](shared:references/missing.md).\n",
+    generatedSource.replace("Original source body.", "See [missing](shared:references/missing.md)."),
     "utf8"
   );
 
@@ -5202,7 +5607,12 @@ test("SET-282: output-wins normalizes equivalent selected paths", async () => {
   });
   await buildSkillset(root);
   const generatedPath = ".claude/skills/demo/SKILL.md";
-  await writeFile(join(root, generatedPath), "---\nname: demo\n---\n\nOutput edit.\n", "utf8");
+  const generatedSource = await readFile(join(root, generatedPath), "utf8");
+  await writeFile(
+    join(root, generatedPath),
+    generatedSource.replace("Source body.", "Output edit."),
+    "utf8"
+  );
 
   const result = await runSkillsetCli(
     "reconcile",

--- a/apps/skillset/src/reconcile.ts
+++ b/apps/skillset/src/reconcile.ts
@@ -108,6 +108,7 @@ export async function reconcileManagedPath(
     : outputExists
     ? await suggestSource(rootPath, managedPath, {
         ...skillsetOptions,
+        ownershipEntries,
         write: false,
       })
     : {
@@ -143,6 +144,7 @@ export async function reconcileManagedPath(
       try {
         outputResolution = await suggestSource(rootPath, managedPath, {
           ...skillsetOptions,
+          ownershipEntries,
           write: true,
         });
         if (!outputResolution.wrote) {

--- a/docs/features/source-suggestions.md
+++ b/docs/features/source-suggestions.md
@@ -26,7 +26,7 @@ Preview mode is read-only. Write mode is allowed only for clean, single-source c
 | Managed generated skill body edit | Preview source `SKILL.md` body replacement, optionally write with `--use output --yes` when clean | `implemented` |
 | Pending changelog wording before release | Do not reverse-patch from generated output; point to `skillset change reason <@ref>` because pending entries are not rendered into committed changelogs | `implemented` |
 | Generated changelog edit after release | Refuse reconciliation and point to `skillset change amend` for applied-history wording or `skillset release amend` for release-event metadata | `implemented` |
-| Generated metadata, lock files, manifests, or version fields | Refuse; source ownership is not a safe text patch | `planned` |
+| Generated metadata, lock files, manifests, or version fields | Refuse; output resolution compares the exact generated frontmatter block with the current expected render and accepts body edits only | `implemented` |
 | Output from partials, shared resources, or multiple source files | Refuse with diagnostics until a richer mapping exists | `implemented` |
 | Provider-native output with no adaptive round trip | Refuse and explain the provider-specific source or manual path | `planned` |
 | Unmanaged files | Refuse; Skillset cannot claim source ownership without lock provenance | `implemented` |
@@ -40,6 +40,13 @@ The first implementation should make diagnostics useful before attempting writes
 - show the source path and explicit write mode for clean cases;
 - explain the generated files that would need to be rebuilt after accepting the source edit;
 - keep refusal messages specific: metadata, multi-source rendering, provider-native no-round-trip, post-release changelog, unmanaged path, or stale/corrupt lock.
+
+Output resolution renders the exact managed path from current source and compares
+its frontmatter block with the actual generated frontmatter after normalizing line
+endings. It does not compare generated frontmatter with adaptive source
+frontmatter, because provider rendering intentionally strips, derives, and
+transforms fields. Any generated-side frontmatter difference—including comments
+or formatting—is refused before a source write; body-only edits remain eligible.
 
 `skillset check --ci --fix` remains mechanical generated-output repair. It may restore generated files from source, but it must not treat a managed generated edit as source truth. For generated changelogs, current diagnostics already point contributors toward `skillset change reason <@ref>` for pending wording before release, `skillset change amend <@ref>` for applied-history wording after release, and `skillset release amend <@ref>` for release-event metadata. Because committed changelog projections render applied history, not pending entries, a generated `CHANGELOG.md` edit is usually a released-history correction and refuses local reverse-patching.
 
@@ -74,7 +81,7 @@ Fork PRs, protected branches, stale branches, corrupt locks, concurrent pushes, 
 
 ## Tests and Fixtures
 
-[SET-151](https://linear.app/outfitter/issue/SET-151/implement-suggest-source-command-for-clean-generated-to-source) added tests for clean skill-body suggestions, generated changelog refusal, read-only previews, explicit write confirmation, and `explain`/suggestion provenance consistency. Broader refusal matrix coverage can grow with future source-suggestion cases.
+[SET-151](https://linear.app/outfitter/issue/SET-151/implement-suggest-source-command-for-clean-generated-to-source) added tests for clean skill-body suggestions, generated changelog refusal, read-only previews, explicit write confirmation, and `explain`/suggestion provenance consistency. [SET-322](https://linear.app/outfitter/issue/SET-322/reconcile-detect-and-refuse-generated-side-frontmatter-divergence) adds expected-render frontmatter comparison, structured recovery, provider-transformed body-only coverage, and provider-native refusal coverage.
 
 [SET-152](https://linear.app/outfitter/issue/SET-152/design-ci-source-suggestion-writeback-for-managed-generated-edits) should add tests for comment-only CI output, safe same-repo writeback, fork/protected-branch refusal, stale lock refusal, conflicts, and preservation of change-entry requirements.
 

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -92,6 +92,7 @@ export interface SourceSuggestionReport {
 }
 
 export interface SourceSuggestionOptions extends SkillsetOptions {
+  readonly ownershipEntries?: readonly GeneratedEntry[];
   readonly write?: boolean;
 }
 
@@ -250,7 +251,13 @@ export async function suggestSource(
   options: SourceSuggestionOptions = {}
 ): Promise<SourceSuggestionReport> {
   const write = options.write === true;
-  const explanation = await explainPath(rootPath, inputPath, options);
+  const explanation = (options.ownershipEntries?.length ?? 0) > 0
+    ? {
+        entries: options.ownershipEntries ?? [],
+        kind: "generated" as const,
+        path: normalizeRepoPath(rootPath, inputPath),
+      }
+    : await explainPath(rootPath, inputPath, options);
   const generatedPath = explanation.path;
   if (explanation.kind !== "generated" || explanation.entries.length === 0) {
     return refusedSourceSuggestion(generatedPath, explanation.entries, "No Skillset lock entry owns this generated path.", [
@@ -303,8 +310,49 @@ export async function suggestSource(
 
   const sourceAbsolute = resolve(rootPath, sourcePath);
   const generatedAbsolute = resolve(rootPath, generatedPath);
+  const generatedSource = await readFile(generatedAbsolute, "utf8");
+  const graph = await loadBuildGraph(rootPath, options);
+  const expectedGenerated = scopedRenderedFiles(
+    graph,
+    await renderBuildGraph(graph),
+    options.scopes
+  ).find((file) => file.path === generatedPath);
+  if (expectedGenerated === undefined) {
+    return refusedSourceSuggestion(generatedPath, explanation.entries, "The managed path is absent from the current rendered output.", [
+      "Update the adaptive source manually, then run `skillset build --yes`.",
+    ], sourcePath);
+  }
+  const expectedSourcePath = expectedGenerated.sourcePath === undefined
+    ? undefined
+    : normalizeRepoPath(rootPath, expectedGenerated.sourcePath);
+  if (expectedSourcePath === undefined || expectedSourcePath !== normalizeRepoPath(rootPath, sourcePath)) {
+    return refusedSourceSuggestion(
+      generatedPath,
+      explanation.entries,
+      "Current rendered ownership differs from the selected lock ownership; output resolution was refused.",
+      ["Re-run `skillset reconcile` from current repository state, or restore the generated output from source."],
+      sourcePath
+    );
+  }
+  const expectedGeneratedSource = textDecoder.decode(expectedGenerated.content);
+  parseMarkdown(expectedGeneratedSource, `${generatedPath} expected render`);
+  if (
+    normalizedMarkdownFrontmatterBlock(generatedSource) !==
+      normalizedMarkdownFrontmatterBlock(expectedGeneratedSource)
+  ) {
+    return refusedSourceSuggestion(
+      generatedPath,
+      explanation.entries,
+      "Generated frontmatter differs from the expected rendered frontmatter; output resolution accepts body edits only.",
+      [
+        "Move intentional metadata changes to adaptive or provider-specific source.",
+        `Run \`skillset reconcile ${generatedPath} --use source --yes\` to restore the generated output.`,
+      ],
+      sourcePath
+    );
+  }
+  const generatedParts = parseMarkdown(generatedSource, generatedPath);
   const sourceParts = parseMarkdown(await readFile(sourceAbsolute, "utf8"), sourcePath);
-  const generatedParts = parseMarkdown(await readFile(generatedAbsolute, "utf8"), generatedPath);
   if (sourceParts.body === generatedParts.body) {
     const lockPath = lockPathForEntry(primaryEntry);
     return {
@@ -340,6 +388,14 @@ export async function suggestSource(
     wouldWrite: true,
     wrote: write,
   };
+}
+
+function normalizedMarkdownFrontmatterBlock(source: string): string {
+  const normalized = source.replaceAll(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") return "";
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line === "---");
+  return lines.slice(0, closingIndex + 1).join("\n");
 }
 
 export function listFeatureCapabilities(featureId?: string): readonly FeatureCapability[] {


### PR DESCRIPTION
## Context

SET-322 closes a silent-loss path in output-wins reconciliation. Generated frontmatter edits were discarded because reconciliation compared Markdown bodies only and rebuilt source with the original source frontmatter.

## What changed

- Render the exact current managed artifact and compare its generated frontmatter block with the actual output after line-ending normalization.
- Refuse metadata, comment, formatting, malformed-frontmatter, missing-render, and ownership-remap cases before any source write.
- Reuse recovered lock ownership without a redundant explain pass, then require the current rendered owner to match that selected source.
- Preserve provider-transformed body-only reconciliation and existing provider-native refusal behavior.
- Return existing structured preview and JSON recovery paths; explicit output `--yes` remains fail-loud.
- Update source-suggestions documentation and add a public `skillset` patch Changeset.

## How to test

- `bun test apps/skillset/src/__tests__/contract.test.ts -t SET-322`
- `bun run typecheck`
- `bun run skillset:check:outputs`
- `bun run conformance:fast`
- `bun run check`
- `bun run skillset:check:ci`
- `bun run changeset:check`
- `bun run hooks:pre-push`

## Review and risk

Standing and fresh targeted Terra reviews are both 5/5 clean with zero P0-P3 after correcting missing-render coverage, stale-lock diagnostics, malformed-frontmatter recovery, redundant graph work, and the stale-owner/current-owner race. Nine focused regressions prove preview/write refusal and byte preservation across every new safety branch.

No publication, global configuration mutation, unrelated discard, generated-source edit, or gate weakening was performed.

Linear: https://linear.app/outfitter/issue/SET-322/reconcile-detect-and-refuse-generated-side-frontmatter-divergence