### PR TITLE
fix(toolkit): preserve Cursor hook payload context

### DIFF
--- a/.changeset/cursor-hook-payload-replay.md
+++ b/.changeset/cursor-hook-payload-replay.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Preserve Cursor hook stdin while deriving toolkit session context from its conversation payload.

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -115,7 +115,7 @@ For `context.strategy: toolkit`, generated hooks call the installable helper:
 skillset-toolkit runtime context --event <event> --format env --fields <field,...>
 ```
 
-The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. It does not erase target-native variables such as `CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, or `CURSOR_SESSION_ID`; scripts that need provider-specific data can still read the raw environment deliberately.
+The helper prints shell `export` statements for the requested `SKILLSET_*` values and preserves provider-native environment access for the hook command. It does not erase target-native variables such as `CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, or `CURSOR_SESSION_ID`; scripts that need provider-specific data can still read the raw environment deliberately. For Cursor hooks, `session.id` resolves in deterministic order from an explicit `SKILLSET_SESSION_ID`, then the JSON stdin `conversation_id`, then `CURSOR_SESSION_ID` as a compatibility fallback. Claude and Codex continue to use their provider session environment variables after an explicit Skillset override.
 
 Generated hooks and out-of-repo scripts should use the `skillset-toolkit` CLI because it is shipped by the published `skillset` package. Repo-local tools that already depend on the internal workspace package can import the typed runtime surface directly:
 

--- a/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
+++ b/packages/core/src/__tests__/adaptive-hook-attachments.test.ts
@@ -907,7 +907,7 @@ hooks:
       hooks: {
         stop: [{
           hooks: [{
-            command: 'eval "$(SKILLSET_PROVIDER=cursor SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\')" && printf \'%s|%s|\' "$SKILLSET_PROVIDER" "$SKILLSET_SESSION_ID"; cat',
+            command: 'skillset_hook_payload="$(mktemp)" && trap \'rm -f "$skillset_hook_payload"\' 0 && cat > "$skillset_hook_payload" && eval "$(SKILLSET_PROVIDER=cursor SKILLSET_HOOK_EVENT=Stop skillset-toolkit runtime context --event Stop --format env --fields \'provider,hook.event,session.id\' < "$skillset_hook_payload")" && cat "$skillset_hook_payload" | ( printf \'%s|%s|\' "$SKILLSET_PROVIDER" "$SKILLSET_SESSION_ID"; cat )',
             type: "command",
           }],
         }],
@@ -915,19 +915,33 @@ hooks:
     });
 
     const command = ((claudeHooks.hooks as JsonRecord).Stop as readonly JsonRecord[])[0]?.hooks as readonly JsonRecord[];
-    expect(await runGeneratedHookCommand(String(command[0]?.command))).toEqual({
+    const codexCommand = ((codexHooks.hooks as JsonRecord).Stop as readonly JsonRecord[])[0]?.hooks as readonly JsonRecord[];
+    const cursorCommand = ((cursorHooks.hooks as JsonRecord).stop as readonly JsonRecord[])[0]?.hooks as readonly JsonRecord[];
+    const cursorPayload = '{"conversation_id":"cursor-hook-conversation","text":"payload"}\n';
+    const [claudeResult, codexResult, cursorResult] = await Promise.all([
+      runGeneratedHookCommand(String(command[0]?.command)),
+      runGeneratedHookCommand(String(codexCommand[0]?.command), {
+        CURSOR_SESSION_ID: "contaminated-cursor-session",
+      }),
+      runGeneratedHookCommand(String(cursorCommand[0]?.command), {
+        CLAUDE_SESSION_ID: "wrong-claude-session",
+        CURSOR_SESSION_ID: "cursor-session",
+      }, cursorPayload),
+    ]);
+    expect(claudeResult).toEqual({
       exitCode: 0,
       stderr: "",
       stdout: "claude||payload",
     });
-    const cursorCommand = ((cursorHooks.hooks as JsonRecord).stop as readonly JsonRecord[])[0]?.hooks as readonly JsonRecord[];
-    expect(await runGeneratedHookCommand(String(cursorCommand[0]?.command), {
-      CLAUDE_SESSION_ID: "wrong-claude-session",
-      CURSOR_SESSION_ID: "cursor-session",
-    })).toEqual({
+    expect(codexResult).toEqual({
       exitCode: 0,
       stderr: "",
-      stdout: "cursor|cursor-session|payload",
+      stdout: "codex||payload",
+    });
+    expect(cursorResult).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: `cursor|cursor-hook-conversation|${cursorPayload}`,
     });
   });
 
@@ -1222,7 +1236,11 @@ function renderedMarkdown(files: readonly { readonly content: Uint8Array; readon
   return parseMarkdown(new TextDecoder().decode(file?.content), path);
 }
 
-async function runGeneratedHookCommand(command: string, providerEnv: Record<string, string> = {}): Promise<{
+async function runGeneratedHookCommand(
+  command: string,
+  providerEnv: Record<string, string> = {},
+  payload = "payload"
+): Promise<{
   readonly exitCode: number;
   readonly stderr: string;
   readonly stdout: string;
@@ -1237,7 +1255,7 @@ async function runGeneratedHookCommand(command: string, providerEnv: Record<stri
   );
   await chmod(shim, 0o755);
   const proc = Bun.spawn({
-    cmd: ["/bin/sh", "-c", `printf payload | (${command})`],
+    cmd: ["/bin/sh", "-c", `printf %s ${shellQuote(payload)} | (${command})`],
     cwd: root,
     env: {
       HOME: process.env.HOME ?? "",

--- a/packages/core/src/render-hooks.ts
+++ b/packages/core/src/render-hooks.ts
@@ -421,6 +421,9 @@ function withAdaptiveHookToolkitContextCommand(
   const fieldArgs =
     fields.length === 0 ? "" : ` --fields ${shellLiteral(fields.join(","))}`;
   const helper = `${provider} ${hookEvent} skillset-toolkit runtime context --event ${event} --format env${fieldArgs}`;
+  if (target === "cursor") {
+    return `skillset_hook_payload="$(mktemp)" && trap 'rm -f "$skillset_hook_payload"' 0 && cat > "$skillset_hook_payload" && eval "$(${helper} < "$skillset_hook_payload")" && cat "$skillset_hook_payload" | ( ${command} )`;
+  }
   return `eval "$(${helper})" && ${command}`;
 }
 

--- a/packages/toolkit/src/__tests__/cli.test.ts
+++ b/packages/toolkit/src/__tests__/cli.test.ts
@@ -28,6 +28,22 @@ describe("@skillset/toolkit CLI", () => {
     expect(result.stdout).toBe(`${JSON.stringify(report, null, 2)}\n`);
   });
 
+  test("reads the Cursor conversation id from hook stdin before the environment fallback", async () => {
+    const result = await runToolkit(
+      ["runtime", "context", "--event", "afterAgentResponse", "--fields", "session.id"],
+      {
+        CURSOR_SESSION_ID: "cursor-env-fallback",
+        SKILLSET_PROVIDER: "cursor",
+      },
+      JSON.stringify({ conversation_id: "cursor-hook-conversation" })
+    );
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      session: { id: "cursor-hook-conversation" },
+    });
+  });
+
   test("prints eval-safe env output for empty, spaced, quoted, and missing values", async () => {
     const command = [
       "eval \"$(",
@@ -89,15 +105,22 @@ describe("@skillset/toolkit CLI", () => {
 
 async function runToolkit(
   args: readonly string[],
-  env: Record<string, string>
+  env: Record<string, string>,
+  stdinText?: string
 ): Promise<{ readonly exitCode: number; readonly stderr: string; readonly stdout: string }> {
   const proc = Bun.spawn({
     cmd: [process.execPath, cliPath, ...args],
     cwd: repoRoot,
     env: testEnv(env),
+    stdin: stdinText === undefined ? "ignore" : "pipe",
     stderr: "pipe",
     stdout: "pipe",
   });
+  if (stdinText !== undefined) {
+    if (proc.stdin === undefined) throw new Error("toolkit CLI stdin pipe was not created");
+    proc.stdin.write(stdinText);
+    proc.stdin.end();
+  }
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),

--- a/packages/toolkit/src/__tests__/runtime.test.ts
+++ b/packages/toolkit/src/__tests__/runtime.test.ts
@@ -79,6 +79,34 @@ describe("@skillset/toolkit runtime", () => {
     expect(nativeCursor.provider).toBe("cursor");
     expect(runtimeContextFieldValue(nativeCursor, "session.id")).toBe("native-cursor-session");
 
+    const cursorPayload = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: {
+        CURSOR_SESSION_ID: "fallback-cursor-session",
+        SKILLSET_PROVIDER: "cursor",
+      },
+      event: "afterAgentResponse",
+      rootPath: "/tmp/repo",
+      stdinText: JSON.stringify({
+        conversation_id: "cursor-conversation",
+        generation_id: "not-a-session-id",
+      }),
+    });
+    expect(runtimeContextFieldValue(cursorPayload, "session.id")).toBe("cursor-conversation");
+
+    const explicitCursorSession = await readRuntimeContext({
+      cwd: "/tmp/repo",
+      env: {
+        CURSOR_SESSION_ID: "fallback-cursor-session",
+        SKILLSET_PROVIDER: "cursor",
+        SKILLSET_SESSION_ID: "explicit-session",
+      },
+      event: "afterAgentResponse",
+      rootPath: "/tmp/repo",
+      stdinText: JSON.stringify({ conversation_id: "cursor-conversation" }),
+    });
+    expect(runtimeContextFieldValue(explicitCursorSession, "session.id")).toBe("explicit-session");
+
     const explicitCursorWithMixedEnv = await readRuntimeContext({
       cwd: "/tmp/repo",
       env: {

--- a/packages/toolkit/src/cli.ts
+++ b/packages/toolkit/src/cli.ts
@@ -9,6 +9,7 @@ import {
 
 export interface ToolkitCliIO {
   readonly stderr?: Pick<typeof process.stderr, "write">;
+  readonly stdinText?: string;
   readonly stdout?: Pick<typeof process.stdout, "write">;
 }
 
@@ -33,7 +34,15 @@ export async function runToolkitCli(rawArgs: readonly string[] = process.argv.sl
       return 0;
     }
     const options = parseRuntimeContextArgs(rawArgs);
-    stdout.write(await renderRuntimeContext(options));
+    const stdinText =
+      io.stdinText ??
+      (isCursorHookProcess() && !process.stdin.isTTY
+        ? await Bun.stdin.text()
+        : undefined);
+    stdout.write(await renderRuntimeContext({
+      ...options,
+      ...(stdinText === undefined ? {} : { stdinText }),
+    }));
     return 0;
   } catch (error) {
     stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
@@ -91,6 +100,13 @@ function readFlagValue(args: readonly string[], index: number, flag: string): st
   const value = args[index + 1];
   if (value === undefined || value.startsWith("--")) throw new Error(`skillset-toolkit: ${flag} requires a value`);
   return value;
+}
+
+function isCursorHookProcess(env: Record<string, string | undefined> = process.env): boolean {
+  if (env.SKILLSET_PROVIDER !== undefined) {
+    return env.SKILLSET_PROVIDER === "cursor";
+  }
+  return env.CURSOR_SESSION_ID !== undefined;
 }
 
 if (import.meta.main) {

--- a/packages/toolkit/src/runtime.ts
+++ b/packages/toolkit/src/runtime.ts
@@ -104,7 +104,7 @@ export const RUNTIME_CONTEXT_FIELD_DEFINITIONS = [
   {
     availability: targetAvailability("available", "unknown"),
     confidence: "provider",
-    description: "Provider session id when the runtime exposes one; absent when unavailable.",
+    description: "Provider session id when the runtime exposes one; Cursor prefers hook stdin conversation_id after an explicit Skillset override, then falls back to its environment.",
     envName: "SKILLSET_SESSION_ID",
     field: "session.id",
   },
@@ -155,6 +155,10 @@ export function runtimeContextFieldValue(
       return context.rawEnv.SKILLSET_HOOK_EVENT ?? context.event;
     case "session.id":
       if (context.rawEnv.SKILLSET_SESSION_ID !== undefined) return context.rawEnv.SKILLSET_SESSION_ID;
+      if (context.provider === "cursor") {
+        const conversationId = cursorConversationId(context.payload);
+        if (conversationId !== undefined) return conversationId;
+      }
       if (context.provider !== "unknown") {
         return context.rawEnv[PROVIDER_ENV[context.provider].sessionId];
       }
@@ -211,6 +215,12 @@ function parsePayload(stdinText: string | undefined): Pick<RuntimeContext, "payl
   } catch (error) {
     return { payloadError: error instanceof Error ? error.message : String(error) };
   }
+}
+
+function cursorConversationId(payload: unknown): string | undefined {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return undefined;
+  const conversationId = (payload as Record<string, unknown>).conversation_id;
+  return typeof conversationId === "string" && conversationId.length > 0 ? conversationId : undefined;
 }
 
 async function gitRoot(cwd: string): Promise<string | undefined> {


### PR DESCRIPTION
## Context

Closes SET-376 and the unresolved PR #302 review gap: Cursor hook session identity must come from stdin `conversation_id` without consuming the user hook payload.

## Changes

- derive Cursor session context with precedence `SKILLSET_SESSION_ID` → stdin `conversation_id` → `CURSOR_SESSION_ID`;
- make explicit `SKILLSET_PROVIDER` authoritative over ambient provider variables;
- buffer/replay Cursor hook stdin exactly while leaving Claude/Codex wrappers unchanged;
- add mixed-environment payload, precedence, and replay regressions plus a patch Changeset.

## Verification

- branch and full-wave standing/fresh local reviews: 5/5 clean;
- adaptive-hook suite stress: 160 tests / 460 assertions across five runs;
- wave pre-push: 1,447 tests, 0 failures.

## Risk

Shell wrapper behavior is covered end to end; no global config or provider runtime installation changes.
