### PR TITLE
fix(registry): validate provider overlay formats

### DIFF
--- a/.changeset/validate-provider-overlay-format-snapshots.md
+++ b/.changeset/validate-provider-overlay-format-snapshots.md
@@ -1,0 +1,5 @@
+---
+"skillset": patch
+---
+
+Reject provider schema manual overlays that reference unknown destination format snapshots before maintenance can fetch or write.

--- a/packages/registry/src/__tests__/provider-maintenance.test.ts
+++ b/packages/registry/src/__tests__/provider-maintenance.test.ts
@@ -23,6 +23,7 @@ import {
   providerSchemaManualOverlays,
   type ProviderDestinationFormatSnapshot,
   type ProviderJsonSchemaSummary,
+  type ProviderSchemaManualOverlay,
   type ProviderSchemaSnapshot,
 } from "../index";
 import {
@@ -154,6 +155,75 @@ describe("SET-335 registry-owned provider maintenance", () => {
       `failed to fetch ${url}: 404 Not Found`
     );
     expect(await Bun.file(schemaPath).exists()).toBe(false);
+  });
+
+  test("SET-382: unknown manual overlay formats fail before fetch or write", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-provider-overlay-"));
+    const schemaPath = join(root, "schema-snapshots.ts");
+    const unknownOverlay = {
+      ...providerSchemaManualOverlays[0],
+      formatSnapshotId: "missing-format-snapshot",
+    } as unknown as ProviderSchemaManualOverlay;
+    let fetches = 0;
+    const fetcher: ProviderFetch = async () => {
+      fetches += 1;
+      return new Response("unexpected fetch");
+    };
+    const options = {
+      destinationSnapshots: [],
+      fetcher,
+      manualOverlays: [unknownOverlay],
+      schemaSnapshotPath: schemaPath,
+      schemaSnapshots: [
+        schemaSnapshot(
+          schemaBody(["alpha"]),
+          "https://example.com/schema.json"
+        ),
+      ],
+      write: true,
+    };
+
+    await expect(
+      runProviderMaintenance(root, "update", options)
+    ).rejects.toThrow(
+      "skillset: provider schema manual overlay claude-hooks-overlay references unknown destination format snapshot missing-format-snapshot"
+    );
+    expect(fetches).toBe(0);
+    expect(await Bun.file(schemaPath).exists()).toBe(false);
+
+    await writeFile(schemaPath, "existing snapshot\n");
+    await expect(
+      runProviderMaintenance(root, "update", options)
+    ).rejects.toThrow(
+      "skillset: provider schema manual overlay claude-hooks-overlay references unknown destination format snapshot missing-format-snapshot"
+    );
+    expect(fetches).toBe(0);
+    expect(await readFile(schemaPath, "utf8")).toBe("existing snapshot\n");
+  });
+
+  test("SET-382: canonical manual overlay formats ignore the report snapshot seam", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skillset-provider-overlay-"));
+    const schemaPath = join(root, "schema-snapshots.ts");
+    const adoptedBody = schemaBody(["alpha"]);
+    const liveBody = schemaBody(["alpha", "beta"]);
+
+    const report = await runProviderMaintenance(root, "update", {
+      destinationSnapshots: [],
+      fetcher: fetchMap({ "https://example.com/schema.json": liveBody }),
+      manualOverlays: [providerSchemaManualOverlays[0]!],
+      schemaSnapshotPath: schemaPath,
+      schemaSnapshots: [
+        schemaSnapshot(adoptedBody, "https://example.com/schema.json"),
+      ],
+      write: true,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.destinationReviews).toEqual([]);
+    expect(report.wrote).toBe(true);
+    expect(await readFile(schemaPath, "utf8")).toContain(
+      'readonly formatSnapshotId:\n    | "claude-hooks";'
+    );
   });
 
   test("SET-191: diff includes destination format manual-review evidence", async () => {

--- a/packages/registry/src/provider-maintenance.ts
+++ b/packages/registry/src/provider-maintenance.ts
@@ -32,6 +32,7 @@ export type ProviderFetch = (url: string) => Promise<ProviderFetchResponse>;
 export interface ProviderMaintenanceOptions {
   readonly destinationSnapshots?: readonly ProviderDestinationFormatSnapshot[];
   readonly fetcher?: ProviderFetch;
+  readonly manualOverlays?: readonly ProviderSchemaManualOverlay[];
   readonly now?: string;
   readonly schemaSnapshotPath?: string;
   readonly schemaSnapshots?: readonly ProviderSchemaSnapshot[];
@@ -88,6 +89,9 @@ export async function runProviderMaintenance(
   command: ProviderMaintenanceSubcommand,
   options: ProviderMaintenanceOptions = {}
 ): Promise<ProviderMaintenanceReport> {
+  const manualOverlays =
+    options.manualOverlays ?? providerSchemaManualOverlays;
+  assertManualOverlayDestinationFormatIds(manualOverlays);
   const schemaPath =
     options.schemaSnapshotPath ??
     resolve(rootPath, "packages/registry/src/schema-snapshots.ts");
@@ -127,7 +131,7 @@ export async function runProviderMaintenance(
     });
     const source = renderProviderSchemaSnapshotsSource(
       nextSnapshots,
-      providerSchemaManualOverlays
+      manualOverlays
     );
     const previous = await readFile(schemaPath, "utf8").catch(() => "");
     if (previous !== source) {
@@ -159,6 +163,23 @@ export async function runProviderMaintenance(
     schemaResults,
     wrote,
   };
+}
+
+function assertManualOverlayDestinationFormatIds(
+  manualOverlays: readonly ProviderSchemaManualOverlay[]
+): void {
+  const knownIds = new Set(
+    listProviderDestinationFormatSnapshots().map((snapshot) => snapshot.id)
+  );
+  for (const overlay of [...manualOverlays].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  )) {
+    if (!knownIds.has(overlay.formatSnapshotId)) {
+      throw new Error(
+        `skillset: provider schema manual overlay ${overlay.id} references unknown destination format snapshot ${overlay.formatSnapshotId}`
+      );
+    }
+  }
 }
 
 async function checkSchemaSnapshot(


### PR DESCRIPTION
## Context

Closes SET-382 and the unresolved PR #339 review gap: provider maintenance derived the manual-overlay format ID union from the same overlay data and therefore accepted unknown IDs.

## Changes

- validate manual overlay IDs against canonical destination snapshots before fetch, render, or write;
- keep `destinationSnapshots` as a report-only seam;
- prove unknown IDs perform no fetch/write and canonical IDs remain deterministic;
- add a patch Changeset.

## Verification

- branch and full-wave standing/fresh local reviews: 5/5 clean;
- provider-maintenance suite 8/8, schema/output/type checks;
- wave pre-push: 1,447 tests, 0 failures.

## Risk

Fail-fast maintenance validation; generated schema source remains renderer-owned and deterministic.
