### PR TITLE
docs: reconcile drift-audit dispositions

### DIFF
--- a/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
+++ b/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
@@ -11,22 +11,22 @@ validate completeness and print the project finding counts.
 | 00.1 | confirmed | wont-fix | SET-343 | — | MCP implementation is explicitly outside this project; retain the terminology evidence. |
 | 00.2 | confirmed | wont-fix | SET-343 | — | Structured CLI output is the current automation contract; MCP implementation is out of scope. |
 | 00.3 | decided-needed | wont-fix | SET-343 | — | Retain as a future constraint if an MCP surface is separately authorized. |
-| 01.1 | confirmed | open | SET-314 | — | Preserve Cursor in hook-attachment provider lists. |
-| 01.2 | confirmed | open | SET-315 | — | Load Cursor island sources and align registry evidence. |
-| 01.3 | confirmed | open | SET-316 | — | Derive Cursor event casing from registry evidence. |
-| 01.4 | confirmed | open | SET-318 | — | Consolidate target root mappings without implicit Cursor fallback. |
+| 01.1 | confirmed | fixed | SET-314 | https://github.com/outfitter-dev/skillset/pull/299 | Hook-attachment provider lists preserve Cursor through the schema-backed target contract. Merged as `c3123238d22a2e5d7f54fd10172a58c7dab5aae0`. |
+| 01.2 | confirmed | fixed | SET-315 | https://github.com/outfitter-dev/skillset/pull/301 | Cursor target-native islands load and align with registry evidence. Merged as `d7468f1145da59bc119f61124b96fe0c504e5a0a`. |
+| 01.3 | confirmed | fixed | SET-316 | https://github.com/outfitter-dev/skillset/pull/300 | Cursor hook-event casing derives from registry-owned evidence. Merged as `a2d421026d6b0853d3a488dd47564476cd9e1700`. |
+| 01.4 | confirmed | fixed | SET-318 | https://github.com/outfitter-dev/skillset/pull/305 | Target roots and project-agent extensions use exhaustive canonical descriptors without an implicit Cursor fallback. Merged as `0ea4c96b72da7bad975988aeafa652716f0ced91`. |
 | 01.5 | confirmed | open | SET-313 | — | Final Cursor default-target and ADR decision; decision evidence required. |
 | 01.6 | confirmed | open | SET-339 | — | Refresh significant Cursor documentation after SET-317 and SET-313. |
 | 01.7 | confirmed | open | SET-339 | — | Refresh moderate Cursor documentation after SET-317 and SET-313. |
 | 01.8 | confirmed | open | SET-339 | — | Refresh minor Cursor documentation after SET-317 and SET-313. |
-| 01.9 | confirmed | open | SET-318 | — | Use the shared target-list formatter. |
-| 02.1 | confirmed | open | SET-320 | — | Define effective override semantics; SET-351 is the rendering follow-on. |
-| 02.2 | confirmed | open | SET-320 | — | `run.*` acceptance belongs to the effective-definition contract. |
+| 01.9 | confirmed | fixed | SET-318 | https://github.com/outfitter-dev/skillset/pull/305 | Target-list diagnostics derive from the canonical target vocabulary and shared formatter. Merged as `0ea4c96b72da7bad975988aeafa652716f0ced91`. |
+| 02.1 | confirmed | fixed | SET-320 | https://github.com/outfitter-dev/skillset/pull/308 | Typed effective provider overrides resolve once before attachment validation in PR 307 (`e8b5e5e2c2703d5c5d9d91cd1d03f1eaad08c8fc`) and render across supported destinations in PR 308 (`312299c83cf80574ac92b2f70c947fbf63100565`). |
+| 02.2 | confirmed | fixed | SET-320 | https://github.com/outfitter-dev/skillset/pull/307 | The effective-definition contract validates and preserves supported `run.*` intent while rejecting unsupported surface combinations. Merged as `e8b5e5e2c2703d5c5d9d91cd1d03f1eaad08c8fc`. |
 | 02.3 | confirmed | fixed | SET-321 | https://github.com/outfitter-dev/skillset/pull/193 | Audit evidence was stale: merged plugin (`537e3e7f9e06613fba557069ee0a311aa2fa131a`) and frontmatter (`dae73c666b5a14ab29216eb329ea57825f05122b`) renderers consume attachment status first, then definition status. SET-321 adds explicit fallback and precedence coverage. |
-| 02.4 | confirmed | open | SET-321 | — | Reject unsupported Codex symlink mode during validation. |
-| 02.5 | confirmed | open | SET-319 | — | Single-source context-specific configuration key contracts. |
-| 02.6 | confirmed | open | SET-321 | — | Remove the fixed-value test output kind if it carries no information. |
-| 02.7 | plausible | open | SET-322 | — | Verify and refuse generated-side frontmatter divergence. |
+| 02.4 | confirmed | fixed | SET-321 | https://github.com/outfitter-dev/skillset/pull/309 | Shared schema validation rejects unsupported Codex instruction symlink mode before resolution. Merged as `673667656188b76e0070eb7299a0d560e9f0052c`. |
+| 02.5 | confirmed | fixed | SET-319 | https://github.com/outfitter-dev/skillset/pull/306 | Schema-owned contracts distinguish single-file root, split workspace, source-manifest, and plugin configuration vocabularies. Merged as `7760699e9b10cb73e3a7b145dfcb73b5936ae46a`. |
+| 02.6 | confirmed | fixed | SET-321 | https://github.com/outfitter-dev/skillset/pull/309 | The inert fixed-value test output container was removed from schema, runtime, docs, examples, and generated artifacts. Merged as `673667656188b76e0070eb7299a0d560e9f0052c`. |
+| 02.7 | plausible | fixed | SET-322 | https://github.com/outfitter-dev/skillset/pull/310 | Output-wins reconciliation compares exact expected generated frontmatter and refuses divergence before source writes. Merged as `588e51d962fec11bff0dd21b81a830912b715389`. |
 | 03.1 | confirmed | open | SET-324 | — | Accept a successor ADR for shipped unsupported-destination policy. |
 | 03.2 | confirmed | open | SET-327 | — | Audit every draft first; SET-325 is the evidence-gated promotion follow-on. |
 | 03.3 | confirmed | open | SET-327 | — | Record the supersession disposition before SET-325 acts. |
@@ -37,10 +37,10 @@ validate completeness and print the project finding counts.
 | 03.8 | confirmed | open | SET-339 | — | Refresh Cursor documentation after registry-backed table checks. |
 | 03.9 | decided-needed | open | SET-317 | — | Mechanically check target-support tables against registry evidence. |
 | 03.10 | plausible | open | SET-339 | — | Verify and correct the lagging feature-doc status row. |
-| 04.1 | confirmed | open | SET-319 | — | Import context-specific key contracts from schema ownership. |
+| 04.1 | confirmed | fixed | SET-319 | https://github.com/outfitter-dev/skillset/pull/306 | Core derives context-specific configuration key sets and unsupported-destination policy from schema ownership. Merged as `7760699e9b10cb73e3a7b145dfcb73b5936ae46a`. |
 | 04.2 | confirmed | open | SET-323 | — | Single-source the semver value contract. |
 | 04.3 | confirmed | open | SET-346 | — | Derive retired-surface guards from canonical tooling contracts. |
-| 04.4 | confirmed | open | SET-318 | — | Consolidate target root and extension mappings. |
+| 04.4 | confirmed | fixed | SET-318 | https://github.com/outfitter-dev/skillset/pull/305 | Canonical target descriptors own project roots, project-agent extensions, display labels, and generated session expressions. Merged as `0ea4c96b72da7bad975988aeafa652716f0ced91`. |
 | 04.5 | confirmed | open | SET-323 | — | Single-source list formatting at the lowest owner. |
 | 04.6 | confirmed | open | SET-346 | — | Add explicit runtime-map partition coverage. |
 | 04.7 | plausible | wont-fix | SET-343 | — | Baseline counts are intentionally prose observations, not product contracts. |


### PR DESCRIPTION
## Context

SET-352 reconciles the durable drift-audit disposition map with the project work already merged through SET-322. This keeps tracker/audit evidence current before the next product branch.

## What changed

- mark 13 findings fixed with their owning issue, merged PR, and full merge SHA
- preserve all still-open and previously recorded rows
- update the summary counts to 51 total / 33 open / 14 fixed / 4 wont-fix

## Verification

- two independent Terra High reviews: 5/5 clean, zero P0-P3
- live verification of all nine referenced PRs, merge SHAs, issue ownership, and diffs
- bun run conformance:fast
- bun run hooks:pre-push (1287 tests, 54141 assertions)

## Risk

Audit-only documentation change. No source, generated output, package, or release behavior changes.

Linear: SET-352