### PR TITLE
refactor: split lookup argument parsing

### DIFF
--- a/.changeset/split-lookup-arguments.md
+++ b/.changeset/split-lookup-arguments.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Split lookup argument parsing from the shared inspection parser while preserving the existing CLI grammar and diagnostics.

--- a/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
+++ b/apps/skillset/src/__tests__/inspection-runtime-args.test.ts
@@ -5,9 +5,9 @@ import { parseHooksCommandRequest } from "../hooks-args";
 import {
   parseExplainCommandRequest,
   parseListCommandRequest,
-  parseLookupCommandRequest,
   parseStatusCommandRequest,
 } from "../inspect-args";
+import { parseLookupCommandRequest } from "../lookup-args";
 import { parseTestCommandRequest } from "../test-args";
 
 const CONTEXT = { cwd: "/workspace/repo" } as const;
@@ -73,7 +73,7 @@ describe("SET-304 inspection and runtime route parsers", () => {
     ).toMatchObject({ options: {} });
   });
 
-  test("inspection routes own roots, scopes, machine mode, and paths", () => {
+  test("list, status, and explain own roots, scopes, machine mode, and paths", () => {
     expect(
       parseListCommandRequest(
         ["list", "--root", "nested", "--scope", "plugins", "--json"],
@@ -106,67 +106,6 @@ describe("SET-304 inspection and runtime route parsers", () => {
       path: "plugins/example",
       rootPath: "/workspace/repo",
     });
-  });
-
-  test("lookup owns optional compatibility values and feature grammar", () => {
-    expect(
-      parseLookupCommandRequest([
-        "lookup",
-        "hooks",
-        "events",
-        "--compat",
-        "claude",
-        "codex,cursor",
-        "--compat=codex",
-        "--fields",
-        "--field",
-        "payload.command",
-        "--json",
-      ])
-    ).toEqual({
-      kind: "query",
-      value: {
-        jsonOutput: true,
-        lookupAspects: ["events"],
-        lookupField: "payload.command",
-        lookupSubject: "hooks",
-        lookupTargets: ["claude", "codex", "cursor"],
-        lookupViews: ["compat", "fields"],
-      },
-    });
-    expect(parseLookupCommandRequest(["lookup", "--compat"])).toEqual({
-      kind: "query",
-      value: {
-        jsonOutput: false,
-        lookupAspects: [],
-        lookupField: undefined,
-        lookupSubject: undefined,
-        lookupTargets: [],
-        lookupViews: ["compat"],
-      },
-    });
-    expect(
-      parseLookupCommandRequest([
-        "lookup",
-        "features",
-        "hooks.runtime-context",
-        "--json",
-      ])
-    ).toEqual({
-      kind: "features",
-      value: { featureId: "hooks.runtime-context", jsonOutput: true },
-    });
-    expect(
-      parseLookupCommandRequest([
-        "lookup",
-        "--scope",
-        "plugins",
-        "--updated",
-        "--yes",
-        "--name",
-        "ignored",
-      ])
-    ).toMatchObject({ kind: "query" });
   });
 
   test("test owns declared, ad hoc, retained, and hidden worker grammar", () => {
@@ -285,7 +224,10 @@ describe("SET-304 inspection and runtime route parsers", () => {
 
   test("preserves exceptional validation and diagnostic precedence", () => {
     expect(() =>
-      parseExplainCommandRequest(["explain", "README.md", "--target", "cursor"], CONTEXT)
+      parseExplainCommandRequest(
+        ["explain", "README.md", "--target", "cursor"],
+        CONTEXT
+      )
     ).toThrow("hook options are only supported with hooks print");
 
     const cases = [
@@ -293,28 +235,6 @@ describe("SET-304 inspection and runtime route parsers", () => {
         message: "skillset: status only supports --root and --json",
         run: () =>
           parseStatusCommandRequest(["status", "--scope", "plugins"], CONTEXT),
-      },
-      {
-        message:
-          "skillset: expected lookup features to use only an optional feature id and --json",
-        run: () =>
-          parseLookupCommandRequest(["lookup", "features", "id", "--fields"]),
-      },
-      {
-        message:
-          "skillset: expected lookup features to use only an optional feature id and --json",
-        run: () =>
-          parseLookupCommandRequest([
-            "lookup",
-            "features",
-            "id",
-            "--scope",
-            "plugins",
-          ]),
-      },
-      {
-        message: "skillset: --root is not supported with lookup",
-        run: () => parseLookupCommandRequest(["lookup", "--root", "nested"]),
       },
       {
         message:

--- a/apps/skillset/src/__tests__/lookup-args.test.ts
+++ b/apps/skillset/src/__tests__/lookup-args.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCliRequest } from "../cli-args";
+import { parseLookupCommandRequest } from "../lookup-args";
+
+const CONTEXT = { cwd: "/workspace/repo" } as const;
+
+describe("SET-336 lookup route parser", () => {
+  test("owns query positionals, optional compatibility values, and views", () => {
+    expect(
+      parseLookupCommandRequest([
+        "lookup",
+        "hooks",
+        "events",
+        "--compat",
+        "claude",
+        "codex,cursor",
+        "--compat=codex",
+        "--fields",
+        "--field",
+        "payload.command",
+        "--json",
+      ])
+    ).toEqual({
+      kind: "query",
+      value: {
+        jsonOutput: true,
+        lookupAspects: ["events"],
+        lookupField: "payload.command",
+        lookupSubject: "hooks",
+        lookupTargets: ["claude", "codex", "cursor"],
+        lookupViews: ["compat", "fields"],
+      },
+    });
+    expect(parseLookupCommandRequest(["lookup", "--compat"])).toEqual({
+      kind: "query",
+      value: {
+        jsonOutput: false,
+        lookupAspects: [],
+        lookupField: undefined,
+        lookupSubject: undefined,
+        lookupTargets: [],
+        lookupViews: ["compat"],
+      },
+    });
+  });
+
+  test("owns features grammar without inheriting query options", () => {
+    expect(
+      parseLookupCommandRequest([
+        "lookup",
+        "features",
+        "hooks.runtime-context",
+        "--json",
+      ])
+    ).toEqual({
+      kind: "features",
+      value: { featureId: "hooks.runtime-context", jsonOutput: true },
+    });
+    for (const args of [
+      ["lookup", "features", "id", "--fields"],
+      ["lookup", "features", "id", "--scope", "plugins"],
+      ["lookup", "features", "id", "--root", "nested"],
+    ] as const) {
+      expect(() => parseLookupCommandRequest(args)).toThrow(
+        "skillset: expected lookup features to use only an optional feature id and --json"
+      );
+    }
+  });
+
+  test("preserves lookup-specific ignored options and root and yes diagnostics", () => {
+    expect(
+      parseLookupCommandRequest([
+        "lookup",
+        "--scope",
+        "plugins",
+        "--updated",
+        "--yes",
+        "--name",
+        "ignored",
+      ])
+    ).toEqual({
+      kind: "query",
+      value: {
+        jsonOutput: false,
+        lookupAspects: [],
+        lookupField: undefined,
+        lookupSubject: undefined,
+        lookupTargets: [],
+        lookupViews: [],
+      },
+    });
+    expect(() =>
+      parseLookupCommandRequest(["lookup", "--root", "nested"])
+    ).toThrow("skillset: --root is not supported with lookup");
+    expect(() => parseLookupCommandRequest(["lookup", "--yes=true"])).toThrow(
+      "skillset: --yes does not take a value"
+    );
+  });
+
+  test("preserves foreign-option validation and diagnostic precedence", () => {
+    expect(() =>
+      parseLookupCommandRequest([
+        "lookup",
+        "--target",
+        "codex",
+        "--append",
+        "--isolated",
+      ])
+    ).toThrow(
+      "skillset: change options are only supported with change commands"
+    );
+    expect(() =>
+      parseLookupCommandRequest([
+        "lookup",
+        "--isolated",
+        "--use",
+        "source",
+        "--id",
+        "example",
+      ])
+    ).toThrow(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+    expect(() =>
+      parseLookupCommandRequest(["lookup", "--field", "one", "--field", "two"])
+    ).toThrow("skillset: pass only one --field value");
+    expect(() => parseLookupCommandRequest(["lookup", "--jsonl"])).toThrow(
+      "skillset: unknown option --jsonl"
+    );
+  });
+
+  test("matches the explicit CLI facade", () => {
+    const cases = [
+      ["lookup"],
+      ["lookup", "hooks", "events", "--compat=codex", "--json"],
+      ["lookup", "features", "hooks.runtime-context", "--json"],
+      ["lookup", "--root", "nested"],
+      ["lookup", "features", "id", "--fields"],
+    ] as const;
+    for (const args of cases) {
+      expect(readOutcome(() => parseLookupCommandRequest(args))).toEqual(
+        readOutcome(() => parseCliRequest(args, CONTEXT).request)
+      );
+    }
+  });
+});
+
+const readOutcome = (run: () => unknown) => {
+  try {
+    return { ok: true, value: run() } as const;
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      ok: false,
+    } as const;
+  }
+};

--- a/apps/skillset/src/cli-args.ts
+++ b/apps/skillset/src/cli-args.ts
@@ -1,34 +1,21 @@
-import { parseBuildCommandRequest, parseDiffCommandRequest } from "./build-args";
+import * as build from "./build-args";
 import { parseChangeCommandRequest } from "./change-args";
 import { parseCheckCommandRequest } from "./check-args";
-import { parseCreateCommandRequest } from "./create-args";
 import type { CliParseContext } from "./cli-arg-values";
 import { isCliCommand, renderExpectedCliCommands } from "./cli-commands";
 import { CliOutputError, readCliCommand } from "./cli-output";
 import type { CliRequest } from "./cli-request";
 import { USAGE } from "./cli-usage";
+import { parseCreateCommandRequest } from "./create-args";
 import { parseDevCommandRequest } from "./dev-args";
-import {
-  parseDistributionCommandRequest,
-  parseMarketplaceCommandRequest,
-} from "./distribution-args";
+import * as distribution from "./distribution-args";
 import { parseHooksCommandRequest } from "./hooks-args";
 import { parseInitCommandRequest } from "./init-args";
-import {
-  parseExplainCommandRequest,
-  parseListCommandRequest,
-  parseLookupCommandRequest,
-  parseStatusCommandRequest,
-} from "./inspect-args";
-import {
-  parseReconcileCommandRequest,
-  parseRestoreCommandRequest,
-} from "./recovery-args";
+import * as inspection from "./inspect-args";
+import { parseLookupCommandRequest } from "./lookup-args";
+import * as recovery from "./recovery-args";
 import { parseReleaseCommandRequest } from "./release-args";
-import {
-  parseImportCommandRequest,
-  parseNewCommandRequest,
-} from "./source-args";
+import * as source from "./source-args";
 import { parseTestCommandRequest } from "./test-args";
 import { parseUpdateCommandRequest } from "./update-args";
 
@@ -50,7 +37,7 @@ export const parseCliRequest = (
       case "build": {
         return {
           command,
-          request: parseBuildCommandRequest(args, parseContext),
+          request: build.parseBuildCommandRequest(args, parseContext),
         };
       }
       case "change": {
@@ -66,7 +53,10 @@ export const parseCliRequest = (
         };
       }
       case "create": {
-        return { command, request: parseCreateCommandRequest(args, parseContext) };
+        return {
+          command,
+          request: parseCreateCommandRequest(args, parseContext),
+        };
       }
       case "dev": {
         return { command, request: parseDevCommandRequest(args, parseContext) };
@@ -74,19 +64,22 @@ export const parseCliRequest = (
       case "diff": {
         return {
           command,
-          request: parseDiffCommandRequest(args, parseContext),
+          request: build.parseDiffCommandRequest(args, parseContext),
         };
       }
       case "distribute": {
         return {
           command,
-          request: parseDistributionCommandRequest(args, parseContext),
+          request: distribution.parseDistributionCommandRequest(
+            args,
+            parseContext
+          ),
         };
       }
       case "explain": {
         return {
           command,
-          request: parseExplainCommandRequest(args, parseContext),
+          request: inspection.parseExplainCommandRequest(args, parseContext),
         };
       }
       case "hooks": {
@@ -98,7 +91,7 @@ export const parseCliRequest = (
       case "import": {
         return {
           command,
-          request: parseImportCommandRequest(args, parseContext),
+          request: source.parseImportCommandRequest(args, parseContext),
         };
       }
       case "init": {
@@ -110,7 +103,7 @@ export const parseCliRequest = (
       case "list": {
         return {
           command,
-          request: parseListCommandRequest(args, parseContext),
+          request: inspection.parseListCommandRequest(args, parseContext),
         };
       }
       case "lookup": {
@@ -119,16 +112,22 @@ export const parseCliRequest = (
       case "marketplace": {
         return {
           command,
-          request: parseMarketplaceCommandRequest(args, parseContext),
+          request: distribution.parseMarketplaceCommandRequest(
+            args,
+            parseContext
+          ),
         };
       }
       case "new": {
-        return { command, request: parseNewCommandRequest(args, parseContext) };
+        return {
+          command,
+          request: source.parseNewCommandRequest(args, parseContext),
+        };
       }
       case "reconcile": {
         return {
           command,
-          request: parseReconcileCommandRequest(args, parseContext),
+          request: recovery.parseReconcileCommandRequest(args, parseContext),
         };
       }
       case "release": {
@@ -140,13 +139,13 @@ export const parseCliRequest = (
       case "restore": {
         return {
           command,
-          request: parseRestoreCommandRequest(args, parseContext),
+          request: recovery.parseRestoreCommandRequest(args, parseContext),
         };
       }
       case "status": {
         return {
           command,
-          request: parseStatusCommandRequest(args, parseContext),
+          request: inspection.parseStatusCommandRequest(args, parseContext),
         };
       }
       case "test": {

--- a/apps/skillset/src/inspect-args.ts
+++ b/apps/skillset/src/inspect-args.ts
@@ -1,8 +1,4 @@
-import type { LookupView } from "@skillset/core";
-import type {
-  SkillsetOptions,
-  TargetName,
-} from "@skillset/core/internal/types";
+import type { SkillsetOptions } from "@skillset/core/internal/types";
 
 import { readChangeBump, setChangeReason } from "./change-args";
 import type { ChangeReasonInput } from "./change-workflow";
@@ -25,25 +21,14 @@ import type { CliParseContext } from "./cli-arg-values";
 import type {
   ExplainCommandRequest,
   ListCommandRequest,
-  LookupFeaturesCommandRequest,
-  LookupRouteRequest,
   StatusCommandRequest,
 } from "./inspect-cli";
-import {
-  addLookupTargets,
-  addLookupView,
-  readLookupSubject,
-  setLookupField,
-} from "./lookup-cli";
+import { addLookupTargets, setLookupField } from "./lookup-cli";
 import {
   readHookRuntimeContextField,
   readHookRuntimeContextFormat,
 } from "./runtime-hooks";
 import { readImportKind, readImportProvider } from "./source-arg-values";
-
-type LookupCommandRequest =
-  | { readonly kind: "features"; readonly value: LookupFeaturesCommandRequest }
-  | { readonly kind: "query"; readonly value: LookupRouteRequest };
 
 export const parseListCommandRequest = (
   args: readonly string[],
@@ -92,247 +77,6 @@ export const parseExplainCommandRequest = (
   };
 };
 
-export const parseLookupCommandRequest = (
-  args: readonly string[]
-): LookupCommandRequest => {
-  let index = 1;
-  let featureId: string | undefined;
-  let features = false;
-  let lookupAspects: string[] = [];
-  let lookupField: string | undefined;
-  let lookupSubject: ReturnType<typeof readLookupSubject> | undefined;
-  let lookupTargets: TargetName[] = [];
-  let lookupViews: LookupView[] = [];
-  let jsonOutput = false;
-  let featureOption = false;
-  let rootExplicit = false;
-  let ignoredBuildMode: "all" | "updated" | undefined;
-  const cross = createInspectionCrossFlags();
-
-  const first = args[index];
-  if (first === "features") {
-    features = true;
-    index += 1;
-    const value = args[index];
-    if (value !== undefined && !value.startsWith("--")) {
-      featureId = value;
-      index += 1;
-    }
-  } else if (first !== undefined && !first.startsWith("--")) {
-    lookupSubject = readLookupSubject(first);
-    index += 1;
-    while (args[index] !== undefined && !args[index]?.startsWith("--")) {
-      const aspect = args[index];
-      if (aspect !== undefined) {
-        lookupAspects = [...lookupAspects, aspect];
-      }
-      index += 1;
-    }
-  }
-
-  const reader = new CliArgReader(args, index);
-  while (!reader.done) {
-    const option = reader.readOption();
-    if (option === undefined) {
-      break;
-    }
-    if (features && option.flag !== "--json") {
-      featureOption = true;
-    }
-    if (readInspectionCrossOption(reader, option, cross, true)) {
-      continue;
-    }
-    switch (option.flag) {
-      case "--compat": {
-        lookupViews = addLookupView(lookupViews, "compat");
-        for (const value of reader.readOptionalOptionValues(option)) {
-          lookupTargets = addLookupTargets(lookupTargets, value);
-        }
-        break;
-      }
-      case "--frontmatter":
-      case "--fields":
-      case "--values":
-      case "--events":
-      case "--examples":
-      case "--schema": {
-        assertBooleanOption(option);
-        lookupViews = addLookupView(
-          lookupViews,
-          option.flag.slice(2) as LookupView
-        );
-        break;
-      }
-      case "--field": {
-        lookupField = setLookupField(
-          lookupField,
-          reader.readRequiredOptionValue(option)
-        );
-        break;
-      }
-      case "--json": {
-        assertBooleanOption(option);
-        jsonOutput = true;
-        break;
-      }
-      case "--scope":
-      case "--name":
-        reader.readRequiredOptionValue(option);
-        break;
-      case "--kind":
-        readImportKind(reader.readRequiredOptionValue(option));
-        break;
-      case "--from": {
-        readImportProvider(reader.readRequiredOptionValue(option));
-        break;
-      }
-      case "--updated":
-      case "--all":
-        assertBooleanOption(option);
-        ignoredBuildMode = mergeBuildMode(
-          ignoredBuildMode,
-          option.flag === "--all" ? "all" : "updated"
-        );
-        break;
-      case "--yes": {
-        assertBooleanOption(option);
-        break;
-      }
-      case "--root": {
-        reader.readRequiredOptionValue(option);
-        rootExplicit = true;
-        break;
-      }
-      case "--append":
-      case "--staged": {
-        assertBooleanOption(option);
-        throw new Error(
-          "skillset: change options are only supported with change commands"
-        );
-      }
-      case "--bump":
-      case "--group":
-      case "--reason":
-      case "--reason-file":
-      case "--ref": {
-        reader.readRequiredOptionValue(option);
-        throw new Error(
-          "skillset: change options are only supported with change commands"
-        );
-      }
-      case "--targets":
-      case "--include": {
-        reader.readRequiredOptionValue(option);
-        throw new Error("skillset: setup options are only supported with init");
-      }
-      case "--adopt": {
-        reader.readRequiredOptionValue(option);
-        throw new Error(
-          "skillset: --adopt is only supported with init"
-        );
-      }
-      case "--fix":
-      case "--ci": {
-        assertBooleanOption(option);
-        throw new Error(
-          "skillset: readiness flags are only supported with check"
-        );
-      }
-      case "--only":
-      case "--report": {
-        const value = reader.readRequiredOptionValue(option);
-        if (option.flag === "--only" && value !== "outputs") {
-          throw new Error("skillset: expected --only outputs");
-        }
-        throw new Error(
-          "skillset: readiness flags are only supported with check"
-        );
-      }
-      case "--since": {
-        reader.readRequiredOptionValue(option);
-        throw new Error(
-          "skillset: --since is only supported with check --ci or change commands"
-        );
-      }
-      case "--write": {
-        assertBooleanOption(option);
-        throw new Error(
-          "skillset: --write is only supported with check or dev"
-        );
-      }
-      case "--isolated": {
-        assertBooleanOption(option);
-        if (features) {
-          featureOption = true;
-          break;
-        }
-        throw new Error(
-          "skillset: --isolated is only supported with build, check --only outputs, or diff"
-        );
-      }
-      case "--use": {
-        const value = reader.readRequiredOptionValue(option);
-        if (value !== "source" && value !== "output") {
-          throw new Error("skillset: --use expects source or output");
-        }
-        if (features) {
-          featureOption = true;
-          break;
-        }
-        throw new Error("skillset: --use is only supported with reconcile");
-      }
-      case "--id":
-      case "--in":
-      case "--preset": {
-        reader.readRequiredOptionValue(option);
-        if (features) {
-          featureOption = true;
-          break;
-        }
-        throw new Error("skillset: new options are only supported with new");
-      }
-      default: {
-        throw new Error(`skillset: unknown option ${option.raw}`);
-      }
-    }
-  }
-
-  validateInspectionCrossFlags(cross);
-
-  if (features) {
-    if (
-      lookupField !== undefined ||
-      lookupTargets.length > 0 ||
-      lookupViews.length > 0 ||
-      featureOption ||
-      cross.isolated ||
-      cross.newSource ||
-      cross.reconcile ||
-      rootExplicit
-    ) {
-      throw new Error(
-        "skillset: expected lookup features to use only an optional feature id and --json"
-      );
-    }
-    return { kind: "features", value: { featureId, jsonOutput } };
-  }
-  if (rootExplicit) {
-    throw new Error("skillset: --root is not supported with lookup");
-  }
-  validateInspectionLateFlags(cross);
-  return {
-    kind: "query",
-    value: {
-      jsonOutput,
-      lookupAspects,
-      lookupField,
-      lookupSubject,
-      lookupTargets,
-      lookupViews,
-    },
-  };
-};
-
 interface InspectionOptions {
   readonly details: boolean;
   readonly jsonOutput: boolean;
@@ -377,8 +121,7 @@ const createInspectionCrossFlags = (): InspectionCrossFlags => ({
 const readInspectionCrossOption = (
   reader: CliArgReader,
   option: CliOptionToken,
-  flags: InspectionCrossFlags,
-  lookupOwned: boolean
+  flags: InspectionCrossFlags
 ): boolean => {
   switch (option.flag) {
     case "--runner":
@@ -441,7 +184,6 @@ const readInspectionCrossOption = (
       flags.jsonl = true;
       return true;
     case "--compat":
-      if (lookupOwned) return false;
       addLookupTargets([], reader.readOptionalOptionValues(option).join(","));
       flags.lookup = true;
       return true;
@@ -451,12 +193,10 @@ const readInspectionCrossOption = (
     case "--events":
     case "--examples":
     case "--schema":
-      if (lookupOwned) return false;
       assertBooleanOption(option);
       flags.lookup = true;
       return true;
     case "--field":
-      if (lookupOwned) return false;
       flags.lookupField = setLookupField(
         flags.lookupField,
         reader.readRequiredOptionValue(option)
@@ -652,7 +392,7 @@ const parseInspectionOptions = (
     if (option === undefined) {
       break;
     }
-    if (readInspectionCrossOption(reader, option, cross, false)) {
+    if (readInspectionCrossOption(reader, option, cross)) {
       continue;
     }
     switch (option.flag) {
@@ -730,9 +470,7 @@ const parseInspectionOptions = (
       }
       case "--adopt": {
         reader.readRequiredOptionValue(option);
-        throw new Error(
-          "skillset: --adopt is only supported with init"
-        );
+        throw new Error("skillset: --adopt is only supported with init");
       }
       case "--fix":
       case "--ci": {

--- a/apps/skillset/src/lookup-args.ts
+++ b/apps/skillset/src/lookup-args.ts
@@ -1,0 +1,449 @@
+import type { LookupView } from "@skillset/core";
+import type { TargetName } from "@skillset/core/internal/types";
+
+import { readChangeBump, setChangeReason } from "./change-args";
+import type { ChangeReasonInput } from "./change-workflow";
+import {
+  assertBooleanOption,
+  CliArgReader,
+  type CliOptionToken,
+} from "./cli-arg-reader";
+import {
+  mergeBuildMode,
+  readClaudeSettingSources,
+  readPositiveInteger,
+  readTargetName,
+  readTargetNames,
+  tokenizeCsv,
+} from "./cli-arg-values";
+import type {
+  LookupFeaturesCommandRequest,
+  LookupRouteRequest,
+} from "./inspect-cli";
+import {
+  addLookupTargets,
+  addLookupView,
+  readLookupSubject,
+  setLookupField,
+} from "./lookup-cli";
+import {
+  readHookRuntimeContextField,
+  readHookRuntimeContextFormat,
+} from "./runtime-hooks";
+import { readImportKind, readImportProvider } from "./source-arg-values";
+
+export type LookupCommandRequest =
+  | { readonly kind: "features"; readonly value: LookupFeaturesCommandRequest }
+  | { readonly kind: "query"; readonly value: LookupRouteRequest };
+
+export const parseLookupCommandRequest = (
+  args: readonly string[]
+): LookupCommandRequest => {
+  let index = 1;
+  let featureId: string | undefined;
+  let features = false;
+  let lookupAspects: string[] = [];
+  let lookupField: string | undefined;
+  let lookupSubject: ReturnType<typeof readLookupSubject> | undefined;
+  let lookupTargets: TargetName[] = [];
+  let lookupViews: LookupView[] = [];
+  let jsonOutput = false;
+  let featureOption = false;
+  let rootExplicit = false;
+  let ignoredBuildMode: "all" | "updated" | undefined;
+  const foreign = createLookupForeignFlags();
+
+  const first = args[index];
+  if (first === "features") {
+    features = true;
+    index += 1;
+    const value = args[index];
+    if (value !== undefined && !value.startsWith("--")) {
+      featureId = value;
+      index += 1;
+    }
+  } else if (first !== undefined && !first.startsWith("--")) {
+    lookupSubject = readLookupSubject(first);
+    index += 1;
+    while (args[index] !== undefined && !args[index]?.startsWith("--")) {
+      const aspect = args[index];
+      if (aspect !== undefined) {
+        lookupAspects = [...lookupAspects, aspect];
+      }
+      index += 1;
+    }
+  }
+
+  const reader = new CliArgReader(args, index);
+  while (!reader.done) {
+    const option = reader.readOption();
+    if (option === undefined) {
+      break;
+    }
+    if (features && option.flag !== "--json") {
+      featureOption = true;
+    }
+    if (readLookupForeignOption(reader, option, foreign)) {
+      continue;
+    }
+    switch (option.flag) {
+      case "--compat": {
+        lookupViews = addLookupView(lookupViews, "compat");
+        for (const value of reader.readOptionalOptionValues(option)) {
+          lookupTargets = addLookupTargets(lookupTargets, value);
+        }
+        break;
+      }
+      case "--frontmatter":
+      case "--fields":
+      case "--values":
+      case "--events":
+      case "--examples":
+      case "--schema": {
+        assertBooleanOption(option);
+        lookupViews = addLookupView(
+          lookupViews,
+          option.flag.slice(2) as LookupView
+        );
+        break;
+      }
+      case "--field": {
+        lookupField = setLookupField(
+          lookupField,
+          reader.readRequiredOptionValue(option)
+        );
+        break;
+      }
+      case "--json": {
+        assertBooleanOption(option);
+        jsonOutput = true;
+        break;
+      }
+      case "--scope":
+      case "--name":
+        reader.readRequiredOptionValue(option);
+        break;
+      case "--kind":
+        readImportKind(reader.readRequiredOptionValue(option));
+        break;
+      case "--from": {
+        readImportProvider(reader.readRequiredOptionValue(option));
+        break;
+      }
+      case "--updated":
+      case "--all":
+        assertBooleanOption(option);
+        ignoredBuildMode = mergeBuildMode(
+          ignoredBuildMode,
+          option.flag === "--all" ? "all" : "updated"
+        );
+        break;
+      case "--yes": {
+        assertBooleanOption(option);
+        break;
+      }
+      case "--root": {
+        reader.readRequiredOptionValue(option);
+        rootExplicit = true;
+        break;
+      }
+      default: {
+        throw new Error(`skillset: unknown option ${option.raw}`);
+      }
+    }
+  }
+
+  validateLookupForeignFlags(foreign);
+
+  if (features) {
+    if (
+      lookupField !== undefined ||
+      lookupTargets.length > 0 ||
+      lookupViews.length > 0 ||
+      featureOption ||
+      foreign.isolated ||
+      foreign.newSource ||
+      foreign.reconcile ||
+      rootExplicit
+    ) {
+      throw new Error(
+        "skillset: expected lookup features to use only an optional feature id and --json"
+      );
+    }
+    return { kind: "features", value: { featureId, jsonOutput } };
+  }
+  if (rootExplicit) {
+    throw new Error("skillset: --root is not supported with lookup");
+  }
+  validateLookupLateFlags(foreign);
+  return {
+    kind: "query",
+    value: {
+      jsonOutput,
+      lookupAspects,
+      lookupField,
+      lookupSubject,
+      lookupTargets,
+      lookupViews,
+    },
+  };
+};
+
+interface LookupForeignFlags {
+  adopt: boolean;
+  change: boolean;
+  changeReason?: ChangeReasonInput;
+  hookContext: boolean;
+  hookPrint: boolean;
+  isolated: boolean;
+  jsonl: boolean;
+  newSource: boolean;
+  readiness: boolean;
+  reconcile: boolean;
+  setup: boolean;
+  since: boolean;
+  test: boolean;
+}
+
+const createLookupForeignFlags = (): LookupForeignFlags => ({
+  adopt: false,
+  change: false,
+  hookContext: false,
+  hookPrint: false,
+  isolated: false,
+  jsonl: false,
+  newSource: false,
+  readiness: false,
+  reconcile: false,
+  setup: false,
+  since: false,
+  test: false,
+});
+
+const readLookupForeignOption = (
+  reader: CliArgReader,
+  option: CliOptionToken,
+  flags: LookupForeignFlags
+): boolean => {
+  switch (option.flag) {
+    case "--runner":
+      readHookRunner(reader.readRequiredOptionValue(option));
+      flags.hookPrint = true;
+      return true;
+    case "--target":
+      readTargetName(reader.readRequiredOptionValue(option));
+      flags.hookPrint = true;
+      return true;
+    case "--agent-runtime":
+    case "--pre-commit":
+    case "--pre-push":
+      assertBooleanOption(option);
+      flags.hookPrint = true;
+      return true;
+    case "--event":
+      reader.readRequiredOptionValue(option);
+      flags.hookContext = true;
+      return true;
+    case "--format":
+      readHookRuntimeContextFormat(reader.readRequiredOptionValue(option));
+      flags.hookContext = true;
+      return true;
+    case "--context-fields": {
+      const fields = tokenizeCsv(reader.readRequiredOptionValue(option));
+      if (fields.length === 0) {
+        throw new Error(
+          "skillset: --context-fields requires at least one field"
+        );
+      }
+      fields.map(readHookRuntimeContextField);
+      flags.hookContext = true;
+      return true;
+    }
+    case "--prompt":
+    case "--prompt-file":
+    case "--plugin":
+      reader.readRequiredOptionValue(option);
+      flags.test = true;
+      return true;
+    case "--claude-setting-sources":
+      readClaudeSettingSources(
+        reader.readRequiredOptionValue(option),
+        "--claude-setting-sources"
+      );
+      flags.test = true;
+      return true;
+    case "--timeout-ms":
+    case "--lines":
+      readPositiveInteger(reader.readRequiredOptionValue(option), option.flag);
+      flags.test = true;
+      return true;
+    case "--background":
+      assertBooleanOption(option);
+      flags.test = true;
+      return true;
+    case "--jsonl":
+      assertBooleanOption(option);
+      flags.jsonl = true;
+      return true;
+    case "--append":
+    case "--staged":
+      assertBooleanOption(option);
+      flags.change = true;
+      return true;
+    case "--bump":
+      readChangeBump(reader.readRequiredOptionValue(option));
+      flags.change = true;
+      return true;
+    case "--group":
+    case "--ref":
+      reader.readRequiredOptionValue(option);
+      flags.change = true;
+      return true;
+    case "--reason": {
+      const value = reader.readRequiredOptionValue(option);
+      flags.changeReason = setChangeReason(
+        flags.changeReason,
+        value === "-" ? { kind: "stdin" } : { kind: "inline", value }
+      );
+      flags.change = true;
+      return true;
+    }
+    case "--reason-file":
+      flags.changeReason = setChangeReason(flags.changeReason, {
+        kind: "file",
+        path: reader.readRequiredOptionValue(option),
+      });
+      flags.change = true;
+      return true;
+    case "--targets":
+      readTargetNames(reader.readRequiredOptionValue(option));
+      flags.setup = true;
+      return true;
+    case "--include": {
+      const includes = tokenizeCsv(reader.readRequiredOptionValue(option));
+      if (includes.length === 0) {
+        throw new Error("skillset: --include requires at least one value");
+      }
+      if (includes.some((include) => include !== "ci")) {
+        throw new Error("skillset: expected --include ci");
+      }
+      flags.setup = true;
+      return true;
+    }
+    case "--adopt":
+      reader.readRequiredOptionValue(option);
+      flags.adopt = true;
+      return true;
+    case "--fix":
+    case "--ci":
+      assertBooleanOption(option);
+      flags.readiness = true;
+      return true;
+    case "--only": {
+      const value = reader.readRequiredOptionValue(option);
+      if (value !== "outputs") {
+        throw new Error("skillset: expected --only outputs");
+      }
+      flags.readiness = true;
+      return true;
+    }
+    case "--report":
+      reader.readRequiredOptionValue(option);
+      flags.readiness = true;
+      return true;
+    case "--since":
+      reader.readRequiredOptionValue(option);
+      flags.since = true;
+      return true;
+    case "--write":
+      assertBooleanOption(option);
+      throw new Error("skillset: --write is only supported with check or dev");
+    case "--isolated":
+      assertBooleanOption(option);
+      flags.isolated = true;
+      return true;
+    case "--use": {
+      const value = reader.readRequiredOptionValue(option);
+      if (value !== "source" && value !== "output") {
+        throw new Error("skillset: --use expects source or output");
+      }
+      flags.reconcile = true;
+      return true;
+    }
+    case "--id":
+    case "--in":
+    case "--preset":
+      reader.readRequiredOptionValue(option);
+      flags.newSource = true;
+      return true;
+    default:
+      return false;
+  }
+};
+
+const validateLookupForeignFlags = (flags: LookupForeignFlags): void => {
+  if (flags.change) {
+    throw new Error(
+      "skillset: change options are only supported with change commands"
+    );
+  }
+  if (flags.hookPrint) {
+    throw new Error(
+      "skillset: hook options are only supported with hooks print"
+    );
+  }
+  if (flags.hookContext) {
+    throw new Error(
+      "skillset: hook context options are only supported with hooks context"
+    );
+  }
+  if (flags.setup) {
+    throw new Error("skillset: setup options are only supported with init");
+  }
+  if (flags.adopt) {
+    throw new Error("skillset: --adopt is only supported with init");
+  }
+  if (flags.readiness) {
+    throw new Error("skillset: readiness flags are only supported with check");
+  }
+  if (flags.since) {
+    throw new Error(
+      "skillset: --since is only supported with check --ci or change commands"
+    );
+  }
+  if (flags.test) {
+    throw new Error(
+      "skillset: ad hoc test options are only supported with test"
+    );
+  }
+  if (flags.jsonl) {
+    throw new Error("skillset: unknown option --jsonl");
+  }
+};
+
+const validateLookupLateFlags = (flags: LookupForeignFlags): void => {
+  if (flags.isolated) {
+    throw new Error(
+      "skillset: --isolated is only supported with build, check --only outputs, or diff"
+    );
+  }
+  if (flags.reconcile) {
+    throw new Error("skillset: --use is only supported with reconcile");
+  }
+  if (flags.newSource) {
+    throw new Error("skillset: new options are only supported with new");
+  }
+};
+
+const readHookRunner = (value: string): void => {
+  if (
+    value !== "git" &&
+    value !== "husky" &&
+    value !== "lefthook" &&
+    value !== "pre-commit"
+  ) {
+    throw new Error(
+      "skillset: expected --runner lefthook, husky, pre-commit, or git"
+    );
+  }
+};


### PR DESCRIPTION
## Context

Implements [SET-336](https://linear.app/outfitter/issue/SET-336/split-inspection-parsers-and-share-lexical-argument-readers) by extracting lookup parsing from the remaining inspection parser owner.

## What changed

- Adds an app-local lookup parser for lookup query/features grammar and diagnostic precedence.
- Retains list, status, and explain ownership in the reduced inspection parser.
- Keeps the explicit 21-route CLI facade below its existing size guard.
- Preserves JSON/JSONL behavior, request shapes, root handling, and foreign-option diagnostics.
- Adds a scoped patch Changeset.

## Verification

- Standing and fresh local reviews: 5/5 clean, zero P0-P3.
- Focused parser/parity suite passed 100 tests with 46,488 assertions.
- Wave-wide typecheck, schema, 82 generated outputs, conformance, and `bun run check`.
- Canonical wave-head pre-push passed with 1,394 tests and 54,725 assertions.

## Risk

Low. This is an ownership extraction with exhaustive facade and compatibility coverage; no Core, schema, or generated contract changes.
