### PR TITLE
fix(schema): validate plugin feature values

### DIFF
--- a/.changeset/validate-plugin-feature-pointers.md
+++ b/.changeset/validate-plugin-feature-pointers.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Reject invalid plugin `bin` and `mcp` feature values during shared schema validation before compiler resolution.

--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -399,6 +399,18 @@ describe("@skillset/schema contracts", () => {
       path: "$.compile",
     });
     expect(validatePluginConfig({ bin: true, hooks: { Stop: ["shell-policy"] }, mcp: true, skillset: { name: "demo" } }).diagnostics).toEqual([]);
+    for (const key of ["bin", "mcp"] as const) {
+      for (const value of [true, false, { source: "repo:features/demo" }] as const) {
+        expect(validatePluginConfig({ [key]: value }).diagnostics).toEqual([]);
+      }
+      for (const value of ["invalid", 1, [], null] as const) {
+        expect(validatePluginConfig({ [key]: value }).diagnostics).toContainEqual({
+          code: `schema/plugin-config/${key}`,
+          message: `$.${key} must be true, false, or an object`,
+          path: `$.${key}`,
+        });
+      }
+    }
     expect(validatePluginConfig({ compile: {} }).diagnostics).toContainEqual({
       code: "schema/plugin-config/key",
       message: "unsupported key compile",

--- a/packages/schema/src/validate.ts
+++ b/packages/schema/src/validate.ts
@@ -104,6 +104,7 @@ export function validateWorkspaceConfig(value: unknown, path = "$"): SkillsetSch
     supportsCompile: true,
     supportsHooks: false,
     supportsMarketplaces: true,
+    supportsPluginFeatures: false,
     supportsSourceMetadata: true,
     supportsWorkspace: true,
   });
@@ -118,6 +119,7 @@ export function validateSingleFileRootConfig(value: unknown, path = "$"): Skills
     supportsCompile: true,
     supportsHooks: false,
     supportsMarketplaces: true,
+    supportsPluginFeatures: false,
     supportsSourceMetadata: true,
     supportsWorkspace: true,
   });
@@ -132,6 +134,7 @@ export function validateSplitWorkspaceConfig(value: unknown, path = "$"): Skills
     supportsCompile: true,
     supportsHooks: false,
     supportsMarketplaces: true,
+    supportsPluginFeatures: false,
     supportsSourceMetadata: false,
     supportsWorkspace: true,
   });
@@ -161,6 +164,7 @@ export function validatePluginConfig(value: unknown, path = "$"): SkillsetSchema
     supportsCompile: false,
     supportsHooks: true,
     supportsMarketplaces: false,
+    supportsPluginFeatures: true,
     supportsSourceMetadata: true,
     supportsWorkspace: false,
   });
@@ -173,6 +177,7 @@ interface ConfigValidationContext {
   readonly supportsCompile: boolean;
   readonly supportsHooks: boolean;
   readonly supportsMarketplaces: boolean;
+  readonly supportsPluginFeatures: boolean;
   readonly supportsSourceMetadata: boolean;
   readonly supportsWorkspace: boolean;
 }
@@ -195,6 +200,10 @@ function validateConfigContext(
   if (context.supportsCompile) checkCompile(value.compile, `${path}.compile`, diagnostics, `schema/${context.code}`);
   checkDependencies(value.dependencies, `${path}.dependencies`, `schema/${context.code}/dependencies`, diagnostics);
   if (context.supportsMarketplaces) checkMarketplaceCatalogs(value.marketplaces, `${path}.marketplaces`, diagnostics);
+  if (context.supportsPluginFeatures) {
+    checkPluginFeature(value.bin, `${path}.bin`, "schema/plugin-config/bin", diagnostics);
+    checkPluginFeature(value.mcp, `${path}.mcp`, "schema/plugin-config/mcp", diagnostics);
+  }
   if (context.supportsWorkspace) checkWorkspace(value.workspace, `${path}.workspace`, diagnostics);
   if (context.supportsSourceMetadata) checkSourceMetadata(value.skillset, `${path}.skillset`, diagnostics);
   checkSupports(value.supports, `${path}.supports`, diagnostics);
@@ -916,6 +925,12 @@ function checkTargetBlock(value: SchemaJsonValue | undefined, path: string, code
 
 function checkTargetFeature(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
   if (value !== undefined && value !== false && !isSchemaRecord(value)) diagnostics.push(diagnostic(path, code, `${path} must be false or an object`));
+}
+
+function checkPluginFeature(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {
+  if (value !== undefined && value !== true && value !== false && !isSchemaRecord(value)) {
+    diagnostics.push(diagnostic(path, code, `${path} must be true, false, or an object`));
+  }
 }
 
 function checkOptionalDialect(value: SchemaJsonValue | undefined, path: string, code: string, diagnostics: SkillsetSchemaDiagnostic[]): void {


### PR DESCRIPTION
## Context

Closes SET-379 and the unresolved PR #306 review gap: shared plugin-config validation accepted invalid scalar `bin` and `mcp` values that Core rejected.

## Changes

- accept only undefined, boolean, or plain-record plugin feature values;
- emit stable `schema/plugin-config/bin|mcp` diagnostics;
- retain Core ownership of source-pointer and filesystem semantics;
- add direct schema coverage and a patch Changeset.

## Verification

- branch and full-wave standing/fresh local reviews: 5/5 clean;
- schema suite 13/13, schema artifact check, typecheck;
- wave pre-push: 1,447 tests, 0 failures.

## Risk

Structural validation only; no duplicate compiler field lists or generated schema edits.
