### PR TITLE
docs: reconcile Cursor coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Skillset
 
-`skillset` compiles portable agent plugin and skill source into target-native Claude and Codex outputs.
+`skillset` compiles portable agent plugin and skill source into target-native Claude, Codex, and Cursor outputs.
 
 It is developed as public source under Outfitter. The npm package now publishes stable releases under `latest`; prerelease channels such as `beta` should be explicit when used.
 
 This repo also self-hosts a small Skillset source tree:
 
-- standalone internal skills for developing the compiler in Claude and Codex;
+- standalone internal skills for developing the compiler across its first-class targets;
 - one generated `skillset` plugin that teaches agents how to use the compiler.
 
 ## Start Here
 
 If you are authoring Skillset source for the first time, start with the
 [Five-Minute Quickstart](docs/quickstart.md). It walks one small source unit
-from scaffold to generated Claude and Codex outputs without touching live
-runtime configuration.
+from scaffold to generated Claude, Codex, and Cursor outputs without touching
+live runtime configuration.
 
 To inspect a complete minimal repo, use the
 [First Author Example](examples/first-author/README.md). It is a Skillset
@@ -27,13 +27,13 @@ watches source/config paths and reruns diagnostics plus generated-output
 previews. It is read-only by default; add `--write` when you want the loop to
 write repo-local generated output with the same ownership, backup, and restore
 safeguards as `skillset build --yes`. Skillset does not automatically install,
-trust, symlink, publish, activate, or mutate user-level Claude/Codex
-configuration.
+trust, symlink, publish, activate, or mutate user-level Claude, Codex, or
+Cursor configuration.
 
 ## Docs
 
 - [Five-Minute Quickstart](docs/quickstart.md): the shortest first-author path from source scaffold to generated output.
-- [First Author Example](examples/first-author/README.md): a minimal source repo that builds one skill and one rule to Claude and Codex.
+- [First Author Example](examples/first-author/README.md): a minimal source repo deliberately narrowed to build one skill and one rule to Claude and Codex.
 - [Share-Ready Checklist](docs/quickstart.md#share-ready-checklist): the 0.16 author handoff bar before hooks or runtime activation enter the path.
 - [Dev Watch](docs/features/dev-watch.md): the default-preview `skillset dev` authoring loop, with explicit `--write` mode.
 - [Skillset Design Tenets](docs/tenets.md): the slow-moving doctrine for source-first loadout authoring and target-native rendering.
@@ -90,10 +90,13 @@ Generated destination defaults:
 - plugin output root: `plugins/`
 - Claude plugin bundle output: `plugins/<plugin-name>/claude/`
 - Codex plugin bundle output: `plugins/<plugin-name>/codex/`
+- Cursor plugin bundle output: `plugins/<plugin-name>/cursor/`
 - Claude standalone skill output: `.claude/skills`
 - Codex standalone skill output: `.agents/skills`
+- Cursor standalone skill output: `.cursor/skills`
 - Claude rule output: `.claude/rules`
 - Codex rule output: `AGENTS.md` files at derived repo directories
+- Cursor rule output: `.cursor/rules/**/*.mdc`
 
 Use explicit paths when building another repo:
 
@@ -104,7 +107,7 @@ skillset check --only outputs --root /path/to/content-repo
 skillset build --root /tmp/example
 ```
 
-Plugin outputs default to plugin-first bundles under `plugins/<plugin-name>/<target>/`. Source config can also set explicit output roots in target output objects such as `claude.plugins.path` or `codex.skills.path`; explicit provider roots remain self-contained target roots.
+Plugin outputs default to plugin-first bundles under `plugins/<plugin-name>/<target>/`. Source config can also set explicit output roots in target output objects such as `claude.plugins.path`, `codex.skills.path`, or `cursor.skills.path`; explicit provider roots remain self-contained target roots.
 
 ## Setup
 
@@ -142,7 +145,7 @@ skillset init --root /path/to/content-repo
 skillset init --root /path/to/content-repo --targets claude --include ci --yes
 ```
 
-`init` is the existing-repo entrypoint. It previews or writes root `skillset.yaml`, the `.skillset/` source scaffold, and operational sentinels. `init` defaults to the Git root when possible, detects repo-local Claude/Codex/Skillset artifacts worth importing, and seeds release-state baselines from current source versions and normalized source hashes without creating a pending change, release, history entry, or changelog projection. That adoption pass is repo-local only; it does not scan or mutate user/global runtime directories.
+`init` is the existing-repo entrypoint. It previews or writes root `skillset.yaml`, the `.skillset/` source scaffold, and operational sentinels. `init` defaults to the Git root when possible, detects repo-local Claude/Codex/Cursor/Skillset artifacts worth importing, and seeds release-state baselines from current source versions and normalized source hashes without creating a pending change, release, history entry, or changelog projection. That adoption pass is repo-local only; it does not scan or mutate user/global runtime directories.
 
 Create a new source repo, defaulting to `my-skillset` under the current directory:
 
@@ -153,7 +156,7 @@ skillset create team-loadout --targets claude,codex --yes
 
 `skillset init [directory]` initializes an existing directory; `skillset create [name]` creates a named child under the current directory or `--root` parent and initializes Git. Both preview before writing and never write live Claude, Codex, Cursor, or `.agents` configuration. The published package ships the `skillset` and `skillset-toolkit` Bun-built bins; stable releases run from the default npm dist-tag with commands such as `npx skillset create my-skillset` or `bunx skillset create my-skillset`. Prerelease builds remain available through their explicit tag, such as `skillset@beta`.
 
-Setup creates source and repo-local operational ignore scaffolds only. In an existing repo, `init` creates root `skillset.yaml`, `.skillset/.gitkeep`, placeholders for the main source families under `.skillset/`, `.skillset/changes/.gitkeep`, `.skillset/.gitignore` that ignores the logical `.skillset/cache/` path, and a snapshots ignore sentinel. For a new destination, it also writes root `skillset.lock`, a root `.gitignore` that ignores `.skillset/cache/` and `.skillset/snapshots/` contents, README, lightweight agent guidance, and initializes Git. `--include ci` adds an optional user-owned GitHub Actions workflow. Generated manifests use `compile.targets`, keep source identity under `skillset`, and keep target adapter config in `claude` and `codex` blocks or root `defaults.<target>.<surface>`.
+Setup creates source and repo-local operational ignore scaffolds only. In an existing repo, `init` creates root `skillset.yaml`, `.skillset/.gitkeep`, placeholders for the main source families under `.skillset/`, `.skillset/changes/.gitkeep`, `.skillset/.gitignore` that ignores the logical `.skillset/cache/` path, and a snapshots ignore sentinel. For a new destination, it also writes root `skillset.lock`, a root `.gitignore` that ignores `.skillset/cache/` and `.skillset/snapshots/` contents, README, lightweight agent guidance, and initializes Git. `--include ci` adds an optional user-owned GitHub Actions workflow. Generated manifests use `compile.targets`, keep source identity under `skillset`, and keep target adapter config in `claude`, `codex`, and `cursor` blocks or root `defaults.<target>.<surface>`.
 
 ## Import
 
@@ -174,10 +177,11 @@ Provider shortcuts import user-global skills from the matching local skill root:
 ```bash
 skillset import claude --root /path/to/content-repo  # ~/.claude/skills
 skillset import codex --root /path/to/content-repo   # ~/.codex/skills
+skillset import cursor --root /path/to/content-repo  # ~/.cursor/skills
 skillset import agents --root /path/to/content-repo  # ~/.agents/skills
 ```
 
-Imports copy files into the active workspace source root, such as `.skillset/skills/<name>` and `.skillset/plugins/<name>`. Passing a `SKILL.md` path imports the full containing skill directory, including sibling `references/`, `scripts/`, `assets/`, `agents/`, and other sidecars. Skills-root imports de-dupe symlinked directories by real path, so the same global skill is not imported twice when `.claude/skills`, `.codex/skills`, and `.agents/skills` point at one another. Plugin imports write plugin-local `skillset.yaml`; when importing a native Claude/Codex generated plugin that only has `.claude-plugin/plugin.json` or `.codex-plugin/plugin.json`, Skillset synthesizes a minimal source `skillset.yaml` from the native manifest while preserving the native manifest files as imported context. Import does not install, trust, symlink, publish, mutate registries, or change user-level Claude/Codex config.
+Imports copy files into the active workspace source root, such as `.skillset/skills/<name>` and `.skillset/plugins/<name>`. Passing a `SKILL.md` path imports the full containing skill directory, including sibling `references/`, `scripts/`, `assets/`, `agents/`, and other sidecars. Skills-root imports de-dupe symlinked directories by real path, so the same global skill is not imported twice when `.claude/skills`, `.codex/skills`, `.cursor/skills`, and `.agents/skills` point at one another. Plugin imports write plugin-local `skillset.yaml`; when importing a native Claude, Codex, or Cursor generated plugin that only has `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, or `.cursor-plugin/plugin.json`, Skillset synthesizes a minimal source `skillset.yaml` from the native manifest while preserving the native manifest files as imported context. Import does not install, trust, symlink, publish, mutate registries, or change user-level Claude, Codex, or Cursor config.
 
 Import is a safe bridge, not a lossy copier. It returns a report — printed by the CLI — summarizing the copied files, recognized and target-native fields, warnings, and the next checks to run (`skillset check`, `skillset build`, `skillset check --only outputs`). Target-native and unknown frontmatter is preserved rather than dropped, so nothing is silently lost. Import never overwrites existing source.
 
@@ -187,11 +191,11 @@ Import shares the same version-baseline adoption machinery as `init` when the de
 
 Repos keep workspace source metadata, build configuration, and destination configuration in root `skillset.yaml`, with authored source under `.skillset/`.
 
-Each plugin lives at `<source-root>/plugins/<plugin-name>/` and has its own `skillset.yaml`. Portable plugin fields live under `skillset`; target-specific overrides live under top-level `claude` and `codex` blocks. Skill source frontmatter can use top-level `name`, `title`, `summary`, `description`, `version`, `resources`, `implicit_invocation`, `allowed_tools`, and the source-only `tools` policy; the compiler derives target-native generated metadata, Claude frontmatter, Codex `agents/openai.yaml` policy where supported, and skill-local copies of declared resources.
+Each plugin lives at `<source-root>/plugins/<plugin-name>/` and has its own `skillset.yaml`. Portable plugin fields live under `skillset`; target-specific overrides live under top-level `claude`, `codex`, and `cursor` blocks. Skill source frontmatter can use top-level `name`, `title`, `summary`, `description`, `version`, `resources`, `implicit_invocation`, `allowed_tools`, and the source-only `tools` policy; the compiler derives target-native generated metadata, Claude frontmatter, Codex `agents/openai.yaml` policy where supported, Cursor-native skill/rule/agent output where supported, and skill-local copies of declared resources.
 
 Use root/plugin `skillset.name` only when explicit identity is needed; directory names are the default. Skill identity uses top-level `name`. `skillset.id`, skill-local `skillset.name`, and skill-local `skillset.version` are unsupported. Use root `compile.targets` for provider selection, and do not use bare top-level `targets:`. `compile.build` defaults to `updated` and accepts `all`; CLI `--updated` and `--all` override config for the current command and the resolved mode is recorded in lock metadata. `compile.skillset.metadata: false` suppresses Skillset's generated skill frontmatter metadata. `compile.features.promptArguments` defaults to `true`; set it to `false` to reject Skillset-owned `{{$ARGUMENTS...}}` placeholders. `compile.unsupportedDestination` currently defaults to `error`; softer modes are reserved until warning, skip, or force provenance is implemented.
 
-Target adapter configuration stays in `claude` and `codex` blocks. Root `defaults.<target>.<surface>` is shorthand for target defaults, and `claude.defaults.<surface>` / `codex.defaults.<surface>` is the canonical target-local form:
+Target adapter configuration stays in `claude`, `codex`, and `cursor` blocks. Root `defaults.<target>.<surface>` is shorthand for target defaults, and `<target>.defaults.<surface>` is the canonical target-local form:
 
 ```yaml
 defaults:
@@ -205,11 +209,18 @@ claude:
   defaults:
     skills:
       model: sonnet
+
+cursor:
+  projectRoot: .cursor
+  userRoot: ~/.cursor
+  defaults:
+    skills:
+      model: cursor-fast
 ```
 
-Defaults fill omitted target options for the named surface (`agents`, `instructions`, `plugins`, or `skills`). Exact file-level `claude` / `codex` fields win over plugin defaults, plugin defaults win over root defaults, and target-specific fields win over shared portable fields at render time. A top-level skill or project-agent `model` is source-only and warns in v1 unless every enabled target has a target-specific model from defaults or an override; use `claude.model`, `codex.model`, or target defaults instead.
+Defaults fill omitted target options for the named surface (`agents`, `instructions`, `plugins`, or `skills`). Exact file-level `claude` / `codex` / `cursor` fields win over plugin defaults, plugin defaults win over root defaults, and target-specific fields win over shared portable fields at render time. A top-level skill or project-agent `model` is source-only and warns in v1 unless every enabled target has a target-specific model from defaults or an override; use `claude.model`, `codex.model`, `cursor.model`, or target defaults instead.
 
-Generated output strips source-only keys such as `skillset`, `claude`, `codex`, `agents`, `resources`, `implicit_invocation`, `allowed_tools`, `tools`, `model`, `defaults`, and `targets`. Generated skills receive only lightweight metadata unless `compile.skillset.metadata: false` suppresses it:
+Generated output strips source-only keys such as `skillset`, `claude`, `codex`, `cursor`, `agents`, `resources`, `implicit_invocation`, `allowed_tools`, `tools`, `model`, `defaults`, and `targets`. Generated skills receive only lightweight metadata unless `compile.skillset.metadata: false` suppresses it:
 
 ```yaml
 metadata:
@@ -237,7 +248,7 @@ resources:
 
 `shared:` points at `<source-root>/shared/`. `plugin:` points at `<source-root>/plugins/<plugin-name>/shared/` and is valid only for plugin-bound skills. Grouped resources default to skill-local target paths such as `references/common.md`, `scripts/check.sh`, `assets/...`, or `templates/...`; use `from` / `to` when the output path should differ.
 
-Generated Claude and Codex skills receive the copied files beside `SKILL.md`, so links and script references stay skill-root-relative. Markdown links that use declared `shared:` or `plugin:` resource URLs are rewritten to the generated skill-local path; undeclared shared resource links fail the build with a suggested `resources` entry. When a resource uses a custom `to`, a bare (schemeless) link to the resource's source path is ambiguous and fails the build with a diagnostic: link to the emitted target path or use the `shared:`/`plugin:` resource URL instead. Resource mappings cannot write outside the generated skill directory or overwrite `SKILL.md`, generated Codex sidecars, or skill-local files. Resource contents participate in `skillset.lock` hashes and `skillset check --only outputs`.
+Generated Claude, Codex, and Cursor skills receive declared copied files beside `SKILL.md`, so links and script references stay skill-root-relative. Markdown links that use declared `shared:` or `plugin:` resource URLs are rewritten to the generated skill-local path; undeclared shared resource links fail the build with a suggested `resources` entry. When a resource uses a custom `to`, a bare (schemeless) link to the resource's source path is ambiguous and fails the build with a diagnostic: link to the emitted target path or use the `shared:`/`plugin:` resource URL instead. Resource mappings cannot write outside the generated skill directory or overwrite `SKILL.md`, generated Codex sidecars, or skill-local files. Resource contents participate in `skillset.lock` hashes and `skillset check --only outputs`.
 
 `skillset check` adds earlier, actionable diagnostics: undeclared resource links (with a suggested entry), skill bodies that depend on plugin-root script paths instead of skill-local copies, and declared `scripts/` resources whose source file is missing an executable bit.
 
@@ -282,13 +293,13 @@ tools:
       - mcp__linear__experimental.*
 ```
 
-`tools: readonly` expands to `read: true`, `search: true`, and `write: false`. Portable keys are `read`, `search`, `write`, `shell`, and `mcp`. Unknown keys fail lint/build. `read`, `search`, and `write` are boolean-only; `shell` accepts booleans or a flat list of shell patterns; `mcp` accepts `false` or literal server names mapped to booleans or tool glob lists. Top-level `tools.allow` / `tools.deny` and target-local `claude.tools` / `codex.tools` are rejected; use `tools.<provider>.allow` / `deny`.
+`tools: readonly` expands to `read: true`, `search: true`, and `write: false`. Portable keys are `read`, `search`, `write`, `shell`, and `mcp`. Unknown keys fail lint/build. `read`, `search`, and `write` are boolean-only; `shell` accepts booleans or a flat list of shell patterns; `mcp` accepts `false` or literal server names mapped to booleans or tool glob lists. Top-level `tools.allow` / `tools.deny` and target-local `claude.tools` / `codex.tools` / `cursor.tools` are rejected; use `tools.<provider>.allow` / `deny`.
 
-`tools` is policy and metadata, not a portable security boundary on every provider. Claude renders portable entries and `tools.claude` strings to `allowed-tools` and `disallowed-tools`, which are **preapproval / no-prompt** and denial rules, not a complete sandbox. Codex has no proven skill-local enforcement surface, so Codex preserves portable policy and `tools.codex` strings in generated `.skillset.tools.yaml` metadata without mutating user-level Codex policy or trust.
+`tools` is policy and metadata, not a portable security boundary on every provider. Claude renders portable entries and `tools.claude` strings to `allowed-tools` and `disallowed-tools`, which are **preapproval / no-prompt** and denial rules, not a complete sandbox. Codex and Cursor have no proven skill-local enforcement surface, so each preserves portable policy and its `tools.<provider>` strings in generated `.skillset.tools.yaml` metadata without mutating user-level policy or trust.
 
 ## Instructions
 
-Use `.skillset/rules/**/*.md` for repo instructions that should become Claude rules and Codex `AGENTS.md` files.
+Use `.skillset/rules/**/*.md` for repo instructions that should become Claude rules, Codex `AGENTS.md` files, and Cursor `.mdc` rules.
 
 ```yaml
 ---
@@ -301,7 +312,7 @@ paths:
 - Keep docs concise and current.
 ```
 
-The compiler preserves the source hierarchy when writing Claude rules, so `<source-root>/rules/docs/writing.md` becomes `.claude/rules/docs/writing.md`. `paths` frontmatter is kept for Claude and stripped from Codex output.
+The compiler preserves the source hierarchy when writing Claude rules, so `<source-root>/rules/docs/writing.md` becomes `.claude/rules/docs/writing.md`; Cursor renders the matching hierarchy as `.cursor/rules/docs/writing.mdc`. `paths` frontmatter is kept for Claude, translated into Cursor rule frontmatter, and stripped from Codex output.
 
 For Codex, `skillset` derives the nearest useful `AGENTS.md` destination from each path pattern. `docs/**/*.md` writes `docs/AGENTS.md`; `**/*.ts` scans matching repo files and writes to the lowest common directory, such as `src/AGENTS.md` when matching TypeScript files live under `src/`. Multiple source rules that land at the same destination are concatenated deterministically, each preceded by a `<!-- source: ... -->` boundary comment naming its source. Codex truncates `AGENTS.md` beyond `project_doc_max_bytes` (32 KiB default); `skillset build` and `skillset check --only outputs` warn when a generated `AGENTS.md` exceeds it so you can split instructions across nested directories or raise the limit.
 
@@ -324,7 +335,7 @@ Partials use `{{shared:path.md}}`, `{{plugin:path.md}}`, or a file path relative
 
 Set `skillset.preprocess: false` in source frontmatter when a Markdown body should keep literal braces. The control is source-only and is stripped from generated output.
 
-Skillset-owned variables use `{{skillset.lower_snake_case}}` to match the source YAML naming style. Prompt argument placeholders use `{{$ARGUMENTS}}`, `{{$ARGUMENTS[0]}}`, `{{$ARGUMENTS[1]}}`, and `{{$ARGUMENTS.name}}` when a command needs user-supplied arguments. Claude output receives native `$ARGUMENTS...` placeholders. Codex output keeps the `{{$ARGUMENTS...}}` markers and adds one short instruction to replace them before using commands. Disable this feature with `compile.features.promptArguments: false`. Target-native raw variables such as Claude `$ARGUMENTS` and `${CLAUDE_*}` remain target-specific and are not rendered by the preprocessing layer.
+Skillset-owned variables use `{{skillset.lower_snake_case}}` to match the source YAML naming style. Prompt argument placeholders use `{{$ARGUMENTS}}`, `{{$ARGUMENTS[0]}}`, `{{$ARGUMENTS[1]}}`, and `{{$ARGUMENTS.name}}` when a command needs user-supplied arguments. Claude output receives native `$ARGUMENTS...` placeholders. Codex output keeps the `{{$ARGUMENTS...}}` markers and adds one short instruction to replace them before using commands; Cursor output preserves the markers without that Codex notice. Disable this feature with `compile.features.promptArguments: false`. Target-native raw variables such as Claude `$ARGUMENTS` and `${CLAUDE_*}` remain target-specific and are not rendered by the preprocessing layer.
 
 Rule target toggles use the same top-level target keys:
 
@@ -343,13 +354,13 @@ Generated Codex `AGENTS.md` files are tracked by the root `skillset.lock`. If a 
 
 ## Target-Specific Plugin Surfaces
 
-Portable project agents live under `<source-root>/agents/*.md`. They render to Claude `.claude/agents/<resolved-name>.md` and Codex `.codex/agents/<resolved-name>.toml`, require `description` plus a body, support shared `skills` and `initialPrompt`, and keep target-native fields under `claude` and `codex` blocks. Codex `skills` become a deterministic `developer_instructions` preface; configure it with `codex.defaults.agents.skillsPrefaceTemplate` or `defaults.codex.agents.skillsPrefaceTemplate`. Project-agent outputs are tracked in the root `skillset.lock` and are visible through `skillset list` / `skillset explain`.
+Portable project agents live under `<source-root>/agents/*.md`. They render to Claude `.claude/agents/<resolved-name>.md`, Codex `.codex/agents/<resolved-name>.toml`, and Cursor `.cursor/agents/<resolved-name>.md`; they require `description` plus a body, support shared `skills` and `initialPrompt`, and keep target-native fields under `claude`, `codex`, and `cursor` blocks. Codex `skills` become a deterministic `developer_instructions` preface; configure it with `codex.defaults.agents.skillsPrefaceTemplate` or `defaults.codex.agents.skillsPrefaceTemplate`. Cursor-specific agent fields remain provider-native. Project-agent outputs are tracked in the root `skillset.lock` and are visible through `skillset list` / `skillset explain`.
 
-Plugin companion directories are target-native. Claude receives `commands/`, `agents/`, `hooks/hooks.json`, `.mcp.json`, `.lsp.json`, `output-styles/`, `themes/`, `monitors/`, `assets/`, `scripts/`, and `src/` when those source paths exist; the generated manifest declares each with its documented field (`lspServers`, `outputStyles`, `experimental.themes`, `experimental.monitors`). Codex receives `hooks/hooks.json`, `.mcp.json`, `.app.json`, `assets/`, `scripts/`, and `src/`; Claude plugin `agents/` is not copied into Codex plugin output, and a Codex-enabled plugin with `agents/` fails loudly because Codex plugins do not document that component. Feature keys can own repo source pointers directly: `mcp.source: repo:path/to/mcp.json` copies a repo-owned MCP file to `.mcp.json` for enabled plugin targets, and `bin.source: repo:path/to/bin` copies a repo-owned directory to Claude plugin `bin/`. `mcp: false` or `bin: false` disables conventional discovery, while absent keys auto-discover conventional `.mcp.json` and Claude `bin/` paths. Codex plugin `bin` output is unsupported and fails loudly when enabled. Pass-through paths are copied as opaque content unless a feature owns validation. Plugin-root `settings.json` is target-native but future-only for reviewed settings suggestion workflows. Build still does not install, trust, enable, or mutate user-level Claude/Codex config.
+Plugin companion directories are target-native. Claude receives `commands/`, `agents/`, `hooks/hooks.json`, `.mcp.json`, `.lsp.json`, `output-styles/`, `themes/`, `monitors/`, `assets/`, `scripts/`, and `src/` when those source paths exist; the generated manifest declares each with its documented field (`lspServers`, `outputStyles`, `experimental.themes`, `experimental.monitors`). Codex receives `hooks/hooks.json`, `.mcp.json`, `.app.json`, `assets/`, `scripts/`, and `src/`; Claude plugin `agents/` is not copied into Codex plugin output, and a Codex-enabled plugin with `agents/` fails loudly because Codex plugins do not document that component. Cursor supports only `commands/`, `agents/`, `hooks/hooks.json`, `mcp.json`, `rules/`, and `skills/`; it does not claim Claude/Codex asset or script companion support. Feature keys can own repo source pointers directly: `mcp.source: repo:path/to/mcp.json` copies a repo-owned MCP file to `.mcp.json` for Claude and Codex and to `mcp.json` for Cursor, and `bin.source: repo:path/to/bin` copies a repo-owned directory to Claude plugin `bin/`. `mcp: false` or `bin: false` disables conventional discovery, while absent keys auto-discover conventional `.mcp.json` and Claude `bin/` paths. Codex plugin `bin` output is unsupported and fails loudly when enabled. Pass-through paths are copied as opaque content unless a feature owns validation. Plugin-root `settings.json` is target-native but future-only for reviewed settings suggestion workflows. Build still does not install, trust, enable, or mutate user-level Claude, Codex, or Cursor config.
 
-Hook files are emitted as definitions only. `skillset` does not install, trust, or enable hooks in user-level Claude/Codex config. Both targets emit hooks at the documented default `hooks/hooks.json` with a top-level `{ "hooks": { ... } }` object, sourced from `hooks/hooks.json`. Plugin-root `hooks.json` is unsupported. The compiler does not auto-render Claude hooks into Codex hooks.
+Hook files are emitted as definitions only. `skillset` does not install, trust, or enable hooks in user-level Claude, Codex, or Cursor config. All three targets emit hooks at the documented default `hooks/hooks.json` with a top-level `{ "hooks": { ... } }` object, sourced from `hooks/hooks.json`. Plugin-root `hooks.json` is unsupported. The compiler does not auto-render one provider's hooks into another provider's hooks.
 
-Hook definitions are checked for target compatibility. Codex hook files must use Codex-supported events — `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `SubagentStart`, `SubagentStop`, `UserPromptSubmit`, `Stop` — and synchronous `command` handlers only, because Codex parses but skips prompt handlers, agent handlers, and `async: true` command handlers. Unsupported Codex events or skipped handler forms fail both `skillset build` and `skillset check`. Claude hook validation stays broad (JSON-object shape) because Claude's hook surface is wider and still evolving.
+Hook definitions are checked for target compatibility. Codex hook files must use Codex-supported events — `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `SubagentStart`, `SubagentStop`, `UserPromptSubmit`, `Stop` — and synchronous `command` handlers only, because Codex parses but skips prompt handlers, agent handlers, and `async: true` command handlers. Cursor hook files must use Cursor-supported events and `command` handlers with only `type`, `command`, and `timeout`; Cursor rejects `async`. Unsupported events or handler forms fail both `skillset build` and `skillset check`. Claude hook validation stays broad (JSON-object shape) because Claude's hook surface is wider and still evolving.
 
 ## Self-Hosted Outputs
 
@@ -366,8 +377,12 @@ Self-hosted source lives under root `skillset.yaml`, `.skillset/`, and `.skillse
 
 - `.claude/skills/skillset-claude-development`
 - `.agents/skills/skillset-codex-development`
+- `.cursor/skills/skillset-claude-development` and `.cursor/skills/skillset-codex-development`
 - `.claude/rules` when source rules exist
+- `.cursor/rules` when source rules exist
 - `plugins/skillset/claude`
 - `plugins/skillset/codex`
+- `plugins/skillset/cursor`
+- `.cursor-plugin/marketplace.json`
 
-These are repo-local generated artifacts. Do not symlink them into global Claude/Codex config or publish them as part of normal compiler development.
+These are repo-local generated artifacts. Do not symlink them into global Claude, Codex, or Cursor config or publish them as part of normal compiler development.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ This directory holds durable documentation for the local Skillset compiler.
 
 - [Tenets](tenets.md): the slow-moving doctrine for how Skillset makes source-first provider loadouts easier to author and safer to render.
 - [Architecture Decision Records](adrs/README.md): accepted decisions for source vocabulary, target rendering, compiler promises, and authoring workflows. Draft decisions live under [adrs/drafts](adrs/drafts/README.md).
-- [Five-Minute Quickstart](quickstart.md): a short first-author path from `init` to one built Claude and Codex skill.
+- [Five-Minute Quickstart](quickstart.md): a short first-author path from `init` to one built Claude, Codex, and Cursor skill.
 - [Share-Ready Checklist](quickstart.md#share-ready-checklist): the 0.16 author handoff bar before hooks or runtime activation enter the path.
-- [First Author Example](../examples/first-author/README.md): a cloneable source repo with one skill and one rule that builds to Claude and Codex.
+- [First Author Example](../examples/first-author/README.md): a cloneable source repo deliberately narrowed to build one skill and one rule to Claude and Codex.
 - [Feature Reference](features/README.md): the support registry layer for source features, target adapters, future-only surfaces, and feature-specific provenance.
 - [Layout](layout.md): the current source layout, generated output shape, shared-resource behavior, rules/instructions rendering, hooks, skill policy, and import flow.
 - [Schema Contracts](schema-contracts.md): the schema-first workflow, generated artifacts, and checklist for adding source/config/frontmatter fields without drift.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -7,12 +7,12 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 ## Initial Pages
 
 - [Activation Probes](tests-and-evals.md#activation-probes): target-aware manual harness prompts generated inside `skillset test` runs.
-- [Agents](agents.md): portable project agents, Claude plugin agents, Codex project agents, and skill-local Codex policy boundaries.
+- [Agents](agents.md): portable project agents, Claude and Cursor plugin agents, Codex project agents, and skill-local policy boundaries.
 - [Apps](apps.md): Codex plugin `.app.json` pass-through and why there is no v1 `apps.source` feature key.
 - [Build Scopes](build-scopes.md): build mode, destination scopes, preview safety, diff/list/explain behavior, and lock semantics.
 - [Changes](changes.md): pending change entries, source coverage, compact refs, groups, and append-only history boundaries.
 - [CI](ci.md): the `skillset check --ci` aggregate check, mechanical drift rebuilds, PR-comment reports, and the `--include ci` workflow scaffold.
-- [Commands](commands.md): Claude plugin command pass-through, manifest wiring, and Codex unsupported boundaries.
+- [Commands](commands.md): Claude and Cursor plugin command pass-through, provider-native wiring, and Codex unsupported boundaries.
 - [Dependencies](dependencies.md): plugin dependency declarations, Claude rendering, Codex fallback notices, and provenance.
 - [Dev Watch](dev-watch.md): default-preview `skillset dev` for first-author source diagnostics, generated-output drift, and explicit write mode.
 - [Distributions](distributions.md): post-build distribution planning, destination reports, and build/distribution/activation boundaries.
@@ -21,7 +21,7 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 - [Feature Registry](feature-registry.md): typed support matrix for feature ids, target capability claims, docs, evidence, render owners, and validation owners.
 - [Hook Guardrails](hook-guardrails.md): Git hook-runner snippets and optional agent-runtime nudges for change/release checks.
 - [Hooks](hooks.md): native aggregate hook emission, adaptive hook units, target validation, and activation boundaries.
-- [Instructions](instructions.md): source-root `rules/` rendering to Claude rules and Codex `AGENTS.md`, preprocessing, and collision safety.
+- [Instructions](instructions.md): source-root `rules/` rendering to Claude rules, Codex `AGENTS.md`, and Cursor `.mdc` rules, with preprocessing and collision safety.
 - [LSP Servers](lsp-servers.md): Claude plugin `.lsp.json` pass-through, manifest wiring, and future validation boundaries.
 - [Marketplaces](marketplaces.md): curated provider catalogs, external plugin references, readiness states, and check/update boundaries.
 - [MCP Servers](mcp-servers.md): plugin `.mcp.json`, `mcp.source`, manifest wiring, and structured validation.
@@ -35,7 +35,7 @@ Use these pages alongside the [target surface evidence matrix](../target-surface
 - [Runtime Adapters](runtime-adapters.md): runtime, distribution, and harness support records that stay separate from `compile.targets`.
 - [Settings](settings.md): future reviewed settings suggestion workflow and why build does not mutate runtime config.
 - [Skills](skills.md): standalone and plugin-bound skill frontmatter, target rendering, versions, metadata, and generated sidecars.
-- [Source Suggestions](source-suggestions.md): future managed-output edit recovery through source-side suggestions, distinct from settings suggestions.
+- [Source Suggestions](source-suggestions.md): implemented local managed-output reconciliation with source-side recovery suggestions, distinct from settings suggestions; CI writeback remains future work.
 - [Supports](supports.md): compatibility metadata, support ranges, source significance, and release severity boundaries.
 - [Provider Source](target-native-islands.md): explicit provider-native source islands, Codex `.rules` pass-through, and leakage rules.
 - [Tests and Evals](tests-and-evals.md): internal fixtures, dogfooding, deterministic `skillset test`, future adapter-aware evals, and generated run output boundaries.
@@ -102,8 +102,8 @@ Future schema generation can turn these fields into richer generated docs, but t
 
 These are tracked as future/reserved unless a later issue promotes them:
 
-- [Reviewed settings suggestion workflow](../adrs/drafts/20260604-reviewed-settings-suggestions.md): Skillset may eventually propose or review target settings changes, but `skillset build` must not mutate user-level Claude or Codex config.
-- [Source Suggestions](source-suggestions.md): managed generated-output edit recovery remains future-only until SET-151 and SET-152 implement local suggestions and CI writeback.
+- [Reviewed settings suggestion workflow](../adrs/drafts/20260604-reviewed-settings-suggestions.md): Skillset may eventually propose or review target settings changes, but `skillset build` must not mutate user-level Claude, Codex, or Cursor config.
+- [Source Suggestions](source-suggestions.md): local managed generated-output reconciliation is implemented; automated CI writeback remains future-only under SET-152.
 - [Model and reasoning alias profiles](../adrs/drafts/20260604-model-and-reasoning-alias-profiles.md): shared aliases such as `review`, `fast`, or `deep` remain deferred; use target-native model and effort fields where supported.
 - [First-class sets](../adrs/drafts/20260604-first-class-sets.md): grouped marketplaces, bundles, and curated collections remain future vocabulary; v1 keeps build scopes and entity selectors separate.
 - [Tests and evals](tests-and-evals.md): adapter-aware eval support and expanded test selectors remain planned/future; deterministic `skillset test` has a first isolated rendering slice.

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -11,7 +11,7 @@ Feature id: `agents`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)
 
-Project agents are a portable source surface for reusable, project-scoped specialized roles. Plugin agents remain target-native because Claude documents plugin `agents/` and Codex plugins do not document an equivalent plugin component.
+Project agents are a portable source surface for reusable, project-scoped specialized roles. Plugin agents remain target-native because Claude and Cursor document plugin `agents/` while Codex plugins do not document an equivalent plugin component.
 
 ## Authoring
 
@@ -34,6 +34,8 @@ codex:
   model: gpt-5-codex
 claude:
   model: sonnet
+cursor:
+  model: cursor-fast
 ---
 
 Review diffs and call out correctness risks.
@@ -44,21 +46,22 @@ Review diffs and call out correctness risks.
 ```text
 .claude/agents/<resolved-name>.md
 .codex/agents/<resolved-name>.toml
+.cursor/agents/<resolved-name>.md
 ```
 
-The active frontmatter contract is generated from `@skillset/schema`; see [schema reference](../reference/schemas/README.md) and [agent frontmatter examples](../reference/examples/agent-frontmatter.yaml) for the current shared fields, common metadata blocks, `supports`, and provider override blocks. Provider-specific fields remain explicit inside `claude` and `codex` blocks rather than being inferred from portable keys.
+The active frontmatter contract is generated from `@skillset/schema`; see [schema reference](../reference/schemas/README.md) and [agent frontmatter examples](../reference/examples/agent-frontmatter.yaml) for the current shared fields, common metadata blocks, `supports`, and provider override blocks. Provider-specific fields remain explicit inside `claude`, `codex`, and `cursor` blocks rather than being inferred from portable keys.
 
 Skillset must keep this separate from plugin `agents/` and skill-local Codex `agents/openai.yaml`. Reusing either surface would hide target differences and make project behavior look portable by accident.
 
 ## Support Table
 
-| Source or surface | Claude | Codex | Status | Notes |
-| --- | --- | --- | --- | --- |
-| `<source-root>/agents/*.md` | `.claude/agents/*.md` | `.codex/agents/*.toml` | `portable` / `implemented` | Target-specific validation runs after rendering. |
-| `<source-root>/plugins/<plugin>/agents/**/*.md` | plugin `agents/` | none | `target_native` / `implemented` for Claude, `unsupported` for Codex | Claude plugin agents stay plugin-scoped and must not be copied into Codex plugins. |
-| skill-local `implicit_invocation` | Claude skill frontmatter | Codex `agents/openai.yaml` policy | `portable` / `implemented` | This is skill policy, not a project or plugin custom agent. |
-| skill-local `tools` | Claude allowed/disallowed tool metadata | Codex `.skillset.tools.yaml` metadata | `metadata_only` for Codex | Records portable policy without mutating user-level config. |
-| `~/.claude/agents` or `~/.codex/agents` writes | user agents | user agents | `future` | User/global writes require explicit setup/review flows and are not a side effect of build. |
+| Source or surface | Claude | Codex | Cursor | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `<source-root>/agents/*.md` | `.claude/agents/*.md` | `.codex/agents/*.toml` | `.cursor/agents/*.md` | `portable` / `implemented` | Target-specific validation runs after rendering. |
+| `<source-root>/plugins/<plugin>/agents/**/*.md` | plugin `agents/` | none | plugin `agents/` | `target_native` / `implemented` for Claude and Cursor; `unsupported` for Codex | Plugin agents stay plugin-scoped and must not be copied into Codex plugins. |
+| skill-local `implicit_invocation` | Claude skill frontmatter | Codex `agents/openai.yaml` policy | n/a | `portable` / `implemented` | This is skill policy, not a project or plugin custom agent. |
+| skill-local `tools` | Claude allowed/disallowed tool metadata | Codex `.skillset.tools.yaml` metadata | Cursor `.skillset.tools.yaml` metadata | `metadata_only` for Codex and Cursor | Records portable policy without mutating user-level config. |
+| user agent writes | `~/.claude/agents` | `~/.codex/agents` | `~/.cursor/agents` | `future` | User/global writes require explicit setup/review flows and are not a side effect of build. |
 
 ## Target Rendering
 
@@ -66,9 +69,11 @@ Claude project agents are Markdown files with YAML frontmatter under `.claude/ag
 
 Codex project agents are standalone TOML files under `.codex/agents/` with `name`, `description`, and `developer_instructions`. Shared `skills` render to a deterministic preface in `developer_instructions`; configure the preface with `codex.defaults.agents.skillsPrefaceTemplate` or root shorthand `defaults.codex.agents.skillsPrefaceTemplate`. Shared `initialPrompt` is appended inside an `<initial_prompt>...</initial_prompt>` block, and source containing `</initial_prompt>` is rejected so generated instructions cannot break the wrapper. Target-specific `codex.*` fields keep exact TOML names, including `developer_instructions` overrides.
 
+Cursor project agents are Markdown files with Cursor frontmatter under `.cursor/agents/`. Shared `name`, `description`, `skills`, `initialPrompt`, target-specific `cursor.*` fields, and the Markdown body render into that file; Cursor-specific fields remain explicit rather than being inferred from portable keys.
+
 The Codex skills preface is a runtime compatibility shim. It is useful and intentional, but it is not the same as Claude's target-enforced agent `skills` metadata. Runtime support records should describe this as `shimmed`, with the mechanism and caveat visible to status, explain, activation tests, and distribution reports.
 
-Claude plugin agents are a separate plugin component. Codex plugin docs do not document plugin agents, so copying Claude plugin agents into Codex output would be fake portability. A Codex-enabled plugin with `agents/` fails loudly; set `codex: false` for that plugin or move project-scoped roles to `<source-root>/agents/`.
+Claude and Cursor plugin agents are separate plugin components. Codex plugin docs do not document plugin agents, so copying them into Codex output would be fake portability. A Codex-enabled plugin with `agents/` fails loudly; set `codex: false` for that plugin or move project-scoped roles to `<source-root>/agents/`.
 
 ## Orchestration Compatibility
 
@@ -78,14 +83,14 @@ Project-agent skill loading is the current orchestration boundary:
 - Cursor receives native project-agent Markdown with the shared `skills` field.
 - Codex receives a deterministic developer-instruction preface that asks the agent to load the named skills first.
 
-The Codex behavior is intentionally classified as `shimmed`, not native, because it depends on instruction following rather than target-enforced metadata. `skillset test` activation probes can cover both sides of that boundary by selecting the helper skill and project agent together, asserting the generated Claude/Codex files, and retaining manual probe assets that label Codex as `manual-shimmed`.
+The Codex behavior is intentionally classified as `shimmed`, not native, because it depends on instruction following rather than target-enforced metadata. `skillset test` activation probes can cover both sides of that boundary by selecting the helper skill and project agent together, asserting generated Claude, Codex, and Cursor files, and retaining manual probe assets that label Codex as `manual-shimmed`.
 
 ## Diagnostics
 
 - Duplicate or invalid resolved agent names fail before writing target files.
 - Missing `description`, empty bodies, invalid `skills`, and unsafe `initialPrompt` values fail before writing target files.
-- Top-level `model` warns unless every enabled target has a target-specific model from `claude.model`, `codex.model`, or target defaults.
-- A Codex-enabled plugin with Claude plugin agents fails instead of silently dropping or promoting them.
+- Top-level `model` warns unless every enabled target has a target-specific model from `claude.model`, `codex.model`, `cursor.model`, or target defaults.
+- A Codex-enabled plugin with Claude or Cursor plugin agents fails instead of silently dropping or promoting them.
 - User/global agent destinations should require explicit future setup workflow, not normal build.
 
 ## Provenance
@@ -94,4 +99,4 @@ Project-agent outputs record source path, resolved name, target output path, gen
 
 ## Tests and Fixtures
 
-Fixtures cover `<source-root>/agents/*.md` rendering to both `.claude/agents/*.md` and `.codex/agents/*.toml`, explicit names that differ from filenames, initial prompts, skills prefaces, metadata suppression, target overrides, collisions, unsafe closing tags, and Codex plugin-agent unsupported diagnostics.
+Fixtures cover `<source-root>/agents/*.md` rendering to `.claude/agents/*.md`, `.codex/agents/*.toml`, and `.cursor/agents/*.md`, explicit names that differ from filenames, initial prompts, skills prefaces, metadata suppression, target overrides, collisions, unsafe closing tags, and Codex plugin-agent unsupported diagnostics.

--- a/docs/features/ci.md
+++ b/docs/features/ci.md
@@ -32,7 +32,7 @@ Generated entity `CHANGELOG.md` files are managed projections. When one has been
 
 For added or changed generated paths, CI runs the same read-only ownership and safety classification used by `skillset reconcile`. Reports include the generated path, owning source path when known, whether output-wins is available or refused, and the next manual command. CI never chooses a conflict direction automatically.
 
-[Source Suggestions](source-suggestions.md) is the future recovery path for managed generated-output edits that should become source changes. CI writeback remains future-only until the local suggestion command can classify clean source patches, refusal cases, and stale lock/conflict risks.
+[Source Suggestions](source-suggestions.md) provides the implemented local recovery path for managed generated-output edits that should become source changes. CI writeback remains future-only and must retain the local reconciliation command's clean-patch, refusal, stale-lock, and conflict safeguards.
 
 `skillset init --include ci` scaffolds `.github/workflows/skillset-ci.yml`. The workflow is user-owned after creation: rerunning `init --include ci` reports an edited workflow as existing and never overwrites it. The scaffolded workflow:
 

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -11,23 +11,23 @@ Feature id: `commands`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)
 
-Claude plugins can include slash-command definitions under `commands/`. Skillset treats commands as target-native Claude plugin pass-through, not as portable command source and not as a Codex plugin feature.
+Claude and Cursor plugins can include command definitions under `commands/`. Skillset treats commands as target-native provider pass-through, not as portable command source; Codex has no corresponding plugin component.
 
 ## Authoring
 
-Place Claude command files under `<source-root>/plugins/<plugin>/commands/`. `<source-root>` is `.skillset/`. The directory is copied only when Claude plugin output for that plugin is active.
+Place command files under `<source-root>/plugins/<plugin>/commands/`. `<source-root>` is `.skillset/`. The directory is copied only when the matching Claude or Cursor plugin output for that plugin is active.
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| `<source-root>/plugins/<plugin>/commands/` | plugin root `commands/` plus manifest `commands: "./commands"` | n/a | `target_native` / `implemented` | Opaque pass-through; command semantics remain Claude-native. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `<source-root>/plugins/<plugin>/commands/` | plugin root `commands/` plus manifest `commands: "./commands"` | n/a | plugin root `commands/` | `target_native` / `implemented` | Opaque pass-through; command semantics remain provider-native. |
 
 ## Diagnostics
 
 - Back up unmanaged generated-output collisions before replacing them in confirmed builds.
 - Reject divergent provider source that tries to emit the same generated command path.
-- Do not copy Claude commands into Codex plugin output.
+- Do not copy commands into Codex plugin output.
 
 ## Provenance
 
@@ -35,4 +35,4 @@ Command files participate in plugin output hashes and lock provenance as target-
 
 ## Tests and Fixtures
 
-Fixtures cover Claude plugin companion copying, manifest field declaration, provider-specific output separation, and no Codex rendering for Claude-only companion paths.
+Fixtures cover Claude and Cursor plugin companion copying, provider-specific output separation, and no Codex rendering for this target-native companion path.

--- a/docs/features/executables.md
+++ b/docs/features/executables.md
@@ -10,7 +10,7 @@ Feature id: `executables`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)
 
-Claude plugin `bin/` is a target-native executable component. Skillset supports it through conventional discovery and `bin.source`; Codex plugin `bin` output is unsupported in v1.
+Claude plugin `bin/` is a target-native executable component. Skillset supports it through conventional discovery and `bin.source`; Codex and Cursor plugin `bin` output is unsupported in v1.
 
 ## Authoring
 
@@ -18,17 +18,17 @@ Use plugin-local `<source-root>/plugins/<plugin>/bin/` for conventional discover
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Conventional `bin/` | plugin root `bin/` | n/a | `target_native` / `implemented` | Copied as executable support files; no Claude manifest field. |
-| `bin.source` | plugin root `bin/` | n/a | `target_native` / `implemented` | Source pointer must be a repo directory outside generated roots. |
-| Codex-enabled `bin` | n/a | unsupported | `unsupported` / `implemented` | Fails loudly unless Codex plugin output is disabled. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Conventional `bin/` | plugin root `bin/` | n/a | n/a | `target_native` / `implemented` | Copied as executable support files; no Claude manifest field. |
+| `bin.source` | plugin root `bin/` | n/a | n/a | `target_native` / `implemented` | Source pointer must be a repo directory outside generated roots. |
+| Codex- or Cursor-enabled `bin` | n/a | unsupported | unsupported | `unsupported` / `implemented` | Fails loudly unless each unsupported plugin output is disabled. |
 
 ## Diagnostics
 
 - Reject `bin` sources that are not directories.
 - Reject `repo:` pointers that escape the repo, point into generated output roots, or reference missing paths.
-- Reject enabled Codex plugin output with `bin` because Codex plugins do not support that component in v1.
+- Reject enabled Codex or Cursor plugin output with `bin` because those plugins do not support that component in v1.
 - Reject divergent feature and provider-source outputs to the same generated path.
 
 ## Provenance
@@ -37,4 +37,4 @@ Locks record `kind: plugin-feature`, `feature: bin`, origin, optional source poi
 
 ## Tests and Fixtures
 
-Fixtures cover conventional discovery, explicit source pointers, disabled discovery, Claude-only copying, Codex unsupported diagnostics, type mismatches, generated-root pointer rejection, list/explain provenance, and divergent output collisions.
+Fixtures cover conventional discovery, explicit source pointers, disabled discovery, Claude-only copying, Codex and Cursor unsupported diagnostics, type mismatches, generated-root pointer rejection, list/explain provenance, and divergent output collisions.

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -13,7 +13,7 @@ Feature id: `hooks`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)
 
-Hooks are rendered definitions only. Skillset never installs, trusts, enables, or mutates user-level Claude or Codex configuration as a side effect of build, check, diff, import, init, or create.
+Hooks are rendered definitions only. Skillset never installs, trusts, enables, or mutates user-level Claude, Codex, or Cursor configuration as a side effect of build, check, diff, import, init, or create.
 
 Skillset supports two hook source styles:
 
@@ -34,11 +34,11 @@ Imported provider-native hook files stay native by default. Skillset should only
 
 ### Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| `hooks/hooks.json` | `hooks/hooks.json` | `hooks/hooks.json` | `target_native` / `implemented` | Destination-specific native aggregate source rendered with a top-level `hooks` object. |
-| root `hooks.json` | n/a | n/a | `unsupported` | Move the file to `hooks/hooks.json`. |
-| Future `hooks.source` | n/a | n/a | `planned` | No feature-key source pointer exists in v1. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `hooks/hooks.json` | `hooks/hooks.json` | `hooks/hooks.json` | `hooks/hooks.json` | `target_native` / `implemented` | Destination-specific native aggregate source rendered with a top-level `hooks` object. |
+| root `hooks.json` | n/a | n/a | n/a | `unsupported` | Move the file to `hooks/hooks.json`. |
+| Future `hooks.source` | n/a | n/a | n/a | `planned` | No feature-key source pointer exists in v1. |
 
 ## Adaptive Hook Units
 
@@ -72,7 +72,7 @@ Adaptive hook `run.script` references have two source-backed forms:
 
 Flat hook units such as `hooks/<name>.json` cannot use `./...` hook-local scripts because they do not own a private sidecar directory. Use a directory hook unit for colocated sidecars or `{{scripts.dir}}/...` for owner-level shared scripts.
 
-Plugin-level adaptive hook rendering copies referenced scripts into the generated plugin root and rewrites commands to provider runtime roots: `$CLAUDE_PLUGIN_ROOT` for Claude plugin hooks and `$PLUGIN_ROOT` for Codex plugin hooks.
+Plugin-level adaptive hook rendering copies referenced scripts into the generated plugin root and rewrites commands to provider runtime roots: `$CLAUDE_PLUGIN_ROOT` for Claude plugin hooks and `$PLUGIN_ROOT` for Codex and Cursor plugin hooks.
 
 ### Runtime Context
 
@@ -202,11 +202,11 @@ Nearest-first resolution only chooses named source definitions. It does not over
 
 The implemented render slices support plugin-level command/script hooks, plugin-level `run.env` shell assignments, and Claude frontmatter command hooks. When a plugin attachment resolves to a provider-compatible adaptive hook, Skillset writes provider-native `hooks/hooks.json` into generated provider plugin outputs and declares `hooks` in the plugin manifest. When a Claude skill-local or project-agent-local attachment resolves to a command hook, Skillset writes provider-native `hooks` frontmatter for the generated skill or agent.
 
-Skill-local and project-agent-local attachments currently render only to Claude frontmatter. Plugin-shipped agent frontmatter hooks are not implemented; use a plugin-level hook or provider-native aggregate source until that destination has a faithful render path. Scope Codex-incompatible skill or agent attachments with `providers: [claude]` when the intent is Claude-only. If Codex is enabled and an attachment cannot be faithfully rendered, build, diff, and output checks surface an `adaptive-hooks` `unsupported:error` render result instead of writing a broader plugin or project hook.
+Skill-local and project-agent-local attachments currently render only to Claude frontmatter. Plugin-shipped agent frontmatter hooks are not implemented; use a plugin-level hook or provider-native aggregate source until that destination has a faithful render path. Scope Codex- or Cursor-incompatible skill or agent attachments with `providers: [claude]` when the intent is Claude-only. If Codex or Cursor is enabled and an attachment cannot be faithfully rendered, build, diff, and output checks surface an `adaptive-hooks` `unsupported:error` render result instead of writing a broader plugin or project hook.
 
 Provider blocks are closed, typed overrides for `events`, `match`, `context`, and `run`. An absent field inherits the portable unit; a supplied field replaces that complete semantic unit; `match: null` and `context: null` clear only those values. An override cannot enable a provider excluded by the unit's `providers` list. Skillset resolves this effective definition once per target before validating attachments, scripts, and target capabilities.
 
-Unsupported cases include Codex skill/agent no-faithful-destination cases, Claude-only plugin events, Codex-ignored matchers, `context.includeRaw` until raw-context semantics exist, ambiguous hooks that define both `run.command` and `run.script`, unsupported `run.args`/`run.cwd` fields, frontmatter `run.env` fields, and frontmatter `run.script` path-proof gaps.
+Unsupported cases include Codex and Cursor skill/agent no-faithful-destination cases, Claude-only plugin events, Codex-ignored matchers, `context.includeRaw` until raw-context semantics exist, ambiguous hooks that define both `run.command` and `run.script`, unsupported `run.args`/`run.cwd` fields, frontmatter `run.env` fields, and frontmatter `run.script` path-proof gaps.
 
 ### Provider Reference
 
@@ -216,7 +216,7 @@ Use `skillset new hook <name> --event <event> --command <command> --attach <sour
 
 Bare interactive `skillset new` exposes the same operation: searchable attachment and event choices come from the live source graph and registry, event choices show compatible providers, unsupported attachment destinations show classifier-derived reasons, and explicit flags skip their matching prompts. The final preview and default-No confirmation still come from the shared scaffold report.
 
-Provider details are intentionally registry-backed instead of duplicated here. Claude has the broader hook surface; Codex support is narrower and currently centers on synchronous command handlers. `skillset lookup hooks --events --compat claude,codex` is the preferred way to inspect the current matrix. Skillset keeps provider-specific validation explicit so incompatible hooks fail visibly instead of being silently widened or dropped.
+Provider details are intentionally registry-backed instead of duplicated here. Claude has the broader hook surface; Codex and Cursor support are narrower and currently center on plugin-level command handlers. Cursor uses provider-native lower-camel event names. `skillset lookup hooks --events --compat claude,codex,cursor` is the preferred way to inspect the current matrix. Skillset keeps provider-specific validation explicit so incompatible hooks fail visibly instead of being silently widened or dropped.
 
 Provider docs checked: 2026-06-25.
 
@@ -226,6 +226,7 @@ Provider docs checked: 2026-06-25.
 - [Codex config reference](https://developers.openai.com/codex/config-reference)
 - [Codex advanced config](https://developers.openai.com/codex/config-advanced)
 - [Codex plugin build docs](https://developers.openai.com/codex/plugins/build)
+- [Cursor hooks docs](https://cursor.com/docs/hooks)
 
 ## Diagnostics
 

--- a/docs/features/instructions.md
+++ b/docs/features/instructions.md
@@ -11,7 +11,7 @@ Feature id: `instructions`
 
 Support vocabulary: [Feature Reference](README.md#support-vocabulary)
 
-Instructions are durable repo guidance authored under `.skillset/rules/**/*.md`. Codex `.rules` files are a separate target-native command policy surface under `.skillset/_codex/rules/**/*.rules`.
+Instructions are durable repo guidance authored under `.skillset/rules/**/*.md`. Codex `.rules` files are a separate target-native command policy surface under `.skillset/_codex/rules/**/*.rules`; Cursor plugin `rules/` files are target-native companions, not portable instruction source.
 
 ## Authoring
 
@@ -21,10 +21,11 @@ Use `skillset new instruction <name>` to preview a canonical workspace instructi
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| `<source-root>/rules/**/*.md` | `.claude/rules/**/*.md` | derived `AGENTS.md` files | `portable` / `implemented` | Claude keeps `paths`; Codex strips frontmatter and concatenates deterministic source sections. |
-| `<source-root>/_codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | `target_native` / `implemented` | Execution policy, not instruction prose. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `<source-root>/rules/**/*.md` | `.claude/rules/**/*.md` | derived `AGENTS.md` files | `.cursor/rules/**/*.mdc` | `portable` / `implemented` | Claude keeps `paths`; Codex strips frontmatter and concatenates deterministic source sections; Cursor renders Cursor rule frontmatter. |
+| `<source-root>/_codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | n/a | `target_native` / `implemented` | Execution policy, not instruction prose. |
+| `<source-root>/plugins/<plugin>/rules/` | n/a | n/a | plugin root `rules/` | `target_native` / `implemented` | Cursor plugin companion rules remain provider-native. |
 
 ## Diagnostics
 

--- a/docs/features/marketplaces.md
+++ b/docs/features/marketplaces.md
@@ -25,6 +25,7 @@ marketplaces:
     targets:
       - claude
       - codex
+      - cursor
     plugins:
       - plugin: outfitter-core
       - plugin: trails-review
@@ -53,7 +54,7 @@ Optional plugin entry fields:
 | `version` | Version policy requested by the catalog source; plugin version authority stays in the plugin repo. |
 | `targets` | Provider targets for this entry, narrowing the catalog targets. |
 
-Provider output paths such as `plugins/<plugin>/<provider>`, `.claude-plugin`, or `.codex-plugin` are not part of the marketplace source contract. Provider-native source forms are derived output details for `marketplace update`.
+Provider output paths such as `plugins/<plugin>/<provider>`, `.claude-plugin`, `.codex-plugin`, or `.cursor-plugin` are not part of the marketplace source contract. Provider-native source forms are derived output details for `marketplace update`.
 
 For Claude, local entries render as relative plugin roots such as `./plugins/outfitter-core`. External entries render as provider-native git subdirectory sources that point at the referenced repo and the derived generated Claude plugin bundle path, such as:
 
@@ -66,7 +67,7 @@ For Claude, local entries render as relative plugin roots such as `./plugins/out
 }
 ```
 
-The authored Skillset source stays repo-shaped (`repo`, `ref`, `sha`, `channel`, `version`) rather than asking users to hand-author provider output roots. Codex plugin bundles are still verified as marketplace entries, but Codex does not currently have a provider-owned generated marketplace index in this repo; Codex marketplace activation/config remains outside `marketplace update`.
+The authored Skillset source stays repo-shaped (`repo`, `ref`, `sha`, `channel`, `version`) rather than asking users to hand-author provider output roots. Cursor renders its provider-owned marketplace index at `.cursor-plugin/marketplace.json` when selected. Codex plugin bundles are still verified as marketplace entries, but Codex does not currently have a provider-owned generated marketplace index in this repo; Codex marketplace activation/config remains outside `marketplace update`.
 
 ## Resolution
 

--- a/docs/features/mcp-servers.md
+++ b/docs/features/mcp-servers.md
@@ -18,10 +18,10 @@ Conventional `<source-root>/plugins/<plugin>/.mcp.json` is discovered automatica
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Conventional `.mcp.json` | `.mcp.json` and manifest `mcpServers` | `.mcp.json` and manifest `mcpServers` | `target_native` / `implemented` | Structured JSON validation. |
-| `mcp.source` | `.mcp.json` and manifest `mcpServers` | `.mcp.json` and manifest `mcpServers` | `target_native` / `implemented` | Source pointer must use `repo:` and stay outside generated roots. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Conventional `.mcp.json` | `.mcp.json` and manifest `mcpServers` | `.mcp.json` and manifest `mcpServers` | `mcp.json` and manifest `mcpServers` | `target_native` / `implemented` | Structured JSON validation. |
+| `mcp.source` | `.mcp.json` and manifest `mcpServers` | `.mcp.json` and manifest `mcpServers` | `mcp.json` and manifest `mcpServers` | `target_native` / `implemented` | Source pointer must use `repo:` and stay outside generated roots. |
 
 ## Diagnostics
 

--- a/docs/features/output-safety.md
+++ b/docs/features/output-safety.md
@@ -48,7 +48,7 @@ Backup manifests use schema version 2 and store backed-up bytes in a per-run bar
 
 Generated changelogs are the currently implemented managed-output case where "just rebuild it" can discard useful author intent. When `skillset diff`, `skillset change status`, or `skillset check --ci` reports drift for a managed `CHANGELOG.md`, treat the edit as a source-side correction request: use `skillset change reason <@ref>` for pending wording before release, `skillset change amend <@ref>` for applied history wording after release, or `skillset release amend <@ref>` for release-event metadata. `skillset check --ci --fix` may still mechanically restore the projection from source, but the diagnostics should make the source-side recovery path visible first.
 
-The broader recovery model is [Source Suggestions](source-suggestions.md). That future workflow should use lock ownership to explain the source path behind a generated edit, preview clean source-side patches, and refuse unsafe reverse patches. Until it lands, output safety remains conservative: back up or rebuild generated output, but do not silently accept generated edits as source truth.
+The broader recovery model is [Source Suggestions](source-suggestions.md). The implemented local reconciliation workflow uses lock ownership to explain the source path behind a generated edit, preview clean source-side patches, and refuse unsafe reverse patches. Automated CI writeback remains future work; output safety stays conservative and never silently accepts generated edits as source truth.
 
 ## Restore
 

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -25,17 +25,18 @@ Plugins group skills and target-native companion files while preserving provider
 
 ## Authoring
 
-Plugin identity derives from the directory unless `skillset.name` is present and agrees. `skillset.id` is rejected. Plugin source can configure `claude` and `codex` blocks for target opt-outs, output selection, defaults, and target-native options. Plugin-local `defaults.<target>.<surface>` is shorthand for target defaults, not provider selection.
+Plugin identity derives from the directory unless `skillset.name` is present and agrees. `skillset.id` is rejected. Plugin source can configure `claude`, `codex`, and `cursor` blocks for target opt-outs, output selection, defaults, and target-native options. Plugin-local `defaults.<target>.<surface>` is shorthand for target defaults, not provider selection.
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| `<source-root>/plugins/<plugin>/skillset.yaml` | `.claude-plugin/plugin.json` | `.codex-plugin/plugin.json` | `portable` / `implemented` | Manifest fields derive from source metadata and target-supported companion paths. |
-| Plugin `skillset.license` or `LICENSE.txt` | `LICENSE.txt` | `LICENSE.txt` | `portable` / `implemented` | Generated as managed plugin-bundle output and inherited by plugin skills unless overridden or opted out. |
-| Plugin `skills/` | `skills/` | `skills/` | `portable` / `implemented` | Skill inclusion is per target and recorded in locks. |
-| Claude companion paths | commands, agents, hooks, MCP, LSP, output styles, themes, monitors, assets, scripts, src, bin | n/a unless separately supported | `target_native` / `implemented` | Target truth wins over fake portability. |
-| Codex companion paths | n/a unless separately supported | hooks, MCP, app manifest, assets, scripts, src | `target_native` / `implemented` | Codex plugin `agents/` and plugin `.rules` are unsupported. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `<source-root>/plugins/<plugin>/skillset.yaml` | `.claude-plugin/plugin.json` | `.codex-plugin/plugin.json` | `.cursor-plugin/plugin.json` | `portable` / `implemented` | Manifest fields derive from source metadata and target-supported companion paths. |
+| Plugin `skillset.license` or `LICENSE.txt` | `LICENSE.txt` | `LICENSE.txt` | `LICENSE.txt` | `portable` / `implemented` | Generated as managed plugin-bundle output and inherited by plugin skills unless overridden or opted out. |
+| Plugin `skills/` | `skills/` | `skills/` | `skills/` | `portable` / `implemented` | Skill inclusion is per target and recorded in locks. |
+| Claude companion paths | commands, agents, hooks, MCP, LSP, output styles, themes, monitors, assets, scripts, src, bin | n/a unless separately supported | n/a unless separately supported | `target_native` / `implemented` | Target truth wins over fake portability. |
+| Codex companion paths | n/a unless separately supported | hooks, MCP, app manifest, assets, scripts, src | n/a unless separately supported | `target_native` / `implemented` | Codex plugin `agents/` and plugin `.rules` are unsupported. |
+| Cursor companion paths | n/a unless separately supported | n/a unless separately supported | commands, agents, hooks, MCP, rules, and provider source | `target_native` / `implemented` | The checked support matrix remains authoritative: assets, LSP, monitors, output styles, README, scripts, src, and themes are not implied by this row. |
 
 ## Manifest Field Authority
 
@@ -50,7 +51,7 @@ Each generated-manifest field has exactly one writer; competing authorities are 
 | Component wiring (`commands`, `agents`, `skills`, `hooks`, `mcpServers`, …) | compiler | Derived from source layout and feature keys; never authored in generated output. |
 | `dependencies` (Claude) | compiler, from source `dependencies` | A `claude.manifest.dependencies` override fails the build rather than competing. |
 
-Target-native `claude.manifest` / `codex.manifest` blocks remain the visible per-target escape hatch: an override wins over the source-owned value for that target only, and stays reviewable in source.
+Target-native `claude.manifest` / `codex.manifest` / `cursor.manifest` blocks remain the visible per-target escape hatch: an override wins over the source-owned value for that target only, and stays reviewable in source.
 
 ## Diagnostics
 

--- a/docs/features/resources.md
+++ b/docs/features/resources.md
@@ -29,10 +29,10 @@ resources:
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Declared resource file | skill-local copied file | skill-local copied file | `portable` / `implemented` | Links and scripts remain relative to the generated skill directory. |
-| Declared resource directory | skill-local copied tree | skill-local copied tree | `portable` / `implemented` | Child links through resource URLs rewrite to generated paths. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Declared resource file | skill-local copied file | skill-local copied file | skill-local copied file | `portable` / `implemented` | Links and scripts remain relative to the generated skill directory. |
+| Declared resource directory | skill-local copied tree | skill-local copied tree | skill-local copied tree | `portable` / `implemented` | Child links through resource URLs rewrite to generated paths. |
 
 ## Diagnostics
 

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -21,13 +21,13 @@ Use `skillset new skill <name>` to create a minimal valid skill source file in t
 
 ## Target Rendering
 
-| Source | Claude output | Codex output | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Plugin skill source | `plugins/<plugin>/claude/skills/<skill>/SKILL.md` | `plugins/<plugin>/codex/skills/<skill>/SKILL.md` plus sidecars when needed | `portable` / `implemented` | Plugin boundaries are preserved per target. |
-| Standalone skill source | `.claude/skills/<skill>/SKILL.md` | `.agents/skills/<skill>/SKILL.md` plus sidecars when needed | `portable` / `implemented` | Standalone roots are configured by target skill output paths. |
-| Release state / inline version fields | `metadata.version` and plugin manifest version | `metadata.version` and plugin manifest version | `metadata_only` / `implemented` | Release state wins after `skillset release apply`; inline versions remain the fallback. `skillset check --only outputs` reports generated version drift. |
-| `{{$ARGUMENTS...}}` source placeholders | native `$ARGUMENTS...` placeholders | preserved `{{$ARGUMENTS...}}` markers plus a one-line replacement instruction | `shimmed` / `implemented` | Enabled by default through `compile.features.promptArguments`; disable to reject the source markers. |
-| `compile.skillset.metadata: false` | suppress generated Skillset metadata | suppress generated Skillset metadata | `implemented` | Locks still carry provenance. |
+| Source | Claude output | Codex output | Cursor output | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Plugin skill source | `plugins/<plugin>/claude/skills/<skill>/SKILL.md` | `plugins/<plugin>/codex/skills/<skill>/SKILL.md` plus Codex sidecars when needed | `plugins/<plugin>/cursor/skills/<skill>/SKILL.md` | `portable` / `implemented` | Plugin boundaries are preserved per target. |
+| Standalone skill source | `.claude/skills/<skill>/SKILL.md` | `.agents/skills/<skill>/SKILL.md` plus Codex sidecars when needed | `.cursor/skills/<skill>/SKILL.md` | `portable` / `implemented` | Standalone roots are configured by target skill output paths. |
+| Release state / inline version fields | `metadata.version` and plugin manifest version | `metadata.version` and plugin manifest version | `metadata.version` and plugin manifest version | `metadata_only` / `implemented` | Release state wins after `skillset release apply`; inline versions remain the fallback. `skillset check --only outputs` reports generated version drift. |
+| `{{$ARGUMENTS...}}` source placeholders | native `$ARGUMENTS...` placeholders | preserved `{{$ARGUMENTS...}}` markers plus a one-line replacement instruction | preserved `{{$ARGUMENTS...}}` markers | `shimmed` / `implemented` | Enabled by default through `compile.features.promptArguments`; disable to reject the source markers. |
+| `compile.skillset.metadata: false` | suppress generated Skillset metadata | suppress generated Skillset metadata | suppress generated Skillset metadata | `implemented` | Locks still carry provenance. |
 
 ## Diagnostics
 

--- a/docs/features/source-suggestions.md
+++ b/docs/features/source-suggestions.md
@@ -28,7 +28,7 @@ Preview mode is read-only. Write mode is allowed only for clean, single-source c
 | Generated changelog edit after release | Refuse reconciliation and point to `skillset change amend` for applied-history wording or `skillset release amend` for release-event metadata | `implemented` |
 | Generated metadata, lock files, manifests, or version fields | Refuse; output resolution compares the exact generated frontmatter block with the current expected render and accepts body edits only | `implemented` |
 | Output from partials, shared resources, or multiple source files | Refuse with diagnostics until a richer mapping exists | `implemented` |
-| Provider-native output with no adaptive round trip | Refuse and explain the provider-specific source or manual path | `planned` |
+| Provider-native output with no adaptive round trip | Refuse and explain the provider-specific source or manual path | `implemented` |
 | Unmanaged files | Refuse; Skillset cannot claim source ownership without lock provenance | `implemented` |
 
 ## Diagnostics
@@ -81,7 +81,7 @@ Fork PRs, protected branches, stale branches, corrupt locks, concurrent pushes, 
 
 ## Tests and Fixtures
 
-[SET-151](https://linear.app/outfitter/issue/SET-151/implement-suggest-source-command-for-clean-generated-to-source) added tests for clean skill-body suggestions, generated changelog refusal, read-only previews, explicit write confirmation, and `explain`/suggestion provenance consistency. [SET-322](https://linear.app/outfitter/issue/SET-322/reconcile-detect-and-refuse-generated-side-frontmatter-divergence) adds expected-render frontmatter comparison, structured recovery, provider-transformed body-only coverage, and provider-native refusal coverage.
+[SET-151](https://linear.app/outfitter/issue/SET-151/implement-suggest-source-command-for-clean-generated-to-source) added tests for clean skill-body suggestions, generated changelog refusal, read-only previews, explicit write confirmation, and `explain`/suggestion provenance consistency. [SET-322](https://linear.app/outfitter/issue/SET-322/reconcile-detect-and-refuse-generated-side-frontmatter-divergence) adds expected-render frontmatter comparison, structured recovery, provider-transformed body-only coverage, and implemented provider-native refusal coverage.
 
 [SET-152](https://linear.app/outfitter/issue/SET-152/design-ci-source-suggestion-writeback-for-managed-generated-edits) should add tests for comment-only CI output, safe same-repo writeback, fork/protected-branch refusal, stale lock refusal, conflicts, and preservation of change-entry requirements.
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -44,12 +44,15 @@ skillset.yaml
       scripts/
       _claude/
       _codex/
+      _cursor/
   hooks/
   agents/
     <agent-name>.md
   _claude/
     ...
   _codex/
+    ...
+  _cursor/
     ...
   changes/
   cache/
@@ -66,6 +69,16 @@ plugins/
       .codex-plugin/
         plugin.json
       skills/
+    cursor/
+      .cursor-plugin/
+        plugin.json
+      agents/
+      commands/
+      mcp.json
+      rules/
+      skills/
+.cursor-plugin/
+  marketplace.json
 .claude-plugin/
   marketplace.json
 .claude/
@@ -85,6 +98,15 @@ plugins/
       SKILL.md
       agents/
         openai.yaml
+.cursor/
+  agents/
+    <agent-name>.md
+  rules/
+    <topic>.mdc
+  skills/
+    skillset.lock
+    <skill-name>/
+      SKILL.md
 AGENTS.md
 .codex/
   agents/
@@ -143,6 +165,7 @@ compile:
   targets:
     - claude
     - codex
+    - cursor
   build: updated
   features:
     promptArguments: true
@@ -186,13 +209,21 @@ codex:
     - skillset
   skills:
     path: .agents/skills
+
+cursor:
+  projectRoot: .cursor
+  userRoot: ~/.cursor
+  plugins:
+    - skillset
+  skills:
+    path: .cursor/skills
 ```
 
-Boolean output settings use the default roots: `plugins/`, `.claude/skills`, and `.agents/skills`; plugin bundles default to `plugins/<plugin-name>/<target>/`. Arrays select specific plugin or standalone skill names. Object settings can set `path`, `include`, or `enabled: false`. Explicit `claude.plugins.path` and `codex.plugins.path` values remain self-contained provider roots. When `compile.targets` is present, a root provider object without `enabled` inherits the compile target set, so output-path objects do not accidentally re-enable a provider. Lower-level plugin, skill, and instruction objects keep the existing opt-in semantics. Do not add a bare top-level `targets:` key; provider selection has one home.
+Boolean output settings use the default roots: `plugins/`, `.claude/skills`, `.agents/skills`, and `.cursor/skills`; plugin bundles default to `plugins/<plugin-name>/<target>/`. Arrays select specific plugin or standalone skill names. Object settings can set `path`, `include`, or `enabled: false`. Explicit `claude.plugins.path`, `codex.plugins.path`, and `cursor.plugins.path` values remain self-contained provider roots. When `compile.targets` is present, a root provider object without `enabled` inherits the compile target set, so output-path objects do not accidentally re-enable a provider. Lower-level plugin, skill, and instruction objects keep the existing opt-in semantics. Do not add a bare top-level `targets:` key; provider selection has one home.
 
-Target defaults use `claude.defaults.<surface>` and `codex.defaults.<surface>` as the canonical target-local form. Root `defaults.<target>.<surface>` is a shorthand that normalizes into the same target defaults without making `targets:` a config surface. Supported surfaces are `agents`, `instructions`, `plugins`, and `skills`; unknown surfaces such as `defaults.codex.skill` fail instead of silently no-oping. Defaults fill omitted target options for that surface: plugin defaults override root defaults, file-level target fields override plugin defaults, and target-specific fields override shared portable fields at render time. For example, a root `codex.defaults.skills.model` applies to Codex-enabled skills unless a plugin or skill provides `codex.model`, and `codex.defaults.agents.skillsPrefaceTemplate` customizes generated Codex project-agent skill prefaces.
+Target defaults use `claude.defaults.<surface>`, `codex.defaults.<surface>`, and `cursor.defaults.<surface>` as the canonical target-local form. Root `defaults.<target>.<surface>` is a shorthand that normalizes into the same target defaults without making `targets:` a config surface. Supported surfaces are `agents`, `instructions`, `plugins`, and `skills`; unknown surfaces such as `defaults.codex.skill` fail instead of silently no-oping. Defaults fill omitted target options for that surface: plugin defaults override root defaults, file-level target fields override plugin defaults, and target-specific fields override shared portable fields at render time. For example, a root `codex.defaults.skills.model` applies to Codex-enabled skills unless a plugin or skill provides `codex.model`, and `codex.defaults.agents.skillsPrefaceTemplate` customizes generated Codex project-agent skill prefaces.
 
-A top-level skill `model` looks portable but is not portable in v1. It is stripped from generated output and emits a warning unless every enabled target has an explicit target model from `claude.model`, `codex.model`, or target defaults.
+A top-level skill `model` looks portable but is not portable in v1. It is stripped from generated output and emits a warning unless every enabled target has an explicit target model from `claude.model`, `codex.model`, `cursor.model`, or target defaults.
 
 Plugin-local `README.md` files are copied into each generated target plugin. Shared source inputs such as `<source-root>/shared/assets`, `<source-root>/shared/scripts`, `<source-root>/shared/references`, `<source-root>/shared/templates`, and plugin-local `<source-root>/plugins/<plugin-name>/shared/` are available for source organization; they are not copied into every output unless a source skill declares them.
 
@@ -309,15 +340,15 @@ paths:
 - Keep docs concise and current.
 ```
 
-Claude output preserves the relative source hierarchy under `.claude/rules/**/*.md` and keeps `paths` frontmatter so Claude can apply path-scoped rules. Rules without `paths` are rendered without frontmatter and load as unconditional Claude project rules.
+Claude output preserves the relative source hierarchy under `.claude/rules/**/*.md` and keeps `paths` frontmatter so Claude can apply path-scoped rules. Cursor output preserves that hierarchy under `.cursor/rules/**/*.mdc` and translates path scopes into Cursor frontmatter. Rules without `paths` are rendered without frontmatter and load as unconditional Claude project rules or unconditional Cursor rules.
 
 Codex output renders rules into the instruction files Codex actually discovers. Rules without `paths` write root `AGENTS.md`. Rules with path patterns write `<derived-base>/AGENTS.md`; for example `docs/**/*.md` writes `docs/AGENTS.md`. If a pattern has no static base, such as `**/*.ts`, the compiler scans matching repo files and uses the lowest common directory for the matched files. Multiple rules that land at the same `AGENTS.md` are concatenated in source-path order, each preceded by a deterministic `<!-- source: <source-root>/rules/<path> -->` boundary comment that names the source instruction. Boundary comments carry the path only; source-only frontmatter (such as `paths`) never reaches the generated `AGENTS.md`. Skillset does not write `.codex/AGENTS.md` as a default project-instruction location; Codex project guidance belongs in `AGENTS.md` files at the repo root or scoped directories.
 
 Codex truncates each `AGENTS.md` beyond `project_doc_max_bytes` (32 KiB by default) silently. When a generated `AGENTS.md` crosses that size, `skillset build` and `skillset check --only outputs` warn. To stay under the limit, split instructions across nested directories so they render to scoped `AGENTS.md` files (which load only when working in that subtree), or raise `project_doc_max_bytes` in Codex config.
 
-Skill and instruction Markdown bodies use Skillset preprocessing before target serialization. `{{this.<field>}}` reads from the current document's shared frontmatter, including nested dot paths such as `{{this.metadata.label}}` and scalar values such as numbers and booleans; missing fields fail with the source path and field name. Object and array values render as fenced `json` code blocks in Markdown prose unless already inside a fenced code block; structured sidecars receive compact JSON. Use triple braces such as `{{{this.description}}}` to keep the literal `{{this.description}}` token in generated output. Instructions also support `{{skillset.repo_root}}`, `{{skillset.output_dir}}`, and `{{skillset.source_rule}}`; these render independently for each generated Claude rule and Codex `AGENTS.md` file. All preprocessed files support `{{skillset.source_path}}`, `{{skillset.source_dir}}`, `{{skillset.source_root}}`, `{{parent.name}}`, `{{parent.dir}}`, and `{{parent.tree}}` / `{{parent.tree depth:<depth>}}`. Skill Markdown also supports prompt argument placeholders: `{{$ARGUMENTS}}`, `{{$ARGUMENTS[0]}}`, `{{$ARGUMENTS[1]}}`, and `{{$ARGUMENTS.name}}`. Claude receives native `$ARGUMENTS...`; Codex keeps the markers and gets a one-line replacement instruction. Path partials use `{{shared:path.md}}`, `{{plugin:path.md}}`, or a file path relative to the current source file. Named partials use `{{> name}}`, resolve first from `.skillset/partials/`, then from the current plugin's `partials/` when the source is plugin-bound, and may recurse. `{{> <plugin>.<name>}}` can explicitly address the current plugin's own partial namespace, but cross-plugin partial references are rejected. If no direct `<name>.md` exists, Skillset falls back to a unique basename match under that partial root; multiple matches are ambiguous and fail loudly. Cycles fail with the partial chain. Set `skillset.preprocess: false` in source frontmatter when a Markdown body should keep literal braces; the control is stripped from generated output.
+Skill and instruction Markdown bodies use Skillset preprocessing before target serialization. `{{this.<field>}}` reads from the current document's shared frontmatter, including nested dot paths such as `{{this.metadata.label}}` and scalar values such as numbers and booleans; missing fields fail with the source path and field name. Object and array values render as fenced `json` code blocks in Markdown prose unless already inside a fenced code block; structured sidecars receive compact JSON. Use triple braces such as `{{{this.description}}}` to keep the literal `{{this.description}}` token in generated output. Instructions also support `{{skillset.repo_root}}`, `{{skillset.output_dir}}`, and `{{skillset.source_rule}}`; these render independently for each generated Claude rule, Codex `AGENTS.md`, and Cursor `.mdc` rule. All preprocessed files support `{{skillset.source_path}}`, `{{skillset.source_dir}}`, `{{skillset.source_root}}`, `{{parent.name}}`, `{{parent.dir}}`, and `{{parent.tree}}` / `{{parent.tree depth:<depth>}}`. Skill Markdown also supports prompt argument placeholders: `{{$ARGUMENTS}}`, `{{$ARGUMENTS[0]}}`, `{{$ARGUMENTS[1]}}`, and `{{$ARGUMENTS.name}}`. Claude receives native `$ARGUMENTS...`; Codex keeps the markers and gets a one-line replacement instruction; Cursor preserves the markers without that Codex notice. Path partials use `{{shared:path.md}}`, `{{plugin:path.md}}`, or a file path relative to the current source file. Named partials use `{{> name}}`, resolve first from `.skillset/partials/`, then from the current plugin's `partials/` when the source is plugin-bound, and may recurse. `{{> <plugin>.<name>}}` can explicitly address the current plugin's own partial namespace, but cross-plugin partial references are rejected. If no direct `<name>.md` exists, Skillset falls back to a unique basename match under that partial root; multiple matches are ambiguous and fail loudly. Cycles fail with the partial chain. Set `skillset.preprocess: false` in source frontmatter when a Markdown body should keep literal braces; the control is stripped from generated output.
 
-Instruction frontmatter can use top-level `claude` and `codex` target toggles. Set `codex: false` for a Claude-only instruction or `claude: false` for a Codex-only instruction. Generated Codex `AGENTS.md` files are tracked by the root `skillset.lock`. If a build needs to replace an unmanaged `AGENTS.md`, it first backs up the existing file and warns with the restore id. Move existing hand-written guidance into `<source-root>/rules` when you want the compiler to own that destination long term.
+Instruction frontmatter can use top-level `claude`, `codex`, and `cursor` target toggles. Set `codex: false` for a Claude-only instruction or `cursor: false` when a rule cannot faithfully render to Cursor. Generated Codex `AGENTS.md` files are tracked by the root `skillset.lock`. If a build needs to replace an unmanaged `AGENTS.md`, it first backs up the existing file and warns with the restore id. Move existing hand-written guidance into `<source-root>/rules` when you want the compiler to own that destination long term.
 
 `codex: symlink` is a recorded follow-up, not a v1 behavior. Directly symlinking Codex `AGENTS.md` to Claude rule files would expose Claude `paths` frontmatter as Codex instructions.
 
@@ -325,15 +356,15 @@ Codex `.rules` files are not instruction Markdown. They are target-native comman
 
 ## Target-Specific Source and Plugin Surfaces
 
-Portable project agents live under `<source-root>/agents/*.md`. They render to Claude `.claude/agents/<resolved-name>.md` and Codex `.codex/agents/<resolved-name>.toml`, using the resolved `name` when present and otherwise the source filename stem. Agent source requires `description` plus a body, supports shared `skills` and `initialPrompt`, and keeps target-native fields under `claude` and `codex` blocks. Codex `skills` become a deterministic `developer_instructions` preface, and `initialPrompt` is wrapped in `<initial_prompt>...</initial_prompt>` with closing-tag input rejected. Project-agent files are tracked in the root `skillset.lock`; `skillset list` and `skillset explain` expose their provenance.
+Portable project agents live under `<source-root>/agents/*.md`. They render to Claude `.claude/agents/<resolved-name>.md`, Codex `.codex/agents/<resolved-name>.toml`, and Cursor `.cursor/agents/<resolved-name>.md`, using the resolved `name` when present and otherwise the source filename stem. Agent source requires `description` plus a body, supports shared `skills` and `initialPrompt`, and keeps target-native fields under `claude`, `codex`, and `cursor` blocks. Codex `skills` become a deterministic `developer_instructions` preface, and `initialPrompt` is wrapped in `<initial_prompt>...</initial_prompt>` with closing-tag input rejected. Cursor-specific agent fields remain provider-native. Project-agent files are tracked in the root `skillset.lock`; `skillset list` and `skillset explain` expose their provenance.
 
-Provider source mirrors explicit provider files to provider project roots: `<source-root>/_claude/**` writes to `.claude/**` by default, and `<source-root>/_codex/**` writes to `.codex/**` by default. `claude.projectRoot` and `codex.projectRoot` can override those roots. Codex `.rules` pass through only from `<source-root>/_codex/rules/**/*.rules` to `.codex/rules/**/*.rules`; portable prose instructions never render to Codex command policy.
+Provider source mirrors explicit provider files to provider project roots: `<source-root>/_claude/**` writes to `.claude/**` by default, `<source-root>/_codex/**` writes to `.codex/**`, and `<source-root>/_cursor/**` writes to `.cursor/**`. `claude.projectRoot`, `codex.projectRoot`, and `cursor.projectRoot` can override those roots. Codex `.rules` pass through only from `<source-root>/_codex/rules/**/*.rules` to `.codex/rules/**/*.rules`; portable prose instructions never render to Codex command policy.
 
-Some plugin companion paths are target-native rather than portable. Claude output copies `commands/`, `agents/`, `hooks/hooks.json`, `.lsp.json`, `output-styles/`, `themes/`, `monitors/`, `assets/`, `scripts/`, and `src/` when present. Codex output copies `hooks/hooks.json`, `.app.json`, `assets/`, `scripts/`, and `src/`. Plugin-local provider source under `<source-root>/plugins/<plugin>/_claude/**` and `<source-root>/plugins/<plugin>/_codex/**` mirrors into the matching generated plugin bundle only. Codex plugin `.rules` remains unsupported. Current generated JSON, YAML, Markdown, TOML utility output, and lock files are parsed after generation; copied unknown files and binary sidecars are not parsed as text.
+Some plugin companion paths are target-native rather than portable. Claude output copies `commands/`, `agents/`, `hooks/hooks.json`, `.lsp.json`, `output-styles/`, `themes/`, `monitors/`, `assets/`, `scripts/`, and `src/` when present. Codex output copies `hooks/hooks.json`, `.app.json`, `assets/`, `scripts/`, and `src/`. Cursor output supports only `commands/`, `agents/`, `hooks/hooks.json`, `mcp.json`, `rules/`, and `skills/`; it does not claim Claude/Codex asset or script companion support. Plugin-local provider source under `<source-root>/plugins/<plugin>/_claude/**`, `<source-root>/plugins/<plugin>/_codex/**`, and `<source-root>/plugins/<plugin>/_cursor/**` mirrors into the matching generated plugin bundle only. Codex plugin `.rules` remains unsupported. Current generated JSON, YAML, Markdown, TOML utility output, and lock files are parsed after generation; copied unknown files and binary sidecars are not parsed as text.
 
-MCP server definitions and Claude plugin `bin/` use feature-key source pointers rather than the generic companion copier. Conventional plugin-local `.mcp.json` and `bin/` are discovered unless disabled with `mcp: false` or `bin: false`; explicit `mcp.source` and `bin.source` values must use `repo:<path>` pointers inside the repo and outside configured generated output roots. MCP sources must be JSON files and are validated after generation; `bin` sources must be directories and are copied only to Claude plugin output. Because Codex plugins do not support `bin` in v1, a Codex-enabled plugin with enabled `bin` fails loudly unless the plugin or Codex plugin output selection opts out.
+MCP server definitions and Claude plugin `bin/` use feature-key source pointers rather than the generic companion copier. Conventional plugin-local `.mcp.json` and `bin/` are discovered unless disabled with `mcp: false` or `bin: false`; explicit `mcp.source` and `bin.source` values must use `repo:<path>` pointers inside the repo and outside configured generated output roots. MCP sources must be JSON files and are validated after generation; Cursor receives the supported MCP component as `mcp.json`, while `bin` sources must be directories and are copied only to Claude plugin output. Because Codex plugins do not support `bin` in v1, a Codex-enabled plugin with enabled `bin` fails loudly unless the plugin or Codex plugin output selection opts out.
 
-When a Claude pass-through path is present, the generated `.claude-plugin/plugin.json` declares it using the documented manifest field: `mcpServers` for `.mcp.json`, `lspServers` for `.lsp.json`, `outputStyles` for `output-styles/`, and the experimental `experimental.themes` / `experimental.monitors` for `themes/` and `monitors/monitors.json`. Codex plugin manifests declare MCP with `mcpServers` when `.mcp.json` is enabled. The supported Claude plugin component paths were live-doc verified against `code.claude.com/docs/en/plugins` and `code.claude.com/docs/en/plugins-reference` (2026-06-04).
+When a Claude pass-through path is present, the generated `.claude-plugin/plugin.json` declares it using the documented manifest field: `mcpServers` for `.mcp.json`, `lspServers` for `.lsp.json`, `outputStyles` for `output-styles/`, and the experimental `experimental.themes` / `experimental.monitors` for `themes/` and `monitors/monitors.json`. Codex plugin manifests declare MCP with `mcpServers` when `.mcp.json` is enabled; Cursor plugin manifests declare their supported `mcp.json` component with `mcpServers`. The supported Claude plugin component paths were live-doc verified against `code.claude.com/docs/en/plugins` and `code.claude.com/docs/en/plugins-reference` (2026-06-04).
 
 Claude plugin docs now document root `bin/` and plugin-root `settings.json`. Treat both as target-native, not portable. `bin/` is a documented executable component and can be supported through feature-key/source-pointer work. Plugin-root `settings.json` applies default configuration when a Claude plugin is enabled, so Skillset must keep it separate from live user/project settings mutation. Build still emits definitions only: it does not install, trust, enable, or symlink generated output into runtime locations. A reviewed settings suggestion workflow is a future non-goal for v1.
 
@@ -378,9 +409,9 @@ tools:
       - mcp__linear__experimental.*
 ```
 
-`tools: readonly` expands to `read: true`, `search: true`, and `write: false`. The first portable keys are `read`, `search`, `write`, `shell`, and `mcp`. `read`, `search`, and `write` are boolean-only; `shell` accepts booleans or a flat list of shell patterns; `mcp` accepts `false` or literal server names mapped to booleans or tool glob lists. Provider-native strings belong only under `tools.<provider>.allow` or `tools.<provider>.deny`. Claude renders portable policy and `tools.claude` native strings to `allowed-tools` / `disallowed-tools` (preapproval and denial rules, not a complete sandbox). Codex preserves portable policy and target-native strings as generated `.skillset.tools.yaml` metadata included in `skillset.lock`; it does not install, trust, or mutate user-level Codex configuration.
+`tools: readonly` expands to `read: true`, `search: true`, and `write: false`. The first portable keys are `read`, `search`, `write`, `shell`, and `mcp`. `read`, `search`, and `write` are boolean-only; `shell` accepts booleans or a flat list of shell patterns; `mcp` accepts `false` or literal server names mapped to booleans or tool glob lists. Provider-native strings belong only under `tools.<provider>.allow` or `tools.<provider>.deny`. Claude renders portable policy and `tools.claude` native strings to `allowed-tools` / `disallowed-tools` (preapproval and denial rules, not a complete sandbox). Codex and Cursor preserve portable policy and target-native strings as generated metadata-only `.skillset.tools.yaml` sidecars included in `skillset.lock`; neither path installs, trusts, or mutates user-level configuration.
 
-Import helpers add imported source under `.skillset/` and seed release baselines when adoption applies. Imported source lands under `.skillset/skills` or `.skillset/plugins`, and baselines use `.skillset/changes/state.json`. Adoption normalizes raw Claude `$ARGUMENTS`, `$ARGUMENTS[n]`, and `$ARGUMENTS.name` occurrences in imported Markdown to Skillset prompt argument placeholders so the source can build for Claude and Codex.
+Import helpers add imported source under `.skillset/` and seed release baselines when adoption applies. Imported source lands under `.skillset/skills` or `.skillset/plugins`, and baselines use `.skillset/changes/state.json`. Adoption normalizes raw `$ARGUMENTS`, `$ARGUMENTS[n]`, and `$ARGUMENTS.name` occurrences in imported Markdown to Skillset prompt argument placeholders so the source can render them according to the selected provider.
 
 ```bash
 skillset import /path/to/SKILL.md --root .

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 This path starts in an existing repo and creates one standalone skill. It proves
 the source-first loop without installing, trusting, symlinking, or changing
-Claude or Codex runtime configuration.
+Claude, Codex, or Cursor runtime configuration.
 
 Use a fresh source repo instead when the repo exists only to author Skillset
 loadouts:
@@ -13,8 +13,9 @@ cd my-skillset
 ```
 
 Prefer to inspect a complete tiny source tree first? See the
-[First Author Example](../examples/first-author/README.md), which includes one
-skill and one instruction rule that build to Claude and Codex.
+[First Author Example](../examples/first-author/README.md), which deliberately
+narrows one skill and one instruction rule to Claude and Codex with explicit
+`compile.targets`.
 
 For an existing content repo, stay in that repo and initialize Skillset:
 
@@ -67,7 +68,7 @@ Use this skill when a notes document needs to become a short decision log.
 
 The directory name is the stable identity. The top-level `name` may stay aligned
 with it; `title` is human-facing skill display text; `description` is the
-triggering text that renders into both target skill formats.
+triggering text that renders into each enabled target's native skill format.
 
 ## Check And Build
 
@@ -87,8 +88,11 @@ On a fresh repo, the first build plan should list new generated files such as:
 
 ```text
 .claude/skills/review-notes/SKILL.md
+.claude/skills/skillset.lock
 .agents/skills/review-notes/SKILL.md
-skillset.lock
+.agents/skills/skillset.lock
+.cursor/skills/review-notes/SKILL.md
+.cursor/skills/skillset.lock
 ```
 
 Write the generated output:
@@ -110,16 +114,18 @@ The default layout writes standalone skill output to:
 ```text
 .claude/skills/review-notes/SKILL.md
 .agents/skills/review-notes/SKILL.md
+.cursor/skills/review-notes/SKILL.md
 ```
 
-Each target skill root also gets a `skillset.lock`, and the repo root gets a
-`skillset.lock`. Locks carry source paths, output paths, hashes, version state,
-target state, and generated metadata policy. They are review evidence for what
-Skillset rendered; the source remains `.skillset/skills/review-notes/`.
+Each target skill root also gets its own `skillset.lock`: `.claude/skills/`,
+`.agents/skills/`, and `.cursor/skills/`. These locks carry source paths, output
+paths, hashes, version state, target state, and generated metadata policy. They
+are review evidence for what Skillset rendered; the source remains
+`.skillset/skills/review-notes/`.
 
 Skillset does not make the generated skill live in a user runtime. It writes
 repo-local target-native files only. Activation, install, trust, and user-level
-Claude or Codex configuration stay separate.
+Claude, Codex, or Cursor configuration stay separate.
 
 ## Useful Next Commands
 
@@ -128,6 +134,7 @@ skillset diff
 skillset dev
 skillset explain .skillset/skills/review-notes/SKILL.md
 skillset explain .claude/skills/review-notes/SKILL.md
+skillset explain .cursor/skills/review-notes/SKILL.md
 skillset status
 ```
 
@@ -148,7 +155,8 @@ Before sharing a 0.16-era Skillset source repo with another author, make sure:
 - `skillset build --yes` has refreshed the repo-local generated output you expect.
 - `skillset check --only outputs` passes so checked-in generated output matches source.
 - The generated output locations are visible in review, usually `.claude/`,
-  `.agents/`, and `skillset.lock` for the default path.
+  `.agents/`, and `.cursor/`, each with its target-local `skillset.lock`, for
+  the default path.
 - Runtime activation is deliberately out of band: do not ask authors to install,
   trust, symlink, or mutate user-level provider config as part of this path.
 - Hook-dependent sharing stays deferred to the hook guardrail work. If a repo

--- a/docs/target-surfaces.md
+++ b/docs/target-surfaces.md
@@ -72,7 +72,7 @@ artifacts.
 | Skills | `.cursor/skills/<skill>/SKILL.md` | Implemented | Project-level Cursor skills use `SKILL.md`; plugin skills live under plugin-root `skills/`. |
 | Rules | `.cursor/rules/**/*.mdc` | Implemented | Skillset renders project and plugin rules as Cursor `.mdc` files with Cursor frontmatter. |
 | Project subagents | `.cursor/agents/*.md` | Implemented | Cursor frontmatter includes `name`, `description`, `model`, `readonly`, and `is_background`; Cursor-specific fields stay provider-native until portable intent is proven. |
-| Plugins | `.cursor-plugin/plugin.json` plus plugin-root components | Implemented | Components include `rules/`, `skills/`, `agents/`, `commands/`, `hooks/hooks.json`, `mcp.json`, `assets/`, `scripts/`, and source companions. |
+| Plugins | `.cursor-plugin/plugin.json` plus plugin-root components | Implemented | Supported components are `rules/`, `skills/`, `agents/`, `commands/`, `hooks/hooks.json`, and `mcp.json`. |
 | Marketplace | `.cursor-plugin/marketplace.json` | Implemented | Multi-plugin repository catalog surface for generated local plugins. External plugin references remain governed by marketplace config and lock provenance. |
 | MCP | plugin-root `mcp.json` with `mcpServers` | Implemented | Cursor receives plugin-root `mcp.json`; manifest `mcpServers` is declared for the generated component path. |
 | Hooks | plugin-root `hooks/hooks.json` | Implemented | Cursor events are lower-camel provider-native names such as `sessionStart`, `beforeShellExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `preCompact`, and `workspaceOpen`. |
@@ -186,10 +186,11 @@ Live-doc verified against `developers.openai.com/codex/plugins/build` and `devel
 
 ## Instructions
 
-| Source | Claude output | Codex output | Status |
-| --- | --- | --- | --- |
-| `<source-root>/rules/**/*.md` | `.claude/rules/**/*.md` (`paths` kept) | `AGENTS.md` at derived dirs, source-boundary comments | Implemented |
-| `<source-root>/_codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | Provider-native / Implemented — Codex command execution policy, not instruction Markdown. |
+| Source | Claude output | Codex output | Cursor output | Status |
+| --- | --- | --- | --- | --- |
+| `<source-root>/rules/**/*.md` | `.claude/rules/**/*.md` (`paths` kept) | `AGENTS.md` at derived dirs, source-boundary comments | `.cursor/rules/**/*.mdc` with Cursor frontmatter | Implemented |
+| `<source-root>/_codex/rules/**/*.rules` | n/a | `.codex/rules/**/*.rules` | n/a | Provider-native / Implemented — Codex command execution policy, not instruction Markdown. |
+| `<source-root>/_cursor/rules/**/*.mdc` | n/a | n/a | `.cursor/rules/**/*.mdc` | Provider-native / Implemented — Cursor-native rules remain separate from portable instruction Markdown. |
 
 Codex truncates `AGENTS.md` beyond `project_doc_max_bytes` (32 KiB default); `skillset build` and `skillset check --only outputs` warn. Verified 2026-06-03 (`developers.openai.com/codex/guides/agents-md`, `openai/codex#7138`).
 
@@ -201,18 +202,18 @@ Codex `.rules` files are execution policy for shell command approval, prompt, or
 
 Verified 2026-07-02 against the provider capability registry, Codex hook schema snapshots, Claude hooks reference, and Cursor hooks docs. Provider-native hook validation is registry-backed for Claude, Codex, and Cursor.
 
-| Concern | Claude | Codex | Status |
-| --- | --- | --- | --- |
-| JSON-object shape | required | required | Implemented |
-| Supported events | registry allowlist | registry allowlist | Implemented |
-| Handler types | event-specific registry allowlist | synchronous `command` only | Implemented |
-| `async: true` command handlers | allowed | rejected (parsed-but-skipped) | Implemented |
+| Concern | Claude | Codex | Cursor | Status |
+| --- | --- | --- | --- | --- |
+| JSON-object shape | required | required | required | Implemented |
+| Supported events | registry allowlist | registry allowlist | registry allowlist | Implemented |
+| Handler types | event-specific registry allowlist | synchronous `command` only | synchronous `command` only | Implemented |
+| `async: true` command handlers | allowed | rejected (parsed-but-skipped) | rejected | Implemented |
 
 ## Tool policy
 
-| Source | Claude output | Codex output | Status |
-| --- | --- | --- | --- |
-| `tools` | `allowed-tools` / `disallowed-tools` (preapproval and denial rules) | `.skillset.tools.yaml` metadata | Implemented / Metadata-only (Codex) |
-| `tool_intent` | n/a | n/a | Retired — use `tools`. |
-| `allowed_tools` | `allowed-tools` | unset/false only | Implemented (Claude); Codex has no skill-local surface. |
-| `tools.<provider>.allow` / `deny` | native rules | `.skillset.tools.yaml` `target_native` | Implemented (provider-native block) |
+| Source | Claude output | Codex output | Cursor output | Status |
+| --- | --- | --- | --- | --- |
+| `tools` | `allowed-tools` / `disallowed-tools` (preapproval and denial rules) | `.skillset.tools.yaml` metadata | `.skillset.tools.yaml` metadata | Implemented / Metadata-only (Codex, Cursor) |
+| `tool_intent` | n/a | n/a | n/a | Retired — use `tools`. |
+| `allowed_tools` | `allowed-tools` | unset/false only | unset/false only | Implemented (Claude); Codex and Cursor have no skill-local surface. |
+| `tools.<provider>.allow` / `deny` | native rules | `.skillset.tools.yaml` `target_native` | `.skillset.tools.yaml` `target_native` | Implemented (provider-native block) |

--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -4,7 +4,7 @@
 
 This is the stable doctrinal layer for the Skillset compiler. It describes what Skillset believes, how it decides between competing designs, and what agents should preserve when changing the source contract. When implementation or tactical docs drift from this document, bring the repo back into alignment or make a deliberate decision to change the tenets.
 
-Skillset exists to make reusable agent loadouts easier to author and safer to ship across Claude and Codex. It should make the happy path smaller, not make authors learn every provider-specific file shape before they can write a useful skill.
+Skillset exists to make reusable agent loadouts easier to author and safer to ship across Claude, Codex, and Cursor. It should make the happy path smaller, not make authors learn every provider-specific file shape before they can write a useful skill.
 
 ## Documentation Tiers
 
@@ -23,7 +23,7 @@ These are the foundational beliefs of Skillset. Every source-schema decision, pr
 
 ### Help the happy path
 
-Building agent loadouts with Skillset should be easier than hand-authoring parallel Claude and Codex trees. A small useful skill or plugin should not require authors to decide target output paths, repeat obvious names, duplicate descriptions, or learn provider-specific edge cases before they have a reason.
+Building agent loadouts with Skillset should be easier than hand-authoring parallel Claude, Codex, and Cursor trees. A small useful skill or plugin should not require authors to decide target output paths, repeat obvious names, duplicate descriptions, or learn provider-specific edge cases before they have a reason.
 
 Power should come from derivation, defaults, validation, and clear escape hatches. If a common authoring flow makes the user copy the same idea into several places, the compiler should treat that as design feedback.
 
@@ -35,7 +35,7 @@ Generated plugin repositories, standalone skill roots, lockfiles, and instructio
 
 ### One meaning, one key
 
-When Claude and Codex expose the same semantic feature, Skillset should provide one adaptive source key for that meaning. Exact matches do not deserve parallel `claude_*` and `codex_*` vocabulary just because provider manifests spell them differently.
+When first-class providers expose the same semantic feature, Skillset should provide one adaptive source key for that meaning. Exact matches do not deserve parallel provider-specific vocabulary just because manifests spell them differently.
 
 Provider-native aliases can be accepted when they are safe and unambiguous. The resolver should normalize aliases into the canonical Skillset concept before adapting source to provider output.
 
@@ -47,7 +47,7 @@ This applies to agents, subagents, hooks, instructions, resources, app/MCP manif
 
 ### Provider truth beats fake portability
 
-Adaptive source keys are for behavior Skillset can meaningfully adapt. Root provider selection is a compile concern, not provider-native semantics: a root `compile.targets` list may say which provider outputs to build, while `claude` and `codex` blocks stay reserved for provider-specific options, explicit provider toggles, and visible provider-native escape hatches.
+Adaptive source keys are for behavior Skillset can meaningfully adapt. Root provider selection is a compile concern, not provider-native semantics: a root `compile.targets` list may say which provider outputs to build, while `claude`, `codex`, and `cursor` blocks stay reserved for provider-specific options, explicit provider toggles, and visible provider-native escape hatches.
 
 It is better for a feature to be honestly provider-specific than falsely unified. Skillset should not introduce a shared abstraction when the providers do not offer a meaningfully equivalent destination.
 
@@ -65,7 +65,7 @@ Build output may define hooks, app manifests, MCP manifests, plugins, skills, an
 
 ### Codify the craft
 
-Skillset should learn what goes into excellent skills, agents, hooks, instructions, resources, and plugins, then turn that knowledge into tooling. The compiler should help authors keep versions current, declare minimum required metadata, link resources safely, avoid unsupported target features, and keep Claude and Codex renderings in sync.
+Skillset should learn what goes into excellent skills, agents, hooks, instructions, resources, and plugins, then turn that knowledge into tooling. The compiler should help authors keep versions current, declare minimum required metadata, link resources safely, avoid unsupported target features, and keep enabled target renderings in sync.
 
 Internal tooling is part of the product: scaffolds, lint rules, explain commands, fixtures, import helpers, review prompts, and self-hosted development skills should all make better loadout authoring easier.
 
@@ -79,7 +79,7 @@ Generated output should be deterministic, disposable, and reviewable. Rebuilding
 
 ### Provider output stays native
 
-Claude output should look like Claude. Codex output should look like Codex. Skillset can normalize source authoring without forcing targets into an unnatural shared shape.
+Claude output should look like Claude. Codex output should look like Codex. Cursor output should look like Cursor. Skillset can normalize source authoring without forcing first-class providers into an unnatural shared shape.
 
 ### Lockfiles carry heavy provenance
 
@@ -101,11 +101,11 @@ These are recurring design shapes that operationalize the principles and promise
 
 ### Normalize exact matches
 
-When a Claude and Codex feature is semantically the same, define an adaptive source key and adapt it to provider-native syntax. `implicit_invocation`, skill version metadata, source descriptions, and provider enablement are examples of this pattern.
+When a provider feature is semantically the same across enabled targets, define an adaptive source key and adapt it to provider-native syntax. `implicit_invocation`, skill version metadata, source descriptions, and provider enablement are examples of this pattern.
 
 ### Model near matches by intent
 
-When features are similar but not identical, name the intent first and design the provider adaptation second. Instructions that build to Claude rules and Codex `AGENTS.md` files, agent roles that may write differently per provider, and hook definitions that stay definitions rather than activation are examples of this pattern.
+When features are similar but not identical, name the intent first and design the provider adaptation second. Instructions that build to Claude rules, Codex `AGENTS.md` files, and Cursor `.mdc` rules, agent roles that may write differently per provider, and hook definitions that stay definitions rather than activation are examples of this pattern.
 
 ### Prefer defaults and scoped overrides
 
@@ -124,7 +124,7 @@ Provider-native escape hatches should be obvious in source. Provider blocks such
 These are not a replacement for the schema reference. They are examples of how the tenets should guide near-term design.
 
 - Prefer `tools` for adaptive tool-policy meaning, with provider-native `tools.<provider>.allow` / `deny` blocks for provider-specific vocabulary.
-- Prefer `instructions` as the source concept for repo guidance, even if Claude output still uses rules and Codex output still uses `AGENTS.md`.
+- Prefer `instructions` as the source concept for repo guidance, even if Claude output uses rules, Codex output uses `AGENTS.md`, and Cursor output uses `.mdc` rules.
 - Use `skillset.schema` for the version of the source contract or compiler schema, while generated skill product versions stay simple through fields like `metadata.version`.
 - Do not require a source name that is distinct from the real plugin or skill name unless there is a concrete identity problem that derivation cannot solve.
 - Use root `compile.targets` for provider selection. Keep bare top-level `targets:` out of the source contract, default to the current provider plan for adaptive source, and keep explicit provider blocks for provider-specific options and nested opt-outs.
@@ -132,6 +132,6 @@ These are not a replacement for the schema reference. They are examples of how t
 
 ## Posture
 
-Skillset is opinionated about source authoring and conservative about provider activation. It should give authors a small, clear, source-first contract while preserving the native expectations of Claude and Codex.
+Skillset is opinionated about source authoring and conservative about provider activation. It should give authors a small, clear, source-first contract while preserving the native expectations of Claude, Codex, and Cursor.
 
 It should grow deliberately. A new adaptive key is valuable when it removes repetition, prevents drift, and builds faithfully. A new provider-specific escape hatch is valuable when it keeps provider truth explicit. A new abstraction is justified only when it makes authoring easier without making the system less honest.


### PR DESCRIPTION
## Context

SET-317 established registry-checked support matrices and SET-313 settled Cursor as a schema-owned first-class default. Authored quickstart, layout, doctrine, and feature prose still contained two-provider assumptions and stale local-reconciliation status.

## What changed

- reconciles the quickstart and README with a verified fresh omitted-target build: Claude, Codex, and Cursor standalone skill outputs with target-local locks;
- keeps the First Author fixture intentionally narrowed to Claude/Codex and labels that choice explicitly;
- updates layout, tenets, and target-surface guidance with Cursor source/output roots, defaults, provider blocks, and explicit capability limits;
- refreshes authored feature prose and output-path tables for Cursor agents, commands, hooks, instructions, marketplaces, MCP, plugins, resources, skills, and unsupported executables;
- records conservative local managed-output reconciliation as implemented while keeping automated CI writeback future;
- leaves every registry-generated support matrix unchanged.

## Verification

- fresh default build wrote and checked exactly six generated skill/lock files under `.claude`, `.agents`, and `.cursor`;
- focused contract 217/1,339; Skillset 119/568; feature registry 31/689; tools 14/263; schema/output checks; determinism 9/22 and adapters 12/27: green;
- `bun run check`: 1,348 tests, 0 failures; 54,471 expectations across 104 files; Ultracite and all guards clean;
- standing and fresh targeted Terra reviews: final 5/5, zero P0-P3; one P2 prose-completeness finding fixed and regraded clean;
- pre-push passed; Changeset guard found no package-facing changes.

## Scope

Twenty authored documentation files only. No generated matrix, product code, fixture, audit disposition, provider/global state, publication, stash, or bridge-worktree change.
