### PR TITLE
test: isolate repo suite from user XDG config

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "skillset:check:ci": "bun ./apps/skillset/src/cli.ts check --ci --root .",
     "skillset:check:ci:report": "bun ./apps/skillset/src/cli.ts check --ci --root . --since \"$(scripts/git-trunk.sh)\" --report .skillset/cache/reports/skillset-ci-report.md",
     "skillset:check:outputs": "bun ./apps/skillset/src/cli.ts check --only outputs --root .",
-    "test": "bun test --timeout 15000 $(git ls-files 'apps/**/*.test.ts' 'packages/**/*.test.ts' 'scripts/**/*.test.ts')",
+    "test": "env -u XDG_CONFIG_HOME NODE_ENV=test bun test --timeout 15000 $(git ls-files 'apps/**/*.test.ts' 'packages/**/*.test.ts' 'scripts/**/*.test.ts')",
     "typecheck": "tsc --noEmit",
     "ultracite:check": "ultracite check",
     "ultracite:doctor": "ultracite doctor",

--- a/scripts/__tests__/test-harness-contract.test.ts
+++ b/scripts/__tests__/test-harness-contract.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+test("repo tests cannot inherit the user XDG config root", async () => {
+  const packageJson = (await Bun.file(join(repoRoot, "package.json")).json()) as {
+    readonly scripts: { readonly test: string };
+  };
+
+  expect(packageJson.scripts.test).toStartWith(
+    "env -u XDG_CONFIG_HOME NODE_ENV=test bun test "
+  );
+});


### PR DESCRIPTION
## Context

Repo tests inherited the caller's `XDG_CONFIG_HOME`, so CLI subprocesses could concurrently write to the real known-Skillsets index. A malformed user index then leaked warnings into SET-278 and made the suite environment-dependent.

Linear: SET-383

## What changed

- Run the canonical root test command with `NODE_ENV=test` and `XDG_CONFIG_HOME` unset.
- Add a contract test that keeps this isolation on the tracked test entrypoint.
- Preserve tests that explicitly provide their own isolated XDG roots.

## How to test

- `bun run check`
- 1,448 tests pass, 0 fail.
- Hash guard confirmed the existing user known-Skillsets index was unchanged.

## Risk / rollout

This only changes the repository test harness. It does not repair or overwrite an existing malformed user index, and it does not change production index-writing behavior.