### PR TITLE
fix(fixtures): preserve external failure reports

### DIFF
--- a/scripts/fixtures/__tests__/external.test.ts
+++ b/scripts/fixtures/__tests__/external.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { checkClonePurity, compareTrees, parseExternalManifest, renderExternalManifest, renderRunReportMarkdown, runExternalRepo } from '../external';
+import { checkClonePurity, compareTrees, parseExternalManifest, renderExternalManifest, renderRunReportMarkdown, runExternalRepo, writeExternalRunReport } from '../external';
 import type { ExternalRepoEntry } from '../external';
 import { gitSafeEnv } from '../../../apps/skillset/src/git-env';
 
@@ -243,6 +243,40 @@ test("runExternalRepo fails the run when no import candidates are detected", asy
   expect(markdown).toContain("- result: fail");
   expect(markdown).toContain("No adoptable surfaces recognized.");
   expect(markdown).toContain("No imported units to compare.");
+});
+
+test("SET-378: runExternalRepo preserves reports after a graph-load build failure", async () => {
+  const clone = await gitFixture({
+    "AGENTS.md": "---\ndialect: 1\n---\n\nImported instructions.\n",
+  });
+
+  const report = await runExternalRepo("invalid-instructions", clone, ["claude"]);
+
+  expect(report.ok).toBe(false);
+  expect(report.stages).toContainEqual(
+    expect.objectContaining({
+      detail: expect.stringContaining("dialect must be claude"),
+      ok: false,
+      stage: "build",
+    })
+  );
+  expect(report.stages).toContainEqual(expect.objectContaining({ ok: true, stage: "purity" }));
+  expect(report.roundTrips).toEqual([]);
+
+  const reportDir = await mkdtemp(join(tmpdir(), "skillset-external-report-"));
+  const entry = { ref: SHA, repo: "https://github.com/example/invalid" };
+  await writeExternalRunReport(reportDir, report, entry);
+
+  const markdown = await readFile(join(reportDir, "report.md"), "utf8");
+  expect(markdown).toContain("- result: fail");
+  expect(markdown).toContain("- FAIL build:");
+  expect(markdown).toContain("dialect must be claude");
+  const json = JSON.parse(await readFile(join(reportDir, "report.json"), "utf8")) as {
+    readonly ok: boolean;
+    readonly roundTrips: readonly unknown[];
+  };
+  expect(json.ok).toBe(false);
+  expect(json.roundTrips).toEqual([]);
 });
 
 test("runExternalRepo reports competing provider plugins before import", async () => {

--- a/scripts/fixtures/external.ts
+++ b/scripts/fixtures/external.ts
@@ -392,6 +392,12 @@ export async function runExternalRepo(
     stages.push({ detail: errorMessage(error), ok: false, stage: "purity" });
   }
 
+  // A failed isolated build already records the graph-load error. Retrying the
+  // load here would prevent the harness from returning its failed report.
+  if (adopt.buildError !== undefined) {
+    return { name, ok: false, roundTrips, stages, survey };
+  }
+
   const graph = await loadBuildGraph(clonePath);
   for (const item of imported) {
     for (const target of targets) {
@@ -497,6 +503,19 @@ export function renderRunReportMarkdown(
     appendCappedList(lines, "Generated-only", comparison.generatedOnly);
   }
   return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export async function writeExternalRunReport(
+  reportDir: string,
+  report: ExternalRunReport,
+  entry: Pick<ExternalRepoEntry, "ref" | "repo">
+): Promise<void> {
+  await mkdir(reportDir, { recursive: true });
+  await writeFile(join(reportDir, "report.md"), renderRunReportMarkdown(report, entry));
+  await writeFile(
+    join(reportDir, "report.json"),
+    `${JSON.stringify(report, null, 2)}\n`
+  );
 }
 
 function appendCappedList(
@@ -690,13 +709,7 @@ async function main(): Promise<void> {
       reportCacheContext,
       join(REPORTS_DIR, entry.name)
     );
-    await mkdir(reportDir, { recursive: true });
-    const markdown = renderRunReportMarkdown(report, entry);
-    await writeFile(join(reportDir, "report.md"), markdown);
-    await writeFile(
-      join(reportDir, "report.json"),
-      `${JSON.stringify(report, null, 2)}\n`
-    );
+    await writeExternalRunReport(reportDir, report, entry);
     for (const stage of report.stages) {
       console.log(
         `  ${stage.ok ? "ok" : "FAIL"} ${stage.stage}: ${stage.detail.split("\n")[0]}`


### PR DESCRIPTION
## Context

Closes SET-378 and the unresolved PR #304 review gap: a failed external fixture build could trigger a second graph load and suppress the failure report.

## Changes

- return the recorded failed report after purity when isolated adoption already has a build error;
- preserve failed stage, `ok: false`, and empty round trips;
- extract a small report writer and test Markdown/JSON persistence with a local git fixture.

## Verification

- branch and full-wave standing/fresh local reviews: 5/5 clean;
- external fixture suite 11/11, typecheck;
- wave pre-push: 1,447 tests, 0 failures.

## Risk

Repo-only external fixture harness; no network conformance or package release surface.
