### PR TITLE
docs: record SET-350 audit disposition

### DIFF
--- a/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
+++ b/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
@@ -30,7 +30,7 @@ validate completeness and print the project finding counts.
 | 03.1 | confirmed | open | SET-324 | — | Accept a successor ADR for shipped unsupported-destination policy. |
 | 03.2 | confirmed | open | SET-327 | — | Audit every draft first; SET-325 is the evidence-gated promotion follow-on. |
 | 03.3 | confirmed | open | SET-327 | — | Record the supersession disposition before SET-325 acts. |
-| 03.4 | confirmed | open | SET-350 | — | Model amendments separately from supersession in the decision map. |
+| 03.4 | confirmed | fixed | SET-350 | https://github.com/outfitter-dev/skillset/pull/319 | Amendment relations are modeled separately from whole-decision supersession, with validated reciprocal decision-map edges and preview-safe ADR mutations. Merged as `12dadf7115ae15d4675f3270ae0623526538a7f9`. |
 | 03.5 | confirmed | open | SET-327 | — | Determine the required amendment before any promotion. |
 | 03.6 | confirmed | open | SET-326 | — | Finish the internal `try` to `test` hard cutover. |
 | 03.7 | plausible | open | SET-327 | — | Audit every remaining draft and record one evidence-backed disposition. |


### PR DESCRIPTION
## Context

SET-350 merged in PR #319, but drift-audit finding 03.4 still recorded the work as open.

## What changed

- Mark finding 03.4 fixed.
- Record PR #319 and merge commit `12dadf7115ae15d4675f3270ae0623526538a7f9`.
- Keep the original confidence and SET-350 ownership unchanged.

## Verification

- Drift-audit checker: 51 total / 27 open / 20 fixed / 4 wont-fix
- Exact diff: one file, one row, one insertion / one deletion
- `git diff --check`: passed
- Canonical pre-push: passed twice
- Standing and fresh targeted Terra reviews: 5/5 clean, zero P0-P3

## Risk

Documentation-only reconciliation of already-merged evidence. No product code, generated output, other finding row, publication, global configuration, stash, or bridge-worktree mutation.
