### PR TITLE
feat: guard target topology drift

### DIFF
--- a/.changeset/guard-target-topology.md
+++ b/.changeset/guard-target-topology.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Guard the compiler against hand-enumerated target subsets and implicit multi-target fallbacks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,15 @@ bun test
 bun run check
 bun run package-ownership:guard
 bun run terminology:guard
+bun run target-topology:guard
 ./scripts/bootstrap.sh [repo|agent|codex|claude|doctor|teardown]
 ```
 
 `bun run package-ownership:guard` blocks app-level package facade files from returning under `apps/skillset/src/`. Prefer importing an owned package root API or a documented private workspace internal directly instead of adding `export * from "@skillset/<package>/internal/*"` shims in the CLI app.
 
 `bun run terminology:guard` blocks retired compiler vocabulary (the render-result and `compile.unsupportedDestination` cutover) from drifting back into active source, docs, generated guidance, CLI output, schema names, and tests. It runs inside `bun run check`. When it fails, prefer fixing the source to use the derive/render/destination vocabulary; only extend the explicit allowlists in `scripts/terminology-guard.ts` for deliberate historical (ADR) or deferred-concept context.
+
+`bun run target-topology:guard` uses the TypeScript AST and the canonical schema target registry to reject hand-enumerated target collections, same-subject target equality subsets, and implicit multi-target dispatch fallbacks. Deliberate schema declarations, historical migrations, and provider-native format boundaries require exact per-match allowlist evidence.
 
 `bun run skillset:check:ci` is the same aggregate check GitHub Actions runs (`.github/workflows/ci.yml`): lint, change-entry coverage, and generated drift. Pass `--fix` to rebuild stale generated output mechanically. Content repos scaffold the equivalent workflow with `skillset init --include ci`.
 

--- a/apps/skillset/src/__tests__/contract.test.ts
+++ b/apps/skillset/src/__tests__/contract.test.ts
@@ -2054,9 +2054,11 @@ Demo body.
   expect(await fileExists(cachePath(root, ".skillset/cache/tests/latest/activation/codex/fixture-guidance.md"))).toBe(true);
   const claudeProbe = await readFile(cachePath(root, ".skillset/cache/tests/latest/activation/claude/fixture-guidance.md"), "utf8");
   expect(claudeProbe).toContain("Manual Claude activation probe");
+  expect(claudeProbe).toContain("Status: manual-native");
   expect(claudeProbe).toContain("- skill: demo");
   const codexProbe = await readFile(cachePath(root, ".skillset/cache/tests/latest/activation/codex/probes.json"), "utf8");
   expect(codexProbe).toContain("manual-shimmed");
+  expect(codexProbe).toContain("Manual Codex activation probe");
   expect(codexProbe).toContain("fixture-guidance");
 });
 

--- a/apps/skillset/src/runtime-hooks/print.ts
+++ b/apps/skillset/src/runtime-hooks/print.ts
@@ -148,9 +148,16 @@ function renderGitSnippet(options: { readonly preCommit: boolean; readonly prePu
   return sections.join("\n\n");
 }
 
+const AGENT_RUNTIME_DESTINATIONS = {
+  claude: ".claude/settings.local.json",
+  codex: ".codex/hooks/hooks.json",
+  cursor: undefined,
+} satisfies Readonly<Record<TargetName, string | undefined>>;
+
 function renderAgentRuntimeSnippet(target: TargetName | undefined): string {
   if (target === undefined) throw new Error("skillset: hooks print --agent-runtime requires --target");
-  if (target === "cursor") {
+  const path = AGENT_RUNTIME_DESTINATIONS[target];
+  if (path === undefined) {
     throw new Error("skillset: hooks print --agent-runtime only supports --target claude or --target codex; Cursor has no documented runtime hook destination");
   }
   const note =
@@ -180,7 +187,6 @@ function renderAgentRuntimeSnippet(target: TargetName | undefined): string {
       ],
     },
   };
-  const path = target === "claude" ? ".claude/settings.local.json" : ".codex/hooks/hooks.json";
   return [
     `# ${target} agent runtime hook snippet`,
     `# Suggested destination: ${path}`,

--- a/apps/skillset/src/test-runner.ts
+++ b/apps/skillset/src/test-runner.ts
@@ -1319,6 +1319,18 @@ async function writeActivationProbes(
   return activationRoot;
 }
 
+const ACTIVATION_HARNESSES = {
+  claude: "Manual Claude activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.",
+  codex: "Manual Codex activation probe. Use generated Codex output or plugin-eval tooling when available; compatibility shims should be reported explicitly.",
+  cursor: "Manual Cursor activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.",
+} satisfies Readonly<Record<TargetName, string>>;
+
+const ACTIVATION_STATUSES = {
+  claude: "manual-native",
+  codex: "manual-shimmed",
+  cursor: "manual-native",
+} satisfies Readonly<Record<TargetName, "manual-native" | "manual-shimmed">>;
+
 function activationProbeRecord(probe: ActivationProbe, target: TargetName): JsonRecord {
   return {
     execution: probe.runtime === undefined ? "manual" : "live",
@@ -1329,19 +1341,13 @@ function activationProbeRecord(probe: ActivationProbe, target: TargetName): Json
     name: slugifyProbeName(probe.name),
     prompt: probe.prompt,
     promptProvenance: probe.promptProvenance,
-    status: target === "codex" ? "manual-shimmed" : "manual-native",
+    status: ACTIVATION_STATUSES[target],
     target,
   };
 }
 
 function activationHarness(target: TargetName): string {
-  if (target === "claude") {
-    return "Manual Claude activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.";
-  }
-  if (target === "cursor") {
-    return "Manual Cursor activation probe. Run against the generated workspace or plugin path and confirm the expected source unit is loaded or invoked.";
-  }
-  return "Manual Codex activation probe. Use generated Codex output or plugin-eval tooling when available; compatibility shims should be reported explicitly.";
+  return ACTIVATION_HARNESSES[target];
 }
 
 function renderActivationProbeMarkdown(record: JsonRecord): string {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   "scripts": {
     "build": "bun run typecheck && bun run build:npm",
     "build:npm": "bun scripts/build-package.ts",
-    "check": "bun run build && bun run schema:check && bun run test && bun run ultracite:doctor && bun run skillset:check && git diff --check && bun run package-ownership:guard && bun run terminology:guard && bun run cli-surface:guard",
+    "check": "bun run build && bun run schema:check && bun run test && bun run ultracite:doctor && bun run skillset:check && git diff --check && bun run package-ownership:guard && bun run terminology:guard && bun run cli-surface:guard && bun run target-topology:guard",
     "package-ownership:guard": "bun scripts/package-ownership-guard.ts",
     "terminology:guard": "bun scripts/terminology-guard.ts",
     "cli-surface:guard": "bun scripts/cli-surface-guard.ts",
+    "target-topology:guard": "bun scripts/target-topology-guard.ts",
     "check:workflows": "if command -v actionlint >/dev/null 2>&1; then actionlint .github/workflows/*.yml; else echo 'skillset: actionlint not installed; skipping workflow lint'; fi",
     "changeset": "changeset",
     "changeset:check": "bun scripts/changeset-guard.ts",

--- a/scripts/__tests__/target-topology-guard.test.ts
+++ b/scripts/__tests__/target-topology-guard.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  formatTargetTopologyFailures,
   isTargetTopologySourcePath,
   scanTargetTopologySource,
+  scanTargetTopologySources,
 } from "../target-topology-guard";
 
 describe("target topology guard", () => {
@@ -313,5 +315,134 @@ const label = target === "claude" ? "Claude" : target === "codex" ? "Codex" : ta
       rule: "R2",
       text,
     }]);
+
+    expect(scanTargetTopologySources(
+      [{ content: source, file: "apps/example.ts" }],
+      ["claude", "codex", "cursor"],
+      allowlist
+    )).toEqual({ duplicateAllowlist: [], unmatchedAllowlist: [], violations });
+  });
+
+  test("complete scans fail a stale allowlist entry", () => {
+    const stale = {
+      column: 17,
+      file: "apps/example.ts",
+      line: 1,
+      owner: "targets",
+      rationale: "Fixture exemption that no longer has an observed match.",
+      rule: "R1" as const,
+      text: '["claude", "codex"]',
+    };
+    const result = scanTargetTopologySources(
+      [{ content: "const targets = targetNames();", file: "apps/example.ts" }],
+      ["claude", "codex", "cursor"],
+      [stale]
+    );
+
+    expect(result).toEqual({ duplicateAllowlist: [], unmatchedAllowlist: [stale], violations: [] });
+    expect(formatTargetTopologyFailures(result)).toEqual([
+      'apps/example.ts:1:17: [ALLOWLIST R1] targets: ["claude", "codex"] (unmatched exemption: Fixture exemption that no longer has an observed match.)',
+    ]);
+  });
+
+  test("complete scans pass when every allowlist entry is observed", () => {
+    const observed = {
+      column: 17,
+      file: "apps/example.ts",
+      line: 1,
+      owner: "targets",
+      rationale: "Fixture permits the exact declaration.",
+      rule: "R1" as const,
+      text: '["claude", "codex"]',
+    };
+
+    expect(scanTargetTopologySources(
+      [{ content: 'const targets = ["claude", "codex"];', file: "apps/example.ts" }],
+      ["claude", "codex", "cursor"],
+      [observed]
+    )).toEqual({ duplicateAllowlist: [], unmatchedAllowlist: [], violations: [] });
+  });
+
+  test("complete scans fail duplicate allowlist identities even when observed", () => {
+    const identity = {
+      column: 17,
+      file: "apps/example.ts",
+      line: 1,
+      owner: "targets",
+      rule: "R1" as const,
+      text: '["claude", "codex"]',
+    };
+    const result = scanTargetTopologySources(
+      [{ content: 'const targets = ["claude", "codex"];', file: "apps/example.ts" }],
+      ["claude", "codex", "cursor"],
+      [
+        { ...identity, rationale: "Second duplicate fixture." },
+        { ...identity, rationale: "First duplicate fixture." },
+      ]
+    );
+
+    expect(result).toEqual({
+      duplicateAllowlist: [{
+        ...identity,
+        count: 2,
+        rationales: ["First duplicate fixture.", "Second duplicate fixture."],
+      }],
+      unmatchedAllowlist: [],
+      violations: [],
+    });
+    expect(formatTargetTopologyFailures(result)).toEqual([
+      'apps/example.ts:1:17: [DUPLICATE ALLOWLIST R1] targets: ["claude", "codex"] (2 exemptions; rationales: ["First duplicate fixture.","Second duplicate fixture."])',
+    ]);
+  });
+
+  test("complete scan failures have deterministic diagnostic order", () => {
+    const staleZ = {
+      column: 1,
+      file: "scripts/z.ts",
+      line: 9,
+      owner: "z",
+      rationale: "Later stale fixture.",
+      rule: "R2" as const,
+      text: "z",
+    };
+    const staleA = {
+      column: 1,
+      file: "apps/a.ts",
+      line: 9,
+      owner: "a",
+      rationale: "Earlier stale fixture.",
+      rule: "R2" as const,
+      text: "a",
+    };
+    const duplicateIdentity = {
+      column: 17,
+      file: "scripts/observed.ts",
+      line: 1,
+      owner: "targets",
+      rule: "R1" as const,
+      text: '["claude", "codex"]',
+    };
+    const result = scanTargetTopologySources(
+      [
+        { content: 'const targets = ["claude", "cursor"];', file: "packages/z.ts" },
+        { content: 'const targets = ["claude", "codex"];', file: "apps/b.ts" },
+        { content: 'const targets = ["claude", "codex"];', file: "scripts/observed.ts" },
+      ],
+      ["claude", "codex", "cursor"],
+      [
+        staleZ,
+        { ...duplicateIdentity, rationale: "Second duplicate fixture." },
+        staleA,
+        { ...duplicateIdentity, rationale: "First duplicate fixture." },
+      ]
+    );
+
+    expect(formatTargetTopologyFailures(result)).toEqual([
+      'apps/b.ts:1:17: [R1] targets: ["claude", "codex"]',
+      'packages/z.ts:1:17: [R1] targets: ["claude", "cursor"]',
+      "apps/a.ts:9:1: [ALLOWLIST R2] a: a (unmatched exemption: Earlier stale fixture.)",
+      "scripts/z.ts:9:1: [ALLOWLIST R2] z: z (unmatched exemption: Later stale fixture.)",
+      'scripts/observed.ts:1:17: [DUPLICATE ALLOWLIST R1] targets: ["claude", "codex"] (2 exemptions; rationales: ["First duplicate fixture.","Second duplicate fixture."])',
+    ]);
   });
 });

--- a/scripts/__tests__/target-topology-guard.test.ts
+++ b/scripts/__tests__/target-topology-guard.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isTargetTopologySourcePath,
+  scanTargetTopologySource,
+} from "../target-topology-guard";
+
+describe("target topology guard", () => {
+  test("R1 rejects raw target-domain collections without matching mixed vocabularies", () => {
+    const violations = scanTargetTopologySource("apps/example.ts", `
+const targets = ["claude", "codex"];
+for (const target of ["claude", "cursor"]) console.log(target);
+const providers = new Set(["codex", "cursor"]);
+const mixedKeys = ["claude", "codex", "metadata"];
+`);
+
+    expect(violations.map(({ rule }) => rule)).toEqual(["R1", "R1", "R1"]);
+  });
+
+  test("R2 rejects same-subject target equality subsets once", () => {
+    const violations = scanTargetTopologySource("packages/example.ts", `
+function supports(target: string) {
+  return target === "claude" || target === "codex" || target === "cursor";
+}
+`);
+
+    expect(violations).toEqual([{
+      column: 10,
+      file: "packages/example.ts",
+      line: 3,
+      owner: "supports",
+      rule: "R2",
+      text: 'target === "claude" || target === "codex" || target === "cursor"',
+    }]);
+  });
+
+  test("R2 preserves parenthesized matches and reports an outer OR chain once", () => {
+    const violations = scanTargetTopologySource("packages/example.ts", `
+function oneParenthesis(target: string) {
+  return (target === "claude" || target === "codex");
+}
+function twoParentheses(target: string) {
+  return ((target === "claude" || target === "codex"));
+}
+function underAnd(target: string, enabled: boolean) {
+  return ((target === "claude" || target === "codex")) && enabled;
+}
+function outerChain(target: string) {
+  return ((target === "claude" || target === "codex")) || target === "cursor";
+}
+`);
+
+    expect(violations.map(({ owner, rule }) => ({ owner, rule }))).toEqual([
+      { owner: "oneParenthesis", rule: "R2" },
+      { owner: "twoParentheses", rule: "R2" },
+      { owner: "underAnd", rule: "R2" },
+      { owner: "outerChain", rule: "R2" },
+    ]);
+  });
+
+  test("R2 treats safe expression wrappers as transparent for outer-chain suppression", () => {
+    const violations = scanTargetTopologySource("packages/example.ts", `
+function asExpression(target: string) {
+  return ((target === "claude" || target === "codex") as boolean) || target === "cursor";
+}
+function satisfiesExpression(target: string) {
+  return ((target === "claude" || target === "codex") satisfies boolean) || target === "cursor";
+}
+function typeAssertion(target: string) {
+  return (<boolean>(target === "claude" || target === "codex")) || target === "cursor";
+}
+function nonNullExpression(target: string) {
+  return ((target === "claude" || target === "codex")!) || target === "cursor";
+}
+`);
+
+    expect(violations.map(({ owner, rule }) => ({ owner, rule }))).toEqual([
+      { owner: "asExpression", rule: "R2" },
+      { owner: "satisfiesExpression", rule: "R2" },
+      { owner: "typeAssertion", rule: "R2" },
+      { owner: "nonNullExpression", rule: "R2" },
+    ]);
+  });
+
+  test("R3 rejects multi-target ternary and if dispatch chains with fallback results", () => {
+    const violations = scanTargetTopologySource("apps/example.ts", `
+const label = target === "claude" ? "Claude" : target === "codex" ? "Codex" : "Cursor";
+function path(target: string) {
+  if (target === "claude") return ".claude";
+  else if (target === "codex") return ".codex";
+  else return ".cursor";
+}
+`);
+
+    expect(violations.map(({ rule, text }) => ({ rule, text }))).toEqual([
+      { rule: "R3", text: 'target === "claude" -> target === "codex" -> else' },
+      { rule: "R3", text: 'target === "claude" -> target === "codex" -> else' },
+    ]);
+  });
+
+  test("R3 rejects sequential target guards followed by an implicit return fallback", () => {
+    const violations = scanTargetTopologySource("apps/example.ts", `
+function historicalReturnFallback(target: string) {
+  if (target === "claude") return "Claude";
+  if (target === "cursor") return "Cursor";
+  return "Codex";
+}
+
+function historicalGuardedTernary(target: string) {
+  if (target === "cursor") throw new Error("unsupported");
+  return target === "claude" ? "Claude" : "Codex";
+}
+`);
+
+    expect(violations).toEqual([
+      {
+        column: 3,
+        file: "apps/example.ts",
+        line: 3,
+        owner: "historicalReturnFallback",
+        rule: "R3",
+        text: 'target === "claude" -> target === "cursor" -> else',
+      },
+      {
+        column: 3,
+        file: "apps/example.ts",
+        line: 9,
+        owner: "historicalGuardedTernary",
+        rule: "R3",
+        text: 'target === "cursor" -> target === "claude" -> else',
+      },
+    ]);
+  });
+
+  test("R3 ignores sequential guards whose return behavior is shared with the fallback", () => {
+    const violations = scanTargetTopologySource("apps/example.ts", `
+function allShared(target: string) {
+  if (target === "claude") return "shared";
+  if (target === "cursor") return "shared";
+  return "shared";
+}
+
+function onlyOneSpecificBranch(target: string) {
+  if (target === "claude") return "Claude";
+  if (target === "cursor") return "shared";
+  return "shared";
+}
+`);
+
+    expect(violations).toEqual([]);
+  });
+
+  test("R3 recognizes safe structural fallback equivalence across literals and wrappers", () => {
+    const violations = scanTargetTopologySource("apps/example.ts", `
+function quoteAndTemplateVariants(target: string) {
+  if (target === "claude") return 'shared';
+  if (target === "cursor") return \`shared\`;
+  return "shared";
+}
+
+function wrappedIdentifiers(target: string) {
+  if (target === "claude") return (shared as string)!;
+  if (target === "cursor") return <string>shared;
+  return shared;
+}
+
+function wrappedMemberChains(target: string) {
+  if (target === "claude") return (config.labels.shared satisfies string);
+  if (target === "cursor") return config.labels.shared!;
+  return config.labels.shared;
+}
+`);
+
+    expect(violations).toEqual([]);
+  });
+
+  test("R3 keeps semantically rich or unequal fallback expressions diagnosed", () => {
+    const violations = scanTargetTopologySource("apps/example.ts", `
+function calls(target: string) {
+  if (target === "claude") return shared();
+  if (target === "cursor") return shared();
+  return shared();
+}
+function binaryExpressions(target: string) {
+  if (target === "claude") return prefix + suffix;
+  if (target === "cursor") return prefix + suffix;
+  return prefix + suffix;
+}
+function objects(target: string) {
+  if (target === "claude") return { kind: "shared" };
+  if (target === "cursor") return { kind: "shared" };
+  return { kind: "shared" };
+}
+function interpolatedTemplates(target: string) {
+  if (target === "claude") return \`\${shared}\`;
+  if (target === "cursor") return \`\${shared}\`;
+  return \`\${shared}\`;
+}
+function computedAccess(target: string) {
+  if (target === "claude") return config["shared"];
+  if (target === "cursor") return config["shared"];
+  return config["shared"];
+}
+function optionalAccess(target: string) {
+  if (target === "claude") return config?.shared;
+  if (target === "cursor") return config?.shared;
+  return config?.shared;
+}
+function differentValues(target: string) {
+  if (target === "claude") return "Claude";
+  if (target === "cursor") return "Cursor";
+  return "Codex";
+}
+`);
+
+    expect(violations.map(({ owner }) => owner)).toEqual([
+      "calls",
+      "binaryExpressions",
+      "objects",
+      "interpolatedTemplates",
+      "computedAccess",
+      "optionalAccess",
+      "differentValues",
+    ]);
+  });
+
+  test("accepts canonical helpers, exhaustive switches, mixed subjects, and single-provider gates", () => {
+    const violations = scanTargetTopologySource("packages/example.ts", `
+const targets = targetNames();
+const descriptions = targetRecord((target) => target);
+const enabled = target === "claude" || isExperimental;
+const unrelated = target === "claude" || provider === "codex";
+const label = target === "claude" ? "Claude" : "Other";
+function oneGuard(target: TargetName) {
+  if (target === "cursor") throw new Error("unsupported");
+  return "shared";
+}
+function mixedGuardSubjects(target: TargetName, provider: TargetName) {
+  if (target === "cursor") return "Cursor";
+  if (provider === "claude") return "Claude";
+  return "shared";
+}
+function mixedDomain(provider: string) {
+  if (provider === "agents") return "Agents";
+  if (provider === "claude") return "Claude";
+  if (provider === "codex") return "Codex";
+  return "Skillset";
+}
+function render(target: TargetName) {
+  switch (target) {
+    case "claude": return "Claude";
+    case "codex": return "Codex";
+    case "cursor": return "Cursor";
+  }
+}
+`);
+
+    expect(violations).toEqual([]);
+  });
+
+  test("uses the supplied registry as evidence for future targets", () => {
+    const targets = ["claude", "codex", "cursor", "future"] as const;
+    const violations = scanTargetTopologySource("packages/example.ts", `
+const current = ["claude", "codex", "cursor"];
+const label = target === "claude" ? "Claude" : target === "codex" ? "Codex" : target === "cursor" ? "Cursor" : "Future";
+`, targets);
+
+    expect(violations.map(({ rule }) => rule)).toEqual(["R1", "R3"]);
+  });
+
+  test("filters generated, fixture, test, and non-TypeScript paths", () => {
+    expect(isTargetTopologySourcePath("apps/skillset/src/cli.ts")).toBe(true);
+    expect(isTargetTopologySourcePath("packages/core/src/render.ts")).toBe(true);
+    expect(isTargetTopologySourcePath("scripts/example.ts")).toBe(true);
+    expect(isTargetTopologySourcePath("apps/skillset/src/__tests__/contract.test.ts")).toBe(false);
+    expect(isTargetTopologySourcePath("scripts/fixtures/example.ts")).toBe(false);
+    expect(isTargetTopologySourcePath("plugins/example.ts")).toBe(false);
+    expect(isTargetTopologySourcePath("docs/example.md")).toBe(false);
+  });
+
+  test("allowlisting a declaration does not hide a co-located copy", () => {
+    const source = `${"\n".repeat(9)}export const TARGET_NAMES = ["claude", "codex", "cursor"] as const;\nconst SHADOW_TARGETS = ["claude", "codex", "cursor"] as const;`;
+    const violations = scanTargetTopologySource("packages/schema/src/contracts.ts", source);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ line: 11, owner: "SHADOW_TARGETS", rule: "R1" });
+  });
+
+  test("allowlisting one position does not hide an identical same-line match", () => {
+    const text = 'target === "claude" || target === "codex"';
+    const source = `function matches(target: string) { return [${text}, ${text}]; }`;
+    const allowlist = [{
+      column: 44,
+      file: "apps/example.ts",
+      line: 1,
+      owner: "matches",
+      rationale: "Fixture permits only the first identical AST match.",
+      rule: "R2" as const,
+      text,
+    }];
+    const violations = scanTargetTopologySource(
+      "apps/example.ts",
+      source,
+      ["claude", "codex", "cursor"],
+      allowlist
+    );
+
+    expect(violations).toEqual([{
+      column: 87,
+      file: "apps/example.ts",
+      line: 1,
+      owner: "matches",
+      rule: "R2",
+      text,
+    }]);
+  });
+});

--- a/scripts/target-topology-guard.ts
+++ b/scripts/target-topology-guard.ts
@@ -22,6 +22,22 @@ export interface TargetTopologyAllowlistEntry extends TargetTopologyViolation {
   readonly rationale: string;
 }
 
+export interface TargetTopologySource {
+  readonly content: string;
+  readonly file: string;
+}
+
+export interface TargetTopologyScanResult {
+  readonly duplicateAllowlist: readonly TargetTopologyDuplicateAllowlist[];
+  readonly unmatchedAllowlist: readonly TargetTopologyAllowlistEntry[];
+  readonly violations: readonly TargetTopologyViolation[];
+}
+
+export interface TargetTopologyDuplicateAllowlist extends TargetTopologyViolation {
+  readonly count: number;
+  readonly rationales: readonly string[];
+}
+
 export const TARGET_TOPOLOGY_ALLOWLIST: readonly TargetTopologyAllowlistEntry[] = [
   allow("packages/schema/src/contracts.ts", 10, 29, "TARGET_NAMES", "R1", '["claude", "codex", "cursor"]', "Canonical target registry declaration."),
   allow("packages/schema/src/examples.ts", 47, 18, "skillsetSchemaExamples", "R1", '["claude", "codex", "cursor"]', "Schema example demonstrates the complete targets field."),
@@ -130,6 +146,87 @@ export function scanTargetTopologySource(
   };
   visit(source);
   return violations;
+}
+
+export function scanTargetTopologySources(
+  sources: readonly TargetTopologySource[],
+  registeredTargets: readonly string[] = TARGET_NAMES,
+  allowlist: readonly TargetTopologyAllowlistEntry[] = TARGET_TOPOLOGY_ALLOWLIST
+): TargetTopologyScanResult {
+  const rawViolations = sources.flatMap(({ content, file }) =>
+    scanTargetTopologySource(file, content, registeredTargets, [])
+  );
+  const observedIdentities = new Set(rawViolations.map(targetTopologyIdentity));
+  const allowlistIdentities = new Set(allowlist.map(targetTopologyIdentity));
+  const allowlistGroups = new Map<string, TargetTopologyAllowlistEntry[]>();
+  for (const entry of allowlist) {
+    const identity = targetTopologyIdentity(entry);
+    const group = allowlistGroups.get(identity);
+    if (group === undefined) allowlistGroups.set(identity, [entry]);
+    else group.push(entry);
+  }
+  return {
+    duplicateAllowlist: [...allowlistGroups.values()]
+      .filter((entries) => entries.length > 1)
+      .map((entries): TargetTopologyDuplicateAllowlist => ({
+        column: entries[0]!.column,
+        count: entries.length,
+        file: entries[0]!.file,
+        line: entries[0]!.line,
+        owner: entries[0]!.owner,
+        rationales: entries.map(({ rationale }) => rationale).toSorted(),
+        rule: entries[0]!.rule,
+        text: entries[0]!.text,
+      }))
+      .toSorted(compareTargetTopologyMatch),
+    unmatchedAllowlist: allowlist
+      .filter((entry) => !observedIdentities.has(targetTopologyIdentity(entry)))
+      .toSorted(compareTargetTopologyAllowlistEntry),
+    violations: rawViolations
+      .filter((violation) => !allowlistIdentities.has(targetTopologyIdentity(violation)))
+      .toSorted(compareTargetTopologyMatch),
+  };
+}
+
+export function formatTargetTopologyFailures(result: TargetTopologyScanResult): readonly string[] {
+  return [
+    ...result.violations.map((violation) =>
+      `${violation.file}:${violation.line}:${violation.column}: [${violation.rule}] ${violation.owner}: ${violation.text}`
+    ),
+    ...result.unmatchedAllowlist.map((entry) =>
+      `${entry.file}:${entry.line}:${entry.column}: [ALLOWLIST ${entry.rule}] ${entry.owner}: ${entry.text} (unmatched exemption: ${entry.rationale})`
+    ),
+    ...result.duplicateAllowlist.map((entry) =>
+      `${entry.file}:${entry.line}:${entry.column}: [DUPLICATE ALLOWLIST ${entry.rule}] ${entry.owner}: ${entry.text} (${entry.count} exemptions; rationales: ${JSON.stringify(entry.rationales)})`
+    ),
+  ];
+}
+
+function targetTopologyIdentity(match: TargetTopologyViolation): string {
+  return JSON.stringify([
+    match.file,
+    match.line,
+    match.column,
+    match.rule,
+    match.owner,
+    match.text,
+  ]);
+}
+
+function compareTargetTopologyMatch(left: TargetTopologyViolation, right: TargetTopologyViolation): number {
+  return left.file.localeCompare(right.file) ||
+    left.line - right.line ||
+    left.column - right.column ||
+    left.rule.localeCompare(right.rule) ||
+    left.owner.localeCompare(right.owner) ||
+    left.text.localeCompare(right.text);
+}
+
+function compareTargetTopologyAllowlistEntry(
+  left: TargetTopologyAllowlistEntry,
+  right: TargetTopologyAllowlistEntry
+): number {
+  return compareTargetTopologyMatch(left, right) || left.rationale.localeCompare(right.rationale);
 }
 
 interface TargetEquality {
@@ -418,15 +515,17 @@ async function gitFiles(): Promise<readonly string[]> {
 
 async function main(): Promise<void> {
   const files = (await gitFiles()).filter(isTargetTopologySourcePath);
-  const violations: TargetTopologyViolation[] = [];
+  const sources: TargetTopologySource[] = [];
   for (const file of files) {
     const path = `${rootDir}/${file}`;
-    if (existsSync(path)) violations.push(...scanTargetTopologySource(file, await Bun.file(path).text()));
+    if (existsSync(path)) sources.push({ content: await Bun.file(path).text(), file });
   }
-  if (violations.length > 0) {
-    console.error(`skillset: target topology guard found ${violations.length} violation(s):`);
-    for (const violation of violations) {
-      console.error(`  ${violation.file}:${violation.line}:${violation.column}: [${violation.rule}] ${violation.owner}: ${violation.text}`);
+  const result = scanTargetTopologySources(sources);
+  const failures = formatTargetTopologyFailures(result);
+  if (failures.length > 0) {
+    console.error(`skillset: target topology guard found ${result.violations.length} violation(s), ${result.unmatchedAllowlist.length} unmatched allowlist entry(s), and ${result.duplicateAllowlist.length} duplicate allowlist identity(s):`);
+    for (const failure of failures) {
+      console.error(`  ${failure}`);
     }
     process.exit(1);
   }

--- a/scripts/target-topology-guard.ts
+++ b/scripts/target-topology-guard.ts
@@ -1,0 +1,439 @@
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+import { gitSafeEnv } from "../apps/skillset/src/git-env";
+import { TARGET_NAMES } from "../packages/schema/src";
+
+export type TargetTopologyRule = "R1" | "R2" | "R3";
+
+export interface TargetTopologyViolation {
+  readonly column: number;
+  readonly file: string;
+  readonly line: number;
+  readonly owner: string;
+  readonly rule: TargetTopologyRule;
+  readonly text: string;
+}
+
+export interface TargetTopologyAllowlistEntry extends TargetTopologyViolation {
+  readonly rationale: string;
+}
+
+export const TARGET_TOPOLOGY_ALLOWLIST: readonly TargetTopologyAllowlistEntry[] = [
+  allow("packages/schema/src/contracts.ts", 10, 29, "TARGET_NAMES", "R1", '["claude", "codex", "cursor"]', "Canonical target registry declaration."),
+  allow("packages/schema/src/examples.ts", 47, 18, "skillsetSchemaExamples", "R1", '["claude", "codex", "cursor"]', "Schema example demonstrates the complete targets field."),
+  allow("packages/schema/src/examples.ts", 93, 20, "skillsetSchemaExamples", "R1", '["claude", "codex", "cursor"]', "Schema example demonstrates the complete marketplace targets field."),
+  allow("packages/schema/src/examples.ts", 214, 24, "skillsetSchemaExamples", "R1", '["claude", "codex"]', "Schema example documents an intentionally provider-scoped hook."),
+  allow("packages/schema/src/examples.ts", 368, 18, "skillsetSchemaExamples", "R1", '["claude", "codex"]', "Schema example documents an intentionally provider-scoped hook."),
+  allow("packages/schema/src/examples.ts", 429, 16, "skillsetSchemaExamples", "R1", '["claude", "codex", "cursor"]', "Schema example demonstrates the complete activation targets field."),
+  allow("packages/registry/src/index.ts", 9, 52, "PROVIDER_DESTINATION_FORMAT_TARGETS", "R1", '["claude", "codex", "cursor"]', "Provider-native format registry declaration."),
+  allow("packages/registry/src/schema-snapshots.ts", 5, 40, "PROVIDER_SCHEMA_TARGETS", "R1", '["claude", "codex", "cursor"]', "Provider-native schema registry declaration."),
+  allow("scripts/source-layout-migration.ts", 72, 24, "readLegacyOutputGroup", "R1", '["claude", "codex"]', "Historical migration reads the two targets supported by that legacy shape."),
+  allow("scripts/bootstrap/main.ts", 59, 15, "parseBootstrapArgs", "R2", 'command === "claude" || command === "codex"', "Bootstrap exposes provider-specific setup commands only for the two supported runtimes."),
+  allow("packages/core/src/render-result-collector.ts", 731, 10, "companionForPath", "R2", 'target === "claude" || target === "cursor"', "Commands are provider-native companion formats for Claude and Cursor."),
+  allow("packages/core/src/render-result-collector.ts", 737, 10, "companionForPath", "R2", 'target === "claude" || target === "cursor"', "Agents are provider-native companion formats for Claude and Cursor."),
+  allow("packages/core/src/render.ts", 2043, 7, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor hooks require normalized provider-native output."),
+  allow("packages/core/src/render.ts", 2063, 10, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor skip copying Claude-native hook files."),
+  allow("apps/skillset/src/provider-format-updates.ts", 195, 10, "displayProvider", "R3", 'provider === "codex" -> provider === "claude" -> else', "Provider display labels preserve unknown registry values."),
+  allow("packages/core/src/provider-format-conformance.ts", 465, 5, "checkSkillMarkdown", "R3", 'target === "codex" -> target === "cursor" -> else', "Provider-native skill formats use distinct registry references."),
+  allow("packages/core/src/render.ts", 622, 5, "renderPluginManifest", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native plugin manifests have distinct formats."),
+  allow("packages/core/src/render.ts", 732, 3, "withOptionalSurfacePaths", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native plugin surfaces have distinct destination fields."),
+  allow("packages/core/src/render.ts", 2025, 5, "copyPluginCompanionFiles", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native companion file sets are intentionally distinct."),
+  allow("packages/core/src/render.ts", 299, 3, "marketplaceReadmeLines", "R3", 'target === "claude" -> target === "cursor" -> else', "Provider-native marketplace README guidance has distinct destination formats."),
+] as const;
+
+function allow(
+  file: string,
+  line: number,
+  column: number,
+  owner: string,
+  rule: TargetTopologyRule,
+  text: string,
+  rationale: string
+): TargetTopologyAllowlistEntry {
+  return { column, file, line, owner, rationale, rule, text };
+}
+
+export function isTargetTopologySourcePath(path: string): boolean {
+  if (!/^(?:apps|packages|scripts)\//u.test(path) || !path.endsWith(".ts")) return false;
+  if (path.includes("/__tests__/") || path.endsWith(".test.ts")) return false;
+  if (path.includes("/fixtures/") || path.startsWith("scripts/fixtures/")) return false;
+  return true;
+}
+
+export function scanTargetTopologySource(
+  file: string,
+  content: string,
+  registeredTargets: readonly string[] = TARGET_NAMES,
+  allowlist: readonly TargetTopologyAllowlistEntry[] = TARGET_TOPOLOGY_ALLOWLIST
+): readonly TargetTopologyViolation[] {
+  const source = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const targets = new Set(registeredTargets);
+  const violations: TargetTopologyViolation[] = [];
+
+  const report = (node: ts.Node, rule: TargetTopologyRule, text: string) => {
+    const start = source.getLineAndCharacterOfPosition(node.getStart(source));
+    const violation = {
+      column: start.character + 1,
+      file,
+      line: start.line + 1,
+      owner: ownerOf(node, source),
+      rule,
+      text,
+    } as const;
+    if (!allowlist.some((entry) =>
+      entry.column === violation.column &&
+      entry.file === violation.file &&
+      entry.line === violation.line &&
+      entry.owner === violation.owner &&
+      entry.rule === violation.rule &&
+      entry.text === violation.text
+    )) violations.push(violation);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isBlock(node) || ts.isSourceFile(node)) {
+      for (const dispatch of sequentialDispatches(node.statements, source, targets)) {
+        report(dispatch.node, "R3", dispatch.text);
+      }
+    }
+
+    if (ts.isArrayLiteralExpression(node)) {
+      const values = node.elements.map((element) => stringValue(element));
+      if (values.length >= 2 && values.every((value) => value !== undefined && targets.has(value)) && new Set(values).size >= 2) {
+        report(node, "R1", normalizedText(node, source));
+      }
+    }
+
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.BarBarToken && !hasParentOr(node)) {
+      const equalities = flattenOr(node).map((operand) => targetEquality(operand, source, targets));
+      const matched = equalities.filter((value): value is TargetEquality => value !== undefined);
+      if (matched.length === equalities.length && matched.length >= 2 && matched.every(({ subject }) => subject === matched[0]?.subject) && new Set(matched.map(({ target }) => target)).size >= 2) {
+        report(node, "R2", normalizedText(node, source));
+      }
+    }
+
+    if (ts.isConditionalExpression(node) && !isFalseBranchConditional(node)) {
+      const chain = conditionalChain(node, source, targets);
+      if (chain !== undefined) report(node, "R3", chain);
+    }
+
+    if (ts.isIfStatement(node) && !isElseIf(node)) {
+      const chain = ifChain(node, source, targets);
+      if (chain !== undefined) report(node, "R3", chain);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return violations;
+}
+
+interface TargetEquality {
+  readonly subject: string;
+  readonly target: string;
+}
+
+function targetEquality(node: ts.Node, source: ts.SourceFile, targets: ReadonlySet<string>): TargetEquality | undefined {
+  const equality = stringEquality(node, source);
+  return equality !== undefined && targets.has(equality.value)
+    ? { subject: equality.subject, target: equality.value }
+    : undefined;
+}
+
+function stringEquality(node: ts.Node, source: ts.SourceFile): { readonly subject: string; readonly value: string } | undefined {
+  node = unwrap(node);
+  if (!ts.isBinaryExpression(node) || (node.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken && node.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsToken)) return undefined;
+  const left = unwrap(node.left);
+  const right = unwrap(node.right);
+  const leftValue = stringValue(left);
+  const rightValue = stringValue(right);
+  if (leftValue !== undefined && rightValue === undefined) return { subject: normalizedText(right, source), value: leftValue };
+  if (rightValue !== undefined && leftValue === undefined) return { subject: normalizedText(left, source), value: rightValue };
+  return undefined;
+}
+
+function conditionalChain(node: ts.ConditionalExpression, source: ts.SourceFile, targets: ReadonlySet<string>): string | undefined {
+  return dispatchSignature(conditionalParts(node).conditions, source, targets);
+}
+
+interface SequentialDispatch {
+  readonly node: ts.IfStatement;
+  readonly text: string;
+}
+
+function sequentialDispatches(
+  statements: readonly ts.Statement[],
+  source: ts.SourceFile,
+  targets: ReadonlySet<string>
+): readonly SequentialDispatch[] {
+  const dispatches: SequentialDispatch[] = [];
+  for (let index = 0; index < statements.length; index += 1) {
+    const first = statements[index];
+    if (first === undefined || !isTerminalTargetGuard(first, source, targets)) continue;
+    const firstEquality = targetEquality(first.expression, source, targets)!;
+    if (hasPrecedingMixedGuard(statements, index, firstEquality.subject, source, targets)) continue;
+    const guards: ts.IfStatement[] = [];
+    let cursor = index;
+    while (cursor < statements.length) {
+      const statement = statements[cursor];
+      if (statement === undefined || !isTerminalTargetGuard(statement, source, targets)) break;
+      guards.push(statement);
+      cursor += 1;
+    }
+
+    const fallback = statements[cursor];
+    if (fallback === undefined || !ts.isReturnStatement(fallback) || fallback.expression === undefined) continue;
+    const returned = unwrapExpression(fallback.expression);
+    let finalFallback = returned;
+    let returnedConditions: readonly ts.Expression[] = [];
+    if (ts.isConditionalExpression(returned)) {
+      const parts = conditionalParts(returned);
+      if (parts.conditions.length >= 2 || containsTargetEquality(parts.fallback, source, targets)) continue;
+      finalFallback = parts.fallback;
+      returnedConditions = parts.conditions;
+    } else if (containsTargetEquality(returned, source, targets)) {
+      continue;
+    }
+
+    const conditions = guards
+      .filter((guard) => !terminalReturnMatchesFallback(guard.thenStatement, finalFallback))
+      .map((guard) => guard.expression);
+    conditions.push(...returnedConditions);
+    const text = dispatchSignature(conditions, source, targets);
+    if (text === undefined) continue;
+    dispatches.push({ node: guards[0]!, text });
+    index = cursor;
+  }
+  return dispatches;
+}
+
+function terminalReturnMatchesFallback(
+  statement: ts.Statement,
+  fallback: ts.Expression
+): boolean {
+  const terminal = ts.isBlock(statement) ? statement.statements[0] : statement;
+  return terminal !== undefined &&
+    ts.isReturnStatement(terminal) &&
+    terminal.expression !== undefined &&
+    structurallyEquivalentFallback(terminal.expression, fallback);
+}
+
+// This proves bounded source-topology equivalence; it is not runtime semantic proof.
+function structurallyEquivalentFallback(left: ts.Expression, right: ts.Expression): boolean {
+  const unwrappedLeft = unwrapExpression(left);
+  const unwrappedRight = unwrapExpression(right);
+  if (ts.isIdentifier(unwrappedLeft) && ts.isIdentifier(unwrappedRight)) {
+    return unwrappedLeft.text === unwrappedRight.text;
+  }
+  if (isCookedStringLiteral(unwrappedLeft) && isCookedStringLiteral(unwrappedRight)) {
+    return unwrappedLeft.text === unwrappedRight.text;
+  }
+  if (ts.isPropertyAccessExpression(unwrappedLeft) && ts.isPropertyAccessExpression(unwrappedRight)) {
+    return unwrappedLeft.questionDotToken === undefined &&
+      unwrappedRight.questionDotToken === undefined &&
+      ts.isIdentifier(unwrappedLeft.name) &&
+      ts.isIdentifier(unwrappedRight.name) &&
+      unwrappedLeft.name.text === unwrappedRight.name.text &&
+      structurallyEquivalentFallback(unwrappedLeft.expression, unwrappedRight.expression);
+  }
+  return false;
+}
+
+function isCookedStringLiteral(node: ts.Expression): node is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function hasPrecedingMixedGuard(
+  statements: readonly ts.Statement[],
+  index: number,
+  subject: string,
+  source: ts.SourceFile,
+  targets: ReadonlySet<string>
+): boolean {
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    const statement = statements[cursor];
+    if (statement === undefined || !isTerminalStringGuard(statement, source)) return false;
+    const equality = stringEquality(statement.expression, source)!;
+    if (equality.subject !== subject) return false;
+    if (!targets.has(equality.value)) return true;
+  }
+  return false;
+}
+
+function isTerminalTargetGuard(
+  statement: ts.Statement,
+  source: ts.SourceFile,
+  targets: ReadonlySet<string>
+): statement is ts.IfStatement {
+  return ts.isIfStatement(statement) &&
+    statement.elseStatement === undefined &&
+    targetEquality(statement.expression, source, targets) !== undefined &&
+    isTerminalStatement(statement.thenStatement);
+}
+
+function isTerminalStringGuard(
+  statement: ts.Statement,
+  source: ts.SourceFile
+): statement is ts.IfStatement {
+  return ts.isIfStatement(statement) &&
+    statement.elseStatement === undefined &&
+    stringEquality(statement.expression, source) !== undefined &&
+    isTerminalStatement(statement.thenStatement);
+}
+
+function isTerminalStatement(statement: ts.Statement): boolean {
+  if (ts.isReturnStatement(statement) || ts.isThrowStatement(statement)) return true;
+  return ts.isBlock(statement) && statement.statements.length === 1 &&
+    (ts.isReturnStatement(statement.statements[0]!) || ts.isThrowStatement(statement.statements[0]!));
+}
+
+function conditionalParts(node: ts.ConditionalExpression): {
+  readonly conditions: readonly ts.Expression[];
+  readonly fallback: ts.Expression;
+} {
+  const conditions: ts.Expression[] = [];
+  let current = node;
+  while (true) {
+    conditions.push(current.condition);
+    const next = unwrapExpression(current.whenFalse);
+    if (!ts.isConditionalExpression(next)) return { conditions, fallback: next };
+    current = next;
+  }
+}
+
+function containsTargetEquality(node: ts.Node, source: ts.SourceFile, targets: ReadonlySet<string>): boolean {
+  if (targetEquality(node, source, targets) !== undefined) return true;
+  let found = false;
+  ts.forEachChild(node, (child) => {
+    if (!found && containsTargetEquality(child, source, targets)) found = true;
+  });
+  return found;
+}
+
+function ifChain(node: ts.IfStatement, source: ts.SourceFile, targets: ReadonlySet<string>): string | undefined {
+  const conditions: ts.Expression[] = [];
+  let current: ts.IfStatement | undefined = node;
+  while (current !== undefined) {
+    conditions.push(current.expression);
+    const next: ts.Statement | undefined = current.elseStatement;
+    if (next === undefined) return undefined;
+    current = ts.isIfStatement(next) ? next : undefined;
+  }
+  return dispatchSignature(conditions, source, targets);
+}
+
+function dispatchSignature(conditions: readonly ts.Expression[], source: ts.SourceFile, targets: ReadonlySet<string>): string | undefined {
+  const equalities = conditions.map((condition) => targetEquality(condition, source, targets));
+  if (equalities.length < 2 || equalities.some((value) => value === undefined)) return undefined;
+  const matched = equalities as readonly TargetEquality[];
+  if (!matched.every(({ subject }) => subject === matched[0]?.subject) || new Set(matched.map(({ target }) => target)).size < 2) return undefined;
+  return `${conditions.map((condition) => normalizedText(condition, source)).join(" -> ")} -> else`;
+}
+
+function flattenOr(node: ts.Expression): readonly ts.Expression[] {
+  const unwrapped = unwrap(node);
+  if (!ts.isBinaryExpression(unwrapped) || unwrapped.operatorToken.kind !== ts.SyntaxKind.BarBarToken) return [unwrapped as ts.Expression];
+  return [...flattenOr(unwrapped.left), ...flattenOr(unwrapped.right)];
+}
+
+function hasParentOr(node: ts.BinaryExpression): boolean {
+  let current: ts.Node = node;
+  let parent: ts.Node = current.parent;
+  while (isTransparentExpressionWrapper(parent, current)) {
+    current = parent;
+    parent = current.parent;
+  }
+  return ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.BarBarToken;
+}
+
+function isTransparentExpressionWrapper(parent: ts.Node, expression: ts.Node): boolean {
+  return (ts.isParenthesizedExpression(parent) ||
+    ts.isAsExpression(parent) ||
+    ts.isTypeAssertionExpression(parent) ||
+    ts.isSatisfiesExpression(parent) ||
+    ts.isNonNullExpression(parent)) &&
+    parent.expression === expression;
+}
+
+function isFalseBranchConditional(node: ts.ConditionalExpression): boolean {
+  let parent: ts.Node = node.parent;
+  while (ts.isParenthesizedExpression(parent)) parent = parent.parent;
+  return ts.isConditionalExpression(parent) && unwrap(parent.whenFalse) === node;
+}
+
+function isElseIf(node: ts.IfStatement): boolean {
+  return ts.isIfStatement(node.parent) && node.parent.elseStatement === node;
+}
+
+function stringValue(node: ts.Node): string | undefined {
+  const value = unwrap(node);
+  return ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value) ? value.text : undefined;
+}
+
+function unwrap<T extends ts.Node>(node: T): ts.Node {
+  let current: ts.Node = node;
+  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current) || ts.isSatisfiesExpression(current) || ts.isNonNullExpression(current)) current = current.expression;
+  return current;
+}
+
+function unwrapExpression(node: ts.Expression): ts.Expression {
+  return unwrap(node) as ts.Expression;
+}
+
+function normalizedText(node: ts.Node, source: ts.SourceFile): string {
+  return node.getText(source).replace(/\s+/gu, " ").trim();
+}
+
+function ownerOf(node: ts.Node, source: ts.SourceFile): string {
+  let variableOwner: string | undefined;
+  for (let current: ts.Node | undefined = node; current !== undefined; current = current.parent) {
+    if (ts.isFunctionDeclaration(current) && current.name !== undefined) return current.name.text;
+    if (ts.isMethodDeclaration(current) && current.name !== undefined) return current.name.getText(source);
+    if (ts.isVariableDeclaration(current)) variableOwner ??= current.name.getText(source);
+  }
+  return variableOwner ?? "<module>";
+}
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+async function gitFiles(): Promise<readonly string[]> {
+  const proc = Bun.spawn(["git", "ls-files", "--cached", "--others", "--exclude-standard"], {
+    cwd: rootDir,
+    env: gitSafeEnv(),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`git ls-files failed: ${stderr.trim()}`);
+  return stdout.split("\n").filter(Boolean);
+}
+
+async function main(): Promise<void> {
+  const files = (await gitFiles()).filter(isTargetTopologySourcePath);
+  const violations: TargetTopologyViolation[] = [];
+  for (const file of files) {
+    const path = `${rootDir}/${file}`;
+    if (existsSync(path)) violations.push(...scanTargetTopologySource(file, await Bun.file(path).text()));
+  }
+  if (violations.length > 0) {
+    console.error(`skillset: target topology guard found ${violations.length} violation(s):`);
+    for (const violation of violations) {
+      console.error(`  ${violation.file}:${violation.line}:${violation.column}: [${violation.rule}] ${violation.owner}: ${violation.text}`);
+    }
+    process.exit(1);
+  }
+  console.error(`skillset: target topology guard scanned ${files.length} TypeScript source files; topology is canonical`);
+}
+
+if (import.meta.main) main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Context\n\nSET-340 prevents future target additions from silently inheriting incomplete Claude/Codex topology. Provider-specific rendering remains legitimate; the unsafe shapes are raw target-domain collections, same-subject target subsets, and implicit final-target fallbacks.\n\n## What changed\n\n- add a TypeScript-AST target topology guard with three narrow structural rules\n- use exact file/line/column/owner/rule/AST-text exemptions with rationale and live 20/20 reconciliation\n- replace two implicit Codex fallbacks with exhaustive app-local TargetName records\n- wire the guard into aggregate check and document its exemption policy\n- add a public skillset patch changeset\n\n## Verification\n\n- final standing Terra review: 5/5, zero P0-P3\n- final targeted Terra review: 5/5, zero P0-P3\n- focused guard: 14 tests / 21 expectations\n- raw exemption reconciliation: 20 entries / 20 violations / zero stale or unexpected\n- owning app contracts: 3 tests / 55 expectations\n- conformance fast: 21 tests / 49 expectations\n- aggregate check: 1316 tests / 54308 expectations\n- pre-push: passed, including self-hosted CI and 225-file topology scan\n\n## Risk\n\nThe guard is deliberately structural rather than semantic. It avoids broad provider-literal bans and treats calls, allocations, computed/optional access, and other rich expressions conservatively. No schema, generated output, Core policy, ADR, or audit file changes.