### PR TITLE
refactor: single-source shared value contracts

### DIFF
--- a/.changeset/single-source-value-contracts.md
+++ b/.changeset/single-source-value-contracts.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Single-source semantic-version matching and human-readable list formatting across schema, Core, and CLI consumers. This tightens validation to reject surrounding whitespace in semantic-version values.

--- a/apps/skillset/src/create-interactive.ts
+++ b/apps/skillset/src/create-interactive.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { targetNames } from "@skillset/core/internal/config";
 import { validateSlug } from "@skillset/core/internal/path";
 import type { TargetName } from "@skillset/core/internal/types";
+import { formatList } from "@skillset/schema";
 
 import type { InteractiveSession } from "./interactive-session";
 import {
@@ -138,7 +139,7 @@ export function formatInteractiveCreatePlan(
   return [
     `Create repository ${plan.report.rootPath}`,
     `Name it ${plan.name}`,
-    `Generate for ${formatHumanList(plan.targets.map(displayTarget))}`,
+    `Generate for ${formatList(plan.targets.map(displayTarget), "and")}`,
     "Create the canonical .skillset/ source layout",
     "Initialize a local Git repository",
     ...(plan.include.includes("ci") ? ["Add the Skillset GitHub Action"] : []),
@@ -167,10 +168,4 @@ function validateCreateName(value: string): true | string {
 
 function displayTarget(target: TargetName): string {
   return `${target[0]?.toUpperCase() ?? ""}${target.slice(1)}`;
-}
-
-function formatHumanList(values: readonly string[]): string {
-  if (values.length <= 1) return values.join("");
-  if (values.length === 2) return values.join(" and ");
-  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
 }

--- a/apps/skillset/src/init-interactive.ts
+++ b/apps/skillset/src/init-interactive.ts
@@ -6,6 +6,7 @@ import {
   targetNames,
 } from "@skillset/core/internal/config";
 import type { TargetName } from "@skillset/core/internal/types";
+import { formatList } from "@skillset/schema";
 
 import { adoptCandidateId, adoptSkillset, type AdoptReport } from "./adopt";
 import { gitSafeEnv } from "./git-env";
@@ -322,7 +323,7 @@ export function formatInteractiveInitPlan(plan: InteractiveInitPlan): string {
         ? []
         : ["Keep the detected files unchanged"]
       : [`Import ${formatCandidateCounts(plan.adoptionCandidates)}`]),
-    `Generate for ${formatHumanList(plan.targets.map(displayTarget))}`,
+    `Generate for ${formatList(plan.targets.map(displayTarget), "and")}`,
     ...(plan.include.includes("ci") ? ["Add the Skillset GitHub Action"] : []),
     ...(plan.adoptionCandidates.length > 0
       ? ["Preserve the existing source files"]
@@ -340,7 +341,7 @@ function formatDiscoveredCandidates(
 function formatCandidateCounts(
   candidates: readonly SetupImportCandidate[]
 ): string {
-  return formatHumanList(candidateCountLabels(candidates));
+  return formatList(candidateCountLabels(candidates), "and");
 }
 
 function candidateCountLabels(
@@ -377,12 +378,6 @@ function interactiveCandidateLabel(candidate: SetupImportCandidate): string {
 
 function displayTarget(target: TargetName): string {
   return `${target[0]?.toUpperCase() ?? ""}${target.slice(1)}`;
-}
-
-function formatHumanList(values: readonly string[]): string {
-  if (values.length <= 1) return values.join("");
-  if (values.length === 2) return values.join(" and ");
-  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
 }
 
 async function gitOutput(

--- a/apps/skillset/src/new-source.ts
+++ b/apps/skillset/src/new-source.ts
@@ -12,6 +12,7 @@ import {
 } from "@skillset/core/internal/path";
 import type { SkillsetOptions } from "@skillset/core/internal/types";
 import type { TargetName } from "@skillset/core/internal/types";
+import { formatList } from "@skillset/schema";
 
 import { planNewAdaptiveHook } from "./new-hook";
 
@@ -466,10 +467,6 @@ function readSkillPresets(
 ): readonly SkillPreset[] {
   const presets = values === undefined ? [] : parseSkillPresets(values);
   return presets.length === 0 ? ["minimal"] : presets;
-}
-
-function formatList(values: readonly string[]): string {
-  return `${values.slice(0, -1).join(", ")}, or ${values.at(-1)}`;
 }
 
 function uniquePlans(plans: readonly NewSourcePlannedFile[]): readonly NewSourcePlannedFile[] {

--- a/docs/schema-contracts.md
+++ b/docs/schema-contracts.md
@@ -8,6 +8,9 @@ The source of truth is `packages/schema/src/`:
 
 - `contracts.ts` defines the JSON Schema descriptors, exported vocabularies,
   and generated artifact shape.
+- `value-contracts.ts` owns reusable scalar and presentation contracts shared
+  by schema validation, Core, and the CLI, including exact semantic versions
+  and human-readable lists.
 - `validate.ts` defines the shared diagnostics used by compiler, Workbench, and
   CLI-adjacent checks.
 - `examples.ts` defines maximal examples that are checked against the same

--- a/packages/core/src/__tests__/semver-contract.test.ts
+++ b/packages/core/src/__tests__/semver-contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateSourceMetadata,
+  validateWorkspaceConfig,
+} from "@skillset/schema";
+
+import {
+  isRemoteRepositoryVersion,
+  validateRemoteRepositoryRevision,
+} from "../remote-repository-reference";
+import { validateVersionField } from "../versioning";
+
+const CASES = [
+  ["0.0.0", true],
+  ["1.2.3", true],
+  ["1.0.0-alpha.1+build.7", true],
+  ["1.0.0+build.01", true],
+  ["1", false],
+  ["1.2", false],
+  ["01.2.3", false],
+  ["1.0.0-01", false],
+  ["1.0.0-alpha..1", false],
+  [" 1.2.3 ", false],
+] as const;
+
+describe("semantic version consumer parity", () => {
+  test.each(CASES)("%s acceptance is identical", (version, accepted) => {
+    expect(validateSourceMetadata({ version }).ok).toBe(accepted);
+    expect(validateWorkspaceConfig({
+      marketplaces: {
+        test: {
+          plugins: [{ plugin: "demo", repo: "github:acme/demo", version }],
+        },
+      },
+    }).ok).toBe(accepted);
+    expect(coreVersionAccepted(version)).toBe(accepted);
+    expect(isRemoteRepositoryVersion(version)).toBe(accepted);
+    expect(remoteRevisionAccepted(version)).toBe(accepted);
+  });
+});
+
+function coreVersionAccepted(version: string): boolean {
+  try {
+    validateVersionField({ version }, "test.version");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function remoteRevisionAccepted(version: string): boolean {
+  try {
+    validateRemoteRepositoryRevision({ kind: "version", version });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/remote-repository-reference.ts
+++ b/packages/core/src/remote-repository-reference.ts
@@ -1,6 +1,7 @@
+import { createSemverRegExp } from "@skillset/schema";
+
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/u;
-const SEMVER_PATTERN =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
+const semverPattern = createSemverRegExp();
 
 export type RemoteRepositoryRevision =
   | { readonly kind: "default" }
@@ -90,7 +91,7 @@ export function validateRemoteRepositoryRevision(revision: RemoteRepositoryRevis
   if (revision.kind === "sha" && !FULL_SHA_PATTERN.test(revision.sha)) {
     throw new Error("skillset: remote repository sha must be a full lowercase 40-character commit");
   }
-  if (revision.kind === "version" && !SEMVER_PATTERN.test(revision.version)) {
+  if (revision.kind === "version" && !semverPattern.test(revision.version)) {
     throw new Error("skillset: remote repository version must be a semantic version");
   }
   if (revision.kind === "ref" && !isSafeRemoteRepositoryRef(revision.ref)) {
@@ -113,7 +114,7 @@ export function isFullRemoteRepositorySha(value: string): boolean {
 }
 
 export function isRemoteRepositoryVersion(value: string): boolean {
-  return SEMVER_PATTERN.test(value);
+  return semverPattern.test(value);
 }
 
 function canonicalRemote(

--- a/packages/core/src/targets.ts
+++ b/packages/core/src/targets.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_TARGET_NAMES as SCHEMA_DEFAULT_TARGET_NAMES,
+  formatList,
   TARGET_NAMES as SCHEMA_TARGET_NAMES,
 } from "@skillset/schema";
 
@@ -56,9 +57,4 @@ export function targetDescriptor(target: TargetName): TargetDescriptor {
 
 export function targetRecord<T>(create: (target: TargetName) => T): Record<TargetName, T> {
   return Object.fromEntries(TARGET_NAMES.map((target) => [target, create(target)])) as Record<TargetName, T>;
-}
-
-function formatList(values: readonly string[]): string {
-  if (values.length <= 1) return values.join("");
-  return `${values.slice(0, -1).join(", ")}, or ${values.at(-1)}`;
 }

--- a/packages/core/src/versioning.ts
+++ b/packages/core/src/versioning.ts
@@ -1,3 +1,5 @@
+import { createSemverRegExp } from "@skillset/schema";
+
 import { readString } from "./config";
 import { selectorForPluginSkill, selectorForRootConfig, selectorForStandaloneSkill, sourceUnitSelector } from "./source-unit-selector";
 import type { BuildGraph, JsonRecord, SourcePlugin, SourceSkill } from "./types";
@@ -12,8 +14,7 @@ export const DEFAULT_VERSION = "0.1.0";
  */
 export const SUPPORTED_SOURCE_SCHEMA = 1;
 
-const SEMVER_PATTERN =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const semverPattern = createSemverRegExp();
 
 /**
  * Validate an explicit `skillset.schema` source marker. The schema is the source
@@ -44,7 +45,7 @@ export function validateVersionField(record: JsonRecord, label: string): void {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new Error(`skillset: expected ${label} to be a semantic version string`);
   }
-  if (!SEMVER_PATTERN.test(value.trim())) {
+  if (!semverPattern.test(value)) {
     throw new Error(`skillset: expected ${label} to be a semantic version`);
   }
 }

--- a/packages/schema/src/__tests__/value-contracts.test.ts
+++ b/packages/schema/src/__tests__/value-contracts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createSemverRegExp,
+  formatList,
+  SEMVER_PATTERN,
+} from "../value-contracts";
+
+describe("shared value contracts", () => {
+  test("semantic versions use one exact Unicode-aware pattern", () => {
+    const valid = [
+      "0.0.0",
+      "1.2.3",
+      "1.0.0-alpha",
+      "1.0.0-alpha.1",
+      "1.0.0-alpha+build.7",
+      "1.0.0+build.01",
+    ];
+    const invalid = [
+      "1",
+      "1.2",
+      "01.2.3",
+      "1.02.3",
+      "1.2.03",
+      "1.0.0-01",
+      "1.0.0-alpha..1",
+      "1.0.0+",
+      " 1.2.3 ",
+      "1.2.3\n",
+      "１.2.3",
+    ];
+
+    const first = createSemverRegExp();
+    const second = createSemverRegExp();
+    expect(first).not.toBe(second);
+    expect(first.source).toBe(SEMVER_PATTERN);
+    expect(first.flags).toBe("u");
+    for (const value of valid) expect(first.test(value)).toBe(true);
+    for (const value of invalid) expect(first.test(value)).toBe(false);
+  });
+
+  test("lists define zero, one, two, and many-item conjunctions", () => {
+    expect(formatList([])).toBe("");
+    expect(formatList(["alpha"])).toBe("alpha");
+    expect(formatList(["alpha", "beta"])).toBe("alpha or beta");
+    expect(formatList(["alpha", "beta", "gamma"])).toBe("alpha, beta, or gamma");
+    expect(formatList(["alpha", "beta"], "and")).toBe("alpha and beta");
+    expect(formatList(["alpha", "beta", "gamma"], "and")).toBe(
+      "alpha, beta, and gamma"
+    );
+  });
+});

--- a/packages/schema/src/contracts.ts
+++ b/packages/schema/src/contracts.ts
@@ -1,12 +1,11 @@
 import { sortSchemaRecord } from "./json";
 import type { SchemaJsonRecord, SkillsetSchemaContract } from "./types";
+import { SEMVER_PATTERN } from "./value-contracts";
 
 export const SKILLSET_SCHEMA_VERSION = "0.1.0";
 export const SKILLSET_SCHEMA_URI_BASE = "https://raw.githubusercontent.com/outfitter-dev/skillset/main/docs/reference/schemas";
 export const CLI_RESULT_SCHEMA_VERSION = "skillset.cli.result@1";
 export const CLI_EVENT_SCHEMA_VERSION = "skillset.cli.event@1";
-const SEMVER_PATTERN =
-  "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$";
 
 export const TARGET_NAMES = ["claude", "codex", "cursor"] as const;
 export const DEFAULT_TARGET_NAMES = TARGET_NAMES;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -50,6 +50,12 @@ export {
 } from "./artifacts";
 export { deriveSkillsetExampleArtifacts } from "./examples";
 export { isSchemaRecord, sortSchemaRecord } from "./json";
+export {
+  createSemverRegExp,
+  formatList,
+  SEMVER_PATTERN,
+  type ListConjunction,
+} from "./value-contracts";
 export type {
   SchemaJsonRecord,
   SchemaJsonScalar,

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -14,6 +14,7 @@ import {
   UNSUPPORTED_DESTINATION_POLICIES,
 } from "./contracts";
 import { isSchemaRecord } from "./json";
+import { createSemverRegExp, formatList } from "./value-contracts";
 import type {
   SchemaJsonRecord,
   SchemaJsonValue,
@@ -36,8 +37,7 @@ const unsupportedDestinationPolicies = new Set<string>(UNSUPPORTED_DESTINATION_P
 const sourceLicenseValues = new Set<string>([...SOURCE_LICENSE_IDS, SOURCE_LICENSE_NONE]);
 const toolsPolicyKeys = new Set<string>(["claude", "codex", "cursor", "mcp", "read", "search", "shell", "write"]);
 const toolsProviderKeys = new Set<string>(["allow", "deny", "mcp", "read", "search", "shell", "write"]);
-const semverPattern =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const semverPattern = createSemverRegExp();
 const fullGitShaPattern = /^[0-9a-f]{40}$/;
 const safeGitRefPattern = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 
@@ -889,7 +889,7 @@ function checkOptionalSemverString(value: SchemaJsonValue | undefined, path: str
     diagnostics.push(diagnostic(path, code, `${path} must be a semantic version string`));
     return;
   }
-  if (!semverPattern.test(value.trim())) diagnostics.push(diagnostic(path, code, `${path} must be a semantic version`));
+  if (!semverPattern.test(value)) diagnostics.push(diagnostic(path, code, `${path} must be a semantic version`));
 }
 
 function checkOptionalNonEmptyString(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
@@ -1425,9 +1425,4 @@ function result(diagnostics: readonly SkillsetSchemaDiagnostic[]): SkillsetSchem
     diagnostics,
     ok: diagnostics.length === 0,
   };
-}
-
-function formatList(values: readonly string[]): string {
-  if (values.length <= 1) return values.join("");
-  return `${values.slice(0, -1).join(", ")}, or ${values.at(-1)}`;
 }

--- a/packages/schema/src/value-contracts.ts
+++ b/packages/schema/src/value-contracts.ts
@@ -1,0 +1,18 @@
+export const SEMVER_PATTERN =
+  "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$";
+
+export type ListConjunction = "and" | "or";
+
+export function createSemverRegExp(): RegExp {
+  return new RegExp(SEMVER_PATTERN, "u");
+}
+
+export function formatList(
+  values: readonly string[],
+  conjunction: ListConjunction = "or"
+): string {
+  if (values.length === 0) return "";
+  if (values.length === 1) return values[0] ?? "";
+  if (values.length === 2) return `${values[0]} ${conjunction} ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, ${conjunction} ${values.at(-1)}`;
+}


### PR DESCRIPTION
## Context

SET-323 removes duplicated semantic-version and human-readable list contracts across Schema, Core, and CLI while preserving the schema package as the lowest shared owner.

## What changed

- add schema-owned semantic-version pattern/factory and typed list formatter
- migrate every audited Schema, Core, and CLI consumer
- define and test exact zero/one/two/many list behavior for `or` and `and`
- add cross-consumer semantic-version parity coverage
- document ownership and add the public `skillset` patch changeset

## Compatibility

This intentionally tightens validation: semantic-version values with surrounding whitespace are rejected instead of silently trimmed. Marketplace, remote revision, and generated JSON Schema boundaries were already exact; this aligns shared validation with them.

## Verification

- standing and fresh Terra High reviews: 5/5 clean, zero P0-P3
- 50 focused tests / 351 assertions
- typecheck, schema generation/check, and 76-file output verification
- generated schema/example diff is empty
- conformance fast
- bun run check
- bun run hooks:pre-push (1299 tests / 54217 assertions)

## Scope

No SET-346 tooling/runtime-map work, generated-source edits, publication, or global mutation.

Linear: SET-323