### PR TITLE
refactor: move provider maintenance into registry

### DIFF
--- a/.changeset/relocate-provider-maintenance.md
+++ b/.changeset/relocate-provider-maintenance.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Relocate repository-only provider schema maintenance into its registry owner while preserving the existing maintainer commands and output contracts.

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./provider-maintenance": "./src/provider-maintenance.ts"
   }
 }

--- a/packages/registry/src/__tests__/provider-maintenance.test.ts
+++ b/packages/registry/src/__tests__/provider-maintenance.test.ts
@@ -1,8 +1,18 @@
+import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+
+import {
+  createProgram,
+  flattenDiagnosticMessageText,
+  getPreEmitDiagnostics,
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptTarget,
+} from "typescript";
 
 import {
   PROVIDER_DESTINATION_FORMAT_SNAPSHOT_SCHEMA,
@@ -14,34 +24,39 @@ import {
   type ProviderDestinationFormatSnapshot,
   type ProviderJsonSchemaSummary,
   type ProviderSchemaSnapshot,
-} from "@skillset/registry";
-import { describe, expect, test } from "bun:test";
-
+} from "../index";
 import {
-  renderProviderMaintenanceReport,
   renderProviderSchemaSnapshotsSource,
   runProviderMaintenance,
   type ProviderFetch,
 } from "../provider-maintenance";
 
-describe("provider maintainer commands", () => {
+describe("SET-335 registry-owned provider maintenance", () => {
   test("SET-191: check reports live schema hash and summary drift", async () => {
     const adoptedBody = schemaBody(["alpha"]);
     const liveBody = schemaBody(["alpha", "beta"]);
-    const snapshot = schemaSnapshot(adoptedBody, "https://example.com/schema.json");
+    const snapshot = schemaSnapshot(
+      adoptedBody,
+      "https://example.com/schema.json"
+    );
 
-    const report = await runProviderMaintenance("/tmp/skillset-provider-check", "check", {
-      destinationSnapshots: [],
-      fetcher: fetchMap({ "https://example.com/schema.json": liveBody }),
-      now: "2026-06-23T12:00:00.000Z",
-      schemaSnapshots: [snapshot],
-    });
+    const report = await runProviderMaintenance(
+      "/tmp/skillset-provider-check",
+      "check",
+      {
+        destinationSnapshots: [],
+        fetcher: fetchMap({ "https://example.com/schema.json": liveBody }),
+        now: "2026-06-23T12:00:00.000Z",
+        schemaSnapshots: [snapshot],
+      }
+    );
 
     expect(report.ok).toBe(false);
     expect(report.schemaChanged).toBe(1);
     expect(report.schemaMatched).toBe(0);
-    expect(report.schemaResults[0]?.summaryChanges).toContain("properties added: beta");
-    expect(renderProviderMaintenanceReport(report)).toContain("schema codex-hooks-schema: changed");
+    expect(report.schemaResults[0]?.summaryChanges).toContain(
+      "properties added: beta"
+    );
   });
 
   test("SET-191: update writes refreshed schema snapshots only after explicit write", async () => {
@@ -49,7 +64,10 @@ describe("provider maintainer commands", () => {
     const schemaPath = join(root, "schema-snapshots.ts");
     const adoptedBody = schemaBody(["alpha"]);
     const liveBody = schemaBody(["alpha", "beta"]);
-    const snapshot = schemaSnapshot(adoptedBody, "https://example.com/schema.json");
+    const snapshot = schemaSnapshot(
+      adoptedBody,
+      "https://example.com/schema.json"
+    );
 
     const preview = await runProviderMaintenance(root, "update", {
       destinationSnapshots: [],
@@ -80,12 +98,17 @@ describe("provider maintainer commands", () => {
   });
 
   test("SET-191: update preserves existing fetchedAt by default for deterministic CLI output", async () => {
-    const root = await mkdtemp(join(tmpdir(), "skillset-providers-deterministic-"));
+    const root = await mkdtemp(
+      join(tmpdir(), "skillset-providers-deterministic-")
+    );
     const firstPath = join(root, "first.ts");
     const secondPath = join(root, "second.ts");
     const adoptedBody = schemaBody(["alpha"]);
     const liveBody = schemaBody(["alpha", "beta"]);
-    const snapshot = schemaSnapshot(adoptedBody, "https://example.com/schema.json");
+    const snapshot = schemaSnapshot(
+      adoptedBody,
+      "https://example.com/schema.json"
+    );
     const fetcher = fetchMap({ "https://example.com/schema.json": liveBody });
 
     await runProviderMaintenance(root, "update", {
@@ -109,44 +132,118 @@ describe("provider maintainer commands", () => {
     expect(first).toContain("2026-06-22T12:00:00.000Z");
   });
 
+  test("SET-335: network failures are actionable and never write snapshots", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-providers-error-"));
+    const schemaPath = join(root, "schema-snapshots.ts");
+    const adoptedBody = schemaBody(["alpha"]);
+    const url = "https://example.com/unavailable-schema.json";
+
+    const report = await runProviderMaintenance(root, "update", {
+      destinationSnapshots: [],
+      fetcher: fetchMap({}),
+      now: "2026-06-23T12:00:00.000Z",
+      schemaSnapshotPath: schemaPath,
+      schemaSnapshots: [schemaSnapshot(adoptedBody, url)],
+      write: true,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toBe(1);
+    expect(report.wrote).toBe(false);
+    expect(report.schemaResults[0]?.error).toBe(
+      `failed to fetch ${url}: 404 Not Found`
+    );
+    expect(await Bun.file(schemaPath).exists()).toBe(false);
+  });
+
   test("SET-191: diff includes destination format manual-review evidence", async () => {
     const body = schemaBody(["alpha"]);
     const destination = destinationSnapshot();
 
-    const report = await runProviderMaintenance("/tmp/skillset-provider-diff", "diff", {
-      destinationSnapshots: [destination],
-      fetcher: fetchMap({ "https://example.com/schema.json": body }),
-      now: "2026-06-23T12:00:00.000Z",
-      schemaSnapshots: [schemaSnapshot(body, "https://example.com/schema.json")],
-    });
+    const report = await runProviderMaintenance(
+      "/tmp/skillset-provider-diff",
+      "diff",
+      {
+        destinationSnapshots: [destination],
+        fetcher: fetchMap({ "https://example.com/schema.json": body }),
+        now: "2026-06-23T12:00:00.000Z",
+        schemaSnapshots: [
+          schemaSnapshot(body, "https://example.com/schema.json"),
+        ],
+      }
+    );
 
     expect(report.ok).toBe(true);
-    const rendered = renderProviderMaintenanceReport(report);
-    expect(rendered).toContain("destination codex-plugin [codex]: manual-review");
-    expect(rendered).toContain("no machine-readable upstream baseline is recorded");
-    expect(rendered).toContain("https://developers.openai.com/codex/plugins/build");
+    expect(report.destinationReviews).toEqual([
+      {
+        contentHash: destination.provenance.contentHash,
+        id: "codex-plugin",
+        reason:
+          "destination format snapshots are adopted from prose docs; no machine-readable upstream baseline is recorded",
+        sources: ["https://developers.openai.com/codex/plugins/build"],
+        status: "manual-review",
+        target: "codex",
+        title: "Codex Plugin Destination Format",
+      },
+    ]);
   });
 
-  test("SET-191: real schema snapshot source rendering stays importable", async () => {
+  test("SET-335: real schema snapshot source rendering is exact and importable", async () => {
     const root = await mkdtemp(join(tmpdir(), "skillset-provider-source-"));
     const path = join(root, "schema-snapshots.ts");
-    const source = renderProviderSchemaSnapshotsSource(listProviderSchemaSnapshots(), providerSchemaManualOverlays);
+    const source = renderProviderSchemaSnapshotsSource(
+      listProviderSchemaSnapshots(),
+      providerSchemaManualOverlays
+    );
 
-    expect(source).toContain("codex-hook-event-schemas");
-    expect(source).toContain("providerSchemaManualOverlays");
-    expect(source).toContain("hashProviderSchemaSnapshot");
-    expect(source).toContain("https://raw.githubusercontent.com/openai/codex/main/codex-rs/hooks/schema/generated/");
+    expect(
+      renderProviderSchemaSnapshotsSource(
+        listProviderSchemaSnapshots(),
+        providerSchemaManualOverlays
+      )
+    ).toBe(source);
+    const formatSnapshotUnion = source.match(
+      /readonly formatSnapshotId:\n([\s\S]*?);\n  readonly id:/u
+    )?.[1];
+    const expectedFormatSnapshotUnion = [
+      ...new Set(
+        providerSchemaManualOverlays.map((overlay) => overlay.formatSnapshotId)
+      ),
+    ]
+      .sort()
+      .map((id) => `    | ${JSON.stringify(id)}`)
+      .join("\n");
+    expect(formatSnapshotUnion).toBe(expectedFormatSnapshotUnion);
+    expect(formatSnapshotUnion).toContain('| "claude-hooks"');
+    expect(hashText(source)).toBe(
+      "sha256:340f6aada58c322156cd754f11c3ccc6c3ed1c87e6e3919c8bffae74b3180f52"
+    );
     await writeFile(path, source);
-    const imported = await import(pathToFileURL(path).href) as {
+    expect(typeDiagnostics(path)).toEqual([]);
+    const missingOverlayTypePath = join(
+      root,
+      "schema-snapshots-missing-overlay-type.ts"
+    );
+    await writeFile(
+      missingOverlayTypePath,
+      source.replace('    | "claude-hooks"\n', "")
+    );
+    expect(
+      typeDiagnostics(missingOverlayTypePath).map(({ code }) => code)
+    ).toContain(2322);
+    const imported = (await import(pathToFileURL(path).href)) as {
       readonly listProviderSchemaSnapshots: () => readonly ProviderSchemaSnapshot[];
     };
-    expect(imported.listProviderSchemaSnapshots().length).toBe(listProviderSchemaSnapshots().length);
+    expect(imported.listProviderSchemaSnapshots().length).toBe(
+      listProviderSchemaSnapshots().length
+    );
   });
 });
 
 function schemaBody(properties: readonly string[]): string {
   const propertyRecord: Record<string, unknown> = {};
-  for (const property of properties) propertyRecord[property] = { type: "string" };
+  for (const property of properties)
+    propertyRecord[property] = { type: "string" };
   return `${JSON.stringify({
     $schema: "http://json-schema.org/draft-07/schema#",
     properties: propertyRecord,
@@ -227,4 +324,24 @@ function fetchMap(responses: Record<string, string>): ProviderFetch {
 
 function hashText(text: string): string {
   return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+function typeDiagnostics(path: string) {
+  const program = createProgram([path], {
+    exactOptionalPropertyTypes: true,
+    module: ModuleKind.ESNext,
+    moduleResolution: ModuleResolutionKind.Bundler,
+    noEmit: true,
+    noUncheckedIndexedAccess: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ScriptTarget.ES2023,
+    types: ["bun"],
+  });
+  return getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.file?.fileName === path)
+    .map((diagnostic) => ({
+      code: diagnostic.code,
+      message: flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    }));
 }

--- a/packages/registry/src/provider-maintenance.ts
+++ b/packages/registry/src/provider-maintenance.ts
@@ -3,18 +3,20 @@ import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import {
-  hashProviderSchemaSnapshot,
   listProviderDestinationFormatSnapshots,
+  type ProviderDestinationFormatSnapshot,
+} from "./index";
+import {
+  hashProviderSchemaSnapshot,
   listProviderSchemaSnapshots,
   providerSchemaManualOverlays,
-  type ProviderDestinationFormatSnapshot,
   type ProviderJsonSchemaSummary,
   type ProviderSchemaManualOverlay,
   type ProviderSchemaSetEntry,
   type ProviderSchemaSetSummary,
   type ProviderSchemaSnapshot,
   type ProviderSchemaSource,
-} from "@skillset/registry";
+} from "./schema-snapshots";
 
 export type ProviderMaintenanceSubcommand = "check" | "diff" | "update";
 
@@ -86,25 +88,47 @@ export async function runProviderMaintenance(
   command: ProviderMaintenanceSubcommand,
   options: ProviderMaintenanceOptions = {}
 ): Promise<ProviderMaintenanceReport> {
-  const schemaPath = options.schemaSnapshotPath ?? resolve(rootPath, "packages/registry/src/schema-snapshots.ts");
-  const schemaSnapshots = options.schemaSnapshots ?? listProviderSchemaSnapshots();
-  const destinationSnapshots = options.destinationSnapshots ?? listProviderDestinationFormatSnapshots();
+  const schemaPath =
+    options.schemaSnapshotPath ??
+    resolve(rootPath, "packages/registry/src/schema-snapshots.ts");
+  const schemaSnapshots =
+    options.schemaSnapshots ?? listProviderSchemaSnapshots();
+  const destinationSnapshots =
+    options.destinationSnapshots ?? listProviderDestinationFormatSnapshots();
   const fetcher = options.fetcher ?? fetch;
   const fetchedAt = options.now;
   const schemaResults = await Promise.all(
-    schemaSnapshots.map((snapshot) => checkSchemaSnapshot(snapshot, fetcher, fetchedAt))
+    schemaSnapshots.map((snapshot) =>
+      checkSchemaSnapshot(snapshot, fetcher, fetchedAt)
+    )
   );
-  const errors = schemaResults.filter((result) => result.status === "error").length;
-  const schemaChanged = schemaResults.filter((result) => result.status === "changed").length;
-  const schemaMatched = schemaResults.filter((result) => result.status === "matched").length;
+  const errors = schemaResults.filter(
+    (result) => result.status === "error"
+  ).length;
+  const schemaChanged = schemaResults.filter(
+    (result) => result.status === "changed"
+  ).length;
+  const schemaMatched = schemaResults.filter(
+    (result) => result.status === "matched"
+  ).length;
   let wrote = false;
 
-  if (command === "update" && options.write === true && errors === 0 && schemaChanged > 0) {
+  if (
+    command === "update" &&
+    options.write === true &&
+    errors === 0 &&
+    schemaChanged > 0
+  ) {
     const nextSnapshots = schemaSnapshots.map((snapshot) => {
-      const result = schemaResults.find((candidate) => candidate.id === snapshot.id);
+      const result = schemaResults.find(
+        (candidate) => candidate.id === snapshot.id
+      );
       return result?.updatedSnapshot ?? snapshot;
     });
-    const source = renderProviderSchemaSnapshotsSource(nextSnapshots, providerSchemaManualOverlays);
+    const source = renderProviderSchemaSnapshotsSource(
+      nextSnapshots,
+      providerSchemaManualOverlays
+    );
     const previous = await readFile(schemaPath, "utf8").catch(() => "");
     if (previous !== source) {
       await writeFile(schemaPath, source);
@@ -112,16 +136,16 @@ export async function runProviderMaintenance(
     }
   }
 
-  const ok = command === "check"
-    ? errors === 0 && schemaChanged === 0
-    : errors === 0;
+  const ok =
+    command === "check" ? errors === 0 && schemaChanged === 0 : errors === 0;
 
   return {
     command,
     destinationReviews: destinationSnapshots.map((snapshot) => ({
       contentHash: snapshot.provenance.contentHash,
       id: snapshot.id,
-      reason: "destination format snapshots are adopted from prose docs; no machine-readable upstream baseline is recorded",
+      reason:
+        "destination format snapshots are adopted from prose docs; no machine-readable upstream baseline is recorded",
       sources: snapshot.provenance.sources.map((source) => source.url),
       status: "manual-review",
       target: snapshot.target,
@@ -135,49 +159,6 @@ export async function runProviderMaintenance(
     schemaResults,
     wrote,
   };
-}
-
-export function renderProviderMaintenanceReport(report: ProviderMaintenanceReport): string {
-  const lines: string[] = [];
-  lines.push(`skillset: provider ${report.command} checked ${report.schemaResults.length} schema snapshots`);
-  for (const result of report.schemaResults) {
-    const marker = result.status === "matched" ? "=" : result.status === "changed" ? "~" : "!";
-    lines.push(`  ${marker} schema ${result.id}: ${result.status}`);
-    if (result.error !== undefined) lines.push(`    error: ${result.error}`);
-    if (result.snapshotHash !== undefined && result.snapshotHash.expected !== result.snapshotHash.actual) {
-      lines.push(`    snapshot: ${result.snapshotHash.expected} -> ${result.snapshotHash.actual}`);
-    }
-    if (report.command !== "check") {
-      for (const source of result.sources) {
-        const actual = source.actualHash ?? "unavailable";
-        if (source.status !== "matched") lines.push(`    source: ${source.url} ${source.expectedHash} -> ${actual}`);
-      }
-      for (const change of result.summaryChanges) lines.push(`    ${change}`);
-    }
-  }
-  lines.push(
-    `skillset: ${report.schemaMatched} matched, ${report.schemaChanged} changed, ${report.errors} failed; ` +
-      `${report.destinationReviews.length} destination format snapshots require manual review`
-  );
-  if (report.command === "diff") {
-    for (const review of report.destinationReviews) {
-      lines.push(`  ? destination ${review.id} [${review.target}]: ${review.status} ${review.contentHash}`);
-      lines.push(`    reason: ${review.reason}`);
-      for (const source of review.sources) lines.push(`    source: ${source}`);
-    }
-  }
-  if (report.command === "update") {
-    if (report.wrote) {
-      lines.push(`skillset: wrote ${report.schemaPath}`);
-    } else if (report.schemaChanged > 0 && report.errors === 0) {
-      lines.push("skillset: rerun providers update with --yes to refresh schema snapshots");
-    } else if (report.errors > 0) {
-      lines.push("skillset: provider schema snapshots were not updated because checks failed");
-    } else {
-      lines.push("skillset: provider schema snapshots are current");
-    }
-  }
-  return `${lines.join("\n")}\n`;
 }
 
 async function checkSchemaSnapshot(
@@ -194,19 +175,25 @@ async function checkSchemaSnapshot(
       return {
         actualHash: source.contentHash,
         expectedHash: previous?.contentHash ?? "",
-        status: previous?.contentHash === source.contentHash ? "matched" as const : "changed" as const,
+        status:
+          previous?.contentHash === source.contentHash
+            ? ("matched" as const)
+            : ("changed" as const),
         url: source.url,
       };
     });
     const summaryChanges = summarizeChanges(snapshot.summary, updated.summary);
-    const hasContentChanges = sources.some((source) => source.status === "changed") ||
+    const hasContentChanges =
+      sources.some((source) => source.status === "changed") ||
       summaryChanges.length > 0;
     const nextSnapshot = hasContentChanges ? updated : snapshot;
-    const snapshotHash = hasContentChanges ? hashProviderSchemaSnapshot(updated) : snapshot.provenance.contentHash;
-    const status = hasContentChanges ||
-      snapshot.provenance.contentHash !== snapshotHash
-      ? "changed"
-      : "matched";
+    const snapshotHash = hasContentChanges
+      ? hashProviderSchemaSnapshot(updated)
+      : snapshot.provenance.contentHash;
+    const status =
+      hasContentChanges || snapshot.provenance.contentHash !== snapshotHash
+        ? "changed"
+        : "matched";
     return {
       id: snapshot.id,
       snapshotHash: {
@@ -217,7 +204,17 @@ async function checkSchemaSnapshot(
       status,
       summaryChanges,
       title: snapshot.title,
-      ...(status === "changed" ? { updatedSnapshot: { ...nextSnapshot, provenance: { ...nextSnapshot.provenance, contentHash: snapshotHash } } } : {}),
+      ...(status === "changed"
+        ? {
+            updatedSnapshot: {
+              ...nextSnapshot,
+              provenance: {
+                ...nextSnapshot.provenance,
+                contentHash: snapshotHash,
+              },
+            },
+          }
+        : {}),
     };
   } catch (error) {
     return {
@@ -240,9 +237,12 @@ async function refreshJsonSchemaSnapshot(
   fetcher: ProviderFetch,
   fetchedAt: string | undefined
 ): Promise<ProviderSchemaSnapshot> {
-  const fetchedSources = await Promise.all(snapshot.provenance.sources.map((source) => fetchSource(source, fetcher)));
+  const fetchedSources = await Promise.all(
+    snapshot.provenance.sources.map((source) => fetchSource(source, fetcher))
+  );
   const primary = fetchedSources[0];
-  if (primary === undefined) throw new Error(`provider schema snapshot ${snapshot.id} has no source`);
+  if (primary === undefined)
+    throw new Error(`provider schema snapshot ${snapshot.id} has no source`);
   const schema = parseJson(primary.text, primary.url);
   const sources = fetchedSources.map((source) => ({
     ...(source.note === undefined ? {} : { note: source.note }),
@@ -267,25 +267,32 @@ async function refreshSchemaSetSnapshot(
   fetchedAt: string | undefined
 ): Promise<ProviderSchemaSnapshot> {
   const [listingSource] = snapshot.provenance.sources;
-  if (listingSource === undefined) throw new Error(`provider schema set ${snapshot.id} has no listing source`);
+  if (listingSource === undefined)
+    throw new Error(`provider schema set ${snapshot.id} has no listing source`);
   const listing = await fetchSource(listingSource, fetcher);
-  const entries = readGithubDirectoryEntries(parseJson(listing.text, listing.url));
-  const schemaEntries = await Promise.all(entries.map(async (entry) => {
-    const fetched = await fetchText(entry.url, fetcher);
-    const parsed = parseJson(fetched.text, entry.url);
-    const summary = summarizeJsonSchema(parsed);
-    return {
-      contentHash: fetched.contentHash,
-      name: entry.name,
-      properties: summary.properties ?? [],
-      required: summary.required ?? [],
-      title: summary.title ?? entry.name.replace(/\.schema\.json$/u, ""),
-      url: entry.url,
-    };
-  }));
+  const entries = readGithubDirectoryEntries(
+    parseJson(listing.text, listing.url)
+  );
+  const schemaEntries = await Promise.all(
+    entries.map(async (entry) => {
+      const fetched = await fetchText(entry.url, fetcher);
+      const parsed = parseJson(fetched.text, entry.url);
+      const summary = summarizeJsonSchema(parsed);
+      return {
+        contentHash: fetched.contentHash,
+        name: entry.name,
+        properties: summary.properties ?? [],
+        required: summary.required ?? [],
+        title: summary.title ?? entry.name.replace(/\.schema\.json$/u, ""),
+        url: entry.url,
+      };
+    })
+  );
   const summary: ProviderSchemaSetSummary = {
     entries: schemaEntries,
-    repositoryPath: isProviderSchemaSetSummary(snapshot.summary) ? snapshot.summary.repositoryPath : "",
+    repositoryPath: isProviderSchemaSetSummary(snapshot.summary)
+      ? snapshot.summary.repositoryPath
+      : "",
     schemaCount: schemaEntries.length,
   };
   return {
@@ -296,7 +303,9 @@ async function refreshSchemaSetSnapshot(
       rollingLatest: true,
       sources: [
         {
-          ...(listingSource.note === undefined ? {} : { note: listingSource.note }),
+          ...(listingSource.note === undefined
+            ? {}
+            : { note: listingSource.note }),
           contentHash: listing.contentHash,
           url: listing.url,
         },
@@ -306,7 +315,10 @@ async function refreshSchemaSetSnapshot(
   };
 }
 
-async function fetchSource(source: ProviderSchemaSource, fetcher: ProviderFetch): Promise<ProviderSchemaSource & { readonly text: string }> {
+async function fetchSource(
+  source: ProviderSchemaSource,
+  fetcher: ProviderFetch
+): Promise<ProviderSchemaSource & { readonly text: string }> {
   const fetched = await fetchText(source.url, fetcher);
   return {
     ...(source.note === undefined ? {} : { note: source.note }),
@@ -316,10 +328,15 @@ async function fetchSource(source: ProviderSchemaSource, fetcher: ProviderFetch)
   };
 }
 
-async function fetchText(url: string, fetcher: ProviderFetch): Promise<{ readonly contentHash: string; readonly text: string }> {
+async function fetchText(
+  url: string,
+  fetcher: ProviderFetch
+): Promise<{ readonly contentHash: string; readonly text: string }> {
   const response = await fetcher(url);
   if (!response.ok) {
-    throw new Error(`failed to fetch ${url}: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `failed to fetch ${url}: ${response.status} ${response.statusText}`
+    );
   }
   const text = await response.text();
   return {
@@ -348,18 +365,30 @@ function summarizeJsonSchema(value: unknown): ProviderJsonSchemaSummary {
   return summary;
 }
 
-function readGithubDirectoryEntries(value: unknown): readonly { readonly name: string; readonly url: string }[] {
-  if (!Array.isArray(value)) throw new Error("expected GitHub directory listing array");
+function readGithubDirectoryEntries(
+  value: unknown
+): readonly { readonly name: string; readonly url: string }[] {
+  if (!Array.isArray(value))
+    throw new Error("expected GitHub directory listing array");
   return value
     .map((entry) => {
       const record = readRecord(entry, "GitHub directory entry");
       const name = readString(record.name);
       const downloadUrl = readString(record.download_url);
       const type = readString(record.type);
-      if (name === undefined || downloadUrl === undefined || type !== "file" || !name.endsWith(".schema.json")) return undefined;
+      if (
+        name === undefined ||
+        downloadUrl === undefined ||
+        type !== "file" ||
+        !name.endsWith(".schema.json")
+      )
+        return undefined;
       return { name, url: downloadUrl };
     })
-    .filter((entry): entry is { readonly name: string; readonly url: string } => entry !== undefined)
+    .filter(
+      (entry): entry is { readonly name: string; readonly url: string } =>
+        entry !== undefined
+    )
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
@@ -368,22 +397,50 @@ function summarizeChanges(
   next: ProviderJsonSchemaSummary | ProviderSchemaSetSummary
 ): readonly string[] {
   if (stableStringify(previous) === stableStringify(next)) return [];
-  if (isProviderSchemaSetSummary(previous) && isProviderSchemaSetSummary(next)) {
+  if (
+    isProviderSchemaSetSummary(previous) &&
+    isProviderSchemaSetSummary(next)
+  ) {
     const previousNames = previous.entries.map((entry) => entry.name);
     const nextNames = next.entries.map((entry) => entry.name);
     return [
       ...collectionDiff("entries", previousNames, nextNames),
-      ...(previous.schemaCount === next.schemaCount ? [] : [`schemaCount: ${previous.schemaCount} -> ${next.schemaCount}`]),
+      ...(previous.schemaCount === next.schemaCount
+        ? []
+        : [`schemaCount: ${previous.schemaCount} -> ${next.schemaCount}`]),
       ...entryHashChanges(previous.entries, next.entries),
     ];
   }
-  if (!isProviderSchemaSetSummary(previous) && !isProviderSchemaSetSummary(next)) {
+  if (
+    !isProviderSchemaSetSummary(previous) &&
+    !isProviderSchemaSetSummary(next)
+  ) {
     return [
-      ...collectionDiff("properties", previous.properties ?? [], next.properties ?? []),
-      ...collectionDiff("required", previous.required ?? [], next.required ?? []),
-      ...collectionDiff("definitions", previous.definitions ?? [], next.definitions ?? []),
-      ...(previous.title === next.title ? [] : [`title: ${previous.title ?? "(none)"} -> ${next.title ?? "(none)"}`]),
-      ...(previous.topLevelType === next.topLevelType ? [] : [`topLevelType: ${previous.topLevelType ?? "(none)"} -> ${next.topLevelType ?? "(none)"}`]),
+      ...collectionDiff(
+        "properties",
+        previous.properties ?? [],
+        next.properties ?? []
+      ),
+      ...collectionDiff(
+        "required",
+        previous.required ?? [],
+        next.required ?? []
+      ),
+      ...collectionDiff(
+        "definitions",
+        previous.definitions ?? [],
+        next.definitions ?? []
+      ),
+      ...(previous.title === next.title
+        ? []
+        : [
+            `title: ${previous.title ?? "(none)"} -> ${next.title ?? "(none)"}`,
+          ]),
+      ...(previous.topLevelType === next.topLevelType
+        ? []
+        : [
+            `topLevelType: ${previous.topLevelType ?? "(none)"} -> ${next.topLevelType ?? "(none)"}`,
+          ]),
     ].filter((line) => line.length > 0);
   }
   return ["summary kind changed"];
@@ -397,21 +454,32 @@ function entryHashChanges(
   const changes: string[] = [];
   for (const entry of previous) {
     const candidate = nextByName.get(entry.name);
-    if (candidate !== undefined && candidate.contentHash !== entry.contentHash) {
-      changes.push(`entry ${entry.name}: ${entry.contentHash} -> ${candidate.contentHash}`);
+    if (
+      candidate !== undefined &&
+      candidate.contentHash !== entry.contentHash
+    ) {
+      changes.push(
+        `entry ${entry.name}: ${entry.contentHash} -> ${candidate.contentHash}`
+      );
     }
   }
   return changes;
 }
 
-function collectionDiff(label: string, previous: readonly string[], next: readonly string[]): readonly string[] {
+function collectionDiff(
+  label: string,
+  previous: readonly string[],
+  next: readonly string[]
+): readonly string[] {
   const previousSet = new Set(previous);
   const nextSet = new Set(next);
   const added = next.filter((item) => !previousSet.has(item));
   const removed = previous.filter((item) => !nextSet.has(item));
   return [
     ...(added.length === 0 ? [] : [`${label} added: ${added.join(", ")}`]),
-    ...(removed.length === 0 ? [] : [`${label} removed: ${removed.join(", ")}`]),
+    ...(removed.length === 0
+      ? []
+      : [`${label} removed: ${removed.join(", ")}`]),
   ];
 }
 
@@ -419,8 +487,15 @@ export function renderProviderSchemaSnapshotsSource(
   snapshots: readonly ProviderSchemaSnapshot[],
   manualOverlays: readonly ProviderSchemaManualOverlay[]
 ): string {
-  const orderedSnapshots = [...snapshots].sort((left, right) => left.id.localeCompare(right.id));
-  const orderedOverlays = [...manualOverlays].sort((left, right) => left.id.localeCompare(right.id));
+  const orderedSnapshots = [...snapshots].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+  const orderedOverlays = [...manualOverlays].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+  const orderedFormatSnapshotIds = [
+    ...new Set(orderedOverlays.map((overlay) => overlay.formatSnapshotId)),
+  ].sort();
   return `import { createHash } from "node:crypto";
 
 export const PROVIDER_SCHEMA_SNAPSHOT_SCHEMA = "skillset-provider-schema@1";
@@ -483,11 +558,7 @@ export interface ProviderSchemaSetSummary {
 
 export interface ProviderSchemaManualOverlay {
   readonly formatSnapshotId:
-    | "claude-skill"
-    | "claude-subagent"
-    | "codex-agents-md"
-    | "codex-plugin"
-    | "codex-subagent";
+${renderStringUnion(orderedFormatSnapshotIds, "    ")};
   readonly id: ProviderSchemaManualOverlayId;
   readonly note: string;
   readonly sources: readonly { readonly url: string }[];
@@ -603,11 +674,18 @@ function sortJson(value: unknown): unknown {
 `;
 }
 
-function renderStringUnion(values: readonly string[]): string {
-  return values.map((value) => `  | ${JSON.stringify(value)}`).join("\n");
+function renderStringUnion(
+  values: readonly string[],
+  indentation = "  "
+): string {
+  return values
+    .map((value) => `${indentation}| ${JSON.stringify(value)}`)
+    .join("\n");
 }
 
-function snapshotInput(snapshot: ProviderSchemaSnapshot): Omit<ProviderSchemaSnapshot, "schema"> {
+function snapshotInput(
+  snapshot: ProviderSchemaSnapshot
+): Omit<ProviderSchemaSnapshot, "schema"> {
   const { schema: _schema, ...input } = snapshot;
   return input;
 }
@@ -626,12 +704,15 @@ function parseJson(text: string, url: string): unknown {
   try {
     return JSON.parse(text);
   } catch (error) {
-    throw new Error(`failed to parse ${url}: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `failed to parse ${url}: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 
 function readRecord(value: unknown, label: string): Record<string, unknown> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) throw new Error(`expected ${label} object`);
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`expected ${label} object`);
   return value as Record<string, unknown>;
 }
 
@@ -640,11 +721,15 @@ function readString(value: unknown): string | undefined {
 }
 
 function readStringArray(value: unknown): readonly string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
 }
 
 function objectKeys(value: unknown): readonly string[] {
-  return value !== null && typeof value === "object" && !Array.isArray(value) ? Object.keys(value) : [];
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? Object.keys(value)
+    : [];
 }
 
 function sha256(text: string): string {

--- a/scripts/__tests__/provider-maintenance-entrypoint.test.ts
+++ b/scripts/__tests__/provider-maintenance-entrypoint.test.ts
@@ -2,26 +2,47 @@ import { expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import type { ProviderMaintenanceReport } from "../../packages/registry/src/provider-maintenance";
+import { renderProviderMaintenanceReport } from "../provider-maintenance";
+
 test("SET-281: provider evidence maintenance is repo-script owned", async () => {
   const root = join(import.meta.dir, "../..");
-  const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
+  const pkg = JSON.parse(
+    await readFile(join(root, "package.json"), "utf8")
+  ) as {
     scripts: Record<string, string>;
   };
 
-  expect(pkg.scripts["providers:check"]).toBe("bun scripts/provider-maintenance.ts check");
-  expect(pkg.scripts["providers:diff"]).toBe("bun scripts/provider-maintenance.ts diff");
-  expect(pkg.scripts["providers:update"]).toBe("bun scripts/provider-maintenance.ts update");
+  expect(pkg.scripts["providers:check"]).toBe(
+    "bun scripts/provider-maintenance.ts check"
+  );
+  expect(pkg.scripts["providers:diff"]).toBe(
+    "bun scripts/provider-maintenance.ts diff"
+  );
+  expect(pkg.scripts["providers:update"]).toBe(
+    "bun scripts/provider-maintenance.ts update"
+  );
 
-  const child = Bun.spawn([process.execPath, "scripts/provider-maintenance.ts", "bogus"], {
-    cwd: root,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+  const child = Bun.spawn(
+    [process.execPath, "scripts/provider-maintenance.ts", "bogus"],
+    {
+      cwd: root,
+      stderr: "pipe",
+      stdout: "pipe",
+    }
+  );
   expect(await child.exited).toBe(1);
-  expect(await new Response(child.stderr).text()).toContain("expected provider maintenance command check, diff, or update");
+  expect(await new Response(child.stderr).text()).toContain(
+    "expected provider maintenance command check, diff, or update"
+  );
 
   const ignoredFlag = Bun.spawn(
-    [process.execPath, "scripts/provider-maintenance.ts", "update", "--dry-run"],
+    [
+      process.execPath,
+      "scripts/provider-maintenance.ts",
+      "update",
+      "--dry-run",
+    ],
     {
       cwd: root,
       stderr: "pipe",
@@ -31,5 +52,105 @@ test("SET-281: provider evidence maintenance is repo-script owned", async () => 
   expect(await ignoredFlag.exited).toBe(1);
   expect(await new Response(ignoredFlag.stderr).text()).toContain(
     "provider maintenance does not accept additional arguments: --dry-run"
+  );
+});
+
+test("SET-335: provider maintenance terminal reports remain exact", () => {
+  const changedResult = {
+    id: "codex-hooks-schema",
+    snapshotHash: {
+      actual: "sha256:next",
+      expected: "sha256:previous",
+    },
+    sources: [
+      {
+        actualHash: "sha256:source-next",
+        expectedHash: "sha256:source-previous",
+        status: "changed" as const,
+        url: "https://example.com/schema.json",
+      },
+    ],
+    status: "changed" as const,
+    summaryChanges: ["properties added: beta"],
+    title: "Codex Hooks JSON Schema",
+  };
+  const destinationReview = {
+    contentHash: "sha256:destination",
+    id: "codex-plugin",
+    reason:
+      "destination format snapshots are adopted from prose docs; no machine-readable upstream baseline is recorded",
+    sources: ["https://developers.openai.com/codex/plugins/build"],
+    status: "manual-review" as const,
+    target: "codex",
+    title: "Codex Plugin Destination Format",
+  };
+  const checkReport = {
+    command: "check",
+    destinationReviews: [],
+    errors: 0,
+    ok: false,
+    schemaChanged: 1,
+    schemaMatched: 0,
+    schemaPath: "/repo/packages/registry/src/schema-snapshots.ts",
+    schemaResults: [changedResult],
+    wrote: false,
+  } as const satisfies ProviderMaintenanceReport;
+  const diffReport = {
+    ...checkReport,
+    command: "diff",
+    destinationReviews: [destinationReview],
+    ok: true,
+  } as const satisfies ProviderMaintenanceReport;
+  const updateReport = {
+    command: "update",
+    destinationReviews: [],
+    errors: 1,
+    ok: false,
+    schemaChanged: 0,
+    schemaMatched: 0,
+    schemaPath: "/repo/packages/registry/src/schema-snapshots.ts",
+    schemaResults: [
+      {
+        error: "failed to fetch https://example.com/schema.json: 404 Not Found",
+        id: "codex-hooks-schema",
+        sources: [
+          {
+            expectedHash: "sha256:source-previous",
+            status: "error",
+            url: "https://example.com/schema.json",
+          },
+        ],
+        status: "error",
+        summaryChanges: [],
+        title: "Codex Hooks JSON Schema",
+      },
+    ],
+    wrote: false,
+  } as const satisfies ProviderMaintenanceReport;
+
+  expect(renderProviderMaintenanceReport(checkReport)).toBe(
+    "skillset: provider check checked 1 schema snapshots\n" +
+      "  ~ schema codex-hooks-schema: changed\n" +
+      "    snapshot: sha256:previous -> sha256:next\n" +
+      "skillset: 0 matched, 1 changed, 0 failed; 0 destination format snapshots require manual review\n"
+  );
+  expect(renderProviderMaintenanceReport(diffReport)).toBe(
+    "skillset: provider diff checked 1 schema snapshots\n" +
+      "  ~ schema codex-hooks-schema: changed\n" +
+      "    snapshot: sha256:previous -> sha256:next\n" +
+      "    source: https://example.com/schema.json sha256:source-previous -> sha256:source-next\n" +
+      "    properties added: beta\n" +
+      "skillset: 0 matched, 1 changed, 0 failed; 1 destination format snapshots require manual review\n" +
+      "  ? destination codex-plugin [codex]: manual-review sha256:destination\n" +
+      "    reason: destination format snapshots are adopted from prose docs; no machine-readable upstream baseline is recorded\n" +
+      "    source: https://developers.openai.com/codex/plugins/build\n"
+  );
+  expect(renderProviderMaintenanceReport(updateReport)).toBe(
+    "skillset: provider update checked 1 schema snapshots\n" +
+      "  ! schema codex-hooks-schema: error\n" +
+      "    error: failed to fetch https://example.com/schema.json: 404 Not Found\n" +
+      "    source: https://example.com/schema.json sha256:source-previous -> unavailable\n" +
+      "skillset: 0 matched, 0 changed, 1 failed; 0 destination format snapshots require manual review\n" +
+      "skillset: provider schema snapshots were not updated because checks failed\n"
   );
 });

--- a/scripts/provider-maintenance.ts
+++ b/scripts/provider-maintenance.ts
@@ -1,26 +1,100 @@
 import {
-  renderProviderMaintenanceReport,
   runProviderMaintenance,
+  type ProviderMaintenanceReport,
   type ProviderMaintenanceSubcommand,
-} from "../apps/skillset/src/provider-maintenance";
+} from "../packages/registry/src/provider-maintenance";
 
-const subcommand = process.argv[2];
-if (!isSubcommand(subcommand)) {
-  throw new Error("skillset: expected provider maintenance command check, diff, or update");
-}
-const unexpectedArgs = process.argv.slice(3);
-if (unexpectedArgs.length > 0) {
-  throw new Error(
-    `skillset: provider maintenance does not accept additional arguments: ${unexpectedArgs.join(" ")}`
+export function renderProviderMaintenanceReport(
+  report: ProviderMaintenanceReport
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `skillset: provider ${report.command} checked ${report.schemaResults.length} schema snapshots`
   );
+  for (const result of report.schemaResults) {
+    const marker =
+      result.status === "matched"
+        ? "="
+        : result.status === "changed"
+          ? "~"
+          : "!";
+    lines.push(`  ${marker} schema ${result.id}: ${result.status}`);
+    if (result.error !== undefined) lines.push(`    error: ${result.error}`);
+    if (
+      result.snapshotHash !== undefined &&
+      result.snapshotHash.expected !== result.snapshotHash.actual
+    ) {
+      lines.push(
+        `    snapshot: ${result.snapshotHash.expected} -> ${result.snapshotHash.actual}`
+      );
+    }
+    if (report.command !== "check") {
+      for (const source of result.sources) {
+        const actual = source.actualHash ?? "unavailable";
+        if (source.status !== "matched")
+          lines.push(
+            `    source: ${source.url} ${source.expectedHash} -> ${actual}`
+          );
+      }
+      for (const change of result.summaryChanges) lines.push(`    ${change}`);
+    }
+  }
+  lines.push(
+    `skillset: ${report.schemaMatched} matched, ${report.schemaChanged} changed, ${report.errors} failed; ` +
+      `${report.destinationReviews.length} destination format snapshots require manual review`
+  );
+  if (report.command === "diff") {
+    for (const review of report.destinationReviews) {
+      lines.push(
+        `  ? destination ${review.id} [${review.target}]: ${review.status} ${review.contentHash}`
+      );
+      lines.push(`    reason: ${review.reason}`);
+      for (const source of review.sources) lines.push(`    source: ${source}`);
+    }
+  }
+  if (report.command === "update") {
+    if (report.wrote) {
+      lines.push(`skillset: wrote ${report.schemaPath}`);
+    } else if (report.schemaChanged > 0 && report.errors === 0) {
+      lines.push(
+        "skillset: rerun providers update with --yes to refresh schema snapshots"
+      );
+    } else if (report.errors > 0) {
+      lines.push(
+        "skillset: provider schema snapshots were not updated because checks failed"
+      );
+    } else {
+      lines.push("skillset: provider schema snapshots are current");
+    }
+  }
+  return `${lines.join("\n")}\n`;
 }
 
-const report = await runProviderMaintenance(process.cwd(), subcommand, {
-  write: subcommand === "update",
-});
-process.stdout.write(renderProviderMaintenanceReport(report));
-if (!report.ok) process.exitCode = 1;
+async function main(args: readonly string[]): Promise<void> {
+  const subcommand = args[0];
+  if (!isSubcommand(subcommand)) {
+    throw new Error(
+      "skillset: expected provider maintenance command check, diff, or update"
+    );
+  }
+  const unexpectedArgs = args.slice(1);
+  if (unexpectedArgs.length > 0) {
+    throw new Error(
+      `skillset: provider maintenance does not accept additional arguments: ${unexpectedArgs.join(" ")}`
+    );
+  }
 
-function isSubcommand(value: string | undefined): value is ProviderMaintenanceSubcommand {
+  const report = await runProviderMaintenance(process.cwd(), subcommand, {
+    write: subcommand === "update",
+  });
+  process.stdout.write(renderProviderMaintenanceReport(report));
+  if (!report.ok) process.exitCode = 1;
+}
+
+function isSubcommand(
+  value: string | undefined
+): value is ProviderMaintenanceSubcommand {
   return value === "check" || value === "diff" || value === "update";
 }
+
+if (import.meta.main) await main(process.argv.slice(2));


### PR DESCRIPTION
## Context

Implements [SET-335](https://linear.app/outfitter/issue/SET-335/relocate-provider-maintenance-codegen-out-of-the-cli-app) by moving provider evidence maintenance out of the CLI app and into its owning registry package.

## What changed

- Moves provider maintenance implementation and tests to `@skillset/registry` behind a private package subpath.
- Keeps the root script responsible only for argv, terminal reporting, stdout, and exit behavior.
- Derives the generated manual-overlay id union from live registry facts and typechecks the rendered source, including a negative control.
- Adds a scoped patch Changeset without refreshing provider facts or adopted snapshots.

## Verification

- Standing and fresh local reviews: 5/5 clean, zero P0-P3.
- Focused provider/script tests and deterministic source hash/type proof.
- Wave-wide typecheck, schema, 82 generated outputs, conformance, and `bun run check`.
- Canonical wave-head pre-push passed with 1,394 tests and 54,725 assertions.

## Risk

Low. The registry owns provider facts and maintenance logic; public CLI grammar and generated provider artifacts are unchanged.
