### PR TITLE
docs: record SET-313 audit disposition

### DIFF
--- a/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
+++ b/.agents/notes/2026-07-18-drift-audit/FINDING-DISPOSITIONS.md
@@ -15,7 +15,7 @@ validate completeness and print the project finding counts.
 | 01.2 | confirmed | fixed | SET-315 | https://github.com/outfitter-dev/skillset/pull/301 | Cursor target-native islands load and align with registry evidence. Merged as `d7468f1145da59bc119f61124b96fe0c504e5a0a`. |
 | 01.3 | confirmed | fixed | SET-316 | https://github.com/outfitter-dev/skillset/pull/300 | Cursor hook-event casing derives from registry-owned evidence. Merged as `a2d421026d6b0853d3a488dd47564476cd9e1700`. |
 | 01.4 | confirmed | fixed | SET-318 | https://github.com/outfitter-dev/skillset/pull/305 | Target roots and project-agent extensions use exhaustive canonical descriptors without an implicit Cursor fallback. Merged as `0ea4c96b72da7bad975988aeafa652716f0ced91`. |
-| 01.5 | confirmed | open | SET-313 | — | Final Cursor default-target and ADR decision; decision evidence required. |
+| 01.5 | confirmed | fixed | SET-313 | https://github.com/outfitter-dev/skillset/pull/323 | Accepted ADR-0002 resolves the draft/default contradiction through schema-owned defaults, explicit narrower classifications, an omitted-target all-provider regression, and a redacted runtime receipt; it was promoted without amending ADR-0001. Merged as `b351e904d14a0af4a39a066d9258f7b1c175bc76`. |
 | 01.6 | confirmed | open | SET-339 | — | Refresh significant Cursor documentation after SET-317 and SET-313. |
 | 01.7 | confirmed | open | SET-339 | — | Refresh moderate Cursor documentation after SET-317 and SET-313. |
 | 01.8 | confirmed | open | SET-339 | — | Refresh minor Cursor documentation after SET-317 and SET-313. |


### PR DESCRIPTION
## Context

SET-313 is verified merged in PR #323, but drift-audit finding 01.5 remained open pending that live merge evidence. This audit-only child reconciles the disposition without widening the product or documentation scope.

## What changed

- moves finding 01.5 from `open` to `fixed` while retaining SET-313 ownership;
- records PR #323 and merge commit `b351e904d14a0af4a39a066d9258f7b1c175bc76`;
- accurately records accepted ADR-0002, schema-owned defaults, explicit narrower classifications, omitted-target all-provider proof, and the redacted runtime receipt;
- preserves the actual decision history: ADR-0002 was promoted without amending ADR-0001.

## Verification

- finding checker: 51 total / 25 open / 22 fixed / 4 wont-fix;
- typecheck, schema check, 82-file generated-output check, determinism 9/22, adapters 12/27: passed;
- `bun run check`: 1,348 tests, 0 failures; 54,471 expectations across 104 files; Ultracite and all guards clean;
- standing and fresh targeted Terra reviews: 5/5, zero P0-P3;
- pre-push passed; submitted diff is exactly one file and one row.

## Scope

No product code, generated output, ADR, SET-339 prose, provider state, stash, or bridge worktree change.
