### PR TITLE
fix(core): close Cursor native island gaps

### DIFF
--- a/.changeset/cursor-native-island-gaps.md
+++ b/.changeset/cursor-native-island-gaps.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Preprocess Cursor rule islands and declare native-only plugin surfaces in generated manifests.

--- a/apps/skillset/src/__tests__/skillset.test.ts
+++ b/apps/skillset/src/__tests__/skillset.test.ts
@@ -3008,7 +3008,37 @@ skillset:
   expect(codexLock).toContain(`"outputPath": "project-cursor/native.txt"`);
 });
 
-test("target-native islands reject frontmatter target escapes", async () => {
+test("Cursor .mdc provider source preprocesses before rendering", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-mdc-root
+claude: false
+codex: false
+cursor: true
+`,
+    ".skillset/_cursor/rules/repo.mdc": `
+---
+description: Cursor rule.
+---
+
+{{shared:templates/policy.md}}
+`,
+    ".skillset/shared/templates/policy.md": "Follow {{this.description}}\n",
+  });
+
+  await buildSkillset(root);
+
+  const rendered = await readFile(join(root, ".cursor/rules/repo.mdc"), "utf8");
+  expect(rendered).toContain("Follow Cursor rule.");
+  expect(rendered).not.toContain("{{shared:templates/policy.md}}");
+  const island = (await collectSourceInventory(root)).units.find(
+    (unit) => unit.sourcePath === ".skillset/_cursor/rules/repo.mdc"
+  );
+  expect(island?.sourcePaths).toContain(".skillset/shared/templates/policy.md");
+});
+
+test("Cursor .mdc provider source rejects frontmatter target escapes", async () => {
   const root = await fixture({
     "skillset.yaml": `
 skillset:
@@ -3017,7 +3047,7 @@ claude: true
 codex: false
 cursor: true
 `,
-    ".skillset/_cursor/agents/bad.md": `
+    ".skillset/_cursor/rules/bad.mdc": `
 ---
 claude: true
 ---
@@ -3221,6 +3251,38 @@ cursor plugin only
   expect(await readFile(join(root, "plugins/alpha/cursor/native.txt"), "utf8")).toContain("cursor plugin only");
   expect(await exists(join(root, "plugins/alpha/claude/native.txt"))).toBe(false);
   expect(await exists(join(root, "plugins/alpha/codex/native.txt"))).toBe(false);
+});
+
+test("plugin-local Cursor provider source declares native manifest surfaces", async () => {
+  const root = await fixture({
+    "skillset.yaml": `
+skillset:
+  name: cursor-native-surface-root
+claude: false
+codex: false
+cursor: true
+`,
+    ".skillset/plugins/alpha/skillset.yaml": `
+skillset:
+  name: alpha
+`,
+    ".skillset/plugins/alpha/_cursor/rules/repo.mdc": "# Cursor rule\n",
+    ".skillset/plugins/alpha/_cursor/commands/review.md": "# Cursor command\n",
+    ".skillset/plugins/alpha/_cursor/agents/reviewer.md": "# Cursor agent\n",
+    ".skillset/plugins/alpha/_cursor/hooks/hooks.json": JSON.stringify({ hooks: {} }),
+  });
+
+  await buildSkillset(root);
+
+  const manifest = JSON.parse(
+    await readFile(join(root, "plugins/alpha/cursor/.cursor-plugin/plugin.json"), "utf8")
+  ) as Record<string, unknown>;
+  expect(manifest).toMatchObject({
+    agents: "./agents/",
+    commands: "./commands/",
+    hooks: "./hooks/hooks.json",
+    rules: "./rules/",
+  });
 });
 
 test("plugin-local provider source requires a plugin manifest", async () => {

--- a/apps/skillset/src/change-status.ts
+++ b/apps/skillset/src/change-status.ts
@@ -706,7 +706,7 @@ async function islandPreprocessDependencies(
 
   const dependencies = new Set<string>();
   const source = await readFile(island.sourcePath, "utf8");
-  if (island.relativePath.endsWith(".md")) {
+  if (isMarkdownIslandFile(island.relativePath)) {
     const parsed = parseMarkdown(source, island.sourcePath);
     await preprocessText(parsed.body, {
       frontmatter: parsed.frontmatter,
@@ -738,7 +738,11 @@ function formattedPreprocessDependencies(
 }
 
 function isTextIslandFile(path: string): boolean {
-  return /\.(json|md|rules|toml|txt|ya?ml)$/.test(path);
+  return /\.(json|mdc?|rules|toml|txt|ya?ml)$/.test(path);
+}
+
+function isMarkdownIslandFile(path: string): boolean {
+  return /\.mdc?$/.test(path);
 }
 
 async function collectFiles(root: string): Promise<readonly string[]> {

--- a/packages/core/src/render-plugin-manifest.ts
+++ b/packages/core/src/render-plugin-manifest.ts
@@ -268,11 +268,17 @@ export function withOptionalSurfacePaths(
     if (pluginHasFeature(plugin, "mcp")) withPaths.mcpServers = "./.mcp.json";
     if (pluginHasPath(plugin, ".app.json")) withPaths.apps = "./.app.json";
   } else {
-    if (pluginHasPath(plugin, "rules")) withPaths.rules = "./rules/";
-    if (pluginHasPath(plugin, "commands")) withPaths.commands = "./commands/";
-    if (pluginHasPath(plugin, "agents")) withPaths.agents = "./agents/";
+    if (pluginHasSurfacePath(graph, plugin, target, "rules")) {
+      withPaths.rules = "./rules/";
+    }
+    if (pluginHasSurfacePath(graph, plugin, target, "commands")) {
+      withPaths.commands = "./commands/";
+    }
+    if (pluginHasSurfacePath(graph, plugin, target, "agents")) {
+      withPaths.agents = "./agents/";
+    }
     if (
-      pluginHasPath(plugin, "hooks/hooks.json") ||
+      pluginHasSurfacePath(graph, plugin, target, "hooks/hooks.json") ||
       hasAdaptivePluginHookOutput(graph, plugin, target)
     ) {
       withPaths.hooks = "./hooks/hooks.json";
@@ -307,6 +313,29 @@ function pluginHasPath(plugin: SourcePlugin, path: string): boolean {
   // Real file-system errors (EACCES, ELOOP, ...) must surface instead of being
   // read as "path absent"; only a missing path counts as no surface.
   return hasRenderableContent(join(plugin.path, path));
+}
+
+function pluginHasSurfacePath(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName,
+  path: string
+): boolean {
+  return pluginHasPath(plugin, path) || pluginHasTargetNativePath(graph, plugin, target, path);
+}
+
+function pluginHasTargetNativePath(
+  graph: BuildGraph,
+  plugin: SourcePlugin,
+  target: TargetName,
+  path: string
+): boolean {
+  return graph.projectIslands.some(
+    (island) =>
+      island.plugin === plugin.id &&
+      island.target === target &&
+      (island.relativePath === path || island.relativePath.startsWith(`${path}/`))
+  );
 }
 
 function hasRenderableContent(path: string): boolean {

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -775,7 +775,7 @@ async function renderTextIslandFile(
   preprocessDependencies: Set<string>
 ): Promise<string> {
   const source = await readFile(island.sourcePath, "utf8");
-  if (island.relativePath.endsWith(".md")) {
+  if (isMarkdownIslandFile(island.relativePath)) {
     const parsed = parseMarkdown(source, island.sourcePath);
     rejectIslandTargetEscape(parsed.frontmatter, island);
     const body = await preprocessText(parsed.body, {
@@ -810,7 +810,11 @@ function rejectIslandTargetEscape(frontmatter: JsonRecord, island: SourceIslandF
 }
 
 function isTextIslandFile(path: string): boolean {
-  return /\.(json|md|rules|toml|txt|ya?ml)$/.test(path);
+  return /\.(json|mdc?|rules|toml|txt|ya?ml)$/.test(path);
+}
+
+function isMarkdownIslandFile(path: string): boolean {
+  return /\.mdc?$/.test(path);
 }
 
 function targetProjectRoot(graph: BuildGraph, target: TargetName): string {

--- a/scripts/target-topology-guard.ts
+++ b/scripts/target-topology-guard.ts
@@ -51,13 +51,13 @@ export const TARGET_TOPOLOGY_ALLOWLIST: readonly TargetTopologyAllowlistEntry[] 
   allow("scripts/bootstrap/main.ts", 59, 15, "parseBootstrapArgs", "R2", 'command === "claude" || command === "codex"', "Bootstrap exposes provider-specific setup commands only for the two supported runtimes."),
   allow("packages/core/src/render-result-collector.ts", 731, 10, "companionForPath", "R2", 'target === "claude" || target === "cursor"', "Commands are provider-native companion formats for Claude and Cursor."),
   allow("packages/core/src/render-result-collector.ts", 737, 10, "companionForPath", "R2", 'target === "claude" || target === "cursor"', "Agents are provider-native companion formats for Claude and Cursor."),
-  allow("packages/core/src/render.ts", 1251, 7, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor hooks require normalized provider-native output."),
-  allow("packages/core/src/render.ts", 1271, 10, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor skip copying Claude-native hook files."),
+  allow("packages/core/src/render.ts", 1255, 7, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor hooks require normalized provider-native output."),
+  allow("packages/core/src/render.ts", 1275, 10, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor skip copying Claude-native hook files."),
   allow("apps/skillset/src/provider-format-updates.ts", 195, 10, "displayProvider", "R3", 'provider === "codex" -> provider === "claude" -> else', "Provider display labels preserve unknown registry values."),
   allow("packages/core/src/provider-format-conformance.ts", 465, 5, "checkSkillMarkdown", "R3", 'target === "codex" -> target === "cursor" -> else', "Provider-native skill formats use distinct registry references."),
   allow("packages/core/src/render-plugin-manifest.ts", 66, 5, "renderPluginManifest", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native plugin manifests have distinct formats."),
   allow("packages/core/src/render-plugin-manifest.ts", 239, 3, "withOptionalSurfacePaths", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native plugin surfaces have distinct destination fields."),
-  allow("packages/core/src/render.ts", 1233, 5, "copyPluginCompanionFiles", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native companion file sets are intentionally distinct."),
+  allow("packages/core/src/render.ts", 1237, 5, "copyPluginCompanionFiles", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native companion file sets are intentionally distinct."),
   allow("packages/core/src/render.ts", 265, 3, "marketplaceReadmeLines", "R3", 'target === "claude" -> target === "cursor" -> else', "Provider-native marketplace README guidance has distinct destination formats."),
 ] as const;
 


### PR DESCRIPTION
## Context

Closes SET-375 and the two unresolved PR #301 review gaps: Cursor `.mdc` native islands bypassed structured Markdown preprocessing, and native-only Cursor plugin surfaces were omitted from manifest discovery.

## Changes

- preprocess `.mdc` islands with dependency/provenance and target-escape validation;
- include same-plugin/same-target native rules, commands, agents, and hooks in Cursor manifest surface discovery;
- add focused regressions and a patch Changeset.

## Verification

- branch and full-wave standing/fresh local reviews: 5/5 clean;
- focused Core tests, typecheck, schema/output/conformance checks;
- wave pre-push: 1,447 tests, 0 failures.

## Risk

Scoped to Cursor native-island rendering and manifest discovery; no provider leakage or generated-source hand edits.
