### PR TITLE
fix(guard): bind topology exemptions to registry

### DIFF
--- a/scripts/__tests__/target-topology-guard.test.ts
+++ b/scripts/__tests__/target-topology-guard.test.ts
@@ -95,8 +95,8 @@ function path(target: string) {
 `);
 
     expect(violations.map(({ rule, text }) => ({ rule, text }))).toEqual([
-      { rule: "R3", text: 'target === "claude" -> target === "codex" -> else' },
-      { rule: "R3", text: 'target === "claude" -> target === "codex" -> else' },
+      { rule: "R3", text: 'target === "claude" -> target === "codex" -> else [cursor]' },
+      { rule: "R3", text: 'target === "claude" -> target === "codex" -> else [cursor]' },
     ]);
   });
 
@@ -121,7 +121,7 @@ function historicalGuardedTernary(target: string) {
         line: 3,
         owner: "historicalReturnFallback",
         rule: "R3",
-        text: 'target === "claude" -> target === "cursor" -> else',
+        text: 'target === "claude" -> target === "cursor" -> else [codex]',
       },
       {
         column: 3,
@@ -129,7 +129,7 @@ function historicalGuardedTernary(target: string) {
         line: 9,
         owner: "historicalGuardedTernary",
         rule: "R3",
-        text: 'target === "cursor" -> target === "claude" -> else',
+        text: 'target === "cursor" -> target === "claude" -> else [codex]',
       },
     ]);
   });
@@ -268,6 +268,38 @@ const label = target === "claude" ? "Claude" : target === "codex" ? "Codex" : ta
 `, targets);
 
     expect(violations.map(({ rule }) => rule)).toEqual(["R1", "R3"]);
+  });
+
+  test("invalidates an allowlisted R3 fallback when the registry grows", () => {
+    const source = 'function render(target: string) { return target === "claude" ? "Claude" : target === "codex" ? "Codex" : "Other"; }';
+    const sources = [{ content: source, file: "apps/example.ts" }];
+    const currentTargets = ["claude", "codex", "cursor"] as const;
+    const current = scanTargetTopologySources(sources, currentTargets, []);
+    const observed = current.violations[0];
+    expect(current).toMatchObject({
+      duplicateAllowlist: [],
+      unmatchedAllowlist: [],
+      violations: [{ rule: "R3", text: 'target === "claude" -> target === "codex" -> else [cursor]' }],
+    });
+    expect(observed).toBeDefined();
+    if (observed === undefined) throw new Error("fixture must produce an R3 violation");
+    const exemption = { ...observed, rationale: "Fixture permits this exact current fallback." };
+
+    expect(scanTargetTopologySources(sources, currentTargets, [exemption])).toEqual({
+      duplicateAllowlist: [],
+      unmatchedAllowlist: [],
+      violations: [],
+    });
+
+    const futureTargets = ["claude", "codex", "cursor", "future"] as const;
+    expect(scanTargetTopologySources(sources, futureTargets, [exemption])).toEqual({
+      duplicateAllowlist: [],
+      unmatchedAllowlist: [exemption],
+      violations: [{
+        ...observed,
+        text: 'target === "claude" -> target === "codex" -> else [cursor, future]',
+      }],
+    });
   });
 
   test("filters generated, fixture, test, and non-TypeScript paths", () => {

--- a/scripts/target-topology-guard.ts
+++ b/scripts/target-topology-guard.ts
@@ -53,12 +53,12 @@ export const TARGET_TOPOLOGY_ALLOWLIST: readonly TargetTopologyAllowlistEntry[] 
   allow("packages/core/src/render-result-collector.ts", 737, 10, "companionForPath", "R2", 'target === "claude" || target === "cursor"', "Agents are provider-native companion formats for Claude and Cursor."),
   allow("packages/core/src/render.ts", 1255, 7, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor hooks require normalized provider-native output."),
   allow("packages/core/src/render.ts", 1275, 10, "copyPluginCompanionFiles", "R2", 'target === "codex" || target === "cursor"', "Codex and Cursor skip copying Claude-native hook files."),
-  allow("apps/skillset/src/provider-format-updates.ts", 195, 10, "displayProvider", "R3", 'provider === "codex" -> provider === "claude" -> else', "Provider display labels preserve unknown registry values."),
-  allow("packages/core/src/provider-format-conformance.ts", 465, 5, "checkSkillMarkdown", "R3", 'target === "codex" -> target === "cursor" -> else', "Provider-native skill formats use distinct registry references."),
-  allow("packages/core/src/render-plugin-manifest.ts", 66, 5, "renderPluginManifest", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native plugin manifests have distinct formats."),
-  allow("packages/core/src/render-plugin-manifest.ts", 239, 3, "withOptionalSurfacePaths", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native plugin surfaces have distinct destination fields."),
-  allow("packages/core/src/render.ts", 1237, 5, "copyPluginCompanionFiles", "R3", 'target === "claude" -> target === "codex" -> else', "Provider-native companion file sets are intentionally distinct."),
-  allow("packages/core/src/render.ts", 265, 3, "marketplaceReadmeLines", "R3", 'target === "claude" -> target === "cursor" -> else', "Provider-native marketplace README guidance has distinct destination formats."),
+  allow("apps/skillset/src/provider-format-updates.ts", 195, 10, "displayProvider", "R3", 'provider === "codex" -> provider === "claude" -> else [cursor]', "Provider display labels preserve unknown registry values."),
+  allow("packages/core/src/provider-format-conformance.ts", 465, 5, "checkSkillMarkdown", "R3", 'target === "codex" -> target === "cursor" -> else [claude]', "Provider-native skill formats use distinct registry references."),
+  allow("packages/core/src/render-plugin-manifest.ts", 66, 5, "renderPluginManifest", "R3", 'target === "claude" -> target === "codex" -> else [cursor]', "Provider-native plugin manifests have distinct formats."),
+  allow("packages/core/src/render-plugin-manifest.ts", 239, 3, "withOptionalSurfacePaths", "R3", 'target === "claude" -> target === "codex" -> else [cursor]', "Provider-native plugin surfaces have distinct destination fields."),
+  allow("packages/core/src/render.ts", 1237, 5, "copyPluginCompanionFiles", "R3", 'target === "claude" -> target === "codex" -> else [cursor]', "Provider-native companion file sets are intentionally distinct."),
+  allow("packages/core/src/render.ts", 265, 3, "marketplaceReadmeLines", "R3", 'target === "claude" -> target === "cursor" -> else [codex]', "Provider-native marketplace README guidance has distinct destination formats."),
 ] as const;
 
 function allow(
@@ -428,7 +428,9 @@ function dispatchSignature(conditions: readonly ts.Expression[], source: ts.Sour
   if (equalities.length < 2 || equalities.some((value) => value === undefined)) return undefined;
   const matched = equalities as readonly TargetEquality[];
   if (!matched.every(({ subject }) => subject === matched[0]?.subject) || new Set(matched.map(({ target }) => target)).size < 2) return undefined;
-  return `${conditions.map((condition) => normalizedText(condition, source)).join(" -> ")} -> else`;
+  const matchedTargets = new Set(matched.map(({ target }) => target));
+  const residualTargets = [...targets].filter((target) => !matchedTargets.has(target));
+  return `${conditions.map((condition) => normalizedText(condition, source)).join(" -> ")} -> else [${residualTargets.join(", ")}]`;
 }
 
 function flattenOr(node: ts.Expression): readonly ts.Expression[] {


### PR DESCRIPTION
## Context

Closes SET-380 and the unresolved PR #316 review gap: R3 topology allowlist identity omitted residual registered targets, so exemptions survived registry growth.

## Changes

- append the ordered residual target set to R3 dispatch signatures;
- deliberately refresh current exact exemptions;
- prove a three-target exemption becomes stale when a future target is registered.

## Verification

- branch and full-wave standing/fresh local reviews: 5/5 clean;
- topology tests 19/19 and live 243-source scan clean;
- wave pre-push: 1,447 tests, 0 failures.

## Risk

Guard/test-only change that tightens exemption identity without weakening topology policy.
