### PR TITLE
refactor: derive tooling contract guards

### DIFF
--- a/.changeset/derive-retired-runtime-contracts.md
+++ b/.changeset/derive-retired-runtime-contracts.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Derive retired CLI surface guards from the canonical command and flag contracts, and guard runtime distribution mappings with an explicit exclusion partition.

--- a/packages/core/src/__tests__/config-contracts.test.ts
+++ b/packages/core/src/__tests__/config-contracts.test.ts
@@ -1,11 +1,32 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  DISTRIBUTION_RUNTIME_TARGETS,
+  NON_DISTRIBUTABLE_RUNTIME_IDS,
   validateConfigDocument,
   validateRootSourceManifestDocument,
   validateWorkspaceConfigDocument,
 } from "../config";
+import { SKILLSET_RUNTIME_IDS } from "../feature-registry";
 import type { JsonRecord } from "../types";
+
+describe("distribution runtime contract", () => {
+  it("SET-346 partitions every registered runtime into one target or the named exclusion set", () => {
+    const mappedRuntimeIds = Object.values(DISTRIBUTION_RUNTIME_TARGETS).flat();
+    const registeredRuntimeIds = new Set<string>(SKILLSET_RUNTIME_IDS);
+
+    for (const runtime of SKILLSET_RUNTIME_IDS) {
+      const mappingCount = mappedRuntimeIds.filter((candidate) => candidate === runtime).length;
+      const partitionCount = mappingCount + Number(NON_DISTRIBUTABLE_RUNTIME_IDS.has(runtime));
+
+      expect(partitionCount).toBe(1);
+    }
+    expect(mappedRuntimeIds.filter((runtime) => !registeredRuntimeIds.has(runtime))).toEqual([]);
+    expect(
+      [...NON_DISTRIBUTABLE_RUNTIME_IDS].filter((runtime) => !registeredRuntimeIds.has(runtime))
+    ).toEqual([]);
+  });
+});
 
 describe("schema-owned config document contexts", () => {
   it("keeps Core validation aligned with each schema-owned document vocabulary", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -68,11 +68,17 @@ const COMPILE_BUILD_MODES = new Set<CompileBuildMode>(SCHEMA_COMPILE_BUILD_MODES
 const UNSUPPORTED_DESTINATION_POLICIES = new Set<UnsupportedDestinationPolicy>(
   SCHEMA_UNSUPPORTED_DESTINATION_POLICIES as readonly UnsupportedDestinationPolicy[]
 );
-const DISTRIBUTION_RUNTIME_TARGETS: Readonly<Record<TargetName, readonly SkillsetRuntimeId[]>> = {
+export const DISTRIBUTION_RUNTIME_TARGETS: Readonly<Record<TargetName, readonly SkillsetRuntimeId[]>> = {
   claude: ["claude-code"],
   codex: ["codex-app", "codex-cli"],
   cursor: ["cursor"],
 };
+export const NON_DISTRIBUTABLE_RUNTIME_IDS: ReadonlySet<SkillsetRuntimeId> = new Set([
+  "devin",
+  "droid",
+  "gemini-cli",
+  "opencode",
+]);
 const SOURCE_ONLY_KEYS = new Set([
   "agents",
   "allowed_tools",

--- a/scripts/__tests__/cli-surface-guard.test.ts
+++ b/scripts/__tests__/cli-surface-guard.test.ts
@@ -3,7 +3,43 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { isCliSurfacePath, scanCliSurface } from "../cli-surface-guard";
+import {
+  buildDirectRetiredSurfacePatterns,
+  isCliSurfacePath,
+  scanCliSurface,
+} from "../cli-surface-guard";
+import { RETIRED_CLI_COMMANDS, RETIRED_CLI_FLAGS } from "../cli-contract";
+
+test("SET-346: CLI surface guard derives direct command and flag patterns", () => {
+  const patterns = buildDirectRetiredSurfacePatterns(
+    ["retire.command"],
+    ["--retire+flag"]
+  );
+  const matches = (text: string) => patterns.some((pattern) => pattern.test(text));
+
+  expect(matches("Run skillset retire.command before handoff.")).toBe(true);
+  expect(matches("Run cli.ts retire.command before handoff.")).toBe(true);
+  expect(matches("Use --retire+flag before handoff.")).toBe(true);
+  expect(matches("Run skillset retire.command-extra before handoff.")).toBe(false);
+  expect(matches("Use --retire+flag-extra before handoff.")).toBe(false);
+});
+
+test("SET-346: CLI surface guard covers every canonical retired command and flag", () => {
+  expect(scanCliSurface("README.md", "Run skillset verify before handoff.")).toHaveLength(1);
+  expect(scanCliSurface("README.md", "Run ./apps/skillset/src/cli.ts verify before handoff.")).toHaveLength(1);
+  for (const invocation of ["mycli.ts", "my-cli.ts", "foo.skillset", "my-skillset"]) {
+    expect(scanCliSurface("README.md", `Run ${invocation} verify before handoff.`)).toEqual([]);
+  }
+  for (const command of RETIRED_CLI_COMMANDS) {
+    expect(scanCliSurface("README.md", `Run skillset ${command} before handoff.`)).toHaveLength(1);
+    expect(scanCliSurface("README.md", `Run bun run skillset:${command} before handoff.`)).toHaveLength(1);
+    expect(scanCliSurface("README.md", `Run skillset ${command}-extended before handoff.`)).toEqual([]);
+  }
+  for (const flag of RETIRED_CLI_FLAGS) {
+    expect(scanCliSurface("README.md", `Use ${flag} before handoff.`)).toHaveLength(1);
+    expect(scanCliSurface("README.md", `Use ${flag}-extended before handoff.`)).toEqual([]);
+  }
+});
 
 test("SET-285: CLI surface guard rejects retired commands, flags, and environment", () => {
   const content = [

--- a/scripts/cli-surface-guard.ts
+++ b/scripts/cli-surface-guard.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { gitSafeEnv } from "../apps/skillset/src/git-env";
+import { RETIRED_CLI_COMMANDS, RETIRED_CLI_FLAGS } from "./cli-contract";
 import { validateCliContractParity } from "./cli-contract-parity";
 
 export interface CliSurfaceViolation {
@@ -11,17 +12,31 @@ export interface CliSurfaceViolation {
   readonly text: string;
 }
 
+export function buildDirectRetiredSurfacePatterns(
+  commands: readonly string[],
+  flags: readonly string[]
+): readonly RegExp[] {
+  const commandAlternation = commands.map(escapeRegExp).join("|");
+  const flagAlternation = flags.map(escapeRegExp).join("|");
+  return [
+    new RegExp(`(?:^|[^\\w.-])(?:skillset|cli\\.ts)\\s+(?:${commandAlternation})(?![-\\w])`, "u"),
+    new RegExp(`\\bbun run skillset:(?:${commandAlternation})(?![-\\w])`, "u"),
+    new RegExp(`(?:^|[^\\w-])(?:${flagAlternation})(?![-\\w])`, "u"),
+  ];
+}
+
 const RETIRED_SURFACE = [
-  /(?:\bskillset|cli\.ts)\s+(?:adopt|ci|doctor|features|lint|providers|suggest-source|try|verify)\b/u,
-  /\bbun run skillset:(?:lint|verify)\b/u,
+  ...buildDirectRetiredSurfacePatterns(RETIRED_CLI_COMMANDS, RETIRED_CLI_FLAGS),
   /\b(?:build|diff)(?:\/|,\s*and\s+)verify\b/u,
   /\b(?:doctor\/explain|explain\/doctor)\b/u,
   /\bSKILLSET_TRY_[A-Z_]+\b/u,
-  /(?:^|[^\w-])--(?:apply|dist|dry-run|global|layout|source|watch)\b/u,
-  /(?:^|[^\w-])--(?:claude|codex|cursor)(?![-\w])/u,
   /["'`]skillset: [^"'`\n]*\btry\b/u,
   /["'`]try (?:command|config|failed|latest|passed|plugin|run|status|tail|list)\b/u,
 ] as const;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
 
 const EXCLUDED = [
   ".agents/",


### PR DESCRIPTION
## Context

SET-346 single-sources the tooling-owned retired CLI guard inputs and makes runtime distribution policy an explicit exhaustive partition.

## What changed

- derive direct retired command/script/flag patterns from authoritative CLI contract arrays
- retain bespoke semantic guard patterns, diagnostics, exclusions, and entrypoint behavior
- fix exact invocation boundaries to avoid unrelated `my-skillset`/`my-cli.ts` false positives
- pair the Core distribution runtime map with named non-distributable runtime IDs
- test that every canonical runtime appears exactly once with no unknowns, overlap, order, or display-name inference
- add the required public `skillset` patch changeset

## Verification

- standing and fresh Terra High final reviews: 5/5 clean, zero P0-P3
- 15 focused tests / 430 assertions
- typecheck; CLI surface, ownership, terminology, and changeset guards
- conformance fast
- bun run check
- bun run hooks:pre-push (1302 tests / 54285 assertions)

## Scope

No SET-323 value-contract, SET-318 topology, generated-source, audit-disposition, publish, global-config, or Bridge worktree changes.

Linear: SET-346