### PR TITLE
refactor: share scaffold report primitives

### DIFF
--- a/.changeset/share-scaffold-report-primitives.md
+++ b/.changeset/share-scaffold-report-primitives.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Share scaffold report formatting and default-safe authoring confirmations without changing command output or write behavior.

--- a/apps/skillset/src/__tests__/interactive-session.test.ts
+++ b/apps/skillset/src/__tests__/interactive-session.test.ts
@@ -7,6 +7,7 @@ import { PassThrough } from "node:stream";
 import { cliErrorExitCode } from "../cli-core";
 import { runInitCommand } from "../init-cli";
 import {
+  confirmProceed,
   createInteractiveSession,
   interactiveSessionEligible,
 } from "../interactive-session";
@@ -95,6 +96,30 @@ describe("SET-291 interactive session eligibility", () => {
 });
 
 describe("SET-291 prompt adapters", () => {
+  test("SET-341 shared confirmation is exact and defaults to no", async () => {
+    const adapter = new ScriptedPromptAdapter([
+      { kind: "confirm", value: false },
+    ]);
+    const session = createInteractiveSession({
+      adapter,
+      env: interactiveEnv,
+      input: ttyInput(),
+      output: ttyOutput(),
+    });
+
+    expect(session).toBeDefined();
+    if (session === undefined) {
+      throw new Error("expected interactive session");
+    }
+    await expect(confirmProceed(session)).resolves.toBe(false);
+    expect(adapter.prompts).toEqual([
+      {
+        kind: "confirm",
+        prompt: { default: false, message: "Proceed?" },
+      },
+    ]);
+  });
+
   test("scripted prompts are deterministic and record display contracts", async () => {
     const adapter = new ScriptedPromptAdapter([
       { kind: "input", value: "demo" },
@@ -263,7 +288,11 @@ describe("SET-291 prompt adapters", () => {
     output.on("data", (chunk: Buffer) => {
       transcript += chunk.toString();
     });
-    const result = new ClackPromptAdapter({ color: true, input, output }).select({
+    const result = new ClackPromptAdapter({
+      color: true,
+      input,
+      output,
+    }).select({
       choices: [
         { description: "recommended", name: "One", value: "one" },
         { disabled: "unavailable", name: "Two", value: "two" },
@@ -504,9 +533,7 @@ describe("SET-291 prompt adapters", () => {
     session?.banner();
     const rendered = output.read()?.toString() ?? "";
     expect(rendered).not.toContain("\u001b[2m");
-    expect(Bun.stripANSI(rendered)).toMatch(
-      /skillset v\d+\.\d+\.\d+\n$/u
-    );
+    expect(Bun.stripANSI(rendered)).toMatch(/skillset v\d+\.\d+\.\d+\n$/u);
   });
 
   test("the init orchestration boundary previews then leaves default-No repositories untouched", async () => {

--- a/apps/skillset/src/__tests__/scaffold-report.test.ts
+++ b/apps/skillset/src/__tests__/scaffold-report.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatScaffoldFileLine,
+  formatScaffoldNextStep,
+  formatScaffoldWriteHint,
+  scaffoldWriteReason,
+} from "../scaffold-report";
+
+describe("SET-341 scaffold report primitives", () => {
+  test.each([
+    ["create", "  + skillset.yaml"],
+    ["exists", "  = skillset.yaml"],
+    ["update", "  ~ skillset.yaml"],
+  ] as const)("formats %s file lines", (state, expected) => {
+    expect(formatScaffoldFileLine("skillset.yaml", state)).toBe(expected);
+  });
+
+  test.each([
+    [false, false, "write confirmation required"],
+    [true, false, "blocked before write"],
+    [true, true, "written"],
+  ] as const)("selects the write reason", (write, written, expected) => {
+    expect(scaffoldWriteReason(write, written)).toBe(expected);
+  });
+
+  test.each([
+    ["skillset check", "  next: skillset check"],
+    [
+      "skillset check, skillset check --only outputs",
+      "  next: skillset check, skillset check --only outputs",
+    ],
+  ] as const)("formats next steps", (command, expected) => {
+    expect(formatScaffoldNextStep(command)).toBe(expected);
+  });
+
+  test.each([
+    [
+      "init with --yes",
+      "setup files",
+      "skillset: rerun init with --yes to write setup files",
+    ],
+    [
+      "init with --adopt and --yes",
+      "adopted source",
+      "skillset: rerun init with --adopt and --yes to write adopted source",
+    ],
+  ] as const)("formats write hints", (invocation, subject, expected) => {
+    expect(formatScaffoldWriteHint(invocation, subject)).toBe(expected);
+  });
+});

--- a/apps/skillset/src/create-cli.ts
+++ b/apps/skillset/src/create-cli.ts
@@ -12,12 +12,16 @@ import {
   normalizeCreateName,
   runInteractiveCreate,
 } from "./create-interactive";
-import { printSetupReport } from "./init-cli";
 import {
   createInteractiveSession,
   type InteractiveSession,
 } from "./interactive-session";
+import {
+  formatScaffoldWriteHint,
+  scaffoldWriteReason,
+} from "./scaffold-report";
 import { createSkillset, type SetupInclude } from "./setup";
+import { printSetupReport } from "./setup-cli";
 
 export interface CreateCommandRequest {
   readonly jsonOutput: boolean;
@@ -44,20 +48,26 @@ export async function runCreateCommand(
   if (!request.yes && interactiveSession !== undefined) {
     interactiveSession.banner();
     const result = await runInteractiveCreate(request, interactiveSession, {
-      printPlan: (plan) => interactiveSession.note(
-        formatInteractiveCreatePlan(plan),
-        "Skillset will"
-      ),
+      printPlan: (plan) =>
+        interactiveSession.note(
+          formatInteractiveCreatePlan(plan),
+          "Skillset will"
+        ),
     });
     if (result.reason === "written") {
       printSetupReport(result.report, result.reason);
-      await rememberKnownSkillsetWorkspace(result.report.rootPath, request.options);
+      await rememberKnownSkillsetWorkspace(
+        result.report.rootPath,
+        request.options
+      );
     }
     return;
   }
 
   if (request.name === undefined) {
-    throw new Error("skillset: create requires a name outside an interactive terminal");
+    throw new Error(
+      "skillset: create requires a name outside an interactive terminal"
+    );
   }
   const name = normalizeCreateName(request.name);
   const parentPath = resolve(request.parentPath);
@@ -74,7 +84,11 @@ export async function runCreateCommand(
     write: request.yes,
   });
   if (request.jsonOutput && request.yes) {
-    await rememberKnownSkillsetWorkspace(report.rootPath, request.options, true);
+    await rememberKnownSkillsetWorkspace(
+      report.rootPath,
+      request.options,
+      true
+    );
   }
   if (request.jsonOutput) {
     const writes = request.yes
@@ -91,12 +105,9 @@ export async function runCreateCommand(
       writes,
     });
   } else {
-    printSetupReport(
-      report,
-      request.yes ? "written" : "write confirmation required"
-    );
+    printSetupReport(report, scaffoldWriteReason(request.yes));
     if (!request.yes) {
-      console.log("skillset: rerun create with --yes to write setup files");
+      console.log(formatScaffoldWriteHint("create with --yes", "setup files"));
     }
   }
   if (!request.jsonOutput && request.yes) {

--- a/apps/skillset/src/create-interactive.ts
+++ b/apps/skillset/src/create-interactive.ts
@@ -5,12 +5,9 @@ import { validateSlug } from "@skillset/core/internal/path";
 import type { TargetName } from "@skillset/core/internal/types";
 import { formatList } from "@skillset/schema";
 
+import { confirmProceed } from "./interactive-session";
 import type { InteractiveSession } from "./interactive-session";
-import {
-  createSkillset,
-  type SetupInclude,
-  type SetupReport,
-} from "./setup";
+import { createSkillset, type SetupInclude, type SetupReport } from "./setup";
 
 export interface InteractiveCreateRequest {
   readonly name: string | undefined;
@@ -42,23 +39,31 @@ export async function runInteractiveCreate(
   session: InteractiveSession,
   context: InteractiveCreateContext
 ): Promise<InteractiveCreateResult> {
-  const name = request.name === undefined
-    ? normalizeCreateName(await session.prompts.input({
-        message: "What should this Skillset be called?",
-        validate: (value) => validateCreateName(value),
-      }))
-    : normalizeCreateName(request.name);
+  const name =
+    request.name === undefined
+      ? normalizeCreateName(
+          await session.prompts.input({
+            message: "What should this Skillset be called?",
+            validate: (value) => validateCreateName(value),
+          })
+        )
+      : normalizeCreateName(request.name);
   const parentPath = request.parentExplicit
     ? resolve(request.parentPath)
-    : resolve(await session.prompts.input({
-        default: resolve(request.parentPath),
-        message: "Where should it be created?",
-        validate: (value) => value.trim().length > 0
-          ? true
-          : "skillset: parent directory is required",
-      }));
-  const targets = request.setupTargets ?? await promptForCreateTargets(session);
-  const include = request.setupIncludes ?? await promptForIntegrations(session);
+    : resolve(
+        await session.prompts.input({
+          default: resolve(request.parentPath),
+          message: "Where should it be created?",
+          validate: (value) =>
+            value.trim().length > 0
+              ? true
+              : "skillset: parent directory is required",
+        })
+      );
+  const targets =
+    request.setupTargets ?? (await promptForCreateTargets(session));
+  const include =
+    request.setupIncludes ?? (await promptForIntegrations(session));
   const report = await createSkillset({
     cwd: parentPath,
     include,
@@ -68,10 +73,7 @@ export async function runInteractiveCreate(
     write: false,
   });
   context.printPlan({ include, name, parentPath, report, targets });
-  const confirmed = await session.prompts.confirm({
-    default: false,
-    message: "Proceed?",
-  });
+  const confirmed = await confirmProceed(session);
   if (!confirmed) return { reason: "write confirmation declined", report };
   return {
     reason: "written",

--- a/apps/skillset/src/init-cli.ts
+++ b/apps/skillset/src/init-cli.ts
@@ -1,6 +1,5 @@
 import { resolve } from "node:path";
 
-import { sourceUnitDisplay } from "@skillset/core/internal/source-unit-selector";
 import type {
   SkillsetOptions,
   TargetName,
@@ -18,8 +17,14 @@ import {
   createInteractiveSession,
   type InteractiveSession,
 } from "./interactive-session";
+import {
+  formatScaffoldFileLine,
+  formatScaffoldWriteHint,
+  scaffoldWriteReason,
+} from "./scaffold-report";
 import { initSkillset } from "./setup";
-import type { SetupInclude, SetupReport } from "./setup";
+import type { SetupInclude } from "./setup";
+import { printSetupReport } from "./setup-cli";
 
 export interface InitCommandRequest {
   readonly directory: string | undefined;
@@ -54,14 +59,13 @@ export async function runInitCommand(
   const initCwd = resolve(rootPath);
   const explicitInitRootPath = rootExplicit ? initCwd : undefined;
   const setupRootPath =
-    directory === undefined ? explicitInitRootPath : resolve(initCwd, directory);
+    directory === undefined
+      ? explicitInitRootPath
+      : resolve(initCwd, directory);
   const interactiveSession = jsonOutput
     ? undefined
     : (context.interactiveSession ?? createInteractiveSession());
-  if (
-    initAdopt !== undefined &&
-    (yes || interactiveSession === undefined)
-  ) {
+  if (initAdopt !== undefined && (yes || interactiveSession === undefined)) {
     const writeMode = yes;
     const inferredRoot = (
       await initSkillset({
@@ -78,11 +82,7 @@ export async function runInitCommand(
       ...(setupTargets === undefined ? {} : { targets: setupTargets }),
       write: writeMode,
     });
-    const reason = writeMode
-      ? report.write
-        ? "written"
-        : "blocked before write"
-      : "write confirmation required";
+    const reason = scaffoldWriteReason(writeMode, report.write);
     if (jsonOutput && writeMode && report.ok) {
       await rememberKnownSkillsetWorkspace(report.rootPath, options, true);
     }
@@ -100,7 +100,10 @@ export async function runInitCommand(
       printAdoptReport(report, reason);
       if (!writeMode && report.ok && initAdopt !== undefined) {
         console.log(
-          "skillset: rerun init with --adopt and --yes to write adopted source"
+          formatScaffoldWriteHint(
+            "init with --adopt and --yes",
+            "adopted source"
+          )
         );
       }
     }
@@ -177,9 +180,9 @@ export async function runInitCommand(
       writes,
     });
   } else {
-    printSetupReport(setup, yes ? "written" : "write confirmation required");
+    printSetupReport(setup, scaffoldWriteReason(yes));
     if (!yes) {
-      console.log("skillset: rerun init with --yes to write setup files");
+      console.log(formatScaffoldWriteHint("init with --yes", "setup files"));
     }
   }
   if (!jsonOutput && yes) {
@@ -201,7 +204,7 @@ function printAdoptReport(report: AdoptReport, reason: string): void {
     );
   }
   for (const file of report.setupFiles) {
-    console.log(`  ${file.status === "create" ? "+" : "="} ${file.path}`);
+    console.log(formatScaffoldFileLine(file.path, file.status));
   }
   for (const candidate of report.candidates) {
     const sources =
@@ -249,58 +252,4 @@ function printAdoptReport(report: AdoptReport, reason: string): void {
   }
   console.log(`  report: ${ADOPT_REPORT_DIR}/report.md`);
   console.log(`skillset: adopt ${report.ok ? "passed" : "found problems"}`);
-}
-
-export function printSetupReport(result: SetupReport, reason: string): void {
-  for (const file of result.files) {
-    const marker = file.status === "create" ? "+" : "=";
-    console.log(`  ${marker} ${file.path}`);
-  }
-  if (result.git !== undefined) {
-    const marker = result.git.status === "create" ? "+" : "=";
-    console.log(`  ${marker} ${result.git.path}`);
-  }
-  for (const baseline of result.baselines) {
-    const marker = baseline.status === "create" ? "+" : "=";
-    console.log(
-      `  ${marker} baseline ${sourceUnitDisplay(baseline.scope)} ${baseline.version}`
-    );
-  }
-  for (const candidate of result.importCandidates) {
-    console.log(
-      `  ? import candidate ${candidate.kind} ${candidate.path} (id: ${adoptCandidateId(candidate)})`
-    );
-  }
-  for (const diagnostic of result.surveyDiagnostics) {
-    const marker = diagnostic.severity === "error" ? "FAIL" : "warning";
-    console.log(
-      `  ${marker} ${diagnostic.code} ${diagnostic.paths.join(", ")}: ${diagnostic.message}`
-    );
-    console.log(`    resolution: ${diagnostic.recommendation}`);
-  }
-  for (const skip of result.surveySkips) {
-    console.log(`  ! skipped ${skip.surface} ${skip.path}: ${skip.reason}`);
-  }
-  const created = result.files.filter(
-    (file) => file.status === "create"
-  ).length;
-  const existing = result.files.length - created;
-  const gitCreated = result.git?.status === "create" ? 1 : 0;
-  const gitExisting = result.git?.status === "exists" ? 1 : 0;
-  const baselines = result.baselines.filter(
-    (baseline) => baseline.status === "create"
-  ).length;
-  const candidates = result.importCandidates.length;
-  const details = [
-    `${created + gitCreated} to create`,
-    `${existing + gitExisting} already present`,
-    ...(baselines === 0
-      ? []
-      : [`${baselines} baseline${baselines === 1 ? "" : "s"} to adopt`]),
-    ...(candidates === 0
-      ? []
-      : [`${candidates} import candidate${candidates === 1 ? "" : "s"}`]),
-  ];
-  console.log(`skillset: ${result.kind} ${details.join(", ")} (${reason})`);
-  console.log(`  root: ${result.rootPath}`);
 }

--- a/apps/skillset/src/init-interactive.ts
+++ b/apps/skillset/src/init-interactive.ts
@@ -10,6 +10,7 @@ import { formatList } from "@skillset/schema";
 
 import { adoptCandidateId, adoptSkillset, type AdoptReport } from "./adopt";
 import { gitSafeEnv } from "./git-env";
+import { confirmProceed } from "./interactive-session";
 import type { InteractiveSession } from "./interactive-session";
 import {
   initSkillset,
@@ -107,10 +108,7 @@ export async function runInteractiveInit(
     location: plan.report.rootPath,
     targets,
   });
-  const confirmed = await session.prompts.confirm({
-    default: false,
-    message: "Proceed?",
-  });
+  const confirmed = await confirmProceed(session);
   if (!confirmed) return { ...plan, reason: "write confirmation declined" };
   return executeInit(initial.rootPath, candidates, include, targets);
 }
@@ -188,7 +186,10 @@ export async function promptForInteractiveCandidates(
   session: InteractiveSession
 ): Promise<readonly string[]> {
   if (candidates.length === 0) return [];
-  session.note(formatDiscoveredCandidates(candidates), "Found in this repository");
+  session.note(
+    formatDiscoveredCandidates(candidates),
+    "Found in this repository"
+  );
   const intent = await session.prompts.select<InteractiveAdoptionIntent>({
     choices: [
       {

--- a/apps/skillset/src/interactive-session.ts
+++ b/apps/skillset/src/interactive-session.ts
@@ -40,6 +40,12 @@ export interface InteractiveSession {
   write(message: string): void;
 }
 
+export const confirmProceed = (
+  session: InteractiveSession
+): Promise<boolean> => {
+  return session.prompts.confirm({ default: false, message: "Proceed?" });
+};
+
 export function interactiveSessionEligible({
   env = process.env,
   input = process.stdin,

--- a/apps/skillset/src/new-interactive.ts
+++ b/apps/skillset/src/new-interactive.ts
@@ -1,13 +1,14 @@
-import type {
-  SkillsetOptions,
-  TargetName,
-} from "@skillset/core/internal/types";
 import {
   adaptiveHookEventDefinitions,
   planAdaptiveHookCompatibility,
 } from "@skillset/core/internal/adaptive-hook-authoring";
 import { targetNames } from "@skillset/core/internal/targets";
+import type {
+  SkillsetOptions,
+  TargetName,
+} from "@skillset/core/internal/types";
 
+import { confirmProceed } from "./interactive-session";
 import type { InteractiveSession } from "./interactive-session";
 import { listNewAdaptiveHookAttachmentTargets } from "./new-hook";
 import {
@@ -59,9 +60,8 @@ export async function runInteractiveNew(
   const identity = await resolveIdentity(request, kind, session);
   const container = await resolveContainer(request, kind, session);
   const presets = await resolvePresets(request, kind, session);
-  const hookIntent = kind === "hook"
-    ? await resolveHookIntent(request, session)
-    : {};
+  const hookIntent =
+    kind === "hook" ? await resolveHookIntent(request, session) : {};
   const options = {
     ...(container === undefined ? {} : { container }),
     ...(identity.id === undefined ? {} : { id: identity.id }),
@@ -80,10 +80,7 @@ export async function runInteractiveNew(
     write: false,
   });
   context.printPlan(plan);
-  const confirmed = await session.prompts.confirm({
-    default: false,
-    message: "Proceed?",
-  });
+  const confirmed = await confirmProceed(session);
   if (!confirmed) {
     return { reason: "write confirmation declined", report: plan };
   }
@@ -113,17 +110,20 @@ async function resolveHookIntent(
       "skillset: new hook requires an existing plugin, skill, or project agent attachment target"
     );
   }
-  const hookAttachment = request.hookAttachment ?? await session.prompts.search({
-    message: "Attach to:",
-    source: (term) => filterChoices(
-      term,
-      targets.map((target) => ({
-        description: target.description,
-        name: target.name,
-        value: target.selector,
-      }))
-    ),
-  });
+  const hookAttachment =
+    request.hookAttachment ??
+    (await session.prompts.search({
+      message: "Attach to:",
+      source: (term) =>
+        filterChoices(
+          term,
+          targets.map((target) => ({
+            description: target.description,
+            name: target.name,
+            value: target.selector,
+          }))
+        ),
+    }));
   const target = targets.find((item) => item.selector === hookAttachment);
   if (target === undefined) {
     throw new Error(
@@ -145,19 +145,18 @@ async function resolveHookIntent(
       value: event.id,
     };
   });
-  const hookEvents = request.hookEvents ?? await session.prompts.searchCheckbox({
-    choices: eventChoices,
-    message: "Events:",
-    required: true,
-    source: (term, choices) => filterChoices(term, choices),
-  });
+  const hookEvents =
+    request.hookEvents ??
+    (await session.prompts.searchCheckbox({
+      choices: eventChoices,
+      message: "Events:",
+      required: true,
+      source: (term, choices) => filterChoices(term, choices),
+    }));
   const action = await resolveHookAction(request, session);
-  const hookProviders = request.hookProviders ?? await resolveHookProviders(
-    action,
-    hookEvents,
-    target.scope,
-    session
-  );
+  const hookProviders =
+    request.hookProviders ??
+    (await resolveHookProviders(action, hookEvents, target.scope, session));
   return {
     hookAttachment,
     ...action,
@@ -172,8 +171,12 @@ async function resolveHookAction(
 ): Promise<{ readonly hookCommand?: string; readonly hookScript?: string }> {
   if (request.hookCommand !== undefined || request.hookScript !== undefined) {
     return {
-      ...(request.hookCommand === undefined ? {} : { hookCommand: request.hookCommand }),
-      ...(request.hookScript === undefined ? {} : { hookScript: request.hookScript }),
+      ...(request.hookCommand === undefined
+        ? {}
+        : { hookCommand: request.hookCommand }),
+      ...(request.hookScript === undefined
+        ? {}
+        : { hookScript: request.hookScript }),
     };
   }
   const kind = await session.prompts.select({
@@ -196,9 +199,7 @@ async function resolveHookAction(
     message: kind === "command" ? "Command:" : "Script path:",
     validate: (input) => input.trim().length > 0 || "Enter a hook action.",
   });
-  return kind === "command"
-    ? { hookCommand: value }
-    : { hookScript: value };
+  return kind === "command" ? { hookCommand: value } : { hookScript: value };
 }
 
 async function resolveHookProviders(
@@ -225,15 +226,18 @@ async function resolveHookProviders(
       description: compatible.has(target)
         ? "Compatible"
         : (classification?.reason ?? "Not compatible with this hook intent"),
-      disabled: compatible.has(target) ? false : (classification?.reason ?? true),
+      disabled: compatible.has(target)
+        ? false
+        : (classification?.reason ?? true),
       name: target,
       value: target,
     };
   });
   session.note(
     choices
-      .map((choice) =>
-        `${choice.name}: ${choice.disabled ? choice.description : "compatible"}`
+      .map(
+        (choice) =>
+          `${choice.name}: ${choice.disabled ? choice.description : "compatible"}`
       )
       .join("\n"),
     "Compatibility"
@@ -254,7 +258,8 @@ function hookRunForCompatibility(action: {
   readonly hookScript?: string;
 }): { readonly command: string } | { readonly script: string } {
   if (
-    (action.hookCommand === undefined) === (action.hookScript === undefined)
+    (action.hookCommand === undefined) ===
+    (action.hookScript === undefined)
   ) {
     throw new Error(
       "skillset: new hook requires exactly one of --command or --script"
@@ -281,7 +286,9 @@ function filterChoices<Value>(
   return query.length === 0
     ? choices
     : choices.filter((choice) =>
-        `${choice.name} ${choice.description ?? ""}`.toLowerCase().includes(query)
+        `${choice.name} ${choice.description ?? ""}`
+          .toLowerCase()
+          .includes(query)
       );
 }
 

--- a/apps/skillset/src/scaffold-report.ts
+++ b/apps/skillset/src/scaffold-report.ts
@@ -1,0 +1,30 @@
+export type ScaffoldFileState = "create" | "exists" | "update";
+
+const SCAFFOLD_FILE_MARKERS: Readonly<Record<ScaffoldFileState, string>> = {
+  create: "+",
+  exists: "=",
+  update: "~",
+};
+
+export const formatScaffoldFileLine = (
+  path: string,
+  state: ScaffoldFileState
+): string => `  ${SCAFFOLD_FILE_MARKERS[state]} ${path}`;
+
+export const scaffoldWriteReason = (
+  write: boolean,
+  written = write
+): "blocked before write" | "write confirmation required" | "written" => {
+  if (!write) {
+    return "write confirmation required";
+  }
+  return written ? "written" : "blocked before write";
+};
+
+export const formatScaffoldNextStep = (command: string): string =>
+  `  next: ${command}`;
+
+export const formatScaffoldWriteHint = (
+  invocation: string,
+  subject: string
+): string => `skillset: rerun ${invocation} to write ${subject}`;

--- a/apps/skillset/src/setup-cli.ts
+++ b/apps/skillset/src/setup-cli.ts
@@ -1,0 +1,59 @@
+import { sourceUnitDisplay } from "@skillset/core/internal/source-unit-selector";
+
+import { adoptCandidateId } from "./adopt";
+import { formatScaffoldFileLine } from "./scaffold-report";
+import type { SetupReport } from "./setup";
+
+export const printSetupReport = (result: SetupReport, reason: string): void => {
+  for (const file of result.files) {
+    console.log(formatScaffoldFileLine(file.path, file.status));
+  }
+  if (result.git !== undefined) {
+    console.log(formatScaffoldFileLine(result.git.path, result.git.status));
+  }
+  for (const baseline of result.baselines) {
+    console.log(
+      formatScaffoldFileLine(
+        `baseline ${sourceUnitDisplay(baseline.scope)} ${baseline.version}`,
+        baseline.status
+      )
+    );
+  }
+  for (const candidate of result.importCandidates) {
+    console.log(
+      `  ? import candidate ${candidate.kind} ${candidate.path} (id: ${adoptCandidateId(candidate)})`
+    );
+  }
+  for (const diagnostic of result.surveyDiagnostics) {
+    const marker = diagnostic.severity === "error" ? "FAIL" : "warning";
+    console.log(
+      `  ${marker} ${diagnostic.code} ${diagnostic.paths.join(", ")}: ${diagnostic.message}`
+    );
+    console.log(`    resolution: ${diagnostic.recommendation}`);
+  }
+  for (const skip of result.surveySkips) {
+    console.log(`  ! skipped ${skip.surface} ${skip.path}: ${skip.reason}`);
+  }
+  const created = result.files.filter(
+    (file) => file.status === "create"
+  ).length;
+  const existing = result.files.length - created;
+  const gitCreated = result.git?.status === "create" ? 1 : 0;
+  const gitExisting = result.git?.status === "exists" ? 1 : 0;
+  const baselines = result.baselines.filter(
+    (baseline) => baseline.status === "create"
+  ).length;
+  const candidates = result.importCandidates.length;
+  const details = [
+    `${created + gitCreated} to create`,
+    `${existing + gitExisting} already present`,
+    ...(baselines === 0
+      ? []
+      : [`${baselines} baseline${baselines === 1 ? "" : "s"} to adopt`]),
+    ...(candidates === 0
+      ? []
+      : [`${candidates} import candidate${candidates === 1 ? "" : "s"}`]),
+  ];
+  console.log(`skillset: ${result.kind} ${details.join(", ")} (${reason})`);
+  console.log(`  root: ${result.rootPath}`);
+};

--- a/apps/skillset/src/source-cli.ts
+++ b/apps/skillset/src/source-cli.ts
@@ -14,12 +14,18 @@ import {
   type InteractiveSession,
 } from "./interactive-session";
 import { runInteractiveNew } from "./new-interactive";
-import { scaffoldSourceUnit } from "./new-source";
 import type {
   NewSourceKind,
   NewSourceReport,
   NewSourceScope,
 } from "./new-source";
+import { scaffoldSourceUnit } from "./new-source";
+import {
+  formatScaffoldFileLine,
+  formatScaffoldNextStep,
+  formatScaffoldWriteHint,
+  scaffoldWriteReason,
+} from "./scaffold-report";
 import type { ImportKind, ImportProvider } from "./source-arg-values";
 
 export interface ImportCommandRequest {
@@ -213,12 +219,9 @@ export async function runNewCommand(
       writes: report.write ? report.files.map((file) => file.path) : [],
     });
   } else {
-    printNewSourceReport(
-      report,
-      yes ? "written" : "write confirmation required"
-    );
+    printNewSourceReport(report, scaffoldWriteReason(yes));
     if (!yes) {
-      console.log("skillset: rerun new with --yes to write source files");
+      console.log(formatScaffoldWriteHint("new with --yes", "source files"));
     }
   }
   return;
@@ -275,19 +278,19 @@ function printImportReport(result: ImportReport): void {
   for (const warning of result.warnings) {
     console.warn(`  warning: ${warning}`);
   }
-  console.log(`  next: ${result.nextChecks.join(", ")}`);
+  console.log(formatScaffoldNextStep(result.nextChecks.join(", ")));
 }
 
 function printNewSourceReport(result: NewSourceReport, reason: string): void {
   for (const file of result.files) {
-    console.log(`  ${file.operation === "update" ? "~" : "+"} ${file.path}`);
+    console.log(formatScaffoldFileLine(file.path, file.operation));
   }
   const action = result.write ? "created" : "planned";
   console.log(`skillset: ${action} ${result.kind} ${result.id} (${reason})`);
   console.log(`  source: ${result.sourceRoot}`);
   console.log(`  name: ${result.displayName}`);
   if (result.write) {
-    console.log("  next: skillset build --yes");
-    console.log("  next: skillset check");
+    console.log(formatScaffoldNextStep("skillset build --yes"));
+    console.log(formatScaffoldNextStep("skillset check"));
   }
 }


### PR DESCRIPTION
## Context

Implements [SET-341](https://linear.app/outfitter/issue/SET-341/share-scaffold-report-primitives-across-authoring-flows) by sharing the small presentation primitives used by authoring flows while retaining command-specific protocols.

## What changed

- Adds pure app-owned helpers for file markers, write reasons, next steps, and write hints.
- Moves setup report ownership out of init so create no longer imports init reporting.
- Adds one exact default-No `Proceed?` helper used only by init, create, and new.
- Applies the primitives narrowly across setup, adopt, new, and import.
- Adds focused helper/flow tests and a scoped patch Changeset.

## Verification

- Standing and fresh local reviews: 5/5 clean, zero P0-P3.
- Affected authoring-flow suite passed 153 tests with 730 assertions.
- Wave-wide typecheck, schema, 82 generated outputs, conformance, and `bun run check`.
- Canonical wave-head pre-push passed with 1,394 tests and 54,725 assertions.

## Risk

Low. Output bytes, order, channels, diagnostics, JSON envelopes, immediate and partial writes, and protocol bypasses are preserved.
