### PR TITLE
feat: check feature support matrices

### DIFF
--- a/.changeset/feature-doc-support-matrices.md
+++ b/.changeset/feature-doc-support-matrices.md
@@ -1,0 +1,5 @@
+---
+"@skillset/core": patch
+---
+
+Render and check bounded feature-document support matrices against the canonical feature registry and target set.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,6 +1,6 @@
 # Feature Reference
 
-The feature reference is the human-readable support registry for Skillset v1. It explains how authored source maps to provider target surfaces, which features are portable, which are target-native, and where support is deferred or future-only. This directory is manual for now; future schema-backed generation is deliberately deferred until the page shape proves itself.
+The feature reference is the human-readable support registry for Skillset v1. It explains how authored source maps to provider target surfaces, which features are portable, which are target-native, and where support is deferred or future-only. Feature-page prose remains human-owned; each delimited feature-status and target-support matrix is rendered from the typed registry and checked for drift.
 
 Use these pages alongside the [target surface evidence matrix](../target-surfaces.md). The matrix is the compact target-fact table; feature pages explain authoring shape, target rendering, diagnostics, provenance, examples, and test coverage.
 
@@ -107,4 +107,4 @@ These are tracked as future/reserved unless a later issue promotes them:
 - [Model and reasoning alias profiles](../adrs/drafts/20260604-model-and-reasoning-alias-profiles.md): shared aliases such as `review`, `fast`, or `deep` remain deferred; use target-native model and effort fields where supported.
 - [First-class sets](../adrs/drafts/20260604-first-class-sets.md): grouped marketplaces, bundles, and curated collections remain future vocabulary; v1 keeps build scopes and entity selectors separate.
 - [Tests and evals](tests-and-evals.md): adapter-aware eval support and expanded test selectors remain planned/future; deterministic `skillset test` has a first isolated rendering slice.
-- Generated feature docs: docs remain manual until the feature reference shape is stable enough to generate from typed registry data.
+- Richer generated feature docs: only the bounded status matrices are registry-rendered today; narrative, examples, output paths, and caveats remain authored until the broader page shape is stable enough to generate.

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -1,5 +1,12 @@
 # Agents
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-agents` | `implemented` | `pass_through` | `unsupported` | `pass_through` |
+| `project-agents` | `implemented` | `native` | `transformed` | `native` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `agents`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -1,5 +1,12 @@
 # Apps
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `future-companion-source-pointers` | `planned` | `planned` | `planned` | `planned` |
+| `plugin-apps` | `implemented` | `not_applicable` | `pass_through` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `apps`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/build-scopes.md
+++ b/docs/features/build-scopes.md
@@ -1,5 +1,11 @@
 # Build Scopes
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `workflows` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `build-scopes`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/changes.md
+++ b/docs/features/changes.md
@@ -1,5 +1,11 @@
 # Changes
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `changes` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `changes`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/ci.md
+++ b/docs/features/ci.md
@@ -1,5 +1,11 @@
 # CI
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `workflows` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `ci`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -1,5 +1,12 @@
 # Commands
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `future-companion-source-pointers` | `planned` | `planned` | `planned` | `planned` |
+| `plugin-commands` | `implemented` | `pass_through` | `not_applicable` | `pass_through` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `commands`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/dependencies.md
+++ b/docs/features/dependencies.md
@@ -1,5 +1,11 @@
 # Dependencies
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `dependencies` | `implemented` | `native` | `degraded` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `dependencies`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/dev-watch.md
+++ b/docs/features/dev-watch.md
@@ -1,5 +1,11 @@
 # Dev Watch
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `dev-watch` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `dev-watch`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/distributions.md
+++ b/docs/features/distributions.md
@@ -1,5 +1,11 @@
 # Distributions
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `distributions` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `distributions`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/executables.md
+++ b/docs/features/executables.md
@@ -1,5 +1,11 @@
 # Executables
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-bin` | `implemented` | `pass_through` | `unsupported` | `unsupported` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `executables`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/feature-registry.md
+++ b/docs/features/feature-registry.md
@@ -1,5 +1,11 @@
 # Feature Registry
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `feature-registry` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `feature-registry`
 
 Related vocabulary: [Feature Reference Vocabulary](README.md#feature-reference-vocabulary)

--- a/docs/features/feature-source-pointers.md
+++ b/docs/features/feature-source-pointers.md
@@ -1,5 +1,12 @@
 # Feature Source Pointers
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-bin` | `implemented` | `pass_through` | `unsupported` | `unsupported` |
+| `plugin-mcp` | `implemented` | `native` | `native` | `native` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `feature-source-pointers`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/hook-guardrails.md
+++ b/docs/features/hook-guardrails.md
@@ -1,5 +1,11 @@
 # Hook Guardrails
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `runtime-context` | `implemented` | `transformed` | `transformed` | `transformed` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `hook-guardrails`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -1,5 +1,14 @@
 # Hooks
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `adaptive-hooks` | `implemented` | `transformed` | `degraded` | `degraded` |
+| `future-companion-source-pointers` | `planned` | `planned` | `planned` | `planned` |
+| `plugin-hooks` | `implemented` | `pass_through` | `pass_through` | `pass_through` |
+| `runtime-context` | `implemented` | `transformed` | `transformed` | `transformed` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `hooks`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/instructions.md
+++ b/docs/features/instructions.md
@@ -1,5 +1,12 @@
 # Instructions
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-rules` | `implemented` | `not_applicable` | `not_applicable` | `pass_through` |
+| `project-instructions` | `implemented` | `transformed` | `transformed` | `transformed` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `instructions`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/lsp-servers.md
+++ b/docs/features/lsp-servers.md
@@ -1,5 +1,11 @@
 # LSP Servers
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-lsp-servers` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `lsp-servers`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -1,5 +1,11 @@
 # Marketplaces
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `marketplaces` | `implemented` | `native` | `future` | `native` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `marketplaces`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/mcp-servers.md
+++ b/docs/features/mcp-servers.md
@@ -1,5 +1,11 @@
 # MCP Servers
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-mcp` | `implemented` | `native` | `native` | `native` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `mcp-servers`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/monitors.md
+++ b/docs/features/monitors.md
@@ -1,5 +1,11 @@
 # Monitors
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-monitors` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `monitors`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/output-safety.md
+++ b/docs/features/output-safety.md
@@ -1,5 +1,11 @@
 # Output Safety
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `output-safety` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `output-safety`
 
 Skillset treats generated target files as reproducible renderings while still protecting hand-authored files that happen to live near those renderings. Output safety is the build-time ownership layer that decides which files are managed, which files are unmanaged neighbors, and when a reversible backup is required before writing.

--- a/docs/features/output-styles.md
+++ b/docs/features/output-styles.md
@@ -1,5 +1,11 @@
 # Output Styles
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-output-styles` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `output-styles`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -1,5 +1,22 @@
 # Plugins
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-assets` | `implemented` | `pass_through` | `pass_through` | `planned` |
+| `plugin-commands` | `implemented` | `pass_through` | `not_applicable` | `pass_through` |
+| `plugin-lsp-servers` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+| `plugin-manifests` | `implemented` | `native` | `native` | `native` |
+| `plugin-monitors` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+| `plugin-output-styles` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+| `plugin-readme` | `implemented` | `pass_through` | `pass_through` | `planned` |
+| `plugin-rules` | `implemented` | `not_applicable` | `not_applicable` | `pass_through` |
+| `plugin-scripts` | `implemented` | `pass_through` | `pass_through` | `planned` |
+| `plugin-skills` | `implemented` | `native` | `native` | `native` |
+| `plugin-src` | `implemented` | `pass_through` | `pass_through` | `planned` |
+| `plugin-themes` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `plugins`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/releases.md
+++ b/docs/features/releases.md
@@ -1,5 +1,11 @@
 # Releases And Changelogs
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `releases` | `implemented` | `metadata_only` | `metadata_only` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `releases`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/render-results.md
+++ b/docs/features/render-results.md
@@ -1,5 +1,11 @@
 # Render Results
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `render-results` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `render-results`
 
 Related vocabulary: [Feature Reference Vocabulary](README.md#feature-reference-vocabulary)

--- a/docs/features/resources.md
+++ b/docs/features/resources.md
@@ -1,5 +1,11 @@
 # Resources
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `resources` | `implemented` | `native` | `native` | `native` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `resources`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/runtime-adapters.md
+++ b/docs/features/runtime-adapters.md
@@ -1,5 +1,11 @@
 # Runtime Adapters
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `runtime-adapters` | `planned` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `runtime-adapters`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -1,5 +1,11 @@
 # Settings
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `future-companion-source-pointers` | `planned` | `planned` | `planned` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `settings`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -1,5 +1,12 @@
 # Skills
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-skills` | `implemented` | `native` | `native` | `native` |
+| `standalone-skills` | `implemented` | `native` | `native` | `native` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `skills`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/supports.md
+++ b/docs/features/supports.md
@@ -1,5 +1,11 @@
 # Supports
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `supports` | `implemented` | `metadata_only` | `metadata_only` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `supports`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/target-native-islands.md
+++ b/docs/features/target-native-islands.md
@@ -1,5 +1,11 @@
 # Provider Source
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `target-native-islands` | `implemented` | `pass_through` | `pass_through` | `pass_through` |
+<!-- skillset:feature-support:end -->
+
 Current internal feature id: `target-native-islands`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/tests-and-evals.md
+++ b/docs/features/tests-and-evals.md
@@ -1,5 +1,11 @@
 # Tests and Evals
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `activation-probes` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `tests-and-evals`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/themes.md
+++ b/docs/features/themes.md
@@ -1,5 +1,11 @@
 # Themes
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `plugin-themes` | `implemented` | `pass_through` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `themes`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/tools-policy.md
+++ b/docs/features/tools-policy.md
@@ -1,5 +1,11 @@
 # Tools Policy
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `tools-policy` | `implemented` | `transformed` | `metadata_only` | `metadata_only` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `tools-policy`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/version-audit.md
+++ b/docs/features/version-audit.md
@@ -1,5 +1,11 @@
 # Version Audit
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `version-audit` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Feature id: `version-audit`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)

--- a/docs/features/workbench.md
+++ b/docs/features/workbench.md
@@ -1,5 +1,11 @@
 # Workbench Check
 
+<!-- skillset:feature-support:start -->
+| Feature | Feature status | claude | codex | cursor |
+| --- | --- | --- | --- | --- |
+| `workflows` | `implemented` | `not_applicable` | `not_applicable` | `planned` |
+<!-- skillset:feature-support:end -->
+
 Related feature id: `workflows`
 
 Support vocabulary: [Feature Reference](README.md#feature-reference-vocabulary)

--- a/packages/core/src/__tests__/feature-registry-check.test.ts
+++ b/packages/core/src/__tests__/feature-registry-check.test.ts
@@ -5,9 +5,12 @@ import { join } from "node:path";
 
 import {
   checkFeatureRegistryDrift,
+  getSkillsetFeature,
   listSkillsetFeatures,
+  renderFeatureSupportMatrix,
   type SkillsetFeatureEntry,
   type SkillsetFeatureEvidence,
+  targetNames,
   targetRecord,
 } from "@skillset/core";
 
@@ -151,12 +154,7 @@ describe("feature registry drift checks", () => {
   });
 
   it("reports missing fixture and test evidence refs", async () => {
-    const root = await fixture({
-      "docs/features/demo.md": "# Demo\n",
-      "src/demo.ts": "export {};\n",
-    });
-
-    const report = await checkFeatureRegistryDrift(root, [
+    const registry = [
       feature({
         docs: ["docs/features/demo.md"],
         evidence: [
@@ -167,7 +165,13 @@ describe("feature registry drift checks", () => {
         renderOwner: "src/demo.ts",
         validationOwner: "src/demo.ts",
       }),
-    ]);
+    ];
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${renderFeatureSupportMatrix(registry)}\n`,
+      "src/demo.ts": "export {};\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
 
     expect(report.issues.map((issue) => `${issue.field}:${issue.ref}`)).toEqual([
       "evidence[0]:fixtures/missing",
@@ -182,11 +186,7 @@ describe("feature registry drift checks", () => {
   });
 
   it("ignores future owner sentinels and external evidence refs", async () => {
-    const root = await fixture({
-      "docs/features/demo.md": "# Demo\n",
-    });
-
-    const report = await checkFeatureRegistryDrift(root, [
+    const registry = [
       feature({
         docs: ["docs/features/demo.md"],
         evidence: [
@@ -197,13 +197,280 @@ describe("feature registry drift checks", () => {
         status: "planned",
         validationOwner: "future",
       }),
-    ]);
+    ];
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${renderFeatureSupportMatrix(registry)}\n`,
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
 
     expect(report).toEqual({
       checkedFeatures: 1,
       issues: [],
       ok: true,
     });
+  });
+
+  it("renders feature status and every canonical target status without a target subset", () => {
+    const entry = feature({
+      id: "demo",
+      targetSupport: targetRecord((target) => ({
+        status: target === "cursor" ? "pass_through" : "native",
+      })),
+    });
+
+    const matrix = renderFeatureSupportMatrix([entry]);
+    const header = `| Feature | Feature status | ${targetNames().join(" | ")} |`;
+
+    expect(matrix).toBe([
+      "<!-- skillset:feature-support:start -->",
+      header,
+      `| ${["Feature", "Feature status", ...targetNames()].map(() => "---").join(" | ")} |`,
+      "| `demo` | `implemented` | `native` | `native` | `pass_through` |",
+      "<!-- skillset:feature-support:end -->",
+    ].join("\n"));
+  });
+
+  it("groups every registry entry that owns the same doc and ignores surrounding prose", async () => {
+    const registry = [
+      feature({ id: "alpha" }),
+      feature({ id: "beta" }),
+    ];
+    const root = await fixture({
+      "docs/features/demo.md": [
+        "# Demo",
+        "",
+        "Narrative before the checked matrix.",
+        "",
+        renderFeatureSupportMatrix(registry),
+        "",
+        "Narrative after the checked matrix remains human-owned.",
+        "",
+      ].join("\n"),
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toEqual([]);
+  });
+
+  it("reports a wrong target value with the feature, target, field, expected, and actual value", async () => {
+    const registry = [feature({ id: "demo" })];
+    const matrix = renderFeatureSupportMatrix(registry).replace(
+      "| `demo` | `implemented` | `native` | `native` | `native` |",
+      "| `demo` | `implemented` | `native` | `native` | `metadata_only` |"
+    );
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "metadata_only",
+      code: "feature-support-table-drift",
+      expected: "native",
+      featureId: "demo",
+      field: "targetSupport.cursor.status",
+      message: "demo cursor targetSupport.cursor.status expected native but found metadata_only",
+      ref: "docs/features/demo.md",
+      target: "cursor",
+    });
+  });
+
+  it("reports a missing target column as a missing exact target-support field", async () => {
+    const registry = [feature({ id: "demo" })];
+    const matrix = renderFeatureSupportMatrix(registry)
+      .replace(" | cursor |", " |")
+      .replace(" | `native` |\n<!-- skillset:feature-support:end -->", " |\n<!-- skillset:feature-support:end -->");
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "missing",
+      code: "feature-support-table-drift",
+      expected: "native",
+      featureId: "demo",
+      field: "targetSupport.cursor.status",
+      message: "demo cursor targetSupport.cursor.status expected native but found missing",
+      ref: "docs/features/demo.md",
+      target: "cursor",
+    });
+  });
+
+  it("rejects non-registry fields inside the bounded matrix", async () => {
+    const registry = [feature({ id: "demo" })];
+    const matrix = renderFeatureSupportMatrix(registry)
+      .replace("| Feature | Feature status | claude", "| Feature | Feature status | Reason | claude")
+      .replace("| --- | --- | ---", "| --- | --- | --- | ---")
+      .replace("| `demo` | `implemented` | `native`", "| `demo` | `implemented` | authored note | `native`");
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "Feature, Feature status, Reason, claude, codex, cursor",
+      code: "feature-support-table-drift",
+      expected: "Feature, Feature status, claude, codex, cursor",
+      featureId: "demo",
+      field: "matrix.columns",
+      message: "demo claude matrix.columns expected Feature, Feature status, claude, codex, cursor but found Feature, Feature status, Reason, claude, codex, cursor",
+      ref: "docs/features/demo.md",
+      target: "claude",
+    });
+  });
+
+  it("rejects a stale duplicate feature row instead of collapsing it by id", async () => {
+    const registry = [feature({ id: "demo" })];
+    const row = "| `demo` | `implemented` | `native` | `native` | `native` |";
+    const staleRow = "| `demo` | `implemented` | `native` | `native` | `metadata_only` |";
+    const matrix = renderFeatureSupportMatrix(registry).replace(row, `${row}\n${staleRow}`);
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "demo, demo",
+      code: "feature-support-table-drift",
+      expected: "demo",
+      featureId: "demo",
+      field: "matrix.rows",
+      message: "demo claude matrix.rows expected demo but found demo, demo",
+      ref: "docs/features/demo.md",
+      target: "claude",
+    });
+  });
+
+  it.each([
+    ["blank row", "|  | `implemented` | `native` | `native` | `native` |"],
+    ["short row", "| `demo` | `implemented` |"],
+    ["non-table row", "unexpected content"],
+  ])("rejects a %s inside the bounded matrix", async (_case, extraRow) => {
+    const registry = [feature({ id: "demo" })];
+    const row = "| `demo` | `implemented` | `native` | `native` | `native` |";
+    const matrix = renderFeatureSupportMatrix(registry).replace(row, `${row}\n${extraRow}`);
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "missing",
+      code: "feature-support-table-drift",
+      expected: "native",
+      featureId: "demo",
+      field: "targetSupport.cursor.status",
+      message: "demo cursor targetSupport.cursor.status expected native but found missing",
+      ref: "docs/features/demo.md",
+      target: "cursor",
+    });
+  });
+
+  it("rejects a malformed separator inside the bounded matrix", async () => {
+    const registry = [feature({ id: "demo" })];
+    const matrix = renderFeatureSupportMatrix(registry).replace(
+      "| --- | --- | --- | --- | --- |",
+      "| --- | --- | --- | invalid | --- |"
+    );
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "missing",
+      code: "feature-support-table-drift",
+      expected: "native",
+      featureId: "demo",
+      field: "targetSupport.cursor.status",
+      message: "demo cursor targetSupport.cursor.status expected native but found missing",
+      ref: "docs/features/demo.md",
+      target: "cursor",
+    });
+  });
+
+  it("rejects feature rows that do not follow deterministic registry order", async () => {
+    const registry = [feature({ id: "alpha" }), feature({ id: "beta" })];
+    const alpha = "| `alpha` | `implemented` | `native` | `native` | `native` |";
+    const beta = "| `beta` | `implemented` | `native` | `native` | `native` |";
+    const matrix = renderFeatureSupportMatrix(registry).replace(
+      `${alpha}\n${beta}`,
+      `${beta}\n${alpha}`
+    );
+    const root = await fixture({
+      "docs/features/demo.md": `# Demo\n\n${matrix}\n`,
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "beta, alpha",
+      code: "feature-support-table-drift",
+      expected: "alpha, beta",
+      featureId: "alpha",
+      field: "matrix.rows",
+      message: "alpha claude matrix.rows expected alpha, beta but found beta, alpha",
+      ref: "docs/features/demo.md",
+      target: "claude",
+    });
+  });
+
+  it("requires a checked matrix for every registry-linked feature doc", async () => {
+    const registry = [feature({ id: "demo" })];
+    const root = await fixture({
+      "docs/features/demo.md": "# Demo\n\nHuman-owned prose only.\n",
+      "src/demo.ts": "export {};\n",
+      "tests/demo.test.ts": "test('demo', () => {});\n",
+    });
+
+    const report = await checkFeatureRegistryDrift(root, registry);
+
+    expect(report.issues).toContainEqual({
+      actual: "missing",
+      code: "feature-support-table-drift",
+      expected: "native",
+      featureId: "demo",
+      field: "targetSupport.cursor.status",
+      message: "demo cursor targetSupport.cursor.status expected native but found missing",
+      ref: "docs/features/demo.md",
+      target: "cursor",
+    });
+  });
+
+  it("derives the shipped Cursor provider-source support from the registry", async () => {
+    const providerSource = getSkillsetFeature("target-native-islands");
+    expect(providerSource).toBeDefined();
+    if (providerSource === undefined) throw new Error("missing target-native-islands fixture");
+
+    const matrix = renderFeatureSupportMatrix([providerSource]);
+
+    expect(providerSource.targetSupport.cursor.status).toBe("pass_through");
+    expect(matrix).toContain("| `target-native-islands` | `implemented` | `pass_through` | `pass_through` | `pass_through` |");
   });
 });
 

--- a/packages/core/src/feature-registry-check.ts
+++ b/packages/core/src/feature-registry-check.ts
@@ -12,8 +12,13 @@ import {
   type SkillsetTargetSupport,
 } from "./feature-registry";
 import { targetNames } from "./targets";
+import type { TargetName } from "./types";
+
+const FEATURE_SUPPORT_MATRIX_START = "<!-- skillset:feature-support:start -->";
+const FEATURE_SUPPORT_MATRIX_END = "<!-- skillset:feature-support:end -->";
 
 export type FeatureRegistryDriftCode =
+  | "feature-support-table-drift"
   | "missing-doc-ref"
   | "missing-evidence"
   | "missing-evidence-ref"
@@ -22,11 +27,14 @@ export type FeatureRegistryDriftCode =
   | "outside-root-ref";
 
 export interface FeatureRegistryDriftIssue {
+  readonly actual?: string;
   readonly code: FeatureRegistryDriftCode;
+  readonly expected?: string;
   readonly featureId: string;
   readonly field: string;
   readonly message: string;
   readonly ref?: string;
+  readonly target?: TargetName;
 }
 
 export interface FeatureRegistryDriftReport {
@@ -48,12 +56,273 @@ export async function checkFeatureRegistryDrift(
     await checkOwners(issues, resolvedRootPath, feature);
     await checkEvidenceRefs(issues, resolvedRootPath, feature);
   }
+  await checkFeatureSupportMatrices(issues, resolvedRootPath, registry);
 
   return {
     checkedFeatures: registry.length,
     issues: issues.sort(compareDriftIssues),
     ok: issues.length === 0,
   };
+}
+
+export function renderFeatureSupportMatrix(registry: SkillsetFeatureRegistry): string {
+  const targets = targetNames();
+  const header = ["Feature", "Feature status", ...targets];
+  const rows = [...registry]
+    .sort((left, right) => compareStrings(left.id, right.id))
+    .map((feature) => [
+      codeCell(feature.id),
+      codeCell(feature.status),
+      ...targets.map((target) => codeCell(feature.targetSupport[target].status)),
+    ]);
+  return [
+    FEATURE_SUPPORT_MATRIX_START,
+    markdownTableRow(header),
+    markdownTableRow(header.map(() => "---")),
+    ...rows.map(markdownTableRow),
+    FEATURE_SUPPORT_MATRIX_END,
+  ].join("\n");
+}
+
+async function checkFeatureSupportMatrices(
+  issues: FeatureRegistryDriftIssue[],
+  rootPath: string,
+  registry: SkillsetFeatureRegistry
+): Promise<void> {
+  const targets = targetNames();
+  for (const [ref, features] of featureDocs(registry)) {
+    if (!isInsideRoot(rootPath, ref) || !(await existsExactLocalRef(rootPath, ref))) continue;
+    const markdown = await readFile(resolve(rootPath, ref), "utf8");
+    const actual = parseFeatureSupportMatrix(markdown);
+
+    if (actual !== undefined) {
+      const expectedColumns = ["Feature", "Feature status", ...targets];
+      if (!sameStrings(actual.columns, expectedColumns)) {
+        const feature = features[0];
+        const target = targets[0];
+        if (feature !== undefined && target !== undefined) {
+          const expected = expectedColumns.join(", ");
+          const found = actual.columns.join(", ");
+          issues.push({
+            actual: found,
+            code: "feature-support-table-drift",
+            expected,
+            featureId: feature.id,
+            field: "matrix.columns",
+            message: `${feature.id} ${target} matrix.columns expected ${expected} but found ${found}`,
+            ref,
+            target,
+          });
+        }
+      }
+
+      const expectedRows = features.map((feature) => feature.id);
+      if (!sameStrings(actual.rows, expectedRows)) {
+        const mismatchIndex = firstMismatchIndex(actual.rows, expectedRows);
+        const featureId = expectedRows[mismatchIndex] ?? actual.rows[mismatchIndex] ?? features[0]?.id;
+        const target = targets[0];
+        if (featureId !== undefined && target !== undefined) {
+          const expected = expectedRows.join(", ");
+          const found = actual.rows.join(", ");
+          issues.push({
+            actual: found,
+            code: "feature-support-table-drift",
+            expected,
+            featureId,
+            field: "matrix.rows",
+            message: `${featureId} ${target} matrix.rows expected ${expected} but found ${found}`,
+            ref,
+            target,
+          });
+        }
+      }
+    }
+
+    for (const feature of features) {
+      const actualFeature = actual?.features.get(feature.id);
+      pushFeatureSupportMismatch(issues, {
+        actual: actualFeature?.status,
+        expected: feature.status,
+        featureId: feature.id,
+        field: "status",
+        ref,
+      });
+      for (const target of targets) {
+        pushFeatureSupportMismatch(issues, {
+          actual: actualFeature?.targetSupport.get(target),
+          expected: feature.targetSupport[target].status,
+          featureId: feature.id,
+          field: `targetSupport.${target}.status`,
+          ref,
+          target,
+        });
+      }
+    }
+
+    if (actual === undefined) continue;
+    const expectedIds = new Set(features.map((feature) => feature.id));
+    for (const featureId of actual.features.keys()) {
+      if (expectedIds.has(featureId)) continue;
+      issues.push({
+        actual: "present",
+        code: "feature-support-table-drift",
+        expected: "absent",
+        featureId,
+        field: "id",
+        message: `${featureId} feature id expected absent but found present`,
+        ref,
+      });
+    }
+  }
+}
+
+function featureDocs(
+  registry: SkillsetFeatureRegistry
+): readonly (readonly [string, readonly SkillsetFeatureEntry[]])[] {
+  const grouped = new Map<string, Map<string, SkillsetFeatureEntry>>();
+  for (const feature of registry) {
+    for (const docRef of feature.docs) {
+      const { path } = parseRef(docRef);
+      if (!path.startsWith("docs/features/") || !path.endsWith(".md")) continue;
+      const features = grouped.get(path) ?? new Map<string, SkillsetFeatureEntry>();
+      features.set(feature.id, feature);
+      grouped.set(path, features);
+    }
+  }
+  return [...grouped.entries()]
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([path, features]) => [
+      path,
+      [...features.values()].sort((left, right) => compareStrings(left.id, right.id)),
+    ] as const);
+}
+
+function pushFeatureSupportMismatch(
+  issues: FeatureRegistryDriftIssue[],
+  args: {
+    readonly actual: string | undefined;
+    readonly expected: string;
+    readonly featureId: string;
+    readonly field: string;
+    readonly ref: string;
+    readonly target?: TargetName;
+  }
+): void {
+  if (args.actual === args.expected) return;
+  const actual = args.actual ?? "missing";
+  const subject = args.target === undefined ? `${args.featureId} feature` : `${args.featureId} ${args.target}`;
+  issues.push({
+    actual,
+    code: "feature-support-table-drift",
+    expected: args.expected,
+    featureId: args.featureId,
+    field: args.field,
+    message: `${subject} ${args.field} expected ${args.expected} but found ${actual}`,
+    ref: args.ref,
+    ...(args.target === undefined ? {} : { target: args.target }),
+  });
+}
+
+function parseFeatureSupportMatrix(markdown: string): {
+  readonly columns: readonly string[];
+  readonly features: ReadonlyMap<
+    string,
+    { readonly status: string | undefined; readonly targetSupport: ReadonlyMap<string, string> }
+  >;
+  readonly rows: readonly string[];
+} | undefined {
+  const start = markdown.indexOf(FEATURE_SUPPORT_MATRIX_START);
+  const end = markdown.indexOf(FEATURE_SUPPORT_MATRIX_END);
+  if (
+    start === -1 ||
+    end === -1 ||
+    end < start ||
+    markdown.indexOf(FEATURE_SUPPORT_MATRIX_START, start + FEATURE_SUPPORT_MATRIX_START.length) !== -1 ||
+    markdown.indexOf(FEATURE_SUPPORT_MATRIX_END, end + FEATURE_SUPPORT_MATRIX_END.length) !== -1
+  ) {
+    return undefined;
+  }
+
+  const block = markdown.slice(start + FEATURE_SUPPORT_MATRIX_START.length, end).trim();
+  const tableLines = block.length === 0 ? [] : block.split(/\r?\n/u).map((line) => line.trim());
+  if (
+    tableLines.length < 3 ||
+    tableLines.some((line) => !line.startsWith("|") || !line.endsWith("|"))
+  ) {
+    return undefined;
+  }
+  const header = tableLines[0] === undefined ? [] : parseMarkdownTableRow(tableLines[0]);
+  const separator = tableLines[1] === undefined ? [] : parseMarkdownTableRow(tableLines[1]);
+  if (
+    separator.length !== header.length ||
+    separator.some((cell) => cell !== "---")
+  ) {
+    return undefined;
+  }
+  const featureIndex = header.indexOf("Feature");
+  const statusIndex = header.indexOf("Feature status");
+  if (featureIndex === -1 || statusIndex === -1) return undefined;
+
+  const targetIndexes = new Map<string, number>();
+  for (const [index, cell] of header.entries()) {
+    if (index === featureIndex || index === statusIndex) continue;
+    targetIndexes.set(cell, index);
+  }
+
+  const features = new Map<
+    string,
+    { readonly status: string | undefined; readonly targetSupport: ReadonlyMap<string, string> }
+  >();
+  const rows: string[] = [];
+  for (const line of tableLines.slice(2)) {
+    const cells = parseMarkdownTableRow(line);
+    if (cells.length !== header.length) return undefined;
+    const featureId = plainCodeCell(cells[featureIndex]);
+    if (featureId === undefined || featureId.length === 0) return undefined;
+    rows.push(featureId);
+    const support = new Map<string, string>();
+    for (const [target, index] of targetIndexes) {
+      const value = plainCodeCell(cells[index]);
+      if (value !== undefined && value.length > 0) support.set(target, value);
+    }
+    features.set(featureId, {
+      status: plainCodeCell(cells[statusIndex]),
+      targetSupport: support,
+    });
+  }
+  return { columns: header, features, rows };
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function firstMismatchIndex(left: readonly string[], right: readonly string[]): number {
+  const sharedLength = Math.min(left.length, right.length);
+  for (let index = 0; index < sharedLength; index += 1) {
+    if (left[index] !== right[index]) return index;
+  }
+  return sharedLength;
+}
+
+function markdownTableRow(cells: readonly string[]): string {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function parseMarkdownTableRow(line: string): readonly string[] {
+  return line.slice(1, -1).split("|").map((cell) => cell.trim());
+}
+
+function codeCell(value: string): string {
+  return `\`${value}\``;
+}
+
+function plainCodeCell(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (value.startsWith("`") && value.endsWith("`") && value.length >= 2) {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 function checkEvidencePresence(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,6 +156,7 @@ export {
 } from "./feature-registry";
 export {
   checkFeatureRegistryDrift,
+  renderFeatureSupportMatrix,
   type FeatureRegistryDriftCode,
   type FeatureRegistryDriftIssue,
   type FeatureRegistryDriftReport,


### PR DESCRIPTION
## Context

SET-317 makes the registry-owned portion of feature documentation mechanically checkable without taking ownership of narrative prose.

## What changed

- render a bounded matrix from the canonical feature registry for every registry-linked feature doc
- check feature status and every canonical target support status with actionable feature/target/field drift diagnostics
- reject missing, malformed, duplicate, reordered, subset, or extra matrix content
- preserve all surrounding prose as human-owned and derive Cursor target-native-islands support directly from the registry
- add a scoped Core Changeset

## Verification

- focused registry tests: 31 passed / 689 expectations
- conformance: determinism 9/9; adapters/provider formats 12/12
- full check: 1348 tests / 54469 expectations; all guards green
- canonical pre-push and submit-time pre-push passed
- standing Terra review: 5/5 clean, zero P0-P3
- fresh targeted Terra review: 5/5 clean, zero P0-P3

## Risk and scope

The generated block owns only feature id, feature status, and canonical target support statuses. Reasons, evidence, paths, runtime/default-target policy, and narrative remain outside the block. No provider output, ledger, audit, global configuration, publication, or bridge worktree state changed.