### PR TITLE
refactor(cli): migrate lookup to finite command shell

### DIFF
--- a/.changeset/migrate-lookup-finite-command.md
+++ b/.changeset/migrate-lookup-finite-command.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Migrate lookup routes onto the finite-command presentation adapter without changing human or JSON output.

--- a/apps/skillset/src/__tests__/lookup-cli.test.ts
+++ b/apps/skillset/src/__tests__/lookup-cli.test.ts
@@ -1,6 +1,139 @@
 import { expect, test } from "bun:test";
 import { join } from "node:path";
 
+test("SET-347: lookup preserves finite human and JSON success and failure parity", async () => {
+  const successHuman = await runSkillsetCli(
+    "lookup",
+    "workspace",
+    "--field",
+    "compile.targets",
+    "--values"
+  );
+  const successJson = await runSkillsetCli(
+    "lookup",
+    "workspace",
+    "--field",
+    "compile.targets",
+    "--values",
+    "--json"
+  );
+  const failureHuman = await runSkillsetCli(
+    "lookup",
+    "workspace",
+    "--field",
+    "no.such.field"
+  );
+  const failureJson = await runSkillsetCli(
+    "lookup",
+    "workspace",
+    "--field",
+    "no.such.field",
+    "--json"
+  );
+
+  expect(successHuman).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout:
+      "skillset lookup workspace\n  fields:\n    compile.targets: array<enum> values: claude, codex, cursor\nskillset: lookup complete\n",
+  });
+  expect(failureHuman).toEqual({
+    exitCode: 1,
+    stderr: "",
+    stdout:
+      "skillset lookup workspace\n  error: lookup/field/not-found: workspace-config does not define field no.such.field.\nskillset: lookup reported diagnostics\n",
+  });
+
+  expect(readFiniteResult(successJson)).toMatchObject({
+    command: "lookup",
+    data: {
+      diagnostics: [],
+      fields: [
+        { path: "compile.targets", values: ["claude", "codex", "cursor"] },
+      ],
+      subject: "workspace",
+    },
+    diagnostics: [],
+    exitCode: 0,
+    kind: "data",
+    ok: true,
+  });
+  expect(readFiniteResult(failureJson)).toMatchObject({
+    command: "lookup",
+    data: {
+      diagnostics: [
+        {
+          code: "lookup/field/not-found",
+          severity: "error",
+        },
+      ],
+      fields: [],
+      subject: "workspace",
+    },
+    diagnostics: [
+      {
+        code: "lookup/field/not-found",
+        severity: "error",
+      },
+    ],
+    exitCode: 1,
+    kind: "diagnostics",
+    ok: false,
+  });
+});
+
+test("SET-347: lookup features preserves finite human and JSON success and sparse failure parity", async () => {
+  const successHuman = await runSkillsetCli("lookup", "features", "plugin-bin");
+  const successJson = await runSkillsetCli(
+    "lookup",
+    "features",
+    "plugin-bin",
+    "--json"
+  );
+  const failureHuman = await runSkillsetCli(
+    "lookup",
+    "features",
+    "no-such-feature"
+  );
+  const failureJson = await runSkillsetCli(
+    "lookup",
+    "features",
+    "no-such-feature",
+    "--json"
+  );
+
+  expect(successHuman).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout:
+      "feature plugin-bin: Plugin Bin\n  status: implemented\n  claude: pass_through\n  codex: unsupported (Codex plugins do not expose a documented plugin-local bin contract.)\n  cursor: unsupported (Cursor plugins do not expose a documented plugin-local bin contract.)\n  docs: docs/features/executables.md, docs/features/feature-source-pointers.md\nskillset: listed 1 feature\n",
+  });
+  expect(failureHuman).toEqual({
+    exitCode: 1,
+    stderr: "",
+    stdout: "skillset: feature no-such-feature not found\n",
+  });
+
+  expect(readFiniteResult(successJson)).toMatchObject({
+    command: "lookup features",
+    data: { features: [{ id: "plugin-bin", title: "Plugin Bin" }] },
+    diagnostics: [],
+    exitCode: 0,
+    kind: "data",
+    ok: true,
+  });
+  expect(readFiniteResult(failureJson)).toEqual(
+    expect.objectContaining({
+      command: "lookup features",
+      data: { features: [] },
+      diagnostics: [],
+      exitCode: 1,
+      kind: "data",
+      ok: false,
+    })
+  );
+});
+
 test("SET-220: lookup without a subject lists static reference subjects", async () => {
   const result = await runSkillsetCli("lookup");
 
@@ -276,4 +409,19 @@ async function runSkillsetCli(...args: readonly string[]): Promise<{
 
 function readResultData(stdout: string): unknown {
   return (JSON.parse(stdout) as { readonly data: unknown }).data;
+}
+
+function readFiniteResult(
+  result: Awaited<ReturnType<typeof runSkillsetCli>>
+): Readonly<Record<string, unknown>> {
+  expect(result.stderr).toBe("");
+  expect(result.stdout.endsWith("\n")).toBe(true);
+  expect(result.stdout.trim().split("\n")).toHaveLength(1);
+  const parsed = JSON.parse(result.stdout) as Readonly<
+    Record<string, unknown>
+  > & {
+    readonly exitCode: number;
+  };
+  expect(parsed.exitCode).toBe(result.exitCode);
+  return parsed;
 }

--- a/apps/skillset/src/inspect-cli.ts
+++ b/apps/skillset/src/inspect-cli.ts
@@ -22,7 +22,6 @@ import {
   type FiniteCommandWriter,
 } from "./cli-finite-command";
 import { renderGeneratedEntryList } from "./cli-list-renderer";
-import { printCliJsonData } from "./cli-output";
 import { runLookupCommand } from "./lookup-cli";
 
 export interface ListCommandRequest {
@@ -57,25 +56,37 @@ export interface LookupFeaturesCommandRequest {
 export function runLookupFeaturesCommand({
   featureId,
   jsonOutput,
-}: LookupFeaturesCommandRequest): void {
-  const features = listFeatureCapabilities(featureId);
-  if (jsonOutput) {
-    const exitCode = featureId !== undefined && features.length === 0 ? 1 : 0;
-    printCliJsonData("lookup features", { features }, exitCode);
-    return;
-  }
+}: LookupFeaturesCommandRequest): Promise<void> {
+  return runFiniteCommand({
+    execute: () => listFeatureCapabilities(featureId),
+    exitCode: (features) =>
+      featureId !== undefined && features.length === 0 ? 1 : 0,
+    json: (features) => ({
+      command: "lookup features",
+      data: { features },
+    }),
+    jsonOutput,
+    renderHuman: (features, writer) =>
+      printFeatureCapabilities(features, featureId, writer),
+  });
+}
+
+function printFeatureCapabilities(
+  features: readonly FeatureCapability[],
+  featureId: string | undefined,
+  writer: FiniteCommandWriter
+): void {
   if (features.length === 0) {
-    console.log(`skillset: feature ${featureId ?? ""} not found`);
-    process.exitCode = 1;
+    writeLine(writer, `skillset: feature ${featureId ?? ""} not found`);
     return;
   }
   for (const feature of features) {
-    printFeatureCapability(feature);
+    printFeatureCapability(feature, writer);
   }
-  console.log(
+  writeLine(
+    writer,
     `skillset: listed ${features.length} feature${features.length === 1 ? "" : "s"}`
   );
-  return;
 }
 
 export interface LookupRouteRequest {
@@ -94,8 +105,8 @@ export function runLookupRoute({
   lookupTargets,
   lookupViews,
   jsonOutput,
-}: LookupRouteRequest): void {
-  runLookupCommand({
+}: LookupRouteRequest): Promise<void> {
+  return runLookupCommand({
     aspects: lookupAspects,
     ...(lookupField === undefined ? {} : { field: lookupField }),
     json: jsonOutput,
@@ -103,7 +114,6 @@ export function runLookupRoute({
     targets: lookupTargets,
     views: lookupViews,
   });
-  return;
 }
 
 export interface ExplainCommandRequest {
@@ -350,14 +360,20 @@ function formatSourceOrigin(origin: SourceOrigin): string {
   return `${remote}path ${origin.path}`;
 }
 
-function printFeatureCapability(feature: FeatureCapability): void {
-  console.log(`feature ${feature.id}: ${feature.title}`);
-  console.log(`  status: ${feature.status}`);
+function printFeatureCapability(
+  feature: FeatureCapability,
+  writer: FiniteCommandWriter
+): void {
+  writeLine(writer, `feature ${feature.id}: ${feature.title}`);
+  writeLine(writer, `  status: ${feature.status}`);
   for (const target of targetNames()) {
-    console.log(`  ${target}: ${formatFeatureSupport(feature.targetSupport[target])}`);
+    writeLine(
+      writer,
+      `  ${target}: ${formatFeatureSupport(feature.targetSupport[target])}`
+    );
   }
   if (feature.docs.length > 0) {
-    console.log(`  docs: ${feature.docs.join(", ")}`);
+    writeLine(writer, `  docs: ${feature.docs.join(", ")}`);
   }
 }
 

--- a/apps/skillset/src/lookup-cli.ts
+++ b/apps/skillset/src/lookup-cli.ts
@@ -4,11 +4,13 @@ import {
   type LookupSubject,
   type LookupView,
 } from "@skillset/core";
-
 import type { TargetName } from "@skillset/core/internal/types";
-import type { SchemaJsonRecord } from "@skillset/schema";
+
 import { readLookupTarget } from "./cli-arg-values";
-import { renderCliDataResult } from "./cli-output";
+import {
+  runFiniteCommand,
+  type FiniteCommandWriter,
+} from "./cli-finite-command";
 
 export interface LookupCommandOptions {
   readonly aspects: readonly string[];
@@ -19,26 +21,33 @@ export interface LookupCommandOptions {
   readonly views: readonly LookupView[];
 }
 
-export function runLookupCommand(options: LookupCommandOptions): void {
-  const report = lookupSkillsetReference({
-    ...(options.aspects.length === 0 ? {} : { aspects: options.aspects }),
-    ...(options.field === undefined ? {} : { field: options.field }),
-    ...(options.subject === undefined ? {} : { subject: options.subject }),
-    ...(options.targets.length === 0 ? {} : { targets: options.targets }),
-    ...(options.views.length === 0 ? {} : { views: options.views }),
-  });
-  if (options.json) {
-    const failed = report.diagnostics.some((diagnostic) => diagnostic.severity === "error");
-    process.stdout.write(renderCliDataResult({
+export function runLookupCommand(options: LookupCommandOptions): Promise<void> {
+  return runFiniteCommand({
+    execute: () =>
+      lookupSkillsetReference({
+        ...(options.aspects.length === 0 ? {} : { aspects: options.aspects }),
+        ...(options.field === undefined ? {} : { field: options.field }),
+        ...(options.subject === undefined ? {} : { subject: options.subject }),
+        ...(options.targets.length === 0 ? {} : { targets: options.targets }),
+        ...(options.views.length === 0 ? {} : { views: options.views }),
+      }),
+    exitCode: (report) => (lookupFailed(report) ? 1 : 0),
+    json: (report) => ({
       command: "lookup",
-      data: report as unknown as SchemaJsonRecord,
-      ...(failed ? { diagnostics: report.diagnostics, kind: "diagnostics" } : {}),
-      exitCode: failed ? 1 : 0,
-    }));
-  } else {
-    printLookupReport(report);
-  }
-  if (report.diagnostics.some((diagnostic) => diagnostic.severity === "error")) process.exitCode = 1;
+      data: report,
+      ...(lookupFailed(report)
+        ? { diagnostics: report.diagnostics, kind: "diagnostics" }
+        : {}),
+    }),
+    jsonOutput: options.json,
+    renderHuman: printLookupReport,
+  });
+}
+
+function lookupFailed(report: LookupReport): boolean {
+  return report.diagnostics.some(
+    (diagnostic) => diagnostic.severity === "error"
+  );
 }
 
 export function readLookupSubject(value: string): LookupSubject {
@@ -76,74 +85,124 @@ export function setLookupField(current: string | undefined, value: string): stri
   return value;
 }
 
-function printLookupReport(report: LookupReport): void {
+function printLookupReport(
+  report: LookupReport,
+  writer: FiniteCommandWriter
+): void {
   if (report.subject === undefined) {
-    console.log("skillset lookup subjects");
+    writeLine(writer, "skillset lookup subjects");
     for (const subject of report.subjects) {
-      console.log(`  ${subject.subject}: ${subject.description}`);
-      console.log(`    views: ${subject.defaultViews.join(", ")}`);
+      writeLine(writer, `  ${subject.subject}: ${subject.description}`);
+      writeLine(writer, `    views: ${subject.defaultViews.join(", ")}`);
     }
-    console.log("  flags: --frontmatter --fields --field <path> --values --events --compat [claude|codex|cursor...] --examples --schema --json");
-    console.log(`skillset: listed ${report.subjects.length} lookup subjects`);
+    writeLine(
+      writer,
+      "  flags: --frontmatter --fields --field <path> --values --events --compat [claude|codex|cursor...] --examples --schema --json"
+    );
+    writeLine(
+      writer,
+      `skillset: listed ${report.subjects.length} lookup subjects`
+    );
     return;
   }
 
-  console.log(`skillset lookup ${report.subject}${report.aspects.length === 0 ? "" : ` ${report.aspects.join(" ")}`}`);
+  writeLine(
+    writer,
+    `skillset lookup ${report.subject}${report.aspects.length === 0 ? "" : ` ${report.aspects.join(" ")}`}`
+  );
   for (const diagnostic of report.diagnostics) {
-    console.log(`  ${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`);
+    writeLine(
+      writer,
+      `  ${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`
+    );
   }
   if (report.fields.length > 0) {
-    console.log("  fields:");
+    writeLine(writer, "  fields:");
     for (const field of report.fields) {
       const required = field.required ? " required" : "";
-      const values = field.values === undefined ? "" : ` values: ${field.values.map(formatLookupValue).join(", ")}`;
-      console.log(`    ${field.path}: ${field.type}${required}${values}`);
+      const values =
+        field.values === undefined
+          ? ""
+          : ` values: ${field.values.map(formatLookupValue).join(", ")}`;
+      writeLine(writer, `    ${field.path}: ${field.type}${required}${values}`);
     }
   }
   if (report.events.length > 0) {
-    console.log("  events:");
+    writeLine(writer, "  events:");
     for (const event of report.events) {
-      const required = event.fields.filter((field) => field.required).map((field) => field.name);
-      const suffix = required.length === 0 ? "" : ` required: ${required.join(", ")}`;
-      const handlers = event.handlerTypes.length === 0 ? "" : ` handlers: ${event.handlerTypes.join(", ")}`;
-      const values = event.matcherValues.length === 0 ? "" : ` values: ${event.matcherValues.join(", ")}`;
-      const outputs = event.outputFields.length === 0 ? "" : ` output: ${event.outputFields.join(", ")}`;
-      const unsupportedOutputs = event.unsupportedOutputFields.length === 0 ? "" : ` unsupported output: ${event.unsupportedOutputFields.join(", ")}`;
+      const required = event.fields
+        .filter((field) => field.required)
+        .map((field) => field.name);
+      const suffix =
+        required.length === 0 ? "" : ` required: ${required.join(", ")}`;
+      const handlers =
+        event.handlerTypes.length === 0
+          ? ""
+          : ` handlers: ${event.handlerTypes.join(", ")}`;
+      const values =
+        event.matcherValues.length === 0
+          ? ""
+          : ` values: ${event.matcherValues.join(", ")}`;
+      const outputs =
+        event.outputFields.length === 0
+          ? ""
+          : ` output: ${event.outputFields.join(", ")}`;
+      const unsupportedOutputs =
+        event.unsupportedOutputFields.length === 0
+          ? ""
+          : ` unsupported output: ${event.unsupportedOutputFields.join(", ")}`;
       const blocking = event.canBlock ? " blocks" : "";
-      console.log(`    [${event.target}] ${event.name} matcher: ${event.matcherKind}/${event.matcherEvaluation}${values}${handlers}${suffix}${outputs}${unsupportedOutputs}${blocking}`);
+      writeLine(
+        writer,
+        `    [${event.target}] ${event.name} matcher: ${event.matcherKind}/${event.matcherEvaluation}${values}${handlers}${suffix}${outputs}${unsupportedOutputs}${blocking}`
+      );
     }
   }
   if (report.compatibility.length > 0) {
-    console.log("  compatibility:");
+    writeLine(writer, "  compatibility:");
     for (const item of report.compatibility) {
       const reason = item.reason === undefined ? "" : ` (${item.reason})`;
       const note = item.note === undefined ? "" : ` note: ${item.note}`;
-      console.log(`    [${item.target}] ${item.featureId}: ${item.status}${reason}${note}`);
+      writeLine(
+        writer,
+        `    [${item.target}] ${item.featureId}: ${item.status}${reason}${note}`
+      );
     }
   }
   if (report.realizations.length > 0) {
-    console.log("  tools realization:");
+    writeLine(writer, "  tools realization:");
     for (const row of report.realizations) {
       const direction = row.direction === undefined ? "" : ` ${row.direction}`;
       const emits = row.emits === undefined ? "" : ` emits: ${row.emits}`;
       const rendered = row.rendered ? "" : " (not rendered)";
-      const diagnostic = row.diagnostic === undefined ? "" : ` note: ${row.diagnostic}`;
-      console.log(`    [${row.target}] ${row.aspect}${direction}: ${row.tier} via ${row.surface}${rendered}${emits}${diagnostic}`);
+      const diagnostic =
+        row.diagnostic === undefined ? "" : ` note: ${row.diagnostic}`;
+      writeLine(
+        writer,
+        `    [${row.target}] ${row.aspect}${direction}: ${row.tier} via ${row.surface}${rendered}${emits}${diagnostic}`
+      );
     }
   }
   if (report.examples.length > 0) {
-    console.log("  examples:");
+    writeLine(writer, "  examples:");
     for (const example of report.examples) {
-      console.log(`    ${example.path}: ${example.description}`);
+      writeLine(writer, `    ${example.path}: ${example.description}`);
     }
   }
   if (report.schema !== undefined) {
-    console.log(`  schema: ${report.schema.id} (${report.schema.title})`);
+    writeLine(writer, `  schema: ${report.schema.id} (${report.schema.title})`);
   }
-  console.log(`skillset: lookup ${report.diagnostics.some((diagnostic) => diagnostic.severity === "error") ? "reported diagnostics" : "complete"}`);
+  writeLine(
+    writer,
+    `skillset: lookup ${lookupFailed(report) ? "reported diagnostics" : "complete"}`
+  );
 }
 
 function formatLookupValue(value: unknown): string {
   if (typeof value === "string") return value;
   return JSON.stringify(value);
+}
+
+function writeLine(writer: FiniteCommandWriter, line: string): void {
+  writer.stdout.write(`${line}\n`);
 }


### PR DESCRIPTION
## Context

SET-347 lands the first coherent downstream migration on the SET-332 finite-command adapter. The live issue explicitly permits incremental route-family PRs.

## What changed

- migrate lookup and lookup features to the shared finite adapter
- convert human lookup renderers to injected writers
- remove command-local JSON framing and exit ownership
- preserve ordinary diagnostic failure and sparse missing-feature failure contracts
- add exact human and JSON success and failure parity tests
- add a patch Changeset

## Verification

- standing and fresh local review: 5/5 clean, zero P0-P3
- exact-final isolated-XDG check: 1,399 tests, zero failures
- whole-wave review: 5/5 clean
- wave-head pre-push: green

## Risk

This is intentionally the complete lookup-family increment, not an all-at-once finite-owner rewrite. JSONL, hooks, protocols, hidden workers, interactive flows, Core, schema, and generated artifacts remain unchanged.