### PR TITLE
feat(cli): add bounded activation observers

### DIFF
--- a/.changeset/bounded-activation-observers.md
+++ b/.changeset/bounded-activation-observers.md
@@ -1,0 +1,5 @@
+---
+"skillset": minor
+---
+
+Add bounded, registry-driven provider observation adapters for activation readiness.

--- a/apps/skillset/src/__tests__/activation-inspection.test.ts
+++ b/apps/skillset/src/__tests__/activation-inspection.test.ts
@@ -62,7 +62,6 @@ test("activation inspection consumes registry argv once per inspector and bounds
     "codex plugin list --json",
     "cursor-agent --version",
     "cursor-agent mcp list",
-    "cursor-agent status --format json",
   ]);
   expect(
     report.inspections.filter(({ effect }) => effect === "active")
@@ -84,7 +83,7 @@ test("activation inspection consumes registry argv once per inspector and bounds
   ).toMatchObject({ observationEffect: "none", state: "unverified" });
   expect(
     requirement(report, "cursor", "mcp-server", "github", "authenticated")
-  ).toMatchObject({ observationEffect: "passive", state: "satisfied" });
+  ).toMatchObject({ observationEffect: "none", state: "unverified" });
   expect(JSON.stringify(report)).not.toContain("must-not-survive");
   expect(JSON.stringify(report)).not.toContain("example.com");
 });

--- a/apps/skillset/src/__tests__/activation-inspection.test.ts
+++ b/apps/skillset/src/__tests__/activation-inspection.test.ts
@@ -1,0 +1,610 @@
+import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+
+import { targetRecord } from "@skillset/core";
+import type { BuildGraph, SourcePlugin } from "@skillset/core/internal/types";
+
+import {
+  ACTIVATION_INSPECTION_SCHEMA,
+  inspectActivationReadiness,
+} from "../activation-inspection";
+import type { ActivationProviderCommandRunner } from "../activation-inspection";
+import type { ProviderCommandExecutionResult } from "../provider-command";
+import { runProviderCommand } from "../provider-command";
+
+test("activation inspection consumes registry argv once per inspector and bounds claims", async () => {
+  const calls: string[][] = [];
+  const runner = fixtureRunner(calls, {
+    "claude --version": "Claude Code 2.1.219\n",
+    "claude mcp list": "github: ✓ Connected\n",
+    "claude plugin list --json": JSON.stringify([
+      { enabled: true, name: "shared" },
+    ]),
+    "codex --version": "codex-cli 0.146.0-alpha.3.1\n",
+    "codex mcp list --json": JSON.stringify([{ name: "github" }]),
+    "codex plugin list --json": JSON.stringify({
+      installed: [{ enabled: true, name: "shared", pluginId: "shared" }],
+    }),
+    "cursor-agent --version": "2026.07.23-e383d2b\n",
+    "cursor-agent mcp list": "github: connected\n",
+    "cursor-agent status --format json": JSON.stringify({
+      authenticated: true,
+      email: "must-not-survive@example.com",
+      token: "must-not-survive",
+    }),
+  });
+
+  const report = await inspectActivationReadiness({
+    allowActive: true,
+    graph: graphFixture(),
+    renderResults: [],
+    rootPath: "/repo",
+    runCommand: runner,
+  });
+
+  expect(report.schema).toBe(ACTIVATION_INSPECTION_SCHEMA);
+  expect(calls.map((call) => call.join(" ")).toSorted()).toEqual([
+    "claude --version",
+    "claude mcp list",
+    "claude plugin list --json",
+    "codex --version",
+    "codex mcp list --json",
+    "codex plugin list --json",
+    "cursor-agent --version",
+    "cursor-agent mcp list",
+    "cursor-agent status --format json",
+  ]);
+  expect(
+    report.inspections.filter(({ effect }) => effect === "active")
+  ).toHaveLength(2);
+  expect(
+    report.inspections.find(
+      ({ inspectorId }) => inspectorId === "codex.mcp.list"
+    )
+  ).toMatchObject({
+    binaryVersion: "0.146.0-alpha.3.1",
+    effect: "passive",
+    outcome: "ran",
+  });
+  expect(
+    requirement(report, "codex", "mcp-server", "github", "discoverable")
+  ).toMatchObject({ observationEffect: "passive", state: "satisfied" });
+  expect(
+    requirement(report, "codex", "mcp-server", "github", "connected")
+  ).toMatchObject({ observationEffect: "none", state: "unverified" });
+  expect(
+    requirement(report, "cursor", "mcp-server", "github", "authenticated")
+  ).toMatchObject({ observationEffect: "passive", state: "satisfied" });
+  expect(JSON.stringify(report)).not.toContain("must-not-survive");
+  expect(JSON.stringify(report)).not.toContain("example.com");
+});
+
+test("passive activation inspection skips active health checks", async () => {
+  const calls: string[][] = [];
+  const runner = fixtureRunner(calls, {
+    "claude --version": "Claude Code 2.1.219\n",
+    "claude plugin list --json": "[]",
+    "codex --version": "codex-cli 0.146.0-alpha.3.1\n",
+    "codex mcp list --json": "[]",
+    "codex plugin list --json": '{"installed":[]}',
+    "cursor-agent --version": "2026.07.23-e383d2b\n",
+    "cursor-agent status --format json": '{"authenticated":false}',
+  });
+
+  const report = await inspectActivationReadiness({
+    allowActive: false,
+    graph: graphFixture(),
+    renderResults: [],
+    rootPath: "/repo",
+    runCommand: runner,
+  });
+
+  expect(calls.some((call) => call.join(" ") === "claude mcp list")).toBe(
+    false
+  );
+  expect(calls.some((call) => call.join(" ") === "cursor-agent mcp list")).toBe(
+    false
+  );
+  expect(
+    report.inspections.filter(({ outcome }) => outcome === "skipped")
+  ).toEqual([
+    expect.objectContaining({ inspectorId: "claude.mcp.list" }),
+    expect.objectContaining({ inspectorId: "cursor.mcp.list" }),
+  ]);
+});
+
+test("timeouts, unavailable binaries, and malformed output remain unverified", async () => {
+  const runner: ActivationProviderCommandRunner = async (command) => {
+    const display = command.cmd.join(" ");
+    if (display.includes("plugin list")) {
+      return execution({ stdout: '{"unexpected":true}' });
+    }
+    if (display === "codex mcp list --json") {
+      return execution({ timedOut: true });
+    }
+    if (display === "claude --version") {
+      return execution({ stdout: "Claude Code 2.1.219\n" });
+    }
+    if (display === "codex --version") {
+      return execution({ stdout: "codex-cli 0.146.0-alpha.3.1\n" });
+    }
+    if (display === "cursor-agent --version") {
+      return execution({ stdout: "2026.07.23-e383d2b\n" });
+    }
+    return execution({ exitCode: 1 });
+  };
+
+  const report = await inspectActivationReadiness({
+    allowActive: true,
+    graph: graphFixture(),
+    renderResults: [],
+    rootPath: "/repo",
+    runCommand: runner,
+  });
+
+  expect(report.inspections).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        inspectorId: "codex.mcp.list",
+        outcome: "timed_out",
+      }),
+      expect.objectContaining({
+        inspectorId: "codex.plugin.list",
+        outcome: "malformed",
+      }),
+    ])
+  );
+  expect(
+    requirement(report, "codex", "mcp-server", "github", "discoverable").state
+  ).toBe("unverified");
+  expect(
+    requirement(report, "codex", "plugin-dependency", "shared", "discoverable")
+      .state
+  ).toBe("unverified");
+});
+
+test("unknown provider versions skip every inspector command", async () => {
+  const calls: string[][] = [];
+  const runner = fixtureRunner(calls, {
+    "claude --version": "Claude Code 99.0.0\n",
+    "claude mcp list": "github: connected\n",
+    "claude plugin list --json": '[{"name":"shared","enabled":true}]',
+    "codex --version": "codex-cli 99.0.0\n",
+    "codex mcp list --json": '[{"name":"github"}]',
+    "codex plugin list --json":
+      '{"installed":[{"name":"shared","enabled":true}]}',
+    "cursor-agent --version": "99.0.0\n",
+    "cursor-agent mcp list": "github: connected\n",
+    "cursor-agent status --format json": '{"authenticated":true}',
+  });
+
+  const report = await inspectActivationReadiness({
+    allowActive: true,
+    graph: graphFixture(),
+    renderResults: [],
+    rootPath: "/repo",
+    runCommand: runner,
+  });
+
+  expect(
+    report.inspections
+      .filter(({ effect }) => effect !== "none")
+      .every(({ outcome }) => outcome === "skipped")
+  ).toBe(true);
+  expect(calls.map((call) => call.join(" ")).sort()).toEqual([
+    "claude --version",
+    "codex --version",
+    "cursor-agent --version",
+  ]);
+  expect(
+    report.readiness.requirements
+      .filter(({ stage }) => !["declared", "rendered"].includes(stage))
+      .every(({ state }) => state === "unverified")
+  ).toBe(true);
+});
+
+test("unavailable version executables stop provider inspection", async () => {
+  for (const code of ["EACCES", "ENOENT", "ENOEXEC", "ENOTDIR"]) {
+    const calls: string[][] = [];
+    const runner: ActivationProviderCommandRunner = async (command) => {
+      calls.push([...command.cmd]);
+      if (command.cmd[1] !== "--version") {
+        throw new Error("an inspector ran after its version probe failed");
+      }
+      throw Object.assign(new Error(`private ${code} fixture detail`), {
+        code,
+      });
+    };
+
+    const report = await inspectActivationReadiness({
+      allowActive: true,
+      graph: graphFixture(),
+      renderResults: [],
+      rootPath: "/repo",
+      runCommand: runner,
+    });
+
+    expect(
+      report.inspections.every(
+        ({ binaryVersion, outcome }) =>
+          binaryVersion === undefined && outcome === "unavailable"
+      )
+    ).toBe(true);
+    expect(calls.map((call) => call.join(" ")).toSorted()).toEqual([
+      "claude --version",
+      "codex --version",
+      "cursor-agent --version",
+    ]);
+    expect(
+      report.readiness.requirements
+        .filter(({ stage }) => !["declared", "rendered"].includes(stage))
+        .every(({ state }) => state === "unverified")
+    ).toBe(true);
+    expect(JSON.stringify(report)).not.toContain(code);
+    expect(JSON.stringify(report)).not.toContain("private");
+  }
+});
+
+test("inspectors becoming unavailable after version checks remain advisory", async () => {
+  for (const code of ["EACCES", "ENOENT", "ENOEXEC", "ENOTDIR"]) {
+    const runner: ActivationProviderCommandRunner = async (command) => {
+      const display = command.cmd.join(" ");
+      if (display === "claude --version") {
+        return execution({ stdout: "Claude Code 2.1.219\n" });
+      }
+      if (display === "codex --version") {
+        return execution({ stdout: "codex-cli 0.146.0-alpha.3.1\n" });
+      }
+      if (display === "cursor-agent --version") {
+        return execution({ stdout: "2026.07.23-e383d2b\n" });
+      }
+      throw Object.assign(new Error(`private ${code} fixture detail`), {
+        code,
+      });
+    };
+
+    const report = await inspectActivationReadiness({
+      allowActive: true,
+      graph: graphFixture(),
+      renderResults: [],
+      rootPath: "/repo",
+      runCommand: runner,
+    });
+
+    const unavailable = report.inspections.filter(
+      ({ effect, outcome }) => effect !== "none" && outcome === "unavailable"
+    );
+    expect(unavailable.length).toBeGreaterThan(0);
+    expect(
+      unavailable.every(({ binaryVersion }) => binaryVersion !== undefined)
+    ).toBe(true);
+    expect(
+      report.inspections
+        .filter(({ effect }) => effect !== "none")
+        .every(({ outcome }) =>
+          ["skipped", "unavailable"].includes(outcome)
+        )
+    ).toBe(true);
+    expect(
+      report.readiness.requirements
+        .filter(({ stage }) => !["declared", "rendered"].includes(stage))
+        .every(({ state }) => state === "unverified")
+    ).toBe(true);
+    expect(JSON.stringify(report)).not.toContain(code);
+    expect(JSON.stringify(report)).not.toContain("private");
+  }
+});
+
+test("provider evidence versions require a complete version token match", async () => {
+  for (const suffix of ["0", "+build", "_extra", "/next"]) {
+    const runner = fixtureRunner([], {
+      "claude --version": `Claude Code 2.1.219${suffix}\n`,
+      "claude mcp list": "github: connected\n",
+      "claude plugin list --json": '[{"name":"shared","enabled":true}]',
+      "codex --version": `codex-cli 0.146.0-alpha.3.1${suffix}\n`,
+      "codex mcp list --json": '[{"name":"github"}]',
+      "codex plugin list --json":
+        '{"installed":[{"name":"shared","enabled":true}]}',
+      "cursor-agent --version": `2026.07.23-e383d2b${suffix}\n`,
+      "cursor-agent mcp list": "github: connected\n",
+      "cursor-agent status --format json": '{"authenticated":true}',
+    });
+
+    const report = await inspectActivationReadiness({
+      allowActive: true,
+      graph: graphFixture(),
+      renderResults: [],
+      rootPath: "/repo",
+      runCommand: runner,
+    });
+
+    expect(
+      report.inspections
+        .filter(({ effect }) => effect !== "none")
+        .every(({ outcome }) => outcome === "skipped")
+    ).toBe(true);
+    expect(
+      report.readiness.requirements
+        .filter(({ stage }) => !["declared", "rendered"].includes(stage))
+        .every(({ state }) => state === "unverified")
+    ).toBe(true);
+  }
+});
+
+test("provider receipts retain only the canonical evidence version", async () => {
+  const runner = fixtureRunner([], {
+    "claude --version":
+      "Claude Code 2.1.219 /Users/alice/.config/provider-token\nignored\n",
+    "claude mcp list": "github: connected\n",
+    "claude plugin list --json": '[{"name":"shared","enabled":true}]',
+    "codex --version": "codex-cli 0.146.0-alpha.3.1\n",
+    "codex mcp list --json": '[{"name":"github"}]',
+    "codex plugin list --json":
+      '{"installed":[{"name":"shared","enabled":true}]}',
+    "cursor-agent --version": "2026.07.23-e383d2b\n",
+    "cursor-agent mcp list": "github: connected\n",
+    "cursor-agent status --format json": '{"authenticated":true}',
+  });
+
+  const report = await inspectActivationReadiness({
+    allowActive: true,
+    graph: graphFixture(),
+    renderResults: [],
+    rootPath: "/repo",
+    runCommand: runner,
+  });
+
+  expect(
+    report.inspections
+      .filter(({ target }) => target === "claude")
+      .every(({ binaryVersion }) => binaryVersion === "2.1.219")
+  ).toBe(true);
+  expect(JSON.stringify(report)).not.toContain("/Users/alice");
+  expect(JSON.stringify(report)).not.toContain("provider-token");
+});
+
+test("invalid activation timeouts fail before launching a provider", async () => {
+  for (const timeoutMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5]) {
+    const calls: string[][] = [];
+    await expect(
+      inspectActivationReadiness({
+        allowActive: true,
+        graph: graphFixture(),
+        renderResults: [],
+        rootPath: "/repo",
+        runCommand: fixtureRunner(calls, {}),
+        timeoutMs,
+      })
+    ).rejects.toThrow("activation timeout must be a positive safe integer");
+    expect(calls).toEqual([]);
+  }
+});
+
+test("provider adapter fixtures preserve workspace, HOME, XDG, and provider state", async () => {
+  const harness = await mkdtemp(join(tmpdir(), "skillset-activation-adapter-"));
+  const workspace = join(harness, "workspace");
+  const home = join(harness, "home");
+  const xdg = join(harness, "xdg");
+  const providerState = join(harness, "provider-state");
+  for (const root of [workspace, home, xdg, providerState]) {
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      join(root, "marker.txt"),
+      `${root.split("/").at(-1)}\n`,
+      "utf8"
+    );
+  }
+  const fakeBin = join(harness, "bin", "provider-fixture");
+  await mkdir(dirname(fakeBin), { recursive: true });
+  await writeFile(
+    fakeBin,
+    `#!/bin/sh
+provider="$1"
+shift
+case "$provider $*" in
+  "claude --version") printf 'Claude Code 2.1.219\\n' ;;
+  "claude plugin list --json") printf '[{"name":"shared","enabled":true}]\\n' ;;
+  "claude mcp list") printf 'github: connected\\n' ;;
+  "codex --version") printf 'codex-cli 0.146.0-alpha.3.1\\n' ;;
+  "codex plugin list --json") printf '{"installed":[{"name":"shared","enabled":true}]}\\n' ;;
+  "codex mcp list --json") printf '[{"name":"github"}]\\n' ;;
+  "cursor-agent --version") printf '2026.07.23-e383d2b\\n' ;;
+  "cursor-agent mcp list") printf 'github: connected\\n' ;;
+  "cursor-agent status --format json") printf '{"authenticated":true}\\n' ;;
+  *) exit 9 ;;
+esac
+`,
+    "utf8"
+  );
+  await chmod(fakeBin, 0o755);
+
+  const protectedRoots = [workspace, home, xdg, providerState];
+  const before = await Promise.all(protectedRoots.map(hashTree));
+  const runner: ActivationProviderCommandRunner = (command, options) =>
+    runProviderCommand(
+      { cmd: [fakeBin, ...command.cmd], cwd: command.cwd },
+      {
+        ...options,
+        env: {
+          ...options.env,
+          HOME: home,
+          SKILLSET_PROVIDER_STATE: providerState,
+          XDG_CACHE_HOME: join(xdg, "cache"),
+          XDG_CONFIG_HOME: join(xdg, "config"),
+          XDG_DATA_HOME: join(xdg, "data"),
+          XDG_STATE_HOME: join(xdg, "state"),
+        },
+      }
+    );
+
+  const report = await inspectActivationReadiness({
+    allowActive: true,
+    graph: graphFixture(),
+    renderResults: [],
+    rootPath: workspace,
+    runCommand: runner,
+  });
+  const after = await Promise.all(protectedRoots.map(hashTree));
+
+  expect(
+    report.inspections.every(
+      ({ outcome }) => outcome === "ran" || outcome === "unavailable"
+    )
+  ).toBe(true);
+  expect(after).toEqual(before);
+});
+
+function fixtureRunner(
+  calls: string[][],
+  outputs: Readonly<Record<string, string>>
+): ActivationProviderCommandRunner {
+  return async (command) => {
+    const cmd = [...command.cmd];
+    calls.push(cmd);
+    const stdout = outputs[cmd.join(" ")];
+    if (stdout === undefined) {
+      throw new Error(`unexpected activation fixture command ${cmd.join(" ")}`);
+    }
+    return execution({ stdout });
+  };
+}
+
+function execution(
+  overrides: Partial<ProviderCommandExecutionResult> = {}
+): ProviderCommandExecutionResult {
+  const stdout = overrides.stdout ?? "";
+  const stderr = overrides.stderr ?? "";
+  return {
+    exitCode: 0,
+    stderr,
+    stderrBytes: Buffer.byteLength(stderr),
+    stderrTruncated: false,
+    stdout,
+    stdoutBytes: Buffer.byteLength(stdout),
+    stdoutTruncated: false,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+function graphFixture(): BuildGraph {
+  return {
+    plugins: [
+      pluginFixture({
+        dependencies: [
+          {
+            kind: "internal",
+            name: "shared",
+            sourceLabel: ".skillset/plugins/tools/skillset.yaml",
+            unversioned: false,
+          },
+        ],
+        features: [
+          {
+            key: "mcp",
+            origin: "conventional",
+            sourcePath: "/repo/.skillset/plugins/tools/.mcp.json",
+            subjects: ["github"],
+            targetPath: ".mcp.json",
+          },
+        ],
+        id: "tools",
+      }),
+      pluginFixture({ id: "shared" }),
+    ],
+    projectIslands: [],
+    root: {
+      outputs: {
+        plugins: targetRecord((target) => `plugins/{plugin}/${target}`),
+        skills: targetRecord((target) => `.${target}/skills`),
+        targetOutputs: targetRecord(() => ({
+          plugins: true,
+          skills: true,
+        })),
+      },
+      targets: targetRecord(() => ({ enabled: true, options: {} })),
+    },
+    rootPath: "/repo",
+  } as unknown as BuildGraph;
+}
+
+function pluginFixture(overrides: {
+  readonly dependencies?: SourcePlugin["dependencies"];
+  readonly features?: SourcePlugin["features"];
+  readonly id: string;
+}): SourcePlugin {
+  return {
+    adaptiveHooks: [],
+    configPath: `/repo/.skillset/plugins/${overrides.id}/skillset.yaml`,
+    dependencies: overrides.dependencies ?? [],
+    features: overrides.features ?? [],
+    hookAttachments: [],
+    id: overrides.id,
+    metadata: {},
+    path: `/repo/.skillset/plugins/${overrides.id}`,
+    skills: [],
+    targets: targetRecord(() => ({ enabled: true, options: {} })),
+  };
+}
+
+function requirement(
+  report: Awaited<ReturnType<typeof inspectActivationReadiness>>,
+  target: "claude" | "codex" | "cursor",
+  capability: "app" | "mcp-server" | "plugin-dependency",
+  subject: string,
+  stage:
+    | "authenticated"
+    | "connected"
+    | "declared"
+    | "discoverable"
+    | "enabled"
+    | "proven"
+    | "rendered"
+) {
+  const found = report.readiness.requirements.find(
+    (candidate) =>
+      candidate.target === target &&
+      candidate.capability === capability &&
+      candidate.subject === subject &&
+      candidate.stage === stage
+  );
+  if (found === undefined) throw new Error("missing activation requirement");
+  return found;
+}
+
+async function hashTree(root: string): Promise<string> {
+  const hash = createHash("sha256");
+  await hashDirectory(root, root, hash);
+  return hash.digest("hex");
+}
+
+async function hashDirectory(
+  root: string,
+  path: string,
+  hash: ReturnType<typeof createHash>
+): Promise<void> {
+  const entries = await readdir(path, { withFileTypes: true });
+  for (const entry of entries.toSorted((left, right) =>
+    left.name.localeCompare(right.name)
+  )) {
+    const fullPath = join(path, entry.name);
+    hash.update(relative(root, fullPath));
+    if (entry.isDirectory()) {
+      hash.update("directory");
+      await hashDirectory(root, fullPath, hash);
+    } else {
+      hash.update("file");
+      hash.update(await readFile(fullPath));
+    }
+  }
+}

--- a/apps/skillset/src/__tests__/activation-parsers.test.ts
+++ b/apps/skillset/src/__tests__/activation-parsers.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import { parseActivationInspectorOutput } from "../activation-parsers";
+
+describe("activation provider output parsers", () => {
+  test("keeps dated provider fixtures for every allowlisted inspector", async () => {
+    const captured = (await Bun.file(
+      join(import.meta.dir, "fixtures/activation/provider-outputs.json")
+    ).json()) as {
+      captureEnvironment: string;
+      capturedAt: string;
+      fixtures: Array<{
+        command: string[];
+        id: string;
+        output: string;
+        providerVersion: string;
+        source: string;
+      }>;
+    };
+
+    expect(captured.captureEnvironment).toBe(
+      "installed provider binary with isolated empty HOME and XDG roots"
+    );
+    expect(captured.capturedAt).toBe("2026-07-24");
+    expect(captured.fixtures.map(({ id }) => id).toSorted()).toEqual([
+      "claude-mcp-list",
+      "claude-plugin-list",
+      "codex-mcp-list",
+      "codex-plugin-list",
+      "cursor-mcp-list",
+      "cursor-status",
+    ]);
+    for (const fixture of captured.fixtures) {
+      expect(fixture.command.length).toBeGreaterThan(1);
+      expect(fixture.output.length).toBeGreaterThan(0);
+      expect(fixture.providerVersion.length).toBeGreaterThan(0);
+      expect(fixture.source).toStartWith("https://");
+    }
+  });
+
+  test("Claude plugin inventory reports discoverable and persisted enabled state", () => {
+    const result = parseActivationInspectorOutput({
+      capability: "plugin-dependency",
+      inspectorId: "claude.plugin.list",
+      stdout: JSON.stringify([
+        { enabled: true, marketplace: "outfitter", name: "trails" },
+        { enabled: false, marketplace: "outfitter", name: "ranger" },
+      ]),
+      subjects: ["outfitter/trails", "outfitter/ranger", "outfitter/missing"],
+    });
+
+    expect(result).toMatchObject({
+      outcome: "ran",
+      facts: [
+        {
+          claim: "discoverable",
+          state: "satisfied",
+          subject: "outfitter/trails",
+        },
+        { claim: "enabled", state: "satisfied", subject: "outfitter/trails" },
+        {
+          claim: "discoverable",
+          state: "satisfied",
+          subject: "outfitter/ranger",
+        },
+        { claim: "enabled", state: "missing", subject: "outfitter/ranger" },
+        {
+          claim: "discoverable",
+          state: "missing",
+          subject: "outfitter/missing",
+        },
+      ],
+    });
+  });
+
+  test("Codex inventories accept only allowlisted names and enabled state", () => {
+    const plugins = parseActivationInspectorOutput({
+      capability: "plugin-dependency",
+      inspectorId: "codex.plugin.list",
+      stdout: JSON.stringify({
+        installed: [
+          {
+            authPolicy: { token: "must-not-survive" },
+            enabled: true,
+            marketplaceName: "outfitter",
+            name: "trails",
+            pluginId: "trails@outfitter",
+          },
+        ],
+      }),
+      subjects: ["trails@outfitter"],
+    });
+    const mcp = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "codex.mcp.list",
+      stdout: JSON.stringify([
+        { bearerToken: "must-not-survive", enabled: true, name: "github" },
+      ]),
+      subjects: ["github", "linear"],
+    });
+
+    expect(plugins.facts).toEqual([
+      expect.objectContaining({ claim: "discoverable", state: "satisfied" }),
+      expect.objectContaining({ claim: "enabled", state: "satisfied" }),
+    ]);
+    expect(mcp.facts).toEqual([
+      expect.objectContaining({
+        claim: "discoverable",
+        state: "satisfied",
+        subject: "github",
+      }),
+      expect.objectContaining({
+        claim: "discoverable",
+        state: "missing",
+        subject: "linear",
+      }),
+    ]);
+    expect(JSON.stringify([plugins, mcp])).not.toContain("must-not-survive");
+  });
+
+  test("Claude and Cursor MCP text can claim only discovery and explicit connection", () => {
+    const claude = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "claude.mcp.list",
+      stdout: "github: ✓ Connected\nlinear: ✗ Failed\n",
+      subjects: ["github", "linear", "missing"],
+    });
+    const cursor = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "cursor.mcp.list",
+      stdout: "● github - ready\n○ linear - disabled\n",
+      subjects: ["github", "linear"],
+    });
+
+    expect(
+      claude.facts.map(({ claim, state, subject }) => ({
+        claim,
+        state,
+        subject,
+      }))
+    ).toEqual([
+      { claim: "discoverable", state: "satisfied", subject: "github" },
+      { claim: "connected", state: "satisfied", subject: "github" },
+      { claim: "discoverable", state: "satisfied", subject: "linear" },
+      { claim: "connected", state: "missing", subject: "linear" },
+      { claim: "discoverable", state: "missing", subject: "missing" },
+    ]);
+    expect(cursor.facts.some((fact) => fact.claim === "authenticated")).toBe(
+      false
+    );
+    expect(
+      cursor.facts.some(
+        (fact) => fact.claim === "connected" && fact.state === "satisfied"
+      )
+    ).toBe(true);
+  });
+
+  test("valid unrelated MCP inventory reports requested subjects missing", () => {
+    const result = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "claude.mcp.list",
+      stdout: "other: connected\n",
+      subjects: ["github"],
+    });
+
+    expect(result).toMatchObject({
+      facts: [
+        { claim: "discoverable", state: "missing", subject: "github" },
+      ],
+      outcome: "ran",
+    });
+  });
+
+  test("connection parsing excludes the MCP server name", () => {
+    const result = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "claude.mcp.list",
+      stdout: "error-tracker: connected\n",
+      subjects: ["error-tracker"],
+    });
+
+    expect(result).toMatchObject({
+      facts: [
+        {
+          claim: "discoverable",
+          state: "satisfied",
+          subject: "error-tracker",
+        },
+        {
+          claim: "connected",
+          state: "satisfied",
+          subject: "error-tracker",
+        },
+      ],
+      outcome: "ran",
+    });
+  });
+
+  test("recognizes only the provider empty MCP inventory phrase", () => {
+    const empty = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "claude.mcp.list",
+      stdout: "No MCP servers configured. Use `claude mcp add` to add one.\n",
+      subjects: ["github", "linear"],
+    });
+    const unrelated = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "claude.mcp.list",
+      stdout: "No configured servers were returned by another subsystem.\n",
+      subjects: ["github"],
+    });
+    const cursorEmpty = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "cursor.mcp.list",
+      stdout:
+        "No MCP servers configured (expected in .cursor/mcp.json or ~/.cursor/mcp.json)\n",
+      subjects: ["github"],
+    });
+
+    expect(empty).toMatchObject({
+      facts: [
+        { claim: "discoverable", state: "missing", subject: "github" },
+        { claim: "discoverable", state: "missing", subject: "linear" },
+      ],
+      outcome: "ran",
+    });
+    expect(cursorEmpty).toMatchObject({
+      facts: [
+        { claim: "discoverable", state: "missing", subject: "github" },
+      ],
+      outcome: "ran",
+    });
+    expect(unrelated).toMatchObject({ facts: [], outcome: "malformed" });
+  });
+
+  test("negative connection phrases cannot satisfy a connection claim", () => {
+    for (const output of [
+      "github: not connected",
+      "github: not ready",
+      "github: not healthy",
+      "github: not running",
+    ]) {
+      const result = parseActivationInspectorOutput({
+        capability: "mcp-server",
+        inspectorId: "claude.mcp.list",
+        stdout: output,
+        subjects: ["github"],
+      });
+
+      expect(result.facts).toContainEqual(
+        expect.objectContaining({
+          claim: "connected",
+          state: "missing",
+          subject: "github",
+        })
+      );
+    }
+  });
+
+  test("text MCP subjects require an exact server name", () => {
+    for (const output of ["github-enterprise: connected"]) {
+      const result = parseActivationInspectorOutput({
+        capability: "mcp-server",
+        inspectorId: "claude.mcp.list",
+        stdout: output,
+        subjects: ["github"],
+      });
+
+      expect(result.facts).toEqual([
+        expect.objectContaining({
+          claim: "discoverable",
+          state: "missing",
+          subject: "github",
+        }),
+      ]);
+      expect(result.outcome).toBe("ran");
+    }
+
+    for (const output of [
+      "github enterprise: connected",
+      "github connected",
+    ]) {
+      const result = parseActivationInspectorOutput({
+        capability: "mcp-server",
+        inspectorId: "claude.mcp.list",
+        stdout: output,
+        subjects: ["github"],
+      });
+
+      expect(result.facts).toEqual([]);
+      expect(result.outcome).toBe("malformed");
+    }
+
+    const exact = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "claude.mcp.list",
+      stdout: "github-enterprise: connected\n● github - ready",
+      subjects: ["github", "github-enterprise"],
+    });
+    expect(exact.facts).toContainEqual(
+      expect.objectContaining({
+        claim: "connected",
+        state: "satisfied",
+        subject: "github",
+      })
+    );
+    expect(exact.facts).toContainEqual(
+      expect.objectContaining({
+        claim: "connected",
+        state: "satisfied",
+        subject: "github-enterprise",
+      })
+    );
+  });
+
+  test("Cursor auth fans one provider fact out to each requested MCP subject", () => {
+    const result = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "cursor.status",
+      stdout: JSON.stringify({
+        authenticated: true,
+        email: "private@example.com",
+        token: "secret",
+      }),
+      subjects: ["github", "linear"],
+    });
+
+    expect(result.facts).toEqual([
+      expect.objectContaining({ claim: "authenticated", subject: "github" }),
+      expect.objectContaining({ claim: "authenticated", subject: "linear" }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain("private@example.com");
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  test("Cursor unauthenticated status emits bounded missing facts", () => {
+    const result = parseActivationInspectorOutput({
+      capability: "mcp-server",
+      inspectorId: "cursor.status",
+      stdout: JSON.stringify({
+        email: "private@example.com",
+        isAuthenticated: false,
+      }),
+      subjects: ["github", "linear"],
+    });
+
+    expect(result).toMatchObject({
+      facts: [
+        { claim: "authenticated", state: "missing", subject: "github" },
+        { claim: "authenticated", state: "missing", subject: "linear" },
+      ],
+      outcome: "ran",
+    });
+    expect(JSON.stringify(result)).not.toContain("private@example.com");
+  });
+
+  test("unknown, malformed, and unauthenticated output produce no positive facts", () => {
+    const cases = [
+      parseActivationInspectorOutput({
+        capability: "plugin-dependency",
+        inspectorId: "codex.plugin.list",
+        stdout: '{"unexpected":true}',
+        subjects: ["demo"],
+      }),
+      parseActivationInspectorOutput({
+        capability: "mcp-server",
+        inspectorId: "codex.mcp.list",
+        stdout: "not json",
+        subjects: ["demo"],
+      }),
+      parseActivationInspectorOutput({
+        capability: "mcp-server",
+        inspectorId: "cursor.status",
+        stdout: '{"authenticated":false}',
+        subjects: ["demo"],
+      }),
+      parseActivationInspectorOutput({
+        capability: "mcp-server",
+        inspectorId: "claude.mcp.list",
+        stdout: "Provider changed its output completely.",
+        subjects: ["demo"],
+      }),
+    ];
+
+    expect(cases.map((entry) => entry.facts)).toEqual([
+      [],
+      [],
+      [
+        {
+          claim: "authenticated",
+          stage: "authenticated",
+          state: "missing",
+          subject: "demo",
+        },
+      ],
+      [],
+    ]);
+    expect(cases.map((entry) => entry.outcome)).toEqual([
+      "malformed",
+      "malformed",
+      "ran",
+      "malformed",
+    ]);
+  });
+});

--- a/apps/skillset/src/__tests__/activation-parsers.test.ts
+++ b/apps/skillset/src/__tests__/activation-parsers.test.ts
@@ -119,6 +119,27 @@ describe("activation provider output parsers", () => {
     expect(JSON.stringify([plugins, mcp])).not.toContain("must-not-survive");
   });
 
+  test("plugin inventories without allowlisted identifiers are malformed", () => {
+    for (const stdout of [
+      JSON.stringify([{ enabled: true }]),
+      JSON.stringify({ installed: [{ displayName: "trails" }] }),
+      JSON.stringify({ plugins: [{ marketplace: "outfitter" }] }),
+    ]) {
+      expect(
+        parseActivationInspectorOutput({
+          capability: "plugin-dependency",
+          inspectorId: "codex.plugin.list",
+          stdout,
+          subjects: ["trails"],
+        })
+      ).toMatchObject({
+        facts: [],
+        outcome: "malformed",
+        summary: "provider plugin inventory used an unknown shape",
+      });
+    }
+  });
+
   test("Claude and Cursor MCP text can claim only discovery and explicit connection", () => {
     const claude = parseActivationInspectorOutput({
       capability: "mcp-server",

--- a/apps/skillset/src/__tests__/activation-parsers.test.ts
+++ b/apps/skillset/src/__tests__/activation-parsers.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { parseActivationInspectorOutput } from "../activation-parsers";
 
 describe("activation provider output parsers", () => {
-  test("keeps dated provider fixtures for every allowlisted inspector", async () => {
+  test("keeps dated fixtures for every Registry provider evidence surface", async () => {
     const captured = (await Bun.file(
       join(import.meta.dir, "fixtures/activation/provider-outputs.json")
     ).json()) as {
@@ -335,48 +335,7 @@ describe("activation provider output parsers", () => {
     );
   });
 
-  test("Cursor auth fans one provider fact out to each requested MCP subject", () => {
-    const result = parseActivationInspectorOutput({
-      capability: "mcp-server",
-      inspectorId: "cursor.status",
-      stdout: JSON.stringify({
-        authenticated: true,
-        email: "private@example.com",
-        token: "secret",
-      }),
-      subjects: ["github", "linear"],
-    });
-
-    expect(result.facts).toEqual([
-      expect.objectContaining({ claim: "authenticated", subject: "github" }),
-      expect.objectContaining({ claim: "authenticated", subject: "linear" }),
-    ]);
-    expect(JSON.stringify(result)).not.toContain("private@example.com");
-    expect(JSON.stringify(result)).not.toContain("secret");
-  });
-
-  test("Cursor unauthenticated status emits bounded missing facts", () => {
-    const result = parseActivationInspectorOutput({
-      capability: "mcp-server",
-      inspectorId: "cursor.status",
-      stdout: JSON.stringify({
-        email: "private@example.com",
-        isAuthenticated: false,
-      }),
-      subjects: ["github", "linear"],
-    });
-
-    expect(result).toMatchObject({
-      facts: [
-        { claim: "authenticated", state: "missing", subject: "github" },
-        { claim: "authenticated", state: "missing", subject: "linear" },
-      ],
-      outcome: "ran",
-    });
-    expect(JSON.stringify(result)).not.toContain("private@example.com");
-  });
-
-  test("unknown, malformed, and unauthenticated output produce no positive facts", () => {
+  test("unknown and malformed output produce no positive facts", () => {
     const cases = [
       parseActivationInspectorOutput({
         capability: "plugin-dependency",
@@ -392,12 +351,6 @@ describe("activation provider output parsers", () => {
       }),
       parseActivationInspectorOutput({
         capability: "mcp-server",
-        inspectorId: "cursor.status",
-        stdout: '{"authenticated":false}',
-        subjects: ["demo"],
-      }),
-      parseActivationInspectorOutput({
-        capability: "mcp-server",
         inspectorId: "claude.mcp.list",
         stdout: "Provider changed its output completely.",
         subjects: ["demo"],
@@ -407,20 +360,11 @@ describe("activation provider output parsers", () => {
     expect(cases.map((entry) => entry.facts)).toEqual([
       [],
       [],
-      [
-        {
-          claim: "authenticated",
-          stage: "authenticated",
-          state: "missing",
-          subject: "demo",
-        },
-      ],
       [],
     ]);
     expect(cases.map((entry) => entry.outcome)).toEqual([
       "malformed",
       "malformed",
-      "ran",
       "malformed",
     ]);
   });

--- a/apps/skillset/src/__tests__/fixtures/activation/provider-outputs.json
+++ b/apps/skillset/src/__tests__/fixtures/activation/provider-outputs.json
@@ -1,0 +1,55 @@
+{
+  "schema": "skillset.activation-provider-fixtures@1",
+  "capturedAt": "2026-07-24",
+  "captureEnvironment": "installed provider binary with isolated empty HOME and XDG roots",
+  "fixtures": [
+    {
+      "id": "claude-plugin-list",
+      "provider": "Claude Code",
+      "providerVersion": "2.1.219",
+      "command": ["claude", "plugin", "list", "--json"],
+      "source": "https://code.claude.com/docs/en/plugins-reference",
+      "output": "[]"
+    },
+    {
+      "id": "claude-mcp-list",
+      "provider": "Claude Code",
+      "providerVersion": "2.1.219",
+      "command": ["claude", "mcp", "list"],
+      "source": "https://code.claude.com/docs/en/mcp",
+      "output": "No MCP servers configured. Use `claude mcp add` to add a server."
+    },
+    {
+      "id": "codex-plugin-list",
+      "provider": "Codex",
+      "providerVersion": "0.146.0-alpha.3.1",
+      "command": ["codex", "plugin", "list", "--json"],
+      "source": "https://developers.openai.com/codex/cli/reference",
+      "output": "{\"installed\":[],\"available\":[]}"
+    },
+    {
+      "id": "codex-mcp-list",
+      "provider": "Codex",
+      "providerVersion": "0.146.0-alpha.3.1",
+      "command": ["codex", "mcp", "list", "--json"],
+      "source": "https://developers.openai.com/codex/mcp",
+      "output": "[]"
+    },
+    {
+      "id": "cursor-mcp-list",
+      "provider": "Cursor Agent",
+      "providerVersion": "2026.07.23-e383d2b",
+      "command": ["cursor-agent", "mcp", "list"],
+      "source": "https://cursor.com/docs/cli/headless",
+      "output": "No MCP servers configured (expected in .cursor/mcp.json or ~/.cursor/mcp.json)"
+    },
+    {
+      "id": "cursor-status",
+      "provider": "Cursor Agent",
+      "providerVersion": "2026.07.23-e383d2b",
+      "command": ["cursor-agent", "status", "--format", "json"],
+      "source": "https://cursor.com/docs/cli/headless",
+      "output": "{\"status\":\"unauthenticated\",\"isAuthenticated\":false,\"hasAccessToken\":false,\"hasRefreshToken\":false,\"message\":\"Not authenticated\"}"
+    }
+  ]
+}

--- a/apps/skillset/src/__tests__/provider-command.test.ts
+++ b/apps/skillset/src/__tests__/provider-command.test.ts
@@ -1,0 +1,205 @@
+import { expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  isProviderCommandMissingBinary,
+  runProviderCommand,
+} from "../provider-command";
+
+test("provider command uses literal argv, accepts optional stdin, and preserves split UTF-8", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-provider-command-"));
+  const marker = join(root, "shell-ran");
+  const bin = await executable(
+    root,
+    "literal-argv",
+    `#!/bin/sh
+printf '%s\\n' "$1"
+cat
+printf '\\303'
+sleep 0.02
+printf '\\251'
+`
+  );
+  const output: string[] = [];
+
+  const result = await runProviderCommand(
+    { cmd: [bin, `literal; touch ${marker}`], cwd: root },
+    {
+      env: process.env,
+      onOutput: async (_stream, text) => {
+        output.push(text);
+      },
+      stdin: "stdin payload",
+      timeoutMs: 10_000,
+    }
+  );
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain(`literal; touch ${marker}`);
+  expect(result.stdout).toContain("stdin payload");
+  expect(result.stdout).toEndWith("é");
+  expect(output.join("")).toContain("é");
+  expect(await Bun.file(marker).exists()).toBe(false);
+});
+
+test("provider command bounds retained output while continuing to drain both streams", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-provider-command-"));
+  const bin = await executable(
+    root,
+    "noisy",
+    `#!/bin/sh
+printf 'abcdefghij'
+printf 'klmnopqrst' >&2
+printf 'done'
+printf 'done' >&2
+`
+  );
+  const output: string[] = [];
+
+  const result = await runProviderCommand(
+    { cmd: [bin], cwd: root },
+    {
+      env: process.env,
+      maxStderrBytes: 10,
+      maxStdoutBytes: 10,
+      onOutput: async (stream, text) => {
+        output.push(`${stream}:${text}`);
+      },
+      timeoutMs: 10_000,
+    }
+  );
+
+  expect(result).toMatchObject({
+    exitCode: 0,
+    stderr: "klmnopqrst",
+    stderrBytes: 14,
+    stderrTruncated: true,
+    stdout: "abcdefghij",
+    stdoutBytes: 14,
+    stdoutTruncated: true,
+  });
+  expect(
+    output
+      .filter((entry) => entry.startsWith("stdout:"))
+      .map((entry) => entry.slice("stdout:".length))
+      .join("")
+  ).toContain("abcdefghijdone");
+  expect(
+    output
+      .filter((entry) => entry.startsWith("stderr:"))
+      .map((entry) => entry.slice("stderr:".length))
+      .join("")
+  ).toContain("klmnopqrstdone");
+});
+
+test("provider command abort and timeout terminate a detached descendant tree", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-provider-command-"));
+  const bin = await processTreeBin(root, "abort-tree");
+  const controller = new AbortController();
+  let pid: number | undefined;
+  let childPid: number | undefined;
+
+  await expect(
+    runProviderCommand(
+      { cmd: [bin], cwd: root },
+      {
+        env: process.env,
+        onOutput: async (stream, text) => {
+          if (stream !== "stdout") return;
+          childPid = Number(text.trim());
+          controller.abort();
+        },
+        onProcess: async (processId) => {
+          pid = processId;
+        },
+        signal: controller.signal,
+        timeoutMs: 10_000,
+      }
+    )
+  ).rejects.toMatchObject({ name: "AbortError" });
+
+  expect(pid).toBeDefined();
+  expect(childPid).toBeDefined();
+  expect(await processIsRunning(pid!)).toBe(false);
+  expect(await processIsRunning(childPid!)).toBe(false);
+
+  const timeoutBin = await processTreeBin(root, "timeout-tree");
+  let timeoutChildPid: number | undefined;
+  const timeout = await runProviderCommand(
+    { cmd: [timeoutBin], cwd: root },
+    {
+      env: process.env,
+      onOutput: async (stream, text) => {
+        if (stream === "stdout") timeoutChildPid = Number(text.trim());
+      },
+      timeoutMs: 50,
+    }
+  );
+  expect(timeout.timedOut).toBe(true);
+  expect(timeoutChildPid).toBeDefined();
+  expect(await processIsRunning(timeoutChildPid!)).toBe(false);
+});
+
+test("provider command classifies missing binaries without exposing spawn details", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skillset-provider-command-"));
+  const missing = join(root, "does-not-exist");
+
+  try {
+    await runProviderCommand(
+      { cmd: [missing], cwd: root },
+      { env: process.env, timeoutMs: 10_000 }
+    );
+    throw new Error("expected the missing provider binary to fail");
+  } catch (error) {
+    expect(isProviderCommandMissingBinary(error)).toBe(true);
+    expect(error).toMatchObject({
+      code: "ENOENT",
+      message: "skillset: provider command executable is unavailable",
+    });
+    expect(String(error)).not.toContain(missing);
+  }
+});
+
+async function executable(
+  root: string,
+  name: string,
+  content: string
+): Promise<string> {
+  const path = join(root, "bin", name);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf8");
+  await chmod(path, 0o755);
+  return path;
+}
+
+async function processTreeBin(root: string, name: string): Promise<string> {
+  return executable(
+    root,
+    name,
+    '#!/bin/sh\ntrap \'\' TERM\nsleep 30 &\nchild=$!\nprintf \'%s\\n\' "$child"\nwait "$child"\n'
+  );
+}
+
+async function processIsRunning(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    return !(
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+  if (process.platform !== "linux") return true;
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+    return stat.slice(stat.lastIndexOf(") ") + 2, stat.lastIndexOf(") ") + 3) !== "Z";
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/apps/skillset/src/__tests__/runtime-probe.test.ts
+++ b/apps/skillset/src/__tests__/runtime-probe.test.ts
@@ -1,8 +1,7 @@
+import { expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-
-import { expect, test } from "bun:test";
 
 import { runRuntimeProbe } from "../runtime-probe";
 
@@ -15,15 +14,17 @@ test("runtime probe cancels a spawned process when onProcess aborts", async () =
   const controller = new AbortController();
   let pid: number | undefined;
 
-  await expect(runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
-    env: process.env,
-    onProcess: async (processId) => {
-      pid = processId;
-      controller.abort();
-    },
-    signal: controller.signal,
-    timeoutMs: 10_000,
-  })).rejects.toMatchObject({ name: "AbortError" });
+  await expect(
+    runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
+      env: process.env,
+      onProcess: async (processId) => {
+        pid = processId;
+        controller.abort();
+      },
+      signal: controller.signal,
+      timeoutMs: 10_000,
+    })
+  ).rejects.toMatchObject({ name: "AbortError" });
 
   expect(pid).toBeDefined();
   expect(() => process.kill(pid!, 0)).toThrow();
@@ -36,15 +37,19 @@ test("runtime probe terminates a spawned process when an output callback fails",
   let pid: number | undefined;
   let childPid: number | undefined;
 
-  await expect(runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
-    env: process.env,
-    onOutput: async (stream, text) => {
-      if (stream === "stdout") childPid = Number(text.trim());
-      throw callbackError;
-    },
-    onProcess: async (processId) => { pid = processId; },
-    timeoutMs: 10_000,
-  })).rejects.toBe(callbackError);
+  await expect(
+    runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
+      env: process.env,
+      onOutput: async (stream, text) => {
+        if (stream === "stdout") childPid = Number(text.trim());
+        throw callbackError;
+      },
+      onProcess: async (processId) => {
+        pid = processId;
+      },
+      timeoutMs: 10_000,
+    })
+  ).rejects.toBe(callbackError);
 
   expect(pid).toBeDefined();
   expect(childPid).toBeDefined();
@@ -60,17 +65,21 @@ test("runtime probe AbortSignal terminates descendants holding provider pipes", 
   let childPid: number | undefined;
   const startedAt = performance.now();
 
-  await expect(runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
-    env: process.env,
-    onOutput: async (stream, text) => {
-      if (stream !== "stdout") return;
-      childPid = Number(text.trim());
-      controller.abort();
-    },
-    onProcess: async (processId) => { pid = processId; },
-    signal: controller.signal,
-    timeoutMs: 10_000,
-  })).rejects.toMatchObject({ name: "AbortError" });
+  await expect(
+    runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
+      env: process.env,
+      onOutput: async (stream, text) => {
+        if (stream !== "stdout") return;
+        childPid = Number(text.trim());
+        controller.abort();
+      },
+      onProcess: async (processId) => {
+        pid = processId;
+      },
+      signal: controller.signal,
+      timeoutMs: 10_000,
+    })
+  ).rejects.toMatchObject({ name: "AbortError" });
 
   expect(performance.now() - startedAt).toBeLessThan(2_000);
   expect(pid).toBeDefined();
@@ -86,14 +95,20 @@ test("runtime probe timeout terminates descendants holding provider pipes", asyn
   let childPid: number | undefined;
   const startedAt = performance.now();
 
-  const result = await runRuntimeProbe({ cmd: [bin], cwd: root, display: [bin] }, "prompt", {
-    env: process.env,
-    onOutput: async (stream, text) => {
-      if (stream === "stdout") childPid = Number(text.trim());
-    },
-    onProcess: async (processId) => { pid = processId; },
-    timeoutMs: 50,
-  });
+  const result = await runRuntimeProbe(
+    { cmd: [bin], cwd: root, display: [bin] },
+    "prompt",
+    {
+      env: process.env,
+      onOutput: async (stream, text) => {
+        if (stream === "stdout") childPid = Number(text.trim());
+      },
+      onProcess: async (processId) => {
+        pid = processId;
+      },
+      timeoutMs: 50,
+    }
+  );
 
   expect(result.timedOut).toBe(true);
   expect(performance.now() - startedAt).toBeLessThan(2_000);
@@ -106,7 +121,11 @@ test("runtime probe timeout terminates descendants holding provider pipes", asyn
 async function processTreeBin(root: string, name: string): Promise<string> {
   const bin = join(root, "bin", name);
   await mkdir(dirname(bin), { recursive: true });
-  await writeFile(bin, "#!/bin/sh\nsleep 30 &\nchild=$!\nprintf '%s\\n' \"$child\"\nwait \"$child\"\n", "utf8");
+  await writeFile(
+    bin,
+    '#!/bin/sh\nsleep 30 &\nchild=$!\nprintf \'%s\\n\' "$child"\nwait "$child"\n',
+    "utf8"
+  );
   await chmod(bin, 0o755);
   return bin;
 }

--- a/apps/skillset/src/activation-inspection.ts
+++ b/apps/skillset/src/activation-inspection.ts
@@ -1,0 +1,393 @@
+import {
+  deriveActivationSubjects,
+  listProviderActivationDescriptors,
+  planActivationReadiness,
+} from "@skillset/core";
+import type {
+  ActivationObservation,
+  ActivationReadinessReport,
+  ProviderActivationEffect,
+  ProviderActivationInspector,
+  ProviderActivationTarget,
+} from "@skillset/core";
+import type { SkillsetRenderResult } from "@skillset/core/internal/render-result";
+import type { BuildGraph } from "@skillset/core/internal/types";
+
+import { parseActivationInspectorOutput } from "./activation-parsers";
+import {
+  isProviderCommandUnavailable,
+  runProviderCommand,
+} from "./provider-command";
+import type {
+  ProviderCommand,
+  ProviderCommandExecutionOptions,
+  ProviderCommandExecutionResult,
+} from "./provider-command";
+
+export const ACTIVATION_INSPECTION_SCHEMA = "skillset.activation-inspection@1";
+
+const DEFAULT_ACTIVATION_TIMEOUT_MS = 5_000;
+const MAX_ACTIVATION_OUTPUT_BYTES = 64 * 1024;
+const MAX_VERSION_OUTPUT_BYTES = 512;
+
+export type ActivationInspectionOutcome =
+  | "malformed"
+  | "ran"
+  | "skipped"
+  | "timed_out"
+  | "unavailable";
+
+export interface ActivationInspectorReceipt {
+  readonly binaryVersion?: string;
+  readonly capability: "app" | "mcp-server" | "plugin-dependency";
+  readonly effect: ProviderActivationEffect;
+  readonly inspectorId: string;
+  readonly outcome: ActivationInspectionOutcome;
+  readonly stderrBytes: number;
+  readonly stderrTruncated: boolean;
+  readonly stdoutBytes: number;
+  readonly stdoutTruncated: boolean;
+  readonly subjects: readonly string[];
+  readonly summary: string;
+  readonly target: ProviderActivationTarget;
+}
+
+export interface ActivationInspectionReport {
+  readonly inspections: readonly ActivationInspectorReceipt[];
+  readonly readiness: ActivationReadinessReport;
+  readonly schema: typeof ACTIVATION_INSPECTION_SCHEMA;
+}
+
+export interface ActivationInspectionOptions {
+  readonly allowActive: boolean;
+  readonly env?: Record<string, string | undefined>;
+  readonly graph: BuildGraph;
+  readonly renderResults: readonly SkillsetRenderResult[];
+  readonly rootPath: string;
+  readonly runCommand?: ActivationProviderCommandRunner;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}
+
+export type ActivationProviderCommandRunner = (
+  command: ProviderCommand,
+  options: ProviderCommandExecutionOptions
+) => Promise<ProviderCommandExecutionResult>;
+
+interface InspectorRun {
+  readonly observations: readonly ActivationObservation[];
+  readonly receipt: ActivationInspectorReceipt;
+}
+
+type BinaryVersionInspection =
+  | { readonly binaryVersion: string; readonly kind: "matched" }
+  | { readonly kind: "outside_evidence_boundary" }
+  | { readonly kind: "unavailable" };
+
+/**
+ * Runs the explicit provider observation path. Bare build, check, status, and
+ * explain routes do not call this operation.
+ */
+export async function inspectActivationReadiness(
+  options: ActivationInspectionOptions
+): Promise<ActivationInspectionReport> {
+  const boundedOptions = {
+    ...options,
+    timeoutMs: activationTimeout(options.timeoutMs),
+  };
+  const runner = options.runCommand ?? runProviderCommand;
+  const subjects = deriveActivationSubjects(options.graph);
+  const versionCache = new Map<string, Promise<BinaryVersionInspection>>();
+  const runs: InspectorRun[] = [];
+
+  for (const descriptor of listProviderActivationDescriptors()) {
+    const matchingSubjects = subjects
+      .filter(
+        (subject) =>
+          subject.target === descriptor.target &&
+          subject.capability === descriptor.capability
+      )
+      .map((subject) => subject.subject);
+    if (matchingSubjects.length === 0) continue;
+
+    for (const inspector of descriptor.inspectors) {
+      runs.push(
+        await runInspector({
+          descriptor,
+          env: options.env ?? process.env,
+          inspector,
+          matchingSubjects,
+          options: boundedOptions,
+          runner,
+          versionCache,
+        })
+      );
+    }
+  }
+
+  return {
+    inspections: runs
+      .map(({ receipt }) => receipt)
+      .toSorted((left, right) =>
+        left.inspectorId.localeCompare(right.inspectorId)
+      ),
+    readiness: planActivationReadiness({
+      graph: options.graph,
+      observations: runs.flatMap(({ observations }) => observations),
+      renderResults: options.renderResults,
+    }),
+    schema: ACTIVATION_INSPECTION_SCHEMA,
+  };
+}
+
+async function runInspector(input: {
+  readonly descriptor: ReturnType<
+    typeof listProviderActivationDescriptors
+  >[number];
+  readonly env: Record<string, string | undefined>;
+  readonly inspector: ProviderActivationInspector;
+  readonly matchingSubjects: readonly string[];
+  readonly options: ActivationInspectionOptions;
+  readonly runner: ActivationProviderCommandRunner;
+  readonly versionCache: Map<string, Promise<BinaryVersionInspection>>;
+}): Promise<InspectorRun> {
+  const base = {
+    capability: input.descriptor.capability,
+    effect: input.inspector.effect,
+    inspectorId: input.inspector.id,
+    stderrBytes: 0,
+    stderrTruncated: false,
+    stdoutBytes: 0,
+    stdoutTruncated: false,
+    subjects: [...input.matchingSubjects].toSorted(),
+    target: input.descriptor.target,
+  } as const;
+
+  if (input.inspector.surface.kind === "unavailable") {
+    return {
+      observations: [],
+      receipt: {
+        ...base,
+        outcome: "unavailable",
+        summary: "the provider exposes no authoritative inspection surface",
+      },
+    };
+  }
+  if (input.inspector.effect === "active" && !input.options.allowActive) {
+    return {
+      observations: [],
+      receipt: {
+        ...base,
+        outcome: "skipped",
+        summary: "active provider observation was not requested",
+      },
+    };
+  }
+
+  const binary = input.inspector.surface.argv[0];
+  const version =
+    input.versionCache.get(binary) ??
+    inspectBinaryVersion(
+      {
+        cmd: input.inspector.surface.versionArgv,
+        cwd: input.options.rootPath,
+      },
+      input,
+      input.descriptor.evidence.providerVersion
+    );
+  input.versionCache.set(binary, version);
+  const versionInspection = await version;
+  if (versionInspection.kind === "unavailable") {
+    return {
+      observations: [],
+      receipt: {
+        ...base,
+        outcome: "unavailable",
+        summary: "the provider version executable is unavailable",
+      },
+    };
+  }
+  if (versionInspection.kind === "outside_evidence_boundary") {
+    return {
+      observations: [],
+      receipt: {
+        ...base,
+        outcome: "skipped",
+        summary:
+          "provider observation was skipped because the binary version is outside the registry evidence boundary",
+      },
+    };
+  }
+  const binaryVersion = versionInspection.binaryVersion;
+
+  let result: ProviderCommandExecutionResult;
+  try {
+    result = await input.runner(
+      {
+        cmd: input.inspector.surface.argv,
+        cwd: input.options.rootPath,
+      },
+      commandOptions(input, MAX_ACTIVATION_OUTPUT_BYTES)
+    );
+  } catch (error) {
+    if (isProviderCommandUnavailable(error)) {
+      return {
+        observations: [],
+        receipt: {
+          ...base,
+          binaryVersion,
+          outcome: "unavailable",
+          summary: "the provider executable is unavailable",
+        },
+      };
+    }
+    throw error;
+  }
+
+  const evidence = {
+    ...(binaryVersion === undefined ? {} : { binaryVersion }),
+    stderrBytes: result.stderrBytes,
+    stderrTruncated: result.stderrTruncated,
+    stdoutBytes: result.stdoutBytes,
+    stdoutTruncated: result.stdoutTruncated,
+  };
+  if (result.timedOut) {
+    return {
+      observations: [],
+      receipt: {
+        ...base,
+        ...evidence,
+        outcome: "timed_out",
+        summary: "provider observation exceeded its bounded timeout",
+      },
+    };
+  }
+  if (result.exitCode !== 0 || result.stdoutTruncated) {
+    return {
+      observations: [],
+      receipt: {
+        ...base,
+        ...evidence,
+        outcome: result.stdoutTruncated ? "malformed" : "unavailable",
+        summary: result.stdoutTruncated
+          ? "provider output exceeded the parser evidence budget"
+          : "provider observation did not complete successfully",
+      },
+    };
+  }
+  const parsed = parseActivationInspectorOutput({
+    capability: input.descriptor.capability,
+    inspectorId: input.inspector.id,
+    stdout: result.stdout,
+    subjects: input.matchingSubjects,
+  });
+  return {
+    observations: parsed.facts.map((fact) => ({
+      capability: input.descriptor.capability,
+      claim: fact.claim,
+      inspectorId: input.inspector.id,
+      observationEffect: input.inspector.effect,
+      origin: "observed",
+      ...(fact.state === "satisfied"
+        ? {}
+        : { reasonCode: reasonCodeForStage(input.descriptor, fact.stage) }),
+      stage: fact.stage,
+      state: fact.state,
+      subject: fact.subject,
+      target: input.descriptor.target,
+    })),
+    receipt: {
+      ...base,
+      ...evidence,
+      outcome: parsed.outcome,
+      summary: parsed.summary,
+    },
+  };
+}
+
+async function inspectBinaryVersion(
+  command: ProviderCommand,
+  input: {
+    readonly env: Record<string, string | undefined>;
+    readonly options: ActivationInspectionOptions;
+    readonly runner: ActivationProviderCommandRunner;
+  },
+  expectedVersion: string
+): Promise<BinaryVersionInspection> {
+  try {
+    const result = await input.runner(
+      command,
+      commandOptions(input, MAX_VERSION_OUTPUT_BYTES)
+    );
+    if (result.exitCode !== 0 || result.timedOut || result.stdoutTruncated) {
+      return { kind: "outside_evidence_boundary" };
+    }
+    const binaryVersion = extractEvidenceVersion(
+      result.stdout,
+      expectedVersion
+    );
+    return binaryVersion === undefined
+      ? { kind: "outside_evidence_boundary" }
+      : { binaryVersion, kind: "matched" };
+  } catch (error) {
+    if (isProviderCommandUnavailable(error)) return { kind: "unavailable" };
+    throw error;
+  }
+}
+
+function reasonCodeForStage(
+  descriptor: ReturnType<typeof listProviderActivationDescriptors>[number],
+  stage: ActivationObservation["stage"]
+): string {
+  const reason = descriptor.reasons.find(
+    (candidate) => candidate.stage === stage
+  );
+  if (reason === undefined) {
+    throw new Error(
+      `skillset: activation descriptor ${descriptor.id} has no reason for ${stage}`
+    );
+  }
+  return reason.code;
+}
+
+function activationTimeout(value: number | undefined): number {
+  const timeoutMs = value ?? DEFAULT_ACTIVATION_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      "skillset: activation timeout must be a positive safe integer"
+    );
+  }
+  return timeoutMs;
+}
+
+function commandOptions(
+  input: {
+    readonly env: Record<string, string | undefined>;
+    readonly options: ActivationInspectionOptions;
+  },
+  maxStdoutBytes: number
+): ProviderCommandExecutionOptions {
+  return {
+    env: input.env,
+    maxStderrBytes: 0,
+    maxStdoutBytes,
+    ...(input.options.signal === undefined
+      ? {}
+      : { signal: input.options.signal }),
+    timeoutMs: input.options.timeoutMs ?? DEFAULT_ACTIVATION_TIMEOUT_MS,
+  };
+}
+
+function extractEvidenceVersion(
+  stdout: string,
+  expectedVersion: string
+): string | undefined {
+  const line = stdout.split(/\r?\n/u)[0]?.trim();
+  if (line === undefined || line.length === 0 || line.length > 160) {
+    return undefined;
+  }
+  const escaped = expectedVersion.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`(?:^|\\s|\\()${escaped}(?:$|\\s|\\))`, "u").test(line)
+    ? expectedVersion
+    : undefined;
+}

--- a/apps/skillset/src/activation-parsers.ts
+++ b/apps/skillset/src/activation-parsers.ts
@@ -41,8 +41,6 @@ export function parseActivationInspectorOutput(
       return parseTextMcpStatus(request);
     case "cursor.mcp.list":
       return parseTextMcpStatus(request);
-    case "cursor.status":
-      return parseCursorStatus(request);
     default:
       return malformed("the registry inspector has no activation parser");
   }
@@ -141,38 +139,6 @@ function parseTextMcpStatus(
   return ran(facts, `parsed ${lines.length} bounded MCP status lines`);
 }
 
-function parseCursorStatus(
-  request: ActivationParserRequest
-): ActivationParserResult {
-  const parsed = parseJson(request.stdout);
-  if (!isRecord(parsed)) {
-    return malformed("Cursor status output used an unknown shape");
-  }
-  const authenticated =
-    readBoolean(parsed, "authenticated") ??
-    readBoolean(parsed, "isAuthenticated") ??
-    (typeof parsed.status === "string"
-      ? statusAuthentication(parsed.status)
-      : undefined);
-  if (authenticated === undefined) {
-    return malformed("Cursor status did not expose an allowlisted auth field");
-  }
-  if (!authenticated) {
-    return ran(
-      request.subjects.map((subject) =>
-        fact(subject, "authenticated", "missing")
-      ),
-      "Cursor reported an unauthenticated session"
-    );
-  }
-  return ran(
-    request.subjects.map((subject) =>
-      fact(subject, "authenticated", "satisfied")
-    ),
-    "Cursor reported an authenticated session"
-  );
-}
-
 function isEmptyMcpInventory(line: string): boolean {
   return /^No MCP servers configured(?:[.!](?:\s+.*)?|\s+\([^)]*\))?$/iu.test(
     line
@@ -261,18 +227,6 @@ function connectionState(line: string): boolean | undefined {
     return false;
   }
   if (/\b(?:connected|ready|healthy|running)\b/iu.test(line)) return true;
-  return undefined;
-}
-
-function statusAuthentication(value: string): boolean | undefined {
-  if (/^(?:authenticated|logged[_ -]?in)$/iu.test(value)) return true;
-  if (
-    /^(?:unauthenticated|logged[_ -]?out|authentication required)$/iu.test(
-      value
-    )
-  ) {
-    return false;
-  }
   return undefined;
 }
 

--- a/apps/skillset/src/activation-parsers.ts
+++ b/apps/skillset/src/activation-parsers.ts
@@ -181,12 +181,23 @@ function isEmptyMcpInventory(line: string): boolean {
 
 function pluginEntries(value: unknown): readonly JsonRecord[] | undefined {
   if (Array.isArray(value)) {
-    return strictRecords(value);
+    return identifiedPluginEntries(value);
   }
   if (!isRecord(value)) return undefined;
-  if (Array.isArray(value.installed)) return strictRecords(value.installed);
-  if (Array.isArray(value.plugins)) return strictRecords(value.plugins);
+  if (Array.isArray(value.installed))
+    return identifiedPluginEntries(value.installed);
+  if (Array.isArray(value.plugins))
+    return identifiedPluginEntries(value.plugins);
   return undefined;
+}
+
+function identifiedPluginEntries(
+  value: readonly unknown[]
+): readonly JsonRecord[] | undefined {
+  const entries = strictRecords(value);
+  return entries?.every((entry) => pluginAliases(entry).length > 0)
+    ? entries
+    : undefined;
 }
 
 function pluginAliases(entry: JsonRecord): readonly string[] {

--- a/apps/skillset/src/activation-parsers.ts
+++ b/apps/skillset/src/activation-parsers.ts
@@ -1,0 +1,319 @@
+import type {
+  ActivationCapability,
+  ActivationRequirementStage,
+  ActivationRequirementState,
+} from "@skillset/core";
+import type { ProviderActivationClaim } from "@skillset/core";
+
+export interface ActivationParsedFact {
+  readonly claim: ProviderActivationClaim;
+  readonly stage: ActivationRequirementStage;
+  readonly state: ActivationRequirementState;
+  readonly subject: string;
+}
+
+export interface ActivationParserRequest {
+  readonly capability: ActivationCapability;
+  readonly inspectorId: string;
+  readonly subjects: readonly string[];
+  readonly stdout: string;
+}
+
+export interface ActivationParserResult {
+  readonly facts: readonly ActivationParsedFact[];
+  readonly outcome: "malformed" | "ran";
+  readonly summary: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+export function parseActivationInspectorOutput(
+  request: ActivationParserRequest
+): ActivationParserResult {
+  switch (request.inspectorId) {
+    case "claude.plugin.list":
+      return parsePluginInventory(request);
+    case "codex.plugin.list":
+      return parsePluginInventory(request);
+    case "codex.mcp.list":
+      return parseJsonMcpInventory(request);
+    case "claude.mcp.list":
+      return parseTextMcpStatus(request);
+    case "cursor.mcp.list":
+      return parseTextMcpStatus(request);
+    case "cursor.status":
+      return parseCursorStatus(request);
+    default:
+      return malformed("the registry inspector has no activation parser");
+  }
+}
+
+function parsePluginInventory(
+  request: ActivationParserRequest
+): ActivationParserResult {
+  const parsed = parseJson(request.stdout);
+  if (parsed === undefined)
+    return malformed("provider output was not valid JSON");
+  const entries = pluginEntries(parsed);
+  if (entries === undefined) {
+    return malformed("provider plugin inventory used an unknown shape");
+  }
+
+  const facts = request.subjects.flatMap((subject) => {
+    const entry = entries.find((candidate) =>
+      pluginAliases(candidate).includes(subject)
+    );
+    if (entry === undefined) {
+      return [fact(subject, "discoverable", "missing")];
+    }
+    const enabled = readBoolean(entry, "enabled");
+    return [
+      fact(subject, "discoverable", "satisfied"),
+      ...(enabled === undefined
+        ? []
+        : [fact(subject, "enabled", enabled ? "satisfied" : "missing")]),
+    ];
+  });
+
+  return ran(facts, `parsed ${entries.length} plugin inventory entries`);
+}
+
+function parseJsonMcpInventory(
+  request: ActivationParserRequest
+): ActivationParserResult {
+  const parsed = parseJson(request.stdout);
+  if (parsed === undefined)
+    return malformed("provider output was not valid JSON");
+  const names = mcpNames(parsed);
+  if (names === undefined) {
+    return malformed("provider MCP inventory used an unknown shape");
+  }
+  return ran(
+    request.subjects.map((subject) =>
+      names.has(subject)
+        ? fact(subject, "discoverable", "satisfied")
+        : fact(subject, "discoverable", "missing")
+    ),
+    `parsed ${names.size} configured MCP server names`
+  );
+}
+
+function parseTextMcpStatus(
+  request: ActivationParserRequest
+): ActivationParserResult {
+  const lines = request.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return malformed("provider MCP status output was empty");
+  }
+  if (lines.every((line) => isEmptyMcpInventory(line))) {
+    return ran(
+      request.subjects.map((subject) =>
+        fact(subject, "discoverable", "missing")
+      ),
+      "parsed an empty MCP inventory"
+    );
+  }
+  const entries = lines.map(parseTextMcpEntry);
+  if (
+    lines.some((line) => isEmptyMcpInventory(line)) ||
+    entries.some((entry) => entry === undefined)
+  ) {
+    return malformed("provider MCP status output used an unknown shape");
+  }
+
+  const facts = request.subjects.flatMap((subject) => {
+    const entry = entries.find((candidate) => candidate?.name === subject);
+    if (entry === undefined) {
+      return [fact(subject, "discoverable", "missing")];
+    }
+    const connected = connectionState(entry.status);
+    return [
+      fact(subject, "discoverable", "satisfied"),
+      ...(connected === undefined
+        ? []
+        : [fact(subject, "connected", connected ? "satisfied" : "missing")]),
+    ];
+  });
+
+  return ran(facts, `parsed ${lines.length} bounded MCP status lines`);
+}
+
+function parseCursorStatus(
+  request: ActivationParserRequest
+): ActivationParserResult {
+  const parsed = parseJson(request.stdout);
+  if (!isRecord(parsed)) {
+    return malformed("Cursor status output used an unknown shape");
+  }
+  const authenticated =
+    readBoolean(parsed, "authenticated") ??
+    readBoolean(parsed, "isAuthenticated") ??
+    (typeof parsed.status === "string"
+      ? statusAuthentication(parsed.status)
+      : undefined);
+  if (authenticated === undefined) {
+    return malformed("Cursor status did not expose an allowlisted auth field");
+  }
+  if (!authenticated) {
+    return ran(
+      request.subjects.map((subject) =>
+        fact(subject, "authenticated", "missing")
+      ),
+      "Cursor reported an unauthenticated session"
+    );
+  }
+  return ran(
+    request.subjects.map((subject) =>
+      fact(subject, "authenticated", "satisfied")
+    ),
+    "Cursor reported an authenticated session"
+  );
+}
+
+function isEmptyMcpInventory(line: string): boolean {
+  return /^No MCP servers configured(?:[.!](?:\s+.*)?|\s+\([^)]*\))?$/iu.test(
+    line
+  );
+}
+
+function pluginEntries(value: unknown): readonly JsonRecord[] | undefined {
+  if (Array.isArray(value)) {
+    return strictRecords(value);
+  }
+  if (!isRecord(value)) return undefined;
+  if (Array.isArray(value.installed)) return strictRecords(value.installed);
+  if (Array.isArray(value.plugins)) return strictRecords(value.plugins);
+  return undefined;
+}
+
+function pluginAliases(entry: JsonRecord): readonly string[] {
+  const name = readString(entry, "name");
+  const pluginId = readString(entry, "pluginId") ?? readString(entry, "id");
+  const marketplace =
+    readString(entry, "marketplaceName") ?? readString(entry, "marketplace");
+  return [
+    pluginId,
+    name,
+    name !== undefined && marketplace !== undefined
+      ? `${marketplace}/${name}`
+      : undefined,
+    name !== undefined && marketplace !== undefined
+      ? `${name}@${marketplace}`
+      : undefined,
+  ].filter((value): value is string => value !== undefined);
+}
+
+function mcpNames(value: unknown): ReadonlySet<string> | undefined {
+  const candidates = Array.isArray(value)
+    ? value
+    : isRecord(value) && Array.isArray(value.servers)
+      ? value.servers
+      : isRecord(value) && Array.isArray(value.mcpServers)
+        ? value.mcpServers
+        : undefined;
+  if (candidates !== undefined) {
+    const entries = strictRecords(candidates);
+    if (entries === undefined) return undefined;
+    const names = entries
+      .map((entry) => readString(entry, "name"))
+      .filter((name): name is string => name !== undefined);
+    return names.length === entries.length ? new Set(names) : undefined;
+  }
+  const record =
+    isRecord(value) && isRecord(value.servers)
+      ? value.servers
+      : isRecord(value) && isRecord(value.mcpServers)
+        ? value.mcpServers
+        : undefined;
+  return record === undefined ? undefined : new Set(Object.keys(record));
+}
+
+function parseTextMcpEntry(
+  line: string
+): { readonly name: string; readonly status: string } | undefined {
+  const match =
+    /^(?:[✓✔✗✘○●⏸]\s*)?([^\s:]+)(?::|\s+-\s+)(.*)$/u.exec(line);
+  const name = match?.[1]?.trim();
+  if (!name) return undefined;
+  return { name, status: match?.[2]?.trim() ?? "" };
+}
+
+function connectionState(line: string): boolean | undefined {
+  if (
+    /\b(?:disconnected|failed|error|pending|rejected|disabled|not (?:configured|connected|ready|healthy|running)|unavailable)\b/iu.test(
+      line
+    )
+  ) {
+    return false;
+  }
+  if (/\b(?:connected|ready|healthy|running)\b/iu.test(line)) return true;
+  return undefined;
+}
+
+function statusAuthentication(value: string): boolean | undefined {
+  if (/^(?:authenticated|logged[_ -]?in)$/iu.test(value)) return true;
+  if (
+    /^(?:unauthenticated|logged[_ -]?out|authentication required)$/iu.test(
+      value
+    )
+  ) {
+    return false;
+  }
+  return undefined;
+}
+
+function fact(
+  subject: string,
+  stage: ActivationRequirementStage,
+  state: ActivationRequirementState
+): ActivationParsedFact {
+  return {
+    claim: stage as ProviderActivationClaim,
+    stage,
+    state,
+    subject,
+  };
+}
+
+function ran(
+  facts: readonly ActivationParsedFact[],
+  summary: string
+): ActivationParserResult {
+  return { facts, outcome: "ran", summary };
+}
+
+function malformed(summary: string): ActivationParserResult {
+  return { facts: [], outcome: "malformed", summary };
+}
+
+function parseJson(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function strictRecords(
+  value: readonly unknown[]
+): readonly JsonRecord[] | undefined {
+  return value.every(isRecord) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readBoolean(value: JsonRecord, key: string): boolean | undefined {
+  return typeof value[key] === "boolean" ? value[key] : undefined;
+}
+
+function readString(value: JsonRecord, key: string): string | undefined {
+  const candidate = value[key];
+  return typeof candidate === "string" && candidate.length > 0
+    ? candidate
+    : undefined;
+}

--- a/apps/skillset/src/provider-command.ts
+++ b/apps/skillset/src/provider-command.ts
@@ -1,0 +1,322 @@
+const PROCESS_CLEANUP_GRACE_MS = 250;
+const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024;
+
+export interface ProviderCommand {
+  readonly cmd: readonly string[];
+  readonly cwd: string;
+}
+
+export interface ProviderCommandExecutionOptions {
+  readonly env: Record<string, string | undefined>;
+  readonly maxStderrBytes?: number;
+  readonly maxStdoutBytes?: number;
+  readonly onOutput?: (
+    stream: "stderr" | "stdout",
+    text: string
+  ) => Promise<void>;
+  readonly onProcess?: (pid: number) => Promise<void>;
+  readonly signal?: AbortSignal;
+  readonly stdin?: string;
+  readonly timeoutMs: number;
+}
+
+export interface ProviderCommandExecutionResult {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stderrBytes: number;
+  readonly stderrTruncated: boolean;
+  readonly stdout: string;
+  readonly stdoutBytes: number;
+  readonly stdoutTruncated: boolean;
+  readonly timedOut: boolean;
+}
+
+export class ProviderCommandError extends Error {
+  readonly code: "EACCES" | "ENOENT";
+  readonly kind: "missing_binary" | "unavailable_binary";
+
+  constructor(kind: "missing_binary" | "unavailable_binary") {
+    super("skillset: provider command executable is unavailable");
+    this.code = kind === "missing_binary" ? "ENOENT" : "EACCES";
+    this.kind = kind;
+    this.name = "ProviderCommandError";
+  }
+}
+
+/**
+ * Executes an injected provider command without a shell. It drains both
+ * streams after capture limits are reached so a noisy provider cannot stall.
+ */
+export async function runProviderCommand(
+  command: ProviderCommand,
+  options: ProviderCommandExecutionOptions
+): Promise<ProviderCommandExecutionResult> {
+  if (isAborted(options.signal)) throw abortError();
+
+  const proc = spawnProviderCommand(command, options.env);
+
+  let termination: Promise<void> | undefined;
+  const scheduleTermination = (): Promise<void> => {
+    if (termination !== undefined) return termination;
+    termination = terminateProviderCommand(proc);
+    void termination.catch(() => undefined);
+    return termination;
+  };
+  const abort = () => {
+    void scheduleTermination();
+  };
+  options.signal?.addEventListener("abort", abort, { once: true });
+
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let completed = false;
+  try {
+    await throwIfAborted(options.signal, scheduleTermination);
+    await options.onProcess?.(proc.pid);
+    await throwIfAborted(options.signal, scheduleTermination);
+    if (options.stdin !== undefined) proc.stdin.write(options.stdin);
+    proc.stdin.end();
+    timer =
+      options.timeoutMs <= 0
+        ? undefined
+        : setTimeout(() => {
+            timedOut = true;
+            void scheduleTermination();
+          }, options.timeoutMs);
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      collectProviderCommandStream(
+        "stdout",
+        proc.stdout,
+        options.maxStdoutBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+        options.onOutput
+      ),
+      collectProviderCommandStream(
+        "stderr",
+        proc.stderr,
+        options.maxStderrBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+        options.onOutput
+      ),
+    ]);
+    if (termination !== undefined) await termination;
+    if (isAborted(options.signal)) throw abortError();
+    completed = true;
+    return {
+      exitCode,
+      stderr: stderr.text,
+      stderrBytes: stderr.bytes,
+      stderrTruncated: stderr.truncated,
+      stdout: stdout.text,
+      stdoutBytes: stdout.bytes,
+      stdoutTruncated: stdout.truncated,
+      timedOut,
+    };
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    options.signal?.removeEventListener("abort", abort);
+    if (!completed) await scheduleTermination();
+  }
+}
+
+export function isProviderCommandMissingBinary(
+  error: unknown
+): error is ProviderCommandError {
+  return (
+    error instanceof ProviderCommandError && error.kind === "missing_binary"
+  );
+}
+
+export function isProviderCommandUnavailable(
+  error: unknown
+): boolean {
+  return (
+    error instanceof ProviderCommandError ||
+    (error instanceof Error &&
+      "code" in error &&
+      ["EACCES", "ENOENT", "ENOEXEC", "ENOTDIR"].includes(String(error.code)))
+  );
+}
+
+function spawnProviderCommand(
+  command: ProviderCommand,
+  env: Record<string, string | undefined>
+) {
+  if (command.cmd.length === 0) {
+    throw new Error("skillset: provider command requires an executable");
+  }
+  try {
+    return Bun.spawn([...command.cmd], {
+      cwd: command.cwd,
+      // Bun creates a POSIX session/process group and a detached Windows process.
+      detached: true,
+      env: cleanEnv(env),
+      stderr: "pipe",
+      stdin: "pipe",
+      stdout: "pipe",
+      windowsHide: true,
+    });
+  } catch (error) {
+    if (isMissingBinaryError(error)) {
+      throw new ProviderCommandError("missing_binary");
+    }
+    if (isUnavailableBinaryError(error)) {
+      throw new ProviderCommandError("unavailable_binary");
+    }
+    throw error;
+  }
+}
+
+async function collectProviderCommandStream(
+  streamName: "stderr" | "stdout",
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  onOutput: ProviderCommandExecutionOptions["onOutput"]
+): Promise<{
+  readonly bytes: number;
+  readonly text: string;
+  readonly truncated: boolean;
+}> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new Error(
+      "skillset: provider command output limits must be non-negative safe integers"
+    );
+  }
+  const chunks: Uint8Array[] = [];
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let retainedBytes = 0;
+  let truncated = false;
+
+  for await (const chunk of stream) {
+    bytes += chunk.byteLength;
+    const remaining = maxBytes - retainedBytes;
+    if (remaining > 0) {
+      const retained = chunk.subarray(0, remaining);
+      chunks.push(retained);
+      retainedBytes += retained.byteLength;
+      if (retained.byteLength < chunk.byteLength) truncated = true;
+    } else if (chunk.byteLength > 0) {
+      truncated = true;
+    }
+
+    const text = decoder.decode(chunk, { stream: true });
+    if (text.length > 0) await onOutput?.(streamName, text);
+  }
+  const finalText = decoder.decode();
+  if (finalText.length > 0) await onOutput?.(streamName, finalText);
+
+  return {
+    bytes,
+    text: new TextDecoder().decode(joinChunks(chunks, retainedBytes)),
+    truncated,
+  };
+}
+
+function joinChunks(chunks: readonly Uint8Array[], length: number): Uint8Array {
+  const joined = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return joined;
+}
+
+async function throwIfAborted(
+  signal: AbortSignal | undefined,
+  terminate: () => Promise<void>
+): Promise<void> {
+  if (!isAborted(signal)) return;
+  await terminate();
+  throw abortError();
+}
+
+async function terminateProviderCommand(
+  proc: ReturnType<typeof Bun.spawn>
+): Promise<void> {
+  signalProviderCommandTree(proc, "SIGTERM");
+  if (await providerCommandTreeExitsWithin(proc, PROCESS_CLEANUP_GRACE_MS)) {
+    return;
+  }
+  signalProviderCommandTree(proc, "SIGKILL");
+  // POSIX process-group probes also report dead zombies as present until an
+  // external init process reaps them. SIGKILL cannot be ignored; once the
+  // owned child exits, stream draining remains the completion boundary.
+  await proc.exited;
+}
+
+async function providerCommandTreeExitsWithin(
+  proc: ReturnType<typeof Bun.spawn>,
+  timeoutMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (providerCommandTreeExists(proc.pid)) {
+    if (Date.now() >= deadline) return false;
+    await Bun.sleep(5);
+  }
+  await proc.exited;
+  return true;
+}
+
+function providerCommandTreeExists(pid: number): boolean {
+  const target = process.platform === "win32" ? pid : -pid;
+  try {
+    process.kill(target, 0);
+    return true;
+  } catch (error) {
+    return !isMissingProcessError(error);
+  }
+}
+
+function signalProviderCommandTree(
+  proc: ReturnType<typeof Bun.spawn>,
+  signal: "SIGKILL" | "SIGTERM"
+): void {
+  if (process.platform === "win32") {
+    Bun.spawnSync(["taskkill", "/PID", String(proc.pid), "/T", "/F"], {
+      stderr: "ignore",
+      stdout: "ignore",
+    });
+    return;
+  }
+  try {
+    process.kill(-proc.pid, signal);
+  } catch {
+    proc.kill(signal);
+  }
+}
+
+function cleanEnv(
+  env: Record<string, string | undefined>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined
+    )
+  );
+}
+
+function isMissingBinaryError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isUnavailableBinaryError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    ["EACCES", "ENOEXEC", "ENOTDIR"].includes(String(error.code))
+  );
+}
+
+function isMissingProcessError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ESRCH";
+}
+
+function abortError(): Error {
+  return new DOMException("Runtime probe cancelled", "AbortError");
+}
+
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted ?? false;
+}

--- a/apps/skillset/src/runtime-probe.ts
+++ b/apps/skillset/src/runtime-probe.ts
@@ -1,14 +1,14 @@
 import { join } from "node:path";
 
+import { compareStrings } from "@skillset/core/internal/path";
 import { pluginTargetRoot } from "@skillset/core/internal/plugin-output";
 import type { BuildGraph, TargetName } from "@skillset/core/internal/types";
-import { compareStrings } from "@skillset/core/internal/path";
 
 import type { ClaudeSettingSources } from "./cli-arg-values";
+import { runProviderCommand } from "./provider-command";
 
 const ISOLATED_CLAUDE_SETTING_SOURCES_ARG = "";
-const CLAUDE_SETTING_SOURCES_DISPLAY = "\"\"";
-const PROCESS_CLEANUP_GRACE_MS = 250;
+const CLAUDE_SETTING_SOURCES_DISPLAY = '""';
 
 export interface RuntimeProbeCommand {
   readonly cmd: readonly string[];
@@ -26,7 +26,10 @@ export interface RuntimeProbeCommandOptions {
 
 export interface RuntimeProbeExecutionOptions {
   readonly env: Record<string, string | undefined>;
-  readonly onOutput?: (stream: "stderr" | "stdout", text: string) => Promise<void>;
+  readonly onOutput?: (
+    stream: "stderr" | "stdout",
+    text: string
+  ) => Promise<void>;
   readonly onProcess?: (pid: number) => Promise<void>;
   readonly signal?: AbortSignal;
   readonly timeoutMs: number;
@@ -46,13 +49,17 @@ export function createRuntimeProbeCommand(
 ): RuntimeProbeCommand {
   if (options.target === "claude") {
     const bin = env.SKILLSET_TEST_CLAUDE_BIN ?? "claude";
-    const pluginArgs = runtimeProbePluginDirs(graph, workspacePath, options.target, options.plugins ?? []).flatMap((pluginDir) => [
-      "--plugin-dir",
-      pluginDir,
-    ]);
-    const settingSourcesArg = options.claudeSettingSources === "isolated" || options.claudeSettingSources === undefined
-      ? ISOLATED_CLAUDE_SETTING_SOURCES_ARG
-      : options.claudeSettingSources;
+    const pluginArgs = runtimeProbePluginDirs(
+      graph,
+      workspacePath,
+      options.target,
+      options.plugins ?? []
+    ).flatMap((pluginDir) => ["--plugin-dir", pluginDir]);
+    const settingSourcesArg =
+      options.claudeSettingSources === "isolated" ||
+      options.claudeSettingSources === undefined
+        ? ISOLATED_CLAUDE_SETTING_SOURCES_ARG
+        : options.claudeSettingSources;
     const cmd = [
       bin,
       "--print",
@@ -69,16 +76,22 @@ export function createRuntimeProbeCommand(
     return {
       cmd,
       cwd: workspacePath,
-      display: cmd.map((arg) => arg === ISOLATED_CLAUDE_SETTING_SOURCES_ARG ? CLAUDE_SETTING_SOURCES_DISPLAY : arg),
+      display: cmd.map((arg) =>
+        arg === ISOLATED_CLAUDE_SETTING_SOURCES_ARG
+          ? CLAUDE_SETTING_SOURCES_DISPLAY
+          : arg
+      ),
     };
   }
 
   if (options.target === "cursor") {
     const bin = env.SKILLSET_TEST_CURSOR_BIN ?? "cursor-agent";
-    const pluginArgs = runtimeProbePluginDirs(graph, workspacePath, options.target, options.plugins ?? []).flatMap((pluginDir) => [
-      "--plugin-dir",
-      pluginDir,
-    ]);
+    const pluginArgs = runtimeProbePluginDirs(
+      graph,
+      workspacePath,
+      options.target,
+      options.plugins ?? []
+    ).flatMap((pluginDir) => ["--plugin-dir", pluginDir]);
     const cmd = [
       bin,
       "--print",
@@ -117,110 +130,19 @@ export async function runRuntimeProbe(
   prompt: string,
   options: RuntimeProbeExecutionOptions
 ): Promise<RuntimeProbeExecutionResult> {
-  if (isAborted(options.signal)) throw abortError();
-  const proc = Bun.spawn([...command.cmd], {
-    cwd: command.cwd,
-    // Bun creates a new POSIX session/process group and a detached Windows process.
-    detached: true,
-    env: cleanEnv(options.env),
-    stderr: "pipe",
-    stdin: "pipe",
-    stdout: "pipe",
-    windowsHide: true,
+  const result = await runProviderCommand(command, {
+    env: options.env,
+    maxStderrBytes: 0,
+    maxStdoutBytes: 0,
+    ...(options.onOutput === undefined ? {} : { onOutput: options.onOutput }),
+    ...(options.onProcess === undefined
+      ? {}
+      : { onProcess: options.onProcess }),
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+    stdin: prompt,
+    timeoutMs: options.timeoutMs,
   });
-  let termination: Promise<void> | undefined;
-  const scheduleTermination = (): Promise<void> => {
-    if (termination !== undefined) return termination;
-    termination = terminateRuntimeProbe(proc);
-    void termination.catch(() => undefined);
-    return termination;
-  };
-  const abort = () => { void scheduleTermination(); };
-  options.signal?.addEventListener("abort", abort, { once: true });
-  let timedOut = false;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let completed = false;
-  try {
-    await throwIfAborted(options.signal, scheduleTermination);
-    await options.onProcess?.(proc.pid);
-    await throwIfAborted(options.signal, scheduleTermination);
-    proc.stdin.write(prompt);
-    proc.stdin.end();
-    timer = options.timeoutMs <= 0
-      ? undefined
-      : setTimeout(() => {
-        timedOut = true;
-        void scheduleTermination();
-      }, options.timeoutMs);
-    const [exitCode] = await Promise.all([
-      proc.exited,
-      collectRuntimeProbeStream("stdout", proc.stdout, options.onOutput),
-      collectRuntimeProbeStream("stderr", proc.stderr, options.onOutput),
-    ]);
-    if (termination !== undefined) await termination;
-    if (isAborted(options.signal)) throw abortError();
-    completed = true;
-    return { exitCode, timedOut };
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-    options.signal?.removeEventListener("abort", abort);
-    if (!completed) await scheduleTermination();
-  }
-}
-
-async function throwIfAborted(signal: AbortSignal | undefined, terminate: () => Promise<void>): Promise<void> {
-  if (!isAborted(signal)) return;
-  await terminate();
-  throw abortError();
-}
-
-async function terminateRuntimeProbe(proc: ReturnType<typeof Bun.spawn>): Promise<void> {
-  signalRuntimeProbeTree(proc, "SIGTERM");
-  if (await runtimeProbeTreeExitsWithin(proc, PROCESS_CLEANUP_GRACE_MS)) return;
-  signalRuntimeProbeTree(proc, "SIGKILL");
-  if (!await runtimeProbeTreeExitsWithin(proc, PROCESS_CLEANUP_GRACE_MS)) {
-    throw new Error(`skillset: provider process tree ${proc.pid} did not terminate`);
-  }
-}
-
-async function runtimeProbeTreeExitsWithin(proc: ReturnType<typeof Bun.spawn>, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (runtimeProbeTreeExists(proc.pid)) {
-    if (Date.now() >= deadline) return false;
-    await Bun.sleep(5);
-  }
-  await proc.exited;
-  return true;
-}
-
-function runtimeProbeTreeExists(pid: number): boolean {
-  const target = process.platform === "win32" ? pid : -pid;
-  try {
-    process.kill(target, 0);
-    return true;
-  } catch (error) {
-    return !isMissingProcessError(error);
-  }
-}
-
-function signalRuntimeProbeTree(proc: ReturnType<typeof Bun.spawn>, signal: "SIGKILL" | "SIGTERM"): void {
-  if (process.platform === "win32") {
-    // Windows has no POSIX process-group signals; taskkill owns descendant traversal.
-    Bun.spawnSync(["taskkill", "/PID", String(proc.pid), "/T", "/F"], {
-      stderr: "ignore",
-      stdout: "ignore",
-    });
-    return;
-  }
-  try {
-    process.kill(-proc.pid, signal);
-  } catch {
-    proc.kill(signal);
-  }
-}
-
-function isMissingProcessError(error: unknown): boolean {
-  return error instanceof Error && "code" in error && error.code === "ESRCH";
+  return { exitCode: result.exitCode, timedOut: result.timedOut };
 }
 
 function runtimeProbePluginDirs(
@@ -229,34 +151,20 @@ function runtimeProbePluginDirs(
   target: "claude" | "cursor",
   plugins: readonly string[]
 ): readonly string[] {
-  const selected = plugins.length === 0 ? graph.plugins.map((plugin) => plugin.id) : plugins;
-  const enabled = new Set(graph.plugins.filter((plugin) => plugin.targets[target].enabled).map((plugin) => plugin.id));
+  const selected =
+    plugins.length === 0 ? graph.plugins.map((plugin) => plugin.id) : plugins;
+  const enabled = new Set(
+    graph.plugins
+      .filter((plugin) => plugin.targets[target].enabled)
+      .map((plugin) => plugin.id)
+  );
   return selected
     .filter((plugin) => enabled.has(plugin))
     .sort(compareStrings)
-    .map((plugin) => join(workspacePath, pluginTargetRoot(graph.root.outputs.plugins[target], target, plugin)));
-}
-
-async function collectRuntimeProbeStream(
-  streamName: "stderr" | "stdout",
-  stream: ReadableStream<Uint8Array>,
-  onOutput: RuntimeProbeExecutionOptions["onOutput"]
-): Promise<void> {
-  const decoder = new TextDecoder();
-  for await (const chunk of stream) {
-    const text = decoder.decode(chunk);
-    if (text.length > 0) await onOutput?.(streamName, text);
-  }
-}
-
-function cleanEnv(env: Record<string, string | undefined>): Record<string, string> {
-  return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined));
-}
-
-function abortError(): Error {
-  return new DOMException("Runtime probe cancelled", "AbortError");
-}
-
-function isAborted(signal: AbortSignal | undefined): boolean {
-  return signal?.aborted ?? false;
+    .map((plugin) =>
+      join(
+        workspacePath,
+        pluginTargetRoot(graph.root.outputs.plugins[target], target, plugin)
+      )
+    );
 }

--- a/docs/adrs/0027-runtime-activation-readiness-is-observational.md
+++ b/docs/adrs/0027-runtime-activation-readiness-is-observational.md
@@ -160,6 +160,8 @@ subject-specific MCP observation or matching runtime proof establishes them.
 The Registry may catalog Cursor account-status evidence for other consumers,
 but activation inspection does not invoke it or fan it into MCP requirements.
 
+Observational means Skillset issues no mutation command and writes no provider state directly. It does not promise byte-immutable provider directories: an invoked provider binary may maintain incidental caches or bookkeeping of its own. Tests isolate HOME and XDG roots so those effects remain outside the workspace and user configuration.
+
 ### Safety boundary
 
 Every inspector is allowlisted, injectable in tests, time-bounded, and mapped to one fixed provider command. Inspection:

--- a/docs/features/runtime-activation-readiness.md
+++ b/docs/features/runtime-activation-readiness.md
@@ -62,9 +62,8 @@ The accepted inspection matrix is:
 | Codex | Plugin dependency | `codex plugin list --json` | passive | discoverable, persisted enabled state |
 | Codex | MCP server | `codex mcp list --json` | passive | configured discovery |
 | Cursor | MCP server | `cursor-agent mcp list` | active | discoverable, provider-reported connection |
-| Cursor | Authentication | `cursor-agent status --format json` | passive | provider-reported authentication |
 
-Provider binaries are versioned with the Registry-owned `<binary> --version` surface. One inspector runs once per target and capability, then fans its bounded facts out to matching requirements. Provider-scoped Cursor authentication likewise runs once and cannot imply plugin or MCP availability.
+Provider binaries are versioned with the Registry-owned `<binary> --version` surface. One inspector runs once per target and capability, then fans its bounded facts out to matching requirements. Cursor account status is not treated as evidence that any particular MCP server is authenticated; that requirement remains unverified without subject-specific observation or matching runtime proof.
 
 Unsupported app state and Cursor persistent plugin inventory stay unverified. Codex MCP inventory cannot establish connection or credentials. Plugin inventory cannot establish current-session load, bundled MCP startup, hosted policy, or runtime proof.
 
@@ -74,7 +73,7 @@ Observational means Skillset issues no mutation command and writes no provider s
 
 Inspection uses literal Registry argv with no shell or arbitrary arguments. The shared provider-command runner applies timeout, cancellation, descendant cleanup, streaming UTF-8 decoding, and independent stdout and stderr byte limits. It continues draining after a capture limit so provider processes cannot block on full pipes.
 
-Only allowlisted names, enabled booleans, connection tokens, authentication booleans, safe binary version text, byte counts, truncation flags, and stable parser summaries survive. Raw provider output, stderr, environment values, tokens, credential material, provider config, and personal paths are not retained. A missing, unsupported, or unrecognized binary version skips every inspector command for that binary. Missing binaries, command failures, timeouts, truncated output, malformed JSON, and unknown shapes make no positive claim; the applicable requirement remains `unverified`.
+Only allowlisted names, enabled booleans, connection tokens, safe binary version text, byte counts, truncation flags, and stable parser summaries survive. Raw provider output, stderr, environment values, tokens, credential material, provider config, and personal paths are not retained. A missing, unsupported, or unrecognized binary version skips every inspector command for that binary. Missing binaries, command failures, timeouts, truncated output, malformed JSON, and unknown shapes make no positive claim; the applicable requirement remains `unverified`.
 
 Bare build, check, status, explain, and CI remain deterministic and launch no provider process.
 

--- a/docs/features/runtime-activation-readiness.md
+++ b/docs/features/runtime-activation-readiness.md
@@ -51,7 +51,30 @@ Stable requirement IDs combine target, capability, canonical subject, and stage.
 
 ## Provider Observation
 
-Provider execution is deliberately outside the foundational Core planner. CLI adapters consume Core activation policy, which joins Registry-owned provider facts with Skillset-owned claims, reasons, actions, and fallback semantics. Active health checks may start configured processes or make connections; their effect must be explicit and opt-in.
+Provider execution is deliberately outside the foundational Core planner. CLI-app adapters consume Core activation policy, which joins Registry-owned provider facts with Skillset-owned claims, reasons, actions, and fallback semantics, then supply sanitized observations. Active health checks may start configured processes or make connections; their effect is explicit and opt-in.
+
+The accepted inspection matrix is:
+
+| Provider | Capability | Exact command | Effect | Maximum claims |
+| --- | --- | --- | --- | --- |
+| Claude | Plugin dependency | `claude plugin list --json` | passive | discoverable, persisted enabled state |
+| Claude | MCP server | `claude mcp list` | active | discoverable, provider-reported connection |
+| Codex | Plugin dependency | `codex plugin list --json` | passive | discoverable, persisted enabled state |
+| Codex | MCP server | `codex mcp list --json` | passive | configured discovery |
+| Cursor | MCP server | `cursor-agent mcp list` | active | discoverable, provider-reported connection |
+| Cursor | Authentication | `cursor-agent status --format json` | passive | provider-reported authentication |
+
+Provider binaries are versioned with the Registry-owned `<binary> --version` surface. One inspector runs once per target and capability, then fans its bounded facts out to matching requirements. Provider-scoped Cursor authentication likewise runs once and cannot imply plugin or MCP availability.
+
+Unsupported app state and Cursor persistent plugin inventory stay unverified. Codex MCP inventory cannot establish connection or credentials. Plugin inventory cannot establish current-session load, bundled MCP startup, hosted policy, or runtime proof.
+
+Observational means Skillset issues no mutation command and writes no provider state directly. It does not promise byte-immutable provider directories: an invoked provider binary may maintain incidental caches or bookkeeping of its own. Tests isolate HOME and XDG roots so those effects remain outside the workspace and user configuration.
+
+### Failure And Redaction Boundary
+
+Inspection uses literal Registry argv with no shell or arbitrary arguments. The shared provider-command runner applies timeout, cancellation, descendant cleanup, streaming UTF-8 decoding, and independent stdout and stderr byte limits. It continues draining after a capture limit so provider processes cannot block on full pipes.
+
+Only allowlisted names, enabled booleans, connection tokens, authentication booleans, safe binary version text, byte counts, truncation flags, and stable parser summaries survive. Raw provider output, stderr, environment values, tokens, credential material, provider config, and personal paths are not retained. A missing, unsupported, or unrecognized binary version skips every inspector command for that binary. Missing binaries, command failures, timeouts, truncated output, malformed JSON, and unknown shapes make no positive claim; the applicable requirement remains `unverified`.
 
 Bare build, check, status, explain, and CI remain deterministic and launch no provider process.
 
@@ -63,5 +86,10 @@ Bare build, check, status, explain, and CI remain deterministic and launch no pr
 - `packages/core/src/__tests__/activation-policy.test.ts`
 - `packages/core/src/runtime-readiness.ts`
 - `packages/core/src/__tests__/runtime-readiness.test.ts`
+- `apps/skillset/src/provider-command.ts`
+- `apps/skillset/src/activation-parsers.ts`
+- `apps/skillset/src/activation-inspection.ts`
+- `apps/skillset/src/__tests__/fixtures/activation/provider-outputs.json`
 - [SET-131](https://linear.app/outfitter/issue/SET-131/research-mcp-and-app-install-or-activation-assistance-without-runtime)
 - [SET-390](https://linear.app/outfitter/issue/SET-390/define-registry-backed-activation-readiness-and-static-planning)
+- [SET-391](https://linear.app/outfitter/issue/SET-391/add-bounded-provider-activation-evidence-adapters)

--- a/packages/core/src/__tests__/activation-policy.test.ts
+++ b/packages/core/src/__tests__/activation-policy.test.ts
@@ -73,14 +73,6 @@ describe("SET-390 provider activation policy", () => {
         output: "text",
         versionArgv: ["cursor-agent", "--version"],
       },
-      {
-        allowedClaims: ["authenticated"],
-        argv: ["cursor-agent", "status", "--format", "json"],
-        effect: "passive",
-        id: "cursor.status",
-        output: "json",
-        versionArgv: ["cursor-agent", "--version"],
-      },
     ]);
   });
 

--- a/packages/core/src/__tests__/activation-policy.test.ts
+++ b/packages/core/src/__tests__/activation-policy.test.ts
@@ -39,6 +39,7 @@ describe("SET-390 provider activation policy", () => {
         effect: "active",
         id: "claude.mcp.list",
         output: "text",
+        versionArgv: ["claude", "--version"],
       },
       {
         allowedClaims: ["discoverable", "enabled"],
@@ -46,6 +47,7 @@ describe("SET-390 provider activation policy", () => {
         effect: "passive",
         id: "claude.plugin.list",
         output: "json",
+        versionArgv: ["claude", "--version"],
       },
       {
         allowedClaims: ["discoverable"],
@@ -53,6 +55,7 @@ describe("SET-390 provider activation policy", () => {
         effect: "passive",
         id: "codex.mcp.list",
         output: "json",
+        versionArgv: ["codex", "--version"],
       },
       {
         allowedClaims: ["discoverable", "enabled"],
@@ -60,6 +63,7 @@ describe("SET-390 provider activation policy", () => {
         effect: "passive",
         id: "codex.plugin.list",
         output: "json",
+        versionArgv: ["codex", "--version"],
       },
       {
         allowedClaims: ["connected", "discoverable"],
@@ -67,6 +71,7 @@ describe("SET-390 provider activation policy", () => {
         effect: "active",
         id: "cursor.mcp.list",
         output: "text",
+        versionArgv: ["cursor-agent", "--version"],
       },
       {
         allowedClaims: ["authenticated"],
@@ -74,6 +79,7 @@ describe("SET-390 provider activation policy", () => {
         effect: "passive",
         id: "cursor.status",
         output: "json",
+        versionArgv: ["cursor-agent", "--version"],
       },
     ]);
   });
@@ -234,6 +240,7 @@ describe("SET-390 provider activation policy", () => {
             argv: ["sh", "-c", "codex mcp list --json"],
             kind: "command",
             output: "json",
+            versionArgv: ["sh", "--version"],
           },
         },
       ],
@@ -256,6 +263,7 @@ function commandSurfaces(): readonly Record<string, unknown>[] {
               effect: inspector.effect,
               id: inspector.id,
               output: inspector.surface.output,
+              versionArgv: inspector.surface.versionArgv,
             },
           ]
         : []

--- a/packages/core/src/activation-policy.ts
+++ b/packages/core/src/activation-policy.ts
@@ -159,14 +159,14 @@ const descriptors = [
     ],
     reasons: [
       reason(
+        "claude.plugin.not-enabled",
+        "enabled",
+        "Claude reported the required plugin as disabled."
+      ),
+      reason(
         "claude.plugin.not-discoverable",
         "discoverable",
         "Claude plugin inventory did not report the required plugin."
-      ),
-      reason(
-        "claude.plugin.not-enabled",
-        "enabled",
-        "Claude plugin inventory reported the required plugin as disabled."
       ),
     ],
     target: "claude",
@@ -268,14 +268,14 @@ const descriptors = [
     ],
     reasons: [
       reason(
+        "codex.plugin.not-enabled",
+        "enabled",
+        "Codex reported the required plugin as disabled."
+      ),
+      reason(
         "codex.plugin.not-discoverable",
         "discoverable",
         "Codex plugin inventory did not report the required plugin."
-      ),
-      reason(
-        "codex.plugin.not-enabled",
-        "enabled",
-        "Codex plugin inventory reported the required plugin as disabled."
       ),
     ],
     target: "codex",
@@ -697,6 +697,10 @@ function normalizeDescriptor(
             ? {
                 ...entry.surface,
                 argv: [...entry.surface.argv] as [string, ...string[]],
+                versionArgv: [...entry.surface.versionArgv] as [
+                  string,
+                  ...string[],
+                ],
               }
             : entry.surface,
       }))
@@ -846,20 +850,33 @@ function assertInspectorSurface(entry: ProviderActivationInspector): void {
       `skillset: command provider activation inspector ${entry.id} must declare passive or active effect`
     );
   }
-  const [executable, ...args] = entry.surface.argv;
+  assertSafeInspectorCommand(entry.id, entry.surface.argv);
+  assertSafeInspectorCommand(`${entry.id} version`, entry.surface.versionArgv);
+  if (entry.surface.argv[0] !== entry.surface.versionArgv[0]) {
+    throw new Error(
+      `skillset: provider activation inspector ${entry.id} must use the same executable for inspection and version evidence`
+    );
+  }
+}
+
+function assertSafeInspectorCommand(
+  id: string,
+  argv: readonly [string, ...string[]]
+): void {
+  const [executable, ...args] = argv;
   if (
     executable === undefined ||
     executable.length === 0 ||
     ["bash", "sh", "zsh"].includes(executable)
   ) {
     throw new Error(
-      `skillset: provider activation inspector ${entry.id} must use a fixed provider executable`
+      `skillset: provider activation inspector ${id} must use a fixed provider executable`
     );
   }
   for (const arg of args) {
     if (arg.length === 0 || /[\0\r\n]/u.test(arg)) {
       throw new Error(
-        `skillset: provider activation inspector ${entry.id} has invalid argv`
+        `skillset: provider activation inspector ${id} has invalid argv`
       );
     }
   }

--- a/packages/core/src/activation-policy.ts
+++ b/packages/core/src/activation-policy.ts
@@ -370,7 +370,7 @@ const descriptors = [
       action(
         "cursor.mcp.authenticate",
         "cursor.mcp.authentication-unverified",
-        "Authenticate Cursor Agent",
+        "Authenticate the MCP server in Cursor",
         "https://cursor.com/docs/cli/headless",
         true
       ),
@@ -389,7 +389,7 @@ const descriptors = [
         true
       ),
     ],
-    allowedClaims: ["authenticated", "connected", "discoverable"],
+    allowedClaims: ["connected", "discoverable"],
     capability: "mcp-server",
     evidence: providerEvidence("cursor"),
     forbiddenClaims: ["credentials", "provider-policy", "proven"],
@@ -404,23 +404,12 @@ const descriptors = [
         ],
         id: "cursor.mcp.list",
       }),
-      inspector({
-        allowedClaims: ["authenticated"],
-        forbiddenClaims: [
-          "availability",
-          "connected",
-          "discoverable",
-          "proven",
-        ],
-        id: "cursor.status",
-        scope: "provider",
-      }),
     ],
     reasons: [
       reason(
         "cursor.mcp.authentication-unverified",
         "authenticated",
-        "Cursor Agent authentication could not be verified."
+        "Authentication for the required Cursor MCP server could not be verified."
       ),
       reason(
         "cursor.mcp.not-connected",

--- a/packages/registry/src/__tests__/provider-runtime-evidence.test.ts
+++ b/packages/registry/src/__tests__/provider-runtime-evidence.test.ts
@@ -44,6 +44,7 @@ describe("SET-390 provider runtime evidence", () => {
         argv: ["claude", "plugin", "list", "--json"],
         kind: "command",
         output: "json",
+        versionArgv: ["claude", "--version"],
       },
     });
     expect(getProviderRuntimeEvidence("cursor")).toMatchObject({

--- a/packages/registry/src/provider-runtime-evidence.ts
+++ b/packages/registry/src/provider-runtime-evidence.ts
@@ -14,6 +14,7 @@ export interface ProviderRuntimeCommandSurface {
   readonly argv: readonly [string, ...string[]];
   readonly kind: "command";
   readonly output: "json" | "text";
+  readonly versionArgv: readonly [string, ...string[]];
 }
 
 export interface ProviderRuntimeInspectorEvidence {
@@ -240,7 +241,12 @@ function command(
   argv: readonly [string, ...string[]],
   output: ProviderRuntimeCommandSurface["output"]
 ): ProviderRuntimeCommandSurface {
-  return { argv, kind: "command", output };
+  return {
+    argv,
+    kind: "command",
+    output,
+    versionArgv: [argv[0], "--version"],
+  };
 }
 
 function assertCommandSurface(entry: ProviderRuntimeInspectorEvidence): void {
@@ -260,6 +266,16 @@ function assertCommandSurface(entry: ProviderRuntimeInspectorEvidence): void {
         `skillset: provider runtime inspector evidence ${entry.id} has invalid argv`
       );
     }
+  }
+  const [versionExecutable, ...versionArgs] = entry.surface.versionArgv;
+  if (
+    versionExecutable !== executable ||
+    versionArgs.length !== 1 ||
+    versionArgs[0] !== "--version"
+  ) {
+    throw new Error(
+      `skillset: provider runtime inspector evidence ${entry.id} must use the matching fixed --version surface`
+    );
   }
 }
 


### PR DESCRIPTION
## Context

Implements SET-391 by adding the bounded provider evidence adapters used only when activation inspection is explicitly requested.

## What changed

- adds exact allowlisted Claude, Codex, and Cursor inspection commands
- parses bounded outputs into registry-owned observations
- preserves passive versus active effect disclosure
- handles timeout, cancellation, malformed output, and provider failure as advisory evidence

## Verification

- focused runner, parser, inspection, Registry, and Core suites pass
- milestone standing and targeted reviews are 5/5 clean
- full stack pre-push gate passes 1,703 tests with zero failures

## Risk

Explicit active inspectors may have provider-owned incidental effects. Bare commands never launch them, and Skillset issues no mutation command.

Stack: SET-131 -> SET-390 -> SET-391 -> SET-392 -> SET-393
